### PR TITLE
Put the head_ref in an envvar to avoid shell injection

### DIFF
--- a/.github/workflows/sync-copywriter-changes.yaml
+++ b/.github/workflows/sync-copywriter-changes.yaml
@@ -104,6 +104,8 @@ jobs:
 
       - name: Commit and push changes
         if: steps.sync.outputs.updated == 'true'
+        env:
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
@@ -116,7 +118,7 @@ jobs:
 
           Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
 
-          git push origin temp-sync-branch:${{ steps.pr.outputs.head_ref }} --force
+          git push origin "temp-sync-branch:$HEAD_REF" --force
 
       - name: Comment on PR
         if: steps.sync.outputs.updated == 'true'


### PR DESCRIPTION
## Motivation

Original code just inserted the content of the head_ref in a command-line, which made it possible to insert shell commands. By putting it in an environment variable first, we ensure it goes within the quotes.

## Author Checklist

- [X] I have reviewed my own PR.
- [X] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [X] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Tell the reviewer how they can make sure the PR is indeed working as intended. Tell them what they should be looking for.

## Blast Radius

What services will this change impact. Is it only DataDog IaC Scanner, internal services, the documentation or anything else?

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
