### PR TITLE
Fix GitHub workflows and tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,5 +27,4 @@ jobs:
           /usr/local/bin/datadog-ci coverage upload cover.out
         env:
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
-          DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
           DD_SITE: ${{ vars.DD_SITE }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: false
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
       - name: Generate mocks and marshall/unmarshall code
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Check out code into the Go module directory

--- a/.github/workflows/go-e2e.yaml
+++ b/.github/workflows/go-e2e.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Check out code

--- a/.github/workflows/go-test-race.yml
+++ b/.github/workflows/go-test-race.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
       - name: Check out code into the Go module directory

--- a/.github/workflows/kics-test-gate.yml
+++ b/.github/workflows/kics-test-gate.yml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
@@ -47,7 +47,7 @@ jobs:
 
       - name: Comment on PR (on failure)
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1,8 +1,8 @@
-name: KICS Test Gate
+name: Test Gate
 
-# This workflow blocks PRs from being merged to main if tests in critical KICS packagesfail.
-# TODO: Expand gate to include all critical KICS packages once their tests are fixed
-# TODO: Expand gate to run ALL tests within KICS packages once their tests are fixed
+# This workflow blocks PRs from being merged to main if tests in critical packages fail.
+# TODO: Expand gate to include all critical packages once their tests are fixed
+# TODO: Expand gate to run ALL tests once their tests are fixed
 on:
   pull_request:
     branches: [main]
@@ -14,8 +14,8 @@ permissions:
   pull-requests: write  # Write access to post PR comments
 
 jobs:
-  kics-tests:
-    name: Critical KICS Tests
+  critical-tests:
+    name: Critical Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -37,13 +37,12 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
-      - name: Run critical KICS tests
+      - name: Run critical tests
         id: engine-tests
-        # TODO: ./pkg/scanner is not included, takes too long to run in Github. Add it back when we have a faster way to run it in CI.
         run: |
-          echo "🔍 Running critical KICS tests..."
-          gotestsum --format testname -- -v -short -timeout 15m ./pkg/engine ./pkg/analyzer ./pkg/parser ./pkg/parser/terraform/... ./pkg/parser/yaml ./pkg/engine/source ./pkg/scan ./pkg/builder/... ./pkg/kics ./test/e2e ./pkg/utils ./test/... ./pkg/report/model
-          echo "✅ All critical KICS tests passed!"
+          echo "🔍 Running critical tests..."
+          gotestsum --format testname -- -v -short -timeout 15m ./pkg/engine ./pkg/analyzer ./pkg/parser ./pkg/parser/terraform/... ./pkg/parser/yaml ./pkg/engine/source ./pkg/scan ./pkg/scanner ./pkg/builder/... ./pkg/kics ./test/e2e ./pkg/utils ./test/... ./pkg/report/model
+          echo "✅ All critical tests passed!"
 
       - name: Comment on PR (on failure)
         if: failure() && github.event_name == 'pull_request'
@@ -54,11 +53,11 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '❌ **Critical Tests Failed**\n\nOne or more critical test suites failed. These packages are critical to KICS security scanning functionality.\n\n**This PR cannot be merged until these tests pass.**\n\nPlease review the test failures and fix the issues.\n\n[View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+              body: '❌ **Critical Tests Failed**\n\nOne or more critical test suites failed. These packages are critical to the security scanning functionality.\n\n**This PR cannot be merged until these tests pass.**\n\nPlease review the test failures and fix the issues.\n\n[View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
             })
 
       - name: Set status
         if: failure()
         run: |
-          echo "::error::Critical KICS tests failed - blocking merge"
+          echo "::error::Critical tests failed - blocking merge"
           exit 1

--- a/.github/workflows/update_software_versions.yml
+++ b/.github/workflows/update_software_versions.yml
@@ -4,13 +4,13 @@ on:
 jobs:
   update-software-versions:
     name: update software versions to latest
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout project
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.x"
       - name: Run update_versions script

--- a/.github/workflows/validate-arm-samples.yaml
+++ b/.github/workflows/validate-arm-samples.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
       - name: Installing jsonlint

--- a/.github/workflows/validate-cfn-samples.yml
+++ b/.github/workflows/validate-cfn-samples.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.x'
       - name: Get commit changed files

--- a/.github/workflows/validate-openapi-samples.yaml
+++ b/.github/workflows/validate-openapi-samples.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
       - name: Installing jsonlint

--- a/internal/console/helpers/helpers_test.go
+++ b/internal/console/helpers/helpers_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestFileAnalyzer(t *testing.T) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -190,7 +190,7 @@ func TestHelpers_GenerateReport(t *testing.T) {
 }
 
 func TestHelpers_GetDefaultQueryPath(t *testing.T) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -127,7 +127,7 @@ func TestInspector_GetCoverageReport(t *testing.T) {
 
 // TestNewInspector tests the functions [NewInspector()] and all the methods called by them
 func TestNewInspector(t *testing.T) { //nolint
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Fatal(err)
 	}
 	contentByte, err := os.ReadFile(filepath.FromSlash("./test/fixtures/get_queries_test/content_get_queries.rego"))
@@ -320,7 +320,7 @@ func TestEngine_contains(t *testing.T) {
 }
 
 func TestEngine_LenQueriesByPlat(t *testing.T) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -367,7 +367,7 @@ func TestEngine_LenQueriesByPlat(t *testing.T) {
 }
 
 func TestEngine_GetFailedQueries(t *testing.T) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Fatal(err)
 	}
 	type args struct {

--- a/pkg/engine/provider/extract_test.go
+++ b/pkg/engine/provider/extract_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestProvider_GetSources(t *testing.T) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/engine/provider/filesystem_test.go
+++ b/pkg/engine/provider/filesystem_test.go
@@ -78,7 +78,7 @@ func TestNewFileSystemSourceProvider(t *testing.T) {
 
 // TestFileSystemSourceProvider_GetSources tests the functions [GetSources()] and all the methods called by them
 func TestFileSystemSourceProvider_GetSources(t *testing.T) { //nolint
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Fatal(err)
 	}
 	type fields struct {
@@ -128,7 +128,7 @@ func TestFileSystemSourceProvider_GetSources(t *testing.T) { //nolint
 }
 
 func TestFileSystemSourceProvider_GetBasePath(t *testing.T) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Errorf("failed to change dir: %s", err)
 	}
 	fsystem, err := initFs([]string{filepath.FromSlash("test")}, []string{})
@@ -175,7 +175,7 @@ func TestFileSystemSourceProvider_GetBasePath(t *testing.T) {
 
 // TestFileSystemSourceProvider_checkConditions tests the functions [checkConditions()] and all the methods called by them
 func TestFileSystemSourceProvider_checkConditions(t *testing.T) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Errorf("failed to change dir: %s", err)
 	}
 	infoHelm, errHelm := os.Stat(filepath.FromSlash("test/fixtures/test_helm"))
@@ -478,7 +478,7 @@ func TestFileSystemSourceProvider_checkConditions(t *testing.T) {
 
 // TestFileSystemSourceProvider_AddExcluded tests the functions [AddExcluded()] and all the methods called by them
 func TestFileSystemSourceProvider_AddExcluded(t *testing.T) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Errorf("failed to change dir: %s", err)
 	}
 	fsystem, err := initFs([]string{filepath.FromSlash("test")}, []string{})

--- a/pkg/engine/source/filesystem_test.go
+++ b/pkg/engine/source/filesystem_test.go
@@ -21,7 +21,7 @@ import (
 
 // BenchmarkFilesystemSource_GetQueries benchmarks getQueries to see improvements
 func BenchmarkFilesystemSource_GetQueries(b *testing.B) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		b.Fatal(err)
 	}
 	type fields struct {
@@ -67,7 +67,7 @@ func BenchmarkFilesystemSource_GetQueries(b *testing.B) {
 
 // TestFilesystemSource_GetQueriesWithExclude test the function GetQuery with QuerySelectionFilter set for Exclude queries
 func TestFilesystemSource_GetQueriesWithExclude(t *testing.T) { //nolint
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Fatal(err)
 	}
 	contentByte, err := os.ReadFile(filepath.FromSlash("./assets/queries/terraform/aws/alb_deletion_protection_disabled/query.rego"))
@@ -166,7 +166,7 @@ func TestFilesystemSource_GetQueriesWithExclude(t *testing.T) { //nolint
 
 // TestFilesystemSource_GetQueriesWithInclude test the function GetQuery with QuerySelectionFilter set for include queries
 func TestFilesystemSource_GetQueriesWithInclude(t *testing.T) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -265,7 +265,7 @@ func TestFilesystemSource_GetQueriesWithInclude(t *testing.T) {
 
 // TestFilesystemSource_GetQueryLibrary tests the functions [GetQueryLibrary()] and all the methods called by them
 func TestFilesystemSource_GetQueryLibrary(t *testing.T) { //nolint
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Fatal(err)
 	}
 	type fields struct {
@@ -395,7 +395,7 @@ func TestFilesystemSource_GetQueryLibrary(t *testing.T) { //nolint
 
 // TestFilesystemSource_GetQueries tests the functions [GetQueries()] and all the methods called by them
 func TestFilesystemSource_GetQueries(t *testing.T) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -484,7 +484,7 @@ func TestFilesystemSource_GetQueries(t *testing.T) {
 
 // Test_ReadMetadata tests the functions [ReadMetadata()] and all the methods called by them
 func Test_ReadMetadata(t *testing.T) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Fatal(err)
 	}
 	type args struct {
@@ -648,7 +648,7 @@ func TestSource_validateMetadata(t *testing.T) {
 }
 
 func TestSource_getLibraryInDir(t *testing.T) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/resolver/file/file_test.go
+++ b/pkg/resolver/file/file_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestResolver_Resolve_With_ResolveReferences(t *testing.T) {
-	err := test.ChangeCurrentDir("kics")
+	err := test.ChangeCurrentDir("datadog-iac-scanner")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestResolver_Resolve_With_ResolveReferences(t *testing.T) {
 }
 
 func TestResolver_Resolve_Without_ResolveReferences(t *testing.T) {
-	err := test.ChangeCurrentDir("kics")
+	err := test.ChangeCurrentDir("datadog-iac-scanner")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func TestResolver_Resolve_Without_ResolveReferences(t *testing.T) {
 
 // when using the key 'include_vars', the resolver will search for the file inside the folder 'current_path/vars' and then in the 'current_path'.
 func TestResolver_Resolve_Ansible_Vars(t *testing.T) {
-	err := test.ChangeCurrentDir("kics")
+	err := test.ChangeCurrentDir("datadog-iac-scanner")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +224,7 @@ func TestResolver_Resolve_Ansible_Vars(t *testing.T) {
 }
 
 func Test_IsOpenApi(t *testing.T) {
-	err := test.ChangeCurrentDir("kics")
+	err := test.ChangeCurrentDir("datadog-iac-scanner")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,28 +29,6 @@ func Test_GetCurrentDirName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := GetCurrentDirName(tt.path)
-			require.Equal(t, tt.expectedOutput, v)
-		})
-	}
-
-}
-
-func Test_FormatCurrentDirError(t *testing.T) {
-	tests := []struct {
-		name           string
-		value          error
-		expectedOutput string
-	}{
-		{
-			name:           "error format test",
-			value:          errors.New("some text"),
-			expectedOutput: "change path error = some text",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			v := formatCurrentDirError(tt.value)
 			require.Equal(t, tt.expectedOutput, v)
 		})
 	}


### PR DESCRIPTION
## Motivation

GitHub workflows were not executing, or if they executed, they were not completing.

## Changes

* Some actions were defined using `vXXX` tags, which is not safe and is not allowed by the repo settings, making the workflows fail. They've been switched to commit SHA pinning.
* Some actions were not allowed because they were not owned by GitHub, DataDog, or a verified Marketplace action. They've been approved specifically.
* Some tests timed out. This was caused by those tests trying to locate a parent subdirectory named `kics` (which was meant to be the repository's name). In this repository, no such directory exists. Changed those tests to look for `datadog-iac-scanner` and fixed the function that changed directory so it will fail if it reaches the filesystem root without finding the directory.
* Added an API key and environment variables to upload the coverage report.
* Changed the "critical tests" gate to remove KICS references and add `pkg/scanner` as it's not _that_ slow.

## Author Checklist

- [X] I have reviewed my own PR.
- [X] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [X] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

We can tell it works because the GitHub checks below have passed.

## Blast Radius

What services will this change impact. Is it only DataDog IaC Scanner, internal services, the documentation or anything else?

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
