### PR TITLE
Enforce the format of tags for releases

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -3,7 +3,8 @@ name: Release new version
 on:
   push:
     tags:
-      - "*" # triggers only if push new tag version, like `v0.8.4`
+      - "v[0-9]+.[0-9]+.[0-9]+"   # release versions, like `v0.8.4`
+      - "v[0-9]+.[0-9]+.[0-9]+-*" # pre-release versions, like `v0.8.4-alpha`
 
 # Restrict jobs in this workflow to have no permissions by default; permissions
 # should be granted per job as needed using a dedicated `permissions` block

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,3 +40,4 @@ changelog:
 
 release:
   draft: true
+  prerelease: auto


### PR DESCRIPTION
## Motivation

Currently, the release workflow will run on any tag. We want to, at the very least, enforce the format of tags as version numbers.

## Changes

Changed the workflow to recognize two patterns and goreleaser to generate prerelease or final releases depending on the format.

Two tag formats are recognized:

- `vX.Y.Z` -- for releases (where `X`, `Y`, `Z` are numbers)
- `vX.Y.Z-A` -- for pre-releases (where `X`, `Y`, `Z` are numbers and `A` is anything)

Goreleaser is configured to mark as prerelease when the second format is used.

## Author Checklist

- [X] I have reviewed my own PR.
- [X] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [X] All new and existing tests pass.
- [x] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

This PR was used to generate a release named `v0.0.3-pre.1`, which [appears as a draft prerelease](https://github.com/DataDog/datadog-iac-scanner/releases/tag/untagged-3afb8227e95a5c4d0734).

## Blast Radius

What services will this change impact. Is it only DataDog IaC Scanner, internal services, the documentation or anything else?

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
