### PR TITLE
Fix parallel file processing

### DIFF
--- a/pkg/kics/service.go
+++ b/pkg/kics/service.go
@@ -77,7 +77,6 @@ func (s *Service) PrepareSources(ctx context.Context,
 	contextLogger := logger.FromContext(ctx)
 	defer wg.Done()
 	// CxSAST query under review
-	data := make([]byte, mbConst)
 	contextLogger.Info().Msgf("Getting sources")
 	var err error
 	// TODO: Remove this if / else upon finishing dogfooding phase
@@ -86,6 +85,8 @@ func (s *Service) PrepareSources(ctx context.Context,
 			ctx,
 			s.Parser.SupportedExtensions(),
 			func(ctx context.Context, filename string, rc io.ReadCloser) error {
+				// data will be used as buffer as the sink is used multiple times concurrently
+				data := make([]byte, mbConst)
 				return s.sink(ctx, filename, scanID, rc, data, openAPIResolveReferences, maxResolverDepth)
 			},
 			func(ctx context.Context, filename string) ([]string, error) { // Sink used for resolver files and templates
@@ -97,6 +98,7 @@ func (s *Service) PrepareSources(ctx context.Context,
 			ctx,
 			s.Parser.SupportedExtensions(),
 			func(ctx context.Context, filename string, rc io.ReadCloser) error {
+				data := make([]byte, mbConst)
 				return s.sink(ctx, filename, scanID, rc, data, openAPIResolveReferences, maxResolverDepth)
 			},
 			func(ctx context.Context, filename string) ([]string, error) { // Sink used for resolver files and templates


### PR DESCRIPTION
## Motivation

The datadog-iac-scanner previously introduced parallel file processing. Parsing issues were encountered, such as:
```
ERR failed to parse file content: ../cloud-inventory/aws/mgmt-1/network-control-blue/main.tf error="main.tf:80,1-2: Argument or block definition required; An argument or block definition is required here."
```
This PR aims to fix those failures.

## Changes

- create `data` buffer for each `sink` execution:
  - The `sink` function write the content of the file inside a `data` buffer. This buffer was used concurrently across the different executions of the function

## Author Checklist

- [x] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- Running the scan locally shows none of the previous failures

## Blast Radius

Kics scanning logic

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
