### PR TITLE
Verify that the files are in the documentation/rules directory

### DIFF
--- a/.github/scripts/sync-copywriter-changes/sync_md_to_metadata.py
+++ b/.github/scripts/sync-copywriter-changes/sync_md_to_metadata.py
@@ -93,13 +93,13 @@ def find_json_paths(
     try:
         rules_idx = parts.index("rules")
     except ValueError:
-        return None
+        return None, None
 
     # Extract platform/provider/rule_name
     relative_parts = parts[rules_idx + 1 :]
 
     if len(relative_parts) < 2:
-        return None
+        return None, None
 
     # Remove .md extension from the last part (rule name)
     rule_name = relative_parts[-1].replace(".md", "")
@@ -290,6 +290,9 @@ def sync_md_to_metadata(
     else:
         md_files = list(md_dir.rglob("*.md"))
 
+    # Resolve the absolute path of the md_dir
+    abs_md_dir = md_dir.resolve()
+
     for md_file in md_files:
         if verbose:
             print(f"\nProcessing: {md_file}")
@@ -297,6 +300,9 @@ def sync_md_to_metadata(
         processed += 1
 
         try:
+            # Throws an exception if the resolved file path is not relative to the abs_md_dir
+            md_file.resolve().relative_to(abs_md_dir)
+
             # Read markdown file
             with open(md_file, "r", encoding="utf-8") as f:
                 content = f.read()


### PR DESCRIPTION
## Motivation

We want to ensure that the files that are passed to the script really belong to the documentation directory.

## Changes

Resolve the directory and file names, verify that there is a relative path from the directory to the file. Tested manually (see QA section.)

Also fix a type mismatch in some return values of `find_json_paths`.

## Author Checklist

- [X] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [X] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

```
% python .github/scripts/sync-copywriter-changes/sync_md_to_metadata.py -f documentation/rules/terraform/gcp/stackdriver_logging_disabled.md --dry-run
Syncing markdown files from documentation/rules to assets/queries
[DRY RUN MODE - No changes will be made]

============================================================
Summary:
  Processed: 1 files
  Updated:   0 files
  Errors:    0 files
============================================================

% python .github/scripts/sync-copywriter-changes/sync_md_to_metadata.py -f ../documentation/rules/terraform/gcp/stackdriver_logging_disabled.md --dry-run
Syncing markdown files from documentation/rules to assets/queries
[DRY RUN MODE - No changes will be made]
Error processing ../documentation/rules/terraform/gcp/stackdriver_logging_disabled.md: '/Users/jacobotb/git/documentation/rules/terraform/gcp/stackdriver_logging_disabled.md' is not in the subpath of '/Users/jacobotb/git/datadog-iac-scanner/documentation/rules' OR one path is relative and the other is absolute.

============================================================
Summary:
  Processed: 1 files
  Updated:   0 files
  Errors:    1 files
============================================================
```

## Blast Radius

What services will this change impact. Is it only DataDog IaC Scanner, internal services, the documentation or anything else?

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
