### PR TITLE
Implement hclsyntax.IndexExpr in parser

### DIFF
--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -52,6 +52,8 @@ func (e *Engine) ExpToString(ctx context.Context, expr hclsyntax.Expression) (st
 	case *hclsyntax.ScopeTraversalExpr:
 		items := evaluateScopeTraversalExpr(t.Traversal)
 		return strings.Join(items, "."), nil
+	case *hclsyntax.IndexExpr:
+		return e.indexExprToString(ctx, t)
 	}
 	err := fmt.Errorf("can't convert expression %T to string", expr)
 	contextLogger.Error().Msg(err.Error())
@@ -75,6 +77,21 @@ func (e *Engine) buildString(ctx context.Context, parts []hclsyntax.Expression) 
 	builder = nil
 
 	return s, nil
+}
+
+func (e *Engine) indexExprToString(ctx context.Context, t *hclsyntax.IndexExpr) (string, error) {
+	if t == nil || t.Collection == nil || t.Key == nil {
+		return "", fmt.Errorf("invalid IndexExpr: nil collection or key")
+	}
+	coll, err := e.ExpToString(ctx, t.Collection)
+	if err != nil {
+		return "", err
+	}
+	key, err := e.ExpToString(ctx, t.Key)
+	if err != nil {
+		return "", err
+	}
+	return coll + "[" + key + "]", nil
 }
 
 func evaluateScopeTraversalExpr(t hcl.Traversal) []string {

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
@@ -54,4 +55,51 @@ func TestEngine_BuildString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExpToString_IndexExpr(t *testing.T) {
+	expr, diags := hclsyntax.ParseExpression([]byte("var.list[var.i]"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse failed: %v", diags)
+	}
+	indexExpr, ok := expr.(*hclsyntax.IndexExpr)
+	if !ok {
+		t.Fatalf("expected *hclsyntax.IndexExpr, got %T", expr)
+	}
+
+	e := &Engine{}
+	ctx := context.Background()
+
+	t.Run("via ExpToString", func(t *testing.T) {
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString(IndexExpr): %v", err)
+		}
+		if want := "var.list[var.i]"; got != want {
+			t.Errorf("ExpToString(IndexExpr) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("via indexExprToString", func(t *testing.T) {
+		got, err := e.indexExprToString(ctx, indexExpr)
+		if err != nil {
+			t.Fatalf("indexExprToString: %v", err)
+		}
+		if want := "var.list[var.i]"; got != want {
+			t.Errorf("indexExprToString() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestExpToString_IndexExpr_edgeCases(t *testing.T) {
+	e := &Engine{}
+	ctx := context.Background()
+
+	t.Run("nil IndexExpr", func(t *testing.T) {
+		var nilIndex *hclsyntax.IndexExpr
+		_, err := e.indexExprToString(ctx, nilIndex)
+		if err == nil {
+			t.Error("indexExprToString(nil) should return error")
+		}
+	})
 }

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -818,9 +818,29 @@ func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) { //nolint:go
 	case *hclsyntax.ObjectConsKeyExpr:
 		return expressionToAST(e.UnwrapExpression())
 
+	case *hclsyntax.IndexExpr:
+		collV, err1 := expressionToAST(e.Collection)
+		keyV, err2 := expressionToAST(e.Key)
+		if err1 != nil || err2 != nil {
+			return ast.String("__UNRESOLVED__"), nil
+		}
+		collStr := astValueToSimpleString(collV)
+		keyStr := astValueToSimpleString(keyV)
+		return ast.String(collStr + "[" + keyStr + "]"), nil
+
 	default:
 		return ast.String("__UNSUPPORTED_EXPR__"), nil
 	}
+}
+
+func astValueToSimpleString(v ast.Value) string {
+	if v == nil {
+		return "__UNRESOLVED__"
+	}
+	if s, ok := v.(ast.String); ok {
+		return string(s)
+	}
+	return v.String()
 }
 
 // Converts HCL literal values to ast.Value


### PR DESCRIPTION
## Motivation

`hclsyntax.IndexExpr` was not implemented in the parser, causing errors when HCL uses index expressions with a variable key (e.g. `var.list[var.i]`). This implements support so those expressions are handled correctly (stringified for rules and converted to AST for Rego evaluation).

## Changes

- **pkg/builder/engine/engine.go**: Add `IndexExpr` case in `ExpToString` and `indexExprToString` helper
- **pkg/engine/inspector.go**: Add `IndexExpr` case in `expressionToAST` and `astValueToSimpleString` helper for Rego

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run `go test ./pkg/builder/engine/ ./pkg/engine/` and confirm all tests pass. Optionally scan Terraform that uses dynamic index expressions (e.g. `var.x[var.y]`) and confirm no parser errors.

## Blast Radius

DataDog IaC Scanner only: HCL parsing and query evaluation paths.

I submit this contribution under the Apache-2.0 license.


[K9VULN-10486]: https://datadoghq.atlassian.net/browse/K9VULN-10486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ