### PR TITLE
Fix overwrites in parallel file parsing

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -581,7 +581,7 @@ func checkYamlPlatform(ctx context.Context, content []byte, path string) string 
 	}
 
 	var yamlContent model.Document
-	if err := yamlContent.UnmarshalYAML(ctx, contentNode); err != nil {
+	if err := yamlContent.UnmarshalYAML(ctx, contentNode, nil); err != nil {
 		contextLogger.Warn().Msgf("failed to unmarshal yaml file (%s): %s", path, err)
 		return ""
 	}

--- a/pkg/model/comment_yaml.go
+++ b/pkg/model/comment_yaml.go
@@ -8,7 +8,6 @@ package model
 import (
 	"reflect"
 	"strings"
-	"sync"
 
 	"gopkg.in/yaml.v3"
 )
@@ -20,20 +19,15 @@ type comment string
 type Ignore struct {
 	// Lines is the lines to ignore
 	Lines []int
-	mu    sync.Mutex
 }
 
 // build builds the ignore struct
 func (i *Ignore) build(lines []int) {
-	i.mu.Lock()
-	defer i.mu.Unlock()
 	i.Lines = append(i.Lines, lines...)
 }
 
 // GetLines returns the lines to ignore
 func (i *Ignore) GetLines() []int {
-	i.mu.Lock()
-	defer i.mu.Unlock()
 	return RemoveDuplicates(i.Lines)
 }
 

--- a/pkg/model/comment_yaml.go
+++ b/pkg/model/comment_yaml.go
@@ -23,10 +23,6 @@ type Ignore struct {
 	mu    sync.Mutex
 }
 
-var (
-	NewIgnore = &Ignore{}
-)
-
 // build builds the ignore struct
 func (i *Ignore) build(lines []int) {
 	i.mu.Lock()
@@ -39,13 +35,6 @@ func (i *Ignore) GetLines() []int {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	return RemoveDuplicates(i.Lines)
-}
-
-// Reset resets the ignore struct
-func (i *Ignore) Reset() {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	i.Lines = make([]int, 0)
 }
 
 // ignoreCommentsYAML sets the lines to ignore for a yaml file

--- a/pkg/model/comment_yaml.go
+++ b/pkg/model/comment_yaml.go
@@ -20,41 +20,41 @@ type comment string
 type Ignore struct {
 	// Lines is the lines to ignore
 	Lines []int
+	mu    sync.Mutex
 }
 
 var (
 	NewIgnore = &Ignore{}
-	mu        sync.Mutex
 )
 
 // build builds the ignore struct
 func (i *Ignore) build(lines []int) {
-	mu.Lock()
-	defer mu.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	i.Lines = append(i.Lines, lines...)
 }
 
 // GetLines returns the lines to ignore
 func (i *Ignore) GetLines() []int {
-	mu.Lock()
-	defer mu.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	return RemoveDuplicates(i.Lines)
 }
 
 // Reset resets the ignore struct
 func (i *Ignore) Reset() {
-	mu.Lock()
-	defer mu.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	i.Lines = make([]int, 0)
 }
 
 // ignoreCommentsYAML sets the lines to ignore for a yaml file
-func ignoreCommentsYAML(node *yaml.Node) {
+func (ignore *Ignore) ignoreCommentsYAML(node *yaml.Node) {
 	linesIgnore := make([]int, 0)
 	if node.HeadComment != "" {
 		// Squence Node - Head Comment comes in root node
 		linesIgnore = append(linesIgnore, processCommentYAML((*comment)(&node.HeadComment), 0, node, node.Kind, false)...)
-		NewIgnore.build(linesIgnore)
+		ignore.build(linesIgnore)
 		return
 	}
 	// check if comment is in the content
@@ -68,7 +68,7 @@ func ignoreCommentsYAML(node *yaml.Node) {
 		linesIgnore = append(linesIgnore, processCommentYAML((*comment)(&content.HeadComment), i, node, node.Kind, false)...)
 	}
 
-	NewIgnore.build(linesIgnore)
+	ignore.build(linesIgnore)
 }
 
 // processCommentYAML returns the lines to ignore

--- a/pkg/model/comment_yaml.go
+++ b/pkg/model/comment_yaml.go
@@ -6,7 +6,6 @@
 package model
 
 import (
-	"context"
 	"reflect"
 	"strings"
 	"sync"
@@ -21,59 +20,41 @@ type comment string
 type Ignore struct {
 	// Lines is the lines to ignore
 	Lines []int
-	mu    sync.Mutex
 }
-
-type ContextKeyIgnore struct{}
 
 var (
 	NewIgnore = &Ignore{}
+	mu        sync.Mutex
 )
-
-func getIgnoreFromContext(ctx context.Context) *Ignore {
-	if ctx == nil {
-		return NewIgnore
-	}
-	if ignore, ok := ctx.Value(ContextKeyIgnore{}).(*Ignore); ok {
-		return ignore
-	}
-	return NewIgnore
-}
-
-// WithIgnore creates a new context with an Ignore instance
-func WithIgnore(ctx context.Context) context.Context {
-	return context.WithValue(ctx, ContextKeyIgnore{}, &Ignore{Lines: make([]int, 0)})
-}
 
 // build builds the ignore struct
 func (i *Ignore) build(lines []int) {
-	i.mu.Lock()
-	defer i.mu.Unlock()
+	mu.Lock()
+	defer mu.Unlock()
 	i.Lines = append(i.Lines, lines...)
 }
 
 // GetLines returns the lines to ignore
 func (i *Ignore) GetLines() []int {
-	i.mu.Lock()
-	defer i.mu.Unlock()
+	mu.Lock()
+	defer mu.Unlock()
 	return RemoveDuplicates(i.Lines)
 }
 
 // Reset resets the ignore struct
 func (i *Ignore) Reset() {
-	i.mu.Lock()
-	defer i.mu.Unlock()
+	mu.Lock()
+	defer mu.Unlock()
 	i.Lines = make([]int, 0)
 }
 
 // ignoreCommentsYAML sets the lines to ignore for a yaml file
-func ignoreCommentsYAML(ctx context.Context, node *yaml.Node) {
-	ignore := getIgnoreFromContext(ctx)
+func ignoreCommentsYAML(node *yaml.Node) {
 	linesIgnore := make([]int, 0)
 	if node.HeadComment != "" {
 		// Squence Node - Head Comment comes in root node
 		linesIgnore = append(linesIgnore, processCommentYAML((*comment)(&node.HeadComment), 0, node, node.Kind, false)...)
-		ignore.build(linesIgnore)
+		NewIgnore.build(linesIgnore)
 		return
 	}
 	// check if comment is in the content
@@ -87,7 +68,7 @@ func ignoreCommentsYAML(ctx context.Context, node *yaml.Node) {
 		linesIgnore = append(linesIgnore, processCommentYAML((*comment)(&content.HeadComment), i, node, node.Kind, false)...)
 	}
 
-	ignore.build(linesIgnore)
+	NewIgnore.build(linesIgnore)
 }
 
 // processCommentYAML returns the lines to ignore

--- a/pkg/model/comment_yaml.go
+++ b/pkg/model/comment_yaml.go
@@ -6,6 +6,7 @@
 package model
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"sync"
@@ -20,42 +21,59 @@ type comment string
 type Ignore struct {
 	// Lines is the lines to ignore
 	Lines []int
+	mu    sync.Mutex
 }
 
+type ContextKeyIgnore struct{}
+
 var (
-	// NewIgnore is the ignore struct
 	NewIgnore = &Ignore{}
-	memoryMu  sync.Mutex
 )
+
+func getIgnoreFromContext(ctx context.Context) *Ignore {
+	if ctx == nil {
+		return NewIgnore
+	}
+	if ignore, ok := ctx.Value(ContextKeyIgnore{}).(*Ignore); ok {
+		return ignore
+	}
+	return NewIgnore
+}
+
+// WithIgnore creates a new context with an Ignore instance
+func WithIgnore(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ContextKeyIgnore{}, &Ignore{Lines: make([]int, 0)})
+}
 
 // build builds the ignore struct
 func (i *Ignore) build(lines []int) {
-	memoryMu.Lock()
-	defer memoryMu.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	i.Lines = append(i.Lines, lines...)
 }
 
 // GetLines returns the lines to ignore
 func (i *Ignore) GetLines() []int {
-	memoryMu.Lock()
-	defer memoryMu.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	return RemoveDuplicates(i.Lines)
 }
 
 // Reset resets the ignore struct
 func (i *Ignore) Reset() {
-	memoryMu.Lock()
-	defer memoryMu.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	i.Lines = make([]int, 0)
 }
 
 // ignoreCommentsYAML sets the lines to ignore for a yaml file
-func ignoreCommentsYAML(node *yaml.Node) {
+func ignoreCommentsYAML(ctx context.Context, node *yaml.Node) {
+	ignore := getIgnoreFromContext(ctx)
 	linesIgnore := make([]int, 0)
 	if node.HeadComment != "" {
 		// Squence Node - Head Comment comes in root node
 		linesIgnore = append(linesIgnore, processCommentYAML((*comment)(&node.HeadComment), 0, node, node.Kind, false)...)
-		NewIgnore.build(linesIgnore)
+		ignore.build(linesIgnore)
 		return
 	}
 	// check if comment is in the content
@@ -69,7 +87,7 @@ func ignoreCommentsYAML(node *yaml.Node) {
 		linesIgnore = append(linesIgnore, processCommentYAML((*comment)(&content.HeadComment), i, node, node.Kind, false)...)
 	}
 
-	NewIgnore.build(linesIgnore)
+	ignore.build(linesIgnore)
 }
 
 // processCommentYAML returns the lines to ignore

--- a/pkg/model/comment_yaml_test.go
+++ b/pkg/model/comment_yaml_test.go
@@ -666,12 +666,11 @@ func Test_ignoreCommentsYAML(t *testing.T) {
 			},
 		},
 	}
-	ignore := Ignore{}
 	for _, tt := range tests {
+		ignore := Ignore{}
 		t.Run(tt.name, func(t *testing.T) {
 			ignore.ignoreCommentsYAML(tt.args.node)
 			ignoreLines := ignore.GetLines()
-			ignore.Reset()
 			if len(ignoreLines) > 0 {
 				sort.Ints(ignoreLines)
 			}

--- a/pkg/model/comment_yaml_test.go
+++ b/pkg/model/comment_yaml_test.go
@@ -6,6 +6,7 @@
 package model
 
 import (
+	"context"
 	"sort"
 	"testing"
 
@@ -666,9 +667,10 @@ func Test_ignoreCommentsYAML(t *testing.T) {
 			},
 		},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ignoreCommentsYAML(tt.args.node)
+			ignoreCommentsYAML(ctx, tt.args.node)
 			ignoreLines := NewIgnore.GetLines()
 			NewIgnore.Reset()
 			if len(ignoreLines) > 0 {

--- a/pkg/model/comment_yaml_test.go
+++ b/pkg/model/comment_yaml_test.go
@@ -666,11 +666,12 @@ func Test_ignoreCommentsYAML(t *testing.T) {
 			},
 		},
 	}
+	ignore := Ignore{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ignoreCommentsYAML(tt.args.node)
-			ignoreLines := NewIgnore.GetLines()
-			NewIgnore.Reset()
+			ignore.ignoreCommentsYAML(tt.args.node)
+			ignoreLines := ignore.GetLines()
+			ignore.Reset()
 			if len(ignoreLines) > 0 {
 				sort.Ints(ignoreLines)
 			}

--- a/pkg/model/comment_yaml_test.go
+++ b/pkg/model/comment_yaml_test.go
@@ -6,7 +6,6 @@
 package model
 
 import (
-	"context"
 	"sort"
 	"testing"
 
@@ -667,10 +666,9 @@ func Test_ignoreCommentsYAML(t *testing.T) {
 			},
 		},
 	}
-	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ignoreCommentsYAML(ctx, tt.args.node)
+			ignoreCommentsYAML(tt.args.node)
 			ignoreLines := NewIgnore.GetLines()
 			NewIgnore.Reset()
 			if len(ignoreLines) > 0 {

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -53,7 +53,7 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 	defer func() { delete(visited, val) }()
 	tmp := make(map[string]interface{})
 	if ignore == nil {
-		ignore = NewIgnore
+		return nil
 	}
 	ignore.ignoreCommentsYAML(val)
 

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -52,10 +52,9 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 	visited[val] = true
 	defer func() { delete(visited, val) }()
 	tmp := make(map[string]interface{})
-	if ignore == nil {
-		ignore = &Ignore{}
+	if ignore != nil {
+		ignore.ignoreCommentsYAML(val)
 	}
-	ignore.ignoreCommentsYAML(val)
 
 	// if Yaml Node is an Array than we are working with ansible
 	// which need to be placed inside "playbooks"

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -52,7 +52,7 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 	visited[val] = true
 	defer func() { delete(visited, val) }()
 	tmp := make(map[string]interface{})
-	ignoreCommentsYAML(val)
+	ignoreCommentsYAML(ctx, val)
 
 	// if Yaml Node is an Array than we are working with ansible
 	// which need to be placed inside "playbooks"

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -52,7 +52,7 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 	visited[val] = true
 	defer func() { delete(visited, val) }()
 	tmp := make(map[string]interface{})
-	ignoreCommentsYAML(ctx, val)
+	ignoreCommentsYAML(val)
 
 	// if Yaml Node is an Array than we are working with ansible
 	// which need to be placed inside "playbooks"

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -16,8 +16,8 @@ import (
 )
 
 // UnmarshalYAML is a custom yaml parser that places line information in the payload
-func (m *Document) UnmarshalYAML(ctx context.Context, value *yaml.Node) error {
-	dpc := unmarshal(ctx, value)
+func (m *Document) UnmarshalYAML(ctx context.Context, value *yaml.Node, ignore *Ignore) error {
+	dpc := unmarshal(ctx, value, ignore)
 	if mapDcp, ok := dpc.(map[string]interface{}); ok {
 		// set line information for root level objects
 		mapDcp["_kics_lines"] = getLines(value, 0)
@@ -40,19 +40,22 @@ func (m *Document) UnmarshalYAML(ctx context.Context, value *yaml.Node) error {
 */
 // unmarshal is the function that will parse the yaml elements and call the functions needed
 // to place their line information in the payload
-func unmarshal(ctx context.Context, val *yaml.Node) interface{} {
-	return unmarshalWithDepth(ctx, val, make(map[*yaml.Node]bool))
+func unmarshal(ctx context.Context, val *yaml.Node, ignore *Ignore) interface{} {
+	return unmarshalWithDepth(ctx, val, make(map[*yaml.Node]bool), ignore)
 }
 
 // unmarshalWithDepth handles recursive unmarshaling with circular reference detection
-func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.Node]bool) interface{} { //nolint:gocyclo
+func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.Node]bool, ignore *Ignore) interface{} { //nolint:gocyclo
 	if visited[val] {
 		return nil
 	}
 	visited[val] = true
 	defer func() { delete(visited, val) }()
 	tmp := make(map[string]interface{})
-	ignoreCommentsYAML(val)
+	if ignore == nil {
+		ignore = NewIgnore
+	}
+	ignore.ignoreCommentsYAML(val)
 
 	// if Yaml Node is an Array than we are working with ansible
 	// which need to be placed inside "playbooks"
@@ -60,7 +63,7 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 	if val.Kind == yaml.SequenceNode {
 		contentArray := make([]interface{}, 0)
 		for _, contentEntry := range val.Content {
-			contentArray = append(contentArray, unmarshalWithDepth(ctx, contentEntry, visited))
+			contentArray = append(contentArray, unmarshalWithDepth(ctx, contentEntry, visited, ignore))
 		}
 		tmp["playbooks"] = contentArray
 	} else if val.Kind == yaml.ScalarNode {
@@ -75,7 +78,7 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 				// in case value iteration is a map
 				case yaml.MappingNode:
 					// unmarshall map value and get its line information
-					result := unmarshalWithDepth(ctx, val.Content[i+1], visited)
+					result := unmarshalWithDepth(ctx, val.Content[i+1], visited, ignore)
 					if tt, ok := result.(map[string]interface{}); ok {
 						tt["_kics_lines"] = getLines(val.Content[i+1], val.Content[i].Line)
 						tmp[val.Content[i].Value] = tt
@@ -87,12 +90,12 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 					contentArray := make([]interface{}, 0)
 					// unmarshall each iteration of the array
 					for _, contentEntry := range val.Content[i+1].Content {
-						contentArray = append(contentArray, unmarshalWithDepth(ctx, contentEntry, visited))
+						contentArray = append(contentArray, unmarshalWithDepth(ctx, contentEntry, visited, ignore))
 					}
 					tmp[val.Content[i].Value] = contentArray
 				case yaml.AliasNode:
 					if val.Content[i+1].Alias != nil {
-						result := unmarshalWithDepth(ctx, val.Content[i+1].Alias, visited)
+						result := unmarshalWithDepth(ctx, val.Content[i+1].Alias, visited, ignore)
 						if tt, ok := result.(map[string]interface{}); ok {
 							tt["_kics_lines"] = getLines(val.Content[i+1], val.Content[i].Line)
 							utils.MergeMaps(tmp, tt)

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -53,7 +53,7 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 	defer func() { delete(visited, val) }()
 	tmp := make(map[string]interface{})
 	if ignore == nil {
-		return nil
+		ignore = &Ignore{}
 	}
 	ignore.ignoreCommentsYAML(val)
 

--- a/pkg/model/model_yaml_test.go
+++ b/pkg/model/model_yaml_test.go
@@ -643,7 +643,7 @@ enabled: true
 	require.Len(t, root.Content, 1)
 
 	doc := &Document{}
-	err = doc.UnmarshalYAML(ctx, root.Content[0])
+	err = doc.UnmarshalYAML(ctx, root.Content[0], nil)
 	require.NoError(t, err)
 
 	// Values go through JSON round-trip so numbers become float64 in Document

--- a/pkg/model/model_yaml_test.go
+++ b/pkg/model/model_yaml_test.go
@@ -541,7 +541,7 @@ func TestDocument_UnmarshalYAML(t *testing.T) {
 	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.m.UnmarshalYAML(ctx, tt.args.value); (err != nil) != tt.wantErr {
+			if err := tt.m.UnmarshalYAML(ctx, tt.args.value, NewIgnore); (err != nil) != tt.wantErr {
 				t.Errorf("Document.UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			compareJSONLine(t, tt.m, tt.want)
@@ -614,7 +614,7 @@ func TestDocument_UnmarshalYAML_CircularReference(t *testing.T) {
 		doc := &Document{}
 
 		// This should not cause a stack overflow with the fix
-		err := doc.UnmarshalYAML(ctx, node1)
+		err := doc.UnmarshalYAML(ctx, node1, nil)
 		require.NoError(t, err)
 
 		// Verify the document was parsed (even with nil values for circular refs)

--- a/pkg/model/model_yaml_test.go
+++ b/pkg/model/model_yaml_test.go
@@ -539,9 +539,10 @@ var tests = []struct {
 
 func TestDocument_UnmarshalYAML(t *testing.T) {
 	ctx := context.Background()
+	ignore := &Ignore{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.m.UnmarshalYAML(ctx, tt.args.value, NewIgnore); (err != nil) != tt.wantErr {
+			if err := tt.m.UnmarshalYAML(ctx, tt.args.value, ignore); (err != nil) != tt.wantErr {
 				t.Errorf("Document.UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			compareJSONLine(t, tt.m, tt.want)
@@ -612,9 +613,9 @@ func TestDocument_UnmarshalYAML_CircularReference(t *testing.T) {
 	t.Run("new_code_succeeds", func(t *testing.T) {
 		ctx := context.Background()
 		doc := &Document{}
-
+		ignore := &Ignore{}
 		// This should not cause a stack overflow with the fix
-		err := doc.UnmarshalYAML(ctx, node1, nil)
+		err := doc.UnmarshalYAML(ctx, node1, ignore)
 		require.NoError(t, err)
 
 		// Verify the document was parsed (even with nil values for circular refs)

--- a/pkg/model/model_yaml_test.go
+++ b/pkg/model/model_yaml_test.go
@@ -539,10 +539,9 @@ var tests = []struct {
 
 func TestDocument_UnmarshalYAML(t *testing.T) {
 	ctx := context.Background()
-	ignore := &Ignore{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.m.UnmarshalYAML(ctx, tt.args.value, ignore); (err != nil) != tt.wantErr {
+			if err := tt.m.UnmarshalYAML(ctx, tt.args.value, nil); (err != nil) != tt.wantErr {
 				t.Errorf("Document.UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			compareJSONLine(t, tt.m, tt.want)

--- a/pkg/parser/ansible/ini/config/parser.go
+++ b/pkg/parser/ansible/ini/config/parser.go
@@ -25,7 +25,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	documents []model.Document,
 	ignoreLines []int,
 	resolvedFiles map[string]model.ResolvedFile,
-	error error) {
+	err error) {
 	reader := strings.NewReader(string(fileContent))
 	configparser.Delimiters("=")
 	inline := configparser.InlineCommentPrefixes([]string{";"})

--- a/pkg/parser/ansible/ini/config/parser.go
+++ b/pkg/parser/ansible/ini/config/parser.go
@@ -25,6 +25,7 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bo
 
 // Parse parses .cfg/.conf file and returns it as a Document
 func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte) ([]model.Document, []int, error) {
+	model.NewIgnore.Reset()
 	reader := strings.NewReader(string(fileContent))
 	configparser.Delimiters("=")
 	inline := configparser.InlineCommentPrefixes([]string{";"})
@@ -110,4 +111,8 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 
 func emptyDocument() *model.Document {
 	return &model.Document{}
+}
+
+func (p *Parser) Clone() any {
+	return &Parser{}
 }

--- a/pkg/parser/ansible/ini/config/parser.go
+++ b/pkg/parser/ansible/ini/config/parser.go
@@ -32,7 +32,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 
 	config, err := configparser.ParseReaderWithOptions(reader, inline)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+		return nil, nil, nil, nil, err
 	}
 
 	doc := make(map[string]interface{})
@@ -40,7 +40,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 
 	ignoreLines = comments.GetIgnoreLines(strings.Split(string(fileContent), "\n"))
 
-	return fileContent, []model.Document{doc}, ignoreLines, map[string]model.ResolvedFile{}, nil
+	return fileContent, []model.Document{doc}, ignoreLines, nil, nil
 }
 
 // refactorConfig removes all extra information and tries to convert

--- a/pkg/parser/ansible/ini/config/parser.go
+++ b/pkg/parser/ansible/ini/config/parser.go
@@ -17,6 +17,7 @@ import (
 
 // Parser defines a parser type
 type Parser struct {
+	ignore *model.Ignore
 }
 
 func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bool, _ int) ([]byte, error) {
@@ -25,7 +26,7 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bo
 
 // Parse parses .cfg/.conf file and returns it as a Document
 func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte) ([]model.Document, []int, error) {
-	model.NewIgnore.Reset()
+	p.ignore.Reset()
 	reader := strings.NewReader(string(fileContent))
 	configparser.Delimiters("=")
 	inline := configparser.InlineCommentPrefixes([]string{";"})
@@ -114,5 +115,7 @@ func emptyDocument() *model.Document {
 }
 
 func (p *Parser) Clone() any {
-	return &Parser{}
+	return &Parser{
+		ignore: &model.Ignore{},
+	}
 }

--- a/pkg/parser/ansible/ini/config/parser.go
+++ b/pkg/parser/ansible/ini/config/parser.go
@@ -16,31 +16,31 @@ import (
 )
 
 // Parser defines a parser type
-type Parser struct {
-	ignore *model.Ignore
-}
-
-func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bool, _ int) ([]byte, error) {
-	return fileContent, nil
-}
+type Parser struct{}
 
 // Parse parses .cfg/.conf file and returns it as a Document
-func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte) ([]model.Document, []int, error) {
+func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
+	resolveReferences bool, maxResolverDepth int) (
+	resolved []byte,
+	documents []model.Document,
+	ignoreLines []int,
+	resolvedFiles map[string]model.ResolvedFile,
+	error error) {
 	reader := strings.NewReader(string(fileContent))
 	configparser.Delimiters("=")
 	inline := configparser.InlineCommentPrefixes([]string{";"})
 
 	config, err := configparser.ParseReaderWithOptions(reader, inline)
 	if err != nil {
-		return nil, nil, err
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
 	}
 
 	doc := make(map[string]interface{})
 	doc["groups"] = refactorConfig(config)
 
-	ignoreLines := comments.GetIgnoreLines(strings.Split(string(fileContent), "\n"))
+	ignoreLines = comments.GetIgnoreLines(strings.Split(string(fileContent), "\n"))
 
-	return []model.Document{doc}, ignoreLines, nil
+	return fileContent, []model.Document{doc}, ignoreLines, map[string]model.ResolvedFile{}, nil
 }
 
 // refactorConfig removes all extra information and tries to convert
@@ -99,11 +99,6 @@ func (p *Parser) GetCommentToken() string {
 	return "#"
 }
 
-// GetResolvedFiles returns resolved files
-func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
-	return make(map[string]model.ResolvedFile)
-}
-
 // StringifyContent converts original content into string formatted version
 func (p *Parser) StringifyContent(content []byte) (string, error) {
 	return string(content), nil
@@ -111,10 +106,4 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 
 func emptyDocument() *model.Document {
 	return &model.Document{}
-}
-
-func (p *Parser) Clone() any {
-	return &Parser{
-		ignore: &model.Ignore{},
-	}
 }

--- a/pkg/parser/ansible/ini/config/parser.go
+++ b/pkg/parser/ansible/ini/config/parser.go
@@ -99,7 +99,7 @@ func (p *Parser) GetCommentToken() string {
 }
 
 // GetResolvedFiles returns resolved files
-func (p *Parser) GetResolvedFiles() map[string]model.ResolvedFile {
+func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
 	return make(map[string]model.ResolvedFile)
 }
 

--- a/pkg/parser/ansible/ini/config/parser.go
+++ b/pkg/parser/ansible/ini/config/parser.go
@@ -26,7 +26,6 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bo
 
 // Parse parses .cfg/.conf file and returns it as a Document
 func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte) ([]model.Document, []int, error) {
-	p.ignore.Reset()
 	reader := strings.NewReader(string(fileContent))
 	configparser.Delimiters("=")
 	inline := configparser.InlineCommentPrefixes([]string{";"})

--- a/pkg/parser/ansible/ini/config/parser.go
+++ b/pkg/parser/ansible/ini/config/parser.go
@@ -25,8 +25,6 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bo
 
 // Parse parses .cfg/.conf file and returns it as a Document
 func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte) ([]model.Document, []int, error) {
-	model.NewIgnore.Reset()
-
 	reader := strings.NewReader(string(fileContent))
 	configparser.Delimiters("=")
 	inline := configparser.InlineCommentPrefixes([]string{";"})

--- a/pkg/parser/ansible/ini/config/parser_test.go
+++ b/pkg/parser/ansible/ini/config/parser_test.go
@@ -81,7 +81,9 @@ profile_tasks = yes
 	ctx := context.Background()
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{}
+			p := &Parser{
+				ignore: &model.Ignore{},
+			}
 			switch i {
 			case 0:
 				got, _, err := p.Parse(ctx, "", tt.args.content)

--- a/pkg/parser/ansible/ini/config/parser_test.go
+++ b/pkg/parser/ansible/ini/config/parser_test.go
@@ -81,12 +81,10 @@ profile_tasks = yes
 	ctx := context.Background()
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{
-				ignore: &model.Ignore{},
-			}
+			p := &Parser{}
 			switch i {
 			case 0:
-				got, _, err := p.Parse(ctx, "", tt.args.content)
+				_, got, _, _, err := p.Parse(ctx, tt.args.content, "", true, 15)
 				if (err != nil) != tt.wantErr {
 					t.Errorf("Parser() error = %v, wantErr %v", err, tt.wantErr)
 					return

--- a/pkg/parser/ansible/ini/hosts/parser.go
+++ b/pkg/parser/ansible/ini/hosts/parser.go
@@ -30,7 +30,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	inventoryReader := strings.NewReader(string(fileContent))
 	var inventory, err = aini.Parse(inventoryReader)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+		return nil, nil, nil, nil, err
 	}
 
 	doc := model.Document{}

--- a/pkg/parser/ansible/ini/hosts/parser.go
+++ b/pkg/parser/ansible/ini/hosts/parser.go
@@ -17,7 +17,6 @@ import (
 
 // Parser defines a parser type
 type Parser struct {
-	ignore *model.Ignore
 }
 
 func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bool, _ int) ([]byte, error) {
@@ -26,7 +25,6 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bo
 
 // Parse parses .ini file and returns it as a Document
 func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]model.Document, []int, error) {
-	p.ignore.Reset()
 	inventoryReader := strings.NewReader(string(fileContent))
 	var inventory, err = aini.Parse(inventoryReader)
 	if err != nil {
@@ -144,7 +142,5 @@ func emptyDocument() *model.Document {
 }
 
 func (p *Parser) Clone() any {
-	return &Parser{
-		ignore: &model.Ignore{},
-	}
+	return &Parser{}
 }

--- a/pkg/parser/ansible/ini/hosts/parser.go
+++ b/pkg/parser/ansible/ini/hosts/parser.go
@@ -19,16 +19,18 @@ import (
 type Parser struct {
 }
 
-func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bool, _ int) ([]byte, error) {
-	return fileContent, nil
-}
-
 // Parse parses .ini file and returns it as a Document
-func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]model.Document, []int, error) {
+func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
+	resolveReferences bool, maxResolverDepth int) (
+	resolved []byte,
+	documents []model.Document,
+	ignoreLines []int,
+	resolvedFiles map[string]model.ResolvedFile,
+	error error) {
 	inventoryReader := strings.NewReader(string(fileContent))
 	var inventory, err = aini.Parse(inventoryReader)
 	if err != nil {
-		return nil, nil, err
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
 	}
 
 	doc := model.Document{}
@@ -39,9 +41,9 @@ func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]mod
 	(*allMap)["children"] = childrenMap
 	doc["all"] = allMap
 
-	ignoreLines := comments.GetIgnoreLines(strings.Split(string(fileContent), "\n"))
+	ignoreLines = comments.GetIgnoreLines(strings.Split(string(fileContent), "\n"))
 
-	return []model.Document{doc}, ignoreLines, nil
+	return fileContent, []model.Document{doc}, ignoreLines, map[string]model.ResolvedFile{}, nil
 }
 
 // refactorInv removes all extra information
@@ -127,11 +129,6 @@ func (p *Parser) GetCommentToken() string {
 	return "#"
 }
 
-// GetResolvedFiles returns resolved files
-func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
-	return make(map[string]model.ResolvedFile)
-}
-
 // StringifyContent converts original content into string formatted version
 func (p *Parser) StringifyContent(content []byte) (string, error) {
 	return string(content), nil
@@ -139,8 +136,4 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 
 func emptyDocument() *model.Document {
 	return &model.Document{}
-}
-
-func (p *Parser) Clone() any {
-	return &Parser{}
 }

--- a/pkg/parser/ansible/ini/hosts/parser.go
+++ b/pkg/parser/ansible/ini/hosts/parser.go
@@ -128,7 +128,7 @@ func (p *Parser) GetCommentToken() string {
 }
 
 // GetResolvedFiles returns resolved files
-func (p *Parser) GetResolvedFiles() map[string]model.ResolvedFile {
+func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
 	return make(map[string]model.ResolvedFile)
 }
 

--- a/pkg/parser/ansible/ini/hosts/parser.go
+++ b/pkg/parser/ansible/ini/hosts/parser.go
@@ -26,9 +26,9 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	documents []model.Document,
 	ignoreLines []int,
 	resolvedFiles map[string]model.ResolvedFile,
-	error error) {
+	err error) {
 	inventoryReader := strings.NewReader(string(fileContent))
-	var inventory, err = aini.Parse(inventoryReader)
+	inventory, err := aini.Parse(inventoryReader)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/pkg/parser/ansible/ini/hosts/parser.go
+++ b/pkg/parser/ansible/ini/hosts/parser.go
@@ -25,6 +25,7 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bo
 
 // Parse parses .ini file and returns it as a Document
 func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]model.Document, []int, error) {
+	model.NewIgnore.Reset()
 	inventoryReader := strings.NewReader(string(fileContent))
 	var inventory, err = aini.Parse(inventoryReader)
 	if err != nil {
@@ -139,4 +140,8 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 
 func emptyDocument() *model.Document {
 	return &model.Document{}
+}
+
+func (p *Parser) Clone() any {
+	return &Parser{}
 }

--- a/pkg/parser/ansible/ini/hosts/parser.go
+++ b/pkg/parser/ansible/ini/hosts/parser.go
@@ -17,6 +17,7 @@ import (
 
 // Parser defines a parser type
 type Parser struct {
+	ignore *model.Ignore
 }
 
 func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bool, _ int) ([]byte, error) {
@@ -25,7 +26,7 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bo
 
 // Parse parses .ini file and returns it as a Document
 func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]model.Document, []int, error) {
-	model.NewIgnore.Reset()
+	p.ignore.Reset()
 	inventoryReader := strings.NewReader(string(fileContent))
 	var inventory, err = aini.Parse(inventoryReader)
 	if err != nil {
@@ -143,5 +144,7 @@ func emptyDocument() *model.Document {
 }
 
 func (p *Parser) Clone() any {
-	return &Parser{}
+	return &Parser{
+		ignore: &model.Ignore{},
+	}
 }

--- a/pkg/parser/ansible/ini/hosts/parser.go
+++ b/pkg/parser/ansible/ini/hosts/parser.go
@@ -25,8 +25,6 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bo
 
 // Parse parses .ini file and returns it as a Document
 func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]model.Document, []int, error) {
-	model.NewIgnore.Reset()
-
 	inventoryReader := strings.NewReader(string(fileContent))
 	var inventory, err = aini.Parse(inventoryReader)
 	if err != nil {

--- a/pkg/parser/ansible/ini/hosts/parser_test.go
+++ b/pkg/parser/ansible/ini/hosts/parser_test.go
@@ -95,7 +95,9 @@ databases`),
 	ctx := context.Background()
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{}
+			p := &Parser{
+				ignore: &model.Ignore{},
+			}
 			switch i {
 			case 0:
 				got, _, err := p.Parse(ctx, "", tt.args.content)

--- a/pkg/parser/ansible/ini/hosts/parser_test.go
+++ b/pkg/parser/ansible/ini/hosts/parser_test.go
@@ -95,9 +95,7 @@ databases`),
 	ctx := context.Background()
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{
-				ignore: &model.Ignore{},
-			}
+			p := &Parser{}
 			switch i {
 			case 0:
 				got, _, err := p.Parse(ctx, "", tt.args.content)

--- a/pkg/parser/ansible/ini/hosts/parser_test.go
+++ b/pkg/parser/ansible/ini/hosts/parser_test.go
@@ -98,7 +98,7 @@ databases`),
 			p := &Parser{}
 			switch i {
 			case 0:
-				got, _, err := p.Parse(ctx, "", tt.args.content)
+				_, got, _, _, err := p.Parse(ctx, tt.args.content, "", true, 15)
 				if (err != nil) != tt.wantErr {
 					t.Errorf("Parser() error = %v, wantErr %v", err, tt.wantErr)
 					return

--- a/pkg/parser/bicep/parser.go
+++ b/pkg/parser/bicep/parser.go
@@ -207,7 +207,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	bicepVisitor := NewBicepVisitor()
 	stream, err := antlr.NewFileStream(filePath)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+		return nil, nil, nil, nil, err
 	}
 	lexer := parser.NewbicepLexer(stream)
 
@@ -231,12 +231,12 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 
 	bicepBytes, err := json.Marshal(jBicep)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+		return nil, nil, nil, nil, err
 	}
 
 	err = json.Unmarshal(bicepBytes, &doc)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+		return nil, nil, nil, nil, err
 	}
 
 	return fileContent, []model.Document{doc}, nil, map[string]model.ResolvedFile{}, nil

--- a/pkg/parser/bicep/parser.go
+++ b/pkg/parser/bicep/parser.go
@@ -197,11 +197,17 @@ func makeResourcesNestedStructure(jBicep *JSONBicep) []interface{} {
 }
 
 // Parse - parses bicep to BicepVisitor template (json file)
-func (p *Parser) Parse(ctx context.Context, file string, _ []byte) ([]model.Document, []int, error) {
+func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
+	resolveReferences bool, maxResolverDepth int) (
+	resolved []byte,
+	documents []model.Document,
+	ignoreLines []int,
+	resolvedFiles map[string]model.ResolvedFile,
+	error error) {
 	bicepVisitor := NewBicepVisitor()
-	stream, err := antlr.NewFileStream(file)
+	stream, err := antlr.NewFileStream(filePath)
 	if err != nil {
-		return nil, nil, err
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
 	}
 	lexer := parser.NewbicepLexer(stream)
 
@@ -225,15 +231,15 @@ func (p *Parser) Parse(ctx context.Context, file string, _ []byte) ([]model.Docu
 
 	bicepBytes, err := json.Marshal(jBicep)
 	if err != nil {
-		return nil, nil, err
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
 	}
 
 	err = json.Unmarshal(bicepBytes, &doc)
 	if err != nil {
-		return nil, nil, err
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
 	}
 
-	return []model.Document{doc}, nil, nil
+	return fileContent, []model.Document{doc}, nil, map[string]model.ResolvedFile{}, nil
 }
 
 func (s *BicepVisitor) VisitProgram(ctx *parser.ProgramContext) interface{} {
@@ -872,18 +878,4 @@ func (p *Parser) GetCommentToken() string {
 // StringifyContent converts original content into string formatted version
 func (p *Parser) StringifyContent(content []byte) (string, error) {
 	return string(content), nil
-}
-
-// Resolve resolves bicep files variables
-func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bool, _ int) ([]byte, error) {
-	return fileContent, nil
-}
-
-// GetResolvedFiles returns the list of files that are resolved
-func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
-	return make(map[string]model.ResolvedFile)
-}
-
-func (p *Parser) Clone() any {
-	return &Parser{}
 }

--- a/pkg/parser/bicep/parser.go
+++ b/pkg/parser/bicep/parser.go
@@ -880,6 +880,6 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bo
 }
 
 // GetResolvedFiles returns the list of files that are resolved
-func (p *Parser) GetResolvedFiles() map[string]model.ResolvedFile {
+func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
 	return make(map[string]model.ResolvedFile)
 }

--- a/pkg/parser/bicep/parser.go
+++ b/pkg/parser/bicep/parser.go
@@ -883,3 +883,7 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bo
 func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
 	return make(map[string]model.ResolvedFile)
 }
+
+func (p *Parser) Clone() any {
+	return &Parser{}
+}

--- a/pkg/parser/bicep/parser.go
+++ b/pkg/parser/bicep/parser.go
@@ -203,7 +203,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	documents []model.Document,
 	ignoreLines []int,
 	resolvedFiles map[string]model.ResolvedFile,
-	error error) {
+	err error) {
 	bicepVisitor := NewBicepVisitor()
 	stream, err := antlr.NewFileStream(filePath)
 	if err != nil {

--- a/pkg/parser/bicep/parser_test.go
+++ b/pkg/parser/bicep/parser_test.go
@@ -53,7 +53,7 @@ func TestParser_GetResolvedFiles(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Parser{}
-			if got := p.GetResolvedFiles(); !reflect.DeepEqual(got, tt.want) {
+			if got := p.GetResolvedFiles(tt.name); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/parser/bicep/parser_test.go
+++ b/pkg/parser/bicep/parser_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -29,35 +28,6 @@ func TestParser_SupportedTypes(t *testing.T) {
 func TestParser_SupportedExtensions(t *testing.T) {
 	p := &Parser{}
 	require.Equal(t, []string{".bicep"}, p.SupportedExtensions())
-}
-
-func Test_Resolve(t *testing.T) {
-	ctx := context.Background()
-	parser := &Parser{}
-	param := `param vmName string = 'simple-vm'`
-	resolved, err := parser.Resolve(ctx, []byte(param), "test.bicep", true, 15)
-	require.NoError(t, err)
-	require.Equal(t, []byte(param), resolved)
-}
-
-func TestParser_GetResolvedFiles(t *testing.T) {
-	tests := []struct {
-		name string
-		want map[string]model.ResolvedFile
-	}{
-		{
-			name: "Should test getting empty resolved files",
-			want: map[string]model.ResolvedFile{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{}
-			if got := p.GetResolvedFiles(tt.name); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
-			}
-		})
-	}
 }
 
 // TestParser_StringifyContent tests the StringifyContent function
@@ -1729,7 +1699,7 @@ func TestParseBicepFile(t *testing.T) {
 	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			document, _, err := parser.Parse(ctx, tt.filename, nil)
+			_, document, _, _, err := parser.Parse(ctx, nil, tt.filename, true, 15)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Parser.Parse() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/parser/buildah/parser.go
+++ b/pkg/parser/buildah/parser.go
@@ -226,6 +226,6 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 }
 
 // GetResolvedFiles returns the resolved files
-func (p *Parser) GetResolvedFiles() map[string]model.ResolvedFile {
+func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
 	return make(map[string]model.ResolvedFile)
 }

--- a/pkg/parser/buildah/parser.go
+++ b/pkg/parser/buildah/parser.go
@@ -55,13 +55,14 @@ const (
 	buildah = "buildah"
 )
 
-// Resolve - replace or modifies in-memory content before parsing
-func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bool, _ int) ([]byte, error) {
-	return fileContent, nil
-}
-
 // Parse - parses Buildah file to Json
-func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]model.Document, []int, error) {
+func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
+	resolveReferences bool, maxResolverDepth int) (
+	resolved []byte,
+	documents []model.Document,
+	ignoreLines []int,
+	resolvedFiles map[string]model.ResolvedFile,
+	error error) {
 	var info Info
 	info.From = map[string][]Command{}
 
@@ -69,7 +70,7 @@ func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]mod
 	f, err := syntax.NewParser(syntax.KeepComments(true)).Parse(reader, "")
 
 	if err != nil {
-		return nil, []int{}, err
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
 	}
 
 	syntax.Walk(f, func(node syntax.Node) bool {
@@ -85,25 +86,24 @@ func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]mod
 	// get dd-iac-scan ignore-block related to from
 	info.ignoreFromBlock()
 
-	var documents []model.Document
 	var resource Resource
 	resource.CommandList = info.From
 	doc := &model.Document{}
 	j, err := json.Marshal(resource)
 	if err != nil {
-		return nil, []int{}, errors.Wrap(err, "failed to Marshal Buildah")
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(err, "failed to Marshal Buildah")
 	}
 
 	err = json.Unmarshal(j, &doc)
 	if err != nil {
-		return nil, []int{}, errors.Wrap(err, "failed to Unmarshal Buildah")
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(err, "failed to Unmarshal Buildah")
 	}
 
 	documents = append(documents, *doc)
 
 	sort.Ints(info.IgnoreLines)
 
-	return documents, info.IgnoreLines, nil
+	return fileContent, documents, info.IgnoreLines, map[string]model.ResolvedFile{}, nil
 }
 
 func (i *Info) getStmt(ctx context.Context, stmt *syntax.Stmt) {
@@ -223,13 +223,4 @@ func (p *Parser) GetCommentToken() string {
 // StringifyContent converts original content into string formatted version
 func (p *Parser) StringifyContent(content []byte) (string, error) {
 	return string(content), nil
-}
-
-// GetResolvedFiles returns the resolved files
-func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
-	return make(map[string]model.ResolvedFile)
-}
-
-func (p *Parser) Clone() any {
-	return &Parser{}
 }

--- a/pkg/parser/buildah/parser.go
+++ b/pkg/parser/buildah/parser.go
@@ -70,7 +70,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	f, err := syntax.NewParser(syntax.KeepComments(true)).Parse(reader, "")
 
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+		return nil, nil, nil, nil, err
 	}
 
 	syntax.Walk(f, func(node syntax.Node) bool {
@@ -91,12 +91,12 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	doc := &model.Document{}
 	j, err := json.Marshal(resource)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(err, "failed to Marshal Buildah")
+		return nil, nil, nil, nil, errors.Wrap(err, "failed to Marshal Buildah")
 	}
 
 	err = json.Unmarshal(j, &doc)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(err, "failed to Unmarshal Buildah")
+		return nil, nil, nil, nil, errors.Wrap(err, "failed to Unmarshal Buildah")
 	}
 
 	documents = append(documents, *doc)

--- a/pkg/parser/buildah/parser.go
+++ b/pkg/parser/buildah/parser.go
@@ -62,7 +62,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	documents []model.Document,
 	ignoreLines []int,
 	resolvedFiles map[string]model.ResolvedFile,
-	error error) {
+	err error) {
 	var info Info
 	info.From = map[string][]Command{}
 

--- a/pkg/parser/buildah/parser.go
+++ b/pkg/parser/buildah/parser.go
@@ -229,3 +229,7 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
 	return make(map[string]model.ResolvedFile)
 }
+
+func (p *Parser) Clone() any {
+	return &Parser{}
+}

--- a/pkg/parser/buildah/parser_test.go
+++ b/pkg/parser/buildah/parser_test.go
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -241,7 +240,7 @@ func TestParser_Parse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Parser{}
-			got, got1, err := p.Parse(ctx, tt.args.in0, tt.args.fileContent)
+			_, got, got1, _, err := p.Parse(ctx, tt.args.fileContent, tt.args.in0, true, 15)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Parser.Parse() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -297,66 +296,6 @@ func TestParser_SupportedTypes(t *testing.T) {
 			p := &Parser{}
 			if got := p.SupportedTypes(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Parser.SupportedTypes() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-// TestParser_Resolve tests the Resolve function
-func TestParser_Resolve(t *testing.T) {
-	type args struct {
-		fileContent []byte
-		filename    string
-	}
-	tests := []struct {
-		name    string
-		p       *Parser
-		args    args
-		want    []byte
-		wantErr bool
-	}{
-		{
-			name: "Buildah resolve",
-			p:    &Parser{},
-			args: args{
-				fileContent: []byte(``),
-				filename:    "test.proto",
-			},
-			want: []byte{},
-		},
-	}
-
-	ctx := context.Background()
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{}
-			got, err := p.Resolve(ctx, tt.args.fileContent, tt.args.filename, true, 15)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Parser.Resolve() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Parser.Resolve() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestParser_GetResolvedFiles(t *testing.T) {
-	tests := []struct {
-		name string
-		want map[string]model.ResolvedFile
-	}{
-		{
-			name: "Buildah get resolved files",
-			want: map[string]model.ResolvedFile{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{}
-			if got := p.GetResolvedFiles(tt.name); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/parser/buildah/parser_test.go
+++ b/pkg/parser/buildah/parser_test.go
@@ -355,7 +355,7 @@ func TestParser_GetResolvedFiles(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Parser{}
-			if got := p.GetResolvedFiles(); !reflect.DeepEqual(got, tt.want) {
+			if got := p.GetResolvedFiles(tt.name); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/parser/docker/parser.go
+++ b/pkg/parser/docker/parser.go
@@ -193,3 +193,7 @@ func saveEnvs(envs map[string]string, envValues []string) map[string]string {
 	}
 	return envs
 }
+
+func (p *Parser) Clone() any {
+	return &Parser{}
+}

--- a/pkg/parser/docker/parser.go
+++ b/pkg/parser/docker/parser.go
@@ -46,7 +46,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 
 	parsed, err := parser.Parse(reader)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(err, "failed to parse Dockerfile")
+		return nil, nil, nil, nil, errors.Wrap(err, "failed to parse Dockerfile")
 	}
 
 	fromValue := ""
@@ -113,11 +113,11 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 
 	j, err := json.Marshal(resource)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(err, "failed to Marshal Dockerfile")
+		return nil, nil, nil, nil, errors.Wrap(err, "failed to Marshal Dockerfile")
 	}
 
 	if err := json.Unmarshal(j, &doc); err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(err, "failed to Unmarshal Dockerfile")
+		return nil, nil, nil, nil, errors.Wrap(err, "failed to Unmarshal Dockerfile")
 	}
 
 	documents = append(documents, *doc)

--- a/pkg/parser/docker/parser.go
+++ b/pkg/parser/docker/parser.go
@@ -41,7 +41,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	documents []model.Document,
 	ignoreLines []int,
 	resolvedFiles map[string]model.ResolvedFile,
-	error error) {
+	err error) {
 	reader := bytes.NewReader(fileContent)
 
 	parsed, err := parser.Parse(reader)

--- a/pkg/parser/docker/parser.go
+++ b/pkg/parser/docker/parser.go
@@ -153,7 +153,7 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 }
 
 // GetResolvedFiles returns the list of files that are resolved
-func (p *Parser) GetResolvedFiles() map[string]model.ResolvedFile {
+func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
 	return make(map[string]model.ResolvedFile)
 }
 

--- a/pkg/parser/docker/parser.go
+++ b/pkg/parser/docker/parser.go
@@ -34,19 +34,19 @@ type Command struct {
 	JSON      bool
 }
 
-// Resolve - replace or modifies in-memory content before parsing
-func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bool, _ int) ([]byte, error) {
-	return fileContent, nil
-}
-
 // Parse - parses dockerfile to Json
-func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]model.Document, []int, error) {
-	var documents []model.Document
+func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
+	resolveReferences bool, maxResolverDepth int) (
+	resolved []byte,
+	documents []model.Document,
+	ignoreLines []int,
+	resolvedFiles map[string]model.ResolvedFile,
+	error error) {
 	reader := bytes.NewReader(fileContent)
 
 	parsed, err := parser.Parse(reader)
 	if err != nil {
-		return nil, []int{}, errors.Wrap(err, "failed to parse Dockerfile")
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(err, "failed to parse Dockerfile")
 	}
 
 	fromValue := ""
@@ -113,18 +113,18 @@ func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]mod
 
 	j, err := json.Marshal(resource)
 	if err != nil {
-		return nil, []int{}, errors.Wrap(err, "failed to Marshal Dockerfile")
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(err, "failed to Marshal Dockerfile")
 	}
 
 	if err := json.Unmarshal(j, &doc); err != nil {
-		return nil, []int{}, errors.Wrap(err, "failed to Unmarshal Dockerfile")
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(err, "failed to Unmarshal Dockerfile")
 	}
 
 	documents = append(documents, *doc)
 
-	ignoreLines := ignoreStruct.getIgnoreLines()
+	ignoreLines = ignoreStruct.getIgnoreLines()
 
-	return documents, ignoreLines, nil
+	return fileContent, documents, ignoreLines, resolvedFiles, nil
 }
 
 // GetKind returns the kind of the parser
@@ -150,11 +150,6 @@ func (p *Parser) GetCommentToken() string {
 // StringifyContent converts original content into string formatted version
 func (p *Parser) StringifyContent(content []byte) (string, error) {
 	return string(content), nil
-}
-
-// GetResolvedFiles returns the list of files that are resolved
-func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
-	return make(map[string]model.ResolvedFile)
 }
 
 func resolveArgsAndEnvs(values []string, args map[string]string) []string {
@@ -192,8 +187,4 @@ func saveEnvs(envs map[string]string, envValues []string) map[string]string {
 		}
 	}
 	return envs
-}
-
-func (p *Parser) Clone() any {
-	return &Parser{}
 }

--- a/pkg/parser/docker/parser_test.go
+++ b/pkg/parser/docker/parser_test.go
@@ -232,7 +232,7 @@ func TestParser_GetResolvedFiles(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Parser{}
-			if got := p.GetResolvedFiles(); !reflect.DeepEqual(got, tt.want) {
+			if got := p.GetResolvedFiles(tt.name); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/parser/docker/parser_test.go
+++ b/pkg/parser/docker/parser_test.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -83,7 +82,7 @@ func TestParser_Parse(t *testing.T) {
 	}
 
 	for idx, sampleFile := range sample {
-		doc, igLines, err := p.Parse(ctx, "Dockerfile", []byte(sampleFile))
+		_, doc, igLines, _, err := p.Parse(ctx, []byte(sampleFile), "Dockerfile", true, 15)
 		switch idx {
 		case 0:
 			require.NoError(t, err)
@@ -134,27 +133,6 @@ func TestParser_Parse(t *testing.T) {
 			require.Contains(t, c.([]interface{})[0].(map[string]interface{})["Value"].([]interface{})[0], "alpine:latest=")
 		}
 	}
-}
-
-// Test_Resolve tests the functions [Resolve()] and all the methods called by them
-func Test_Resolve(t *testing.T) {
-	ctx := context.Background()
-	parser := &Parser{}
-	have := `
-		FROM openjdk:11-jdk
-		VOLUME /tmp
-		ADD http://source.file/package.file.tar.gz /temp
-		RUN tar --xjf /temp/package.file.tar.gz \
-  			&& make -C /tmp/package.file \
-  			&& rm /tmp/ package.file.tar.gz
-		ARG JAR_FILE
-		ADD ${JAR_FILE} app.jar
-		ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
-		`
-
-	resolved, err := parser.Resolve(ctx, []byte(have), "Dockerfile", true, 15)
-	require.NoError(t, err)
-	require.Equal(t, []byte(have), resolved)
 }
 
 // Test_GetCommentToken must get the token that represents a comment
@@ -215,26 +193,6 @@ ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
 			got, err := tt.fields.parser.StringifyContent(tt.args.content)
 			require.Equal(t, tt.wantErr, (err != nil))
 			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestParser_GetResolvedFiles(t *testing.T) {
-	tests := []struct {
-		name string
-		want map[string]model.ResolvedFile
-	}{
-		{
-			name: "test get resolved files",
-			want: map[string]model.ResolvedFile{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{}
-			if got := p.GetResolvedFiles(tt.name); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
-			}
 		})
 	}
 }

--- a/pkg/parser/grpc/parser.go
+++ b/pkg/parser/grpc/parser.go
@@ -31,7 +31,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	parserProto := proto.NewParser(reader)
 	nodes, err := parserProto.Parse()
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+		return nil, nil, nil, nil, err
 	}
 
 	var doc model.Document
@@ -40,12 +40,12 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 
 	protoBytes, err := json.Marshal(jproto)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+		return nil, nil, nil, nil, err
 	}
 
 	err = json.Unmarshal(protoBytes, &doc)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+		return nil, nil, nil, nil, err
 	}
 
 	return fileContent, []model.Document{doc}, linesIgnore, resolvedFiles, nil

--- a/pkg/parser/grpc/parser.go
+++ b/pkg/parser/grpc/parser.go
@@ -20,12 +20,18 @@ type Parser struct {
 }
 
 // Parse - parses grpc to Json
-func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]model.Document, []int, error) {
+func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
+	resolveReferences bool, maxResolverDepth int) (
+	resolved []byte,
+	documents []model.Document,
+	ignoreLines []int,
+	resolvedFiles map[string]model.ResolvedFile,
+	error error) {
 	reader := bytes.NewReader(fileContent)
 	parserProto := proto.NewParser(reader)
 	nodes, err := parserProto.Parse()
 	if err != nil {
-		return nil, nil, err
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
 	}
 
 	var doc model.Document
@@ -34,15 +40,15 @@ func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]mod
 
 	protoBytes, err := json.Marshal(jproto)
 	if err != nil {
-		return nil, nil, err
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
 	}
 
 	err = json.Unmarshal(protoBytes, &doc)
 	if err != nil {
-		return nil, nil, err
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
 	}
 
-	return []model.Document{doc}, linesIgnore, nil
+	return fileContent, []model.Document{doc}, linesIgnore, resolvedFiles, nil
 }
 
 // GetKind returns the kind of the parser
@@ -68,18 +74,4 @@ func (p *Parser) GetCommentToken() string {
 // StringifyContent converts original content into string formatted version
 func (p *Parser) StringifyContent(content []byte) (string, error) {
 	return string(content), nil
-}
-
-// Resolve resolves proto files variables
-func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bool, _ int) ([]byte, error) {
-	return fileContent, nil
-}
-
-// GetResolvedFiles returns the list of files that are resolved
-func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
-	return make(map[string]model.ResolvedFile)
-}
-
-func (p *Parser) Clone() any {
-	return &Parser{}
 }

--- a/pkg/parser/grpc/parser.go
+++ b/pkg/parser/grpc/parser.go
@@ -26,7 +26,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	documents []model.Document,
 	ignoreLines []int,
 	resolvedFiles map[string]model.ResolvedFile,
-	error error) {
+	err error) {
 	reader := bytes.NewReader(fileContent)
 	parserProto := proto.NewParser(reader)
 	nodes, err := parserProto.Parse()

--- a/pkg/parser/grpc/parser.go
+++ b/pkg/parser/grpc/parser.go
@@ -76,6 +76,6 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bo
 }
 
 // GetResolvedFiles returns the list of files that are resolved
-func (p *Parser) GetResolvedFiles() map[string]model.ResolvedFile {
+func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
 	return make(map[string]model.ResolvedFile)
 }

--- a/pkg/parser/grpc/parser.go
+++ b/pkg/parser/grpc/parser.go
@@ -79,3 +79,7 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, _ string, _ bo
 func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
 	return make(map[string]model.ResolvedFile)
 }
+
+func (p *Parser) Clone() any {
+	return &Parser{}
+}

--- a/pkg/parser/grpc/parser_test.go
+++ b/pkg/parser/grpc/parser_test.go
@@ -562,7 +562,7 @@ func TestParser_GetResolvedFiles(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Parser{}
-			if got := p.GetResolvedFiles(); !reflect.DeepEqual(got, tt.want) {
+			if got := p.GetResolvedFiles(tt.name); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/parser/grpc/parser_test.go
+++ b/pkg/parser/grpc/parser_test.go
@@ -361,7 +361,7 @@ func TestParser_Parse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Parser{}
-			got, got1, err := p.Parse(ctx, tt.args.in0, tt.args.fileContent)
+			_, got, got1, _, err := p.Parse(ctx, tt.args.fileContent, tt.args.in0, true, 15)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Parser.Parse() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -504,66 +504,6 @@ import "google/protobuf/descriptor.proto";`,
 			}
 			if got != tt.want {
 				t.Errorf("Parser.StringifyContent() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-// TestParser_Resolve tests the Resolve function
-func TestParser_Resolve(t *testing.T) {
-	type args struct {
-		fileContent []byte
-		filename    string
-	}
-	tests := []struct {
-		name    string
-		p       *Parser
-		args    args
-		want    []byte
-		wantErr bool
-	}{
-		{
-			name: "grpc resolve",
-			p:    &Parser{},
-			args: args{
-				fileContent: []byte(``),
-				filename:    "test.proto",
-			},
-			want: []byte{},
-		},
-	}
-
-	ctx := context.Background()
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{}
-			got, err := p.Resolve(ctx, tt.args.fileContent, tt.args.filename, true, 15)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Parser.Resolve() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Parser.Resolve() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestParser_GetResolvedFiles(t *testing.T) {
-	tests := []struct {
-		name string
-		want map[string]model.ResolvedFile
-	}{
-		{
-			name: "grpc get resolved files",
-			want: map[string]model.ResolvedFile{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{}
-			if got := p.GetResolvedFiles(tt.name); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/parser/json/parser.go
+++ b/pkg/parser/json/parser.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"maps"
 	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -26,51 +25,56 @@ type Parser struct {
 
 // Resolve - replace or modifies in-memory content before parsing
 func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename string,
-	resolveReferences bool, maxResolverDepth int) ([]byte, error) {
+	resolveReferences bool, maxResolverDepth int) (resolved []byte, resolvedFiles map[string]model.ResolvedFile, err error) {
 	// Resolve files passed as arguments with file resolver (e.g. file://)
 	res := file.NewResolver(json.Unmarshal, json.Marshal, p.SupportedExtensions())
 	resolvedFilesCache := make(map[string]file.ResolvedFile)
-	resolved := res.Resolve(ctx, fileContent, filename, 0, maxResolverDepth, resolvedFilesCache, resolveReferences)
-
-	p.resolvedFilesMu.Lock()
-	if p.resolvedFiles == nil {
-		p.resolvedFiles = make(map[string]map[string]model.ResolvedFile)
-	}
-
-	p.resolvedFiles[filename] = res.ResolvedFiles
-	p.resolvedFilesMu.Unlock()
+	resolved = res.Resolve(ctx, fileContent, filename, 0, maxResolverDepth, resolvedFilesCache, resolveReferences)
 
 	if len(res.ResolvedFiles) == 0 {
-		return fileContent, nil
+		return fileContent, res.ResolvedFiles, nil
 	}
-	return resolved, nil
+
+	return resolved, res.ResolvedFiles, nil
 }
 
 // Parse parses json file and returns it as a Document
-func (p *Parser) Parse(ctx context.Context, _ string, fileContent []byte) ([]model.Document, []int, error) {
-	r := model.Document{}
-	err := json.Unmarshal(fileContent, &r)
+func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
+	resolveReferences bool, maxResolverDepth int) (
+	resolved []byte,
+	documents []model.Document,
+	ignoreLines []int,
+	resolvedFiles map[string]model.ResolvedFile,
+	error error) {
+
+	resolved, resolvedFiles, err := p.Resolve(ctx, fileContent, filePath, resolveReferences, maxResolverDepth)
 	if err != nil {
-		var r []model.Document
-		err = json.Unmarshal(fileContent, &r)
-		return r, []int{}, err
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
 	}
 
-	jLine := initializeJSONLine(fileContent)
+	r := model.Document{}
+	err = json.Unmarshal(resolved, &r)
+	if err != nil {
+		var r []model.Document
+		err = json.Unmarshal(resolved, &r)
+		return []byte{}, r, []int{}, resolvedFiles, err
+	}
+
+	jLine := initializeJSONLine(resolved)
 	kicsJSON := jLine.setLineInfo(r)
 
 	// Try to parse JSON as Terraform plan
 	kicsPlan, err := parseTFPlan(kicsJSON)
 	if err != nil {
 		// JSON is not a tf plan
-		return []model.Document{kicsJSON}, []int{}, nil
+		return resolved, []model.Document{kicsJSON}, []int{}, resolvedFiles, nil
 	}
 
 	p.shouldIdentMu.Lock()
 	p.shouldIdent = true
 	p.shouldIdentMu.Unlock()
 
-	return []model.Document{kicsPlan}, []int{}, nil
+	return resolved, []model.Document{kicsPlan}, []int{}, resolvedFiles, nil
 }
 
 // SupportedExtensions returns extensions supported by this parser, which is json extension
@@ -115,27 +119,4 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 		return out.String(), nil
 	}
 	return string(content), nil
-}
-
-// GetResolvedFiles returns resolved files
-func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
-	p.resolvedFilesMu.RLock()
-	defer p.resolvedFilesMu.RUnlock()
-	resolvedFiles := make(map[string]model.ResolvedFile, len(p.resolvedFiles))
-	maps.Copy(resolvedFiles, p.resolvedFiles[filename])
-	return resolvedFiles
-}
-
-func (p *Parser) Clone() any {
-	p.resolvedFilesMu.RLock()
-	defer p.resolvedFilesMu.RUnlock()
-	resolvedFiles := make(map[string]map[string]model.ResolvedFile, len(p.resolvedFiles))
-	for filename, innerMap := range p.resolvedFiles {
-		innerCopy := make(map[string]model.ResolvedFile, len(innerMap))
-		maps.Copy(innerCopy, innerMap)
-		resolvedFiles[filename] = innerCopy
-	}
-	return &Parser{
-		resolvedFiles: resolvedFiles,
-	}
 }

--- a/pkg/parser/json/parser.go
+++ b/pkg/parser/json/parser.go
@@ -125,3 +125,17 @@ func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile
 	maps.Copy(resolvedFiles, p.resolvedFiles[filename])
 	return resolvedFiles
 }
+
+func (p *Parser) Clone() any {
+	p.resolvedFilesMu.RLock()
+	defer p.resolvedFilesMu.RUnlock()
+	resolvedFiles := make(map[string]map[string]model.ResolvedFile, len(p.resolvedFiles))
+	for filename, innerMap := range p.resolvedFiles {
+		innerCopy := make(map[string]model.ResolvedFile, len(innerMap))
+		maps.Copy(innerCopy, innerMap)
+		resolvedFiles[filename] = innerCopy
+	}
+	return &Parser{
+		resolvedFiles: resolvedFiles,
+	}
+}

--- a/pkg/parser/json/parser.go
+++ b/pkg/parser/json/parser.go
@@ -20,7 +20,7 @@ import (
 type Parser struct {
 	shouldIdent     bool
 	shouldIdentMu   sync.RWMutex
-	resolvedFiles   map[string]model.ResolvedFile
+	resolvedFiles   map[string]map[string]model.ResolvedFile
 	resolvedFilesMu sync.RWMutex
 }
 
@@ -33,7 +33,11 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename strin
 	resolved := res.Resolve(ctx, fileContent, filename, 0, maxResolverDepth, resolvedFilesCache, resolveReferences)
 
 	p.resolvedFilesMu.Lock()
-	p.resolvedFiles = res.ResolvedFiles
+	if p.resolvedFiles == nil {
+		p.resolvedFiles = make(map[string]map[string]model.ResolvedFile)
+	}
+
+	p.resolvedFiles[filename] = res.ResolvedFiles
 	p.resolvedFilesMu.Unlock()
 
 	if len(res.ResolvedFiles) == 0 {
@@ -114,10 +118,10 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 }
 
 // GetResolvedFiles returns resolved files
-func (p *Parser) GetResolvedFiles() map[string]model.ResolvedFile {
+func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
 	p.resolvedFilesMu.RLock()
 	defer p.resolvedFilesMu.RUnlock()
 	resolvedFiles := make(map[string]model.ResolvedFile, len(p.resolvedFiles))
-	maps.Copy(resolvedFiles, p.resolvedFiles)
+	maps.Copy(resolvedFiles, p.resolvedFiles[filename])
 	return resolvedFiles
 }

--- a/pkg/parser/json/parser.go
+++ b/pkg/parser/json/parser.go
@@ -49,7 +49,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 
 	resolved, resolvedFiles, err := p.Resolve(ctx, fileContent, filePath, resolveReferences, maxResolverDepth)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+		return nil, nil, nil, nil, err
 	}
 
 	r := model.Document{}
@@ -57,7 +57,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	if err != nil {
 		var r []model.Document
 		err = json.Unmarshal(resolved, &r)
-		return []byte{}, r, []int{}, resolvedFiles, err
+		return nil, r, nil, resolvedFiles, err
 	}
 
 	jLine := initializeJSONLine(resolved)
@@ -67,14 +67,14 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	kicsPlan, err := parseTFPlan(kicsJSON)
 	if err != nil {
 		// JSON is not a tf plan
-		return resolved, []model.Document{kicsJSON}, []int{}, resolvedFiles, nil
+		return resolved, []model.Document{kicsJSON}, nil, resolvedFiles, nil
 	}
 
 	p.shouldIdentMu.Lock()
 	p.shouldIdent = true
 	p.shouldIdentMu.Unlock()
 
-	return resolved, []model.Document{kicsPlan}, []int{}, resolvedFiles, nil
+	return resolved, []model.Document{kicsPlan}, nil, resolvedFiles, nil
 }
 
 // SupportedExtensions returns extensions supported by this parser, which is json extension

--- a/pkg/parser/json/parser.go
+++ b/pkg/parser/json/parser.go
@@ -17,10 +17,8 @@ import (
 
 // Parser defines a parser type
 type Parser struct {
-	shouldIdent     bool
-	shouldIdentMu   sync.RWMutex
-	resolvedFiles   map[string]map[string]model.ResolvedFile
-	resolvedFilesMu sync.RWMutex
+	shouldIdent   bool
+	shouldIdentMu sync.RWMutex
 }
 
 // Resolve - replace or modifies in-memory content before parsing
@@ -45,9 +43,8 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	documents []model.Document,
 	ignoreLines []int,
 	resolvedFiles map[string]model.ResolvedFile,
-	error error) {
-
-	resolved, resolvedFiles, err := p.Resolve(ctx, fileContent, filePath, resolveReferences, maxResolverDepth)
+	err error) {
+	resolved, resolvedFiles, err = p.Resolve(ctx, fileContent, filePath, resolveReferences, maxResolverDepth)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/pkg/parser/json/parser_test.go
+++ b/pkg/parser/json/parser_test.go
@@ -7,7 +7,6 @@ package json
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -46,7 +45,7 @@ func TestParser_Parse(t *testing.T) {
 	ctx := context.Background()
 	p := &Parser{}
 
-	doc, _, err := p.Parse(ctx, "test.json", []byte(have))
+	_, doc, _, _, err := p.Parse(ctx, []byte(have), "test.json", true, 15)
 	require.NoError(t, err)
 	require.Len(t, doc, 1)
 	require.Contains(t, doc[0], "martin")
@@ -57,7 +56,7 @@ func Test_Resolve(t *testing.T) {
 	ctx := context.Background()
 	parser := &Parser{}
 
-	resolved, err := parser.Resolve(ctx, []byte(have), "test.json", true, 15)
+	resolved, _, err := parser.Resolve(ctx, []byte(have), "test.json", true, 15)
 	require.NoError(t, err)
 	require.Equal(t, have, string(resolved))
 }
@@ -119,50 +118,6 @@ func TestJSON_StringifyContent(t *testing.T) {
 			got, err := tt.fields.parser.StringifyContent(tt.args.content)
 			require.Equal(t, tt.wantErr, (err != nil))
 			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestParser_GetResolvedFiles(t *testing.T) {
-	type fields struct {
-		shouldIdent   bool
-		resolvedFiles map[string]map[string]model.ResolvedFile
-		filename      string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   map[string]model.ResolvedFile
-	}{
-		{
-			name: "test get resolved files",
-			fields: fields{
-				shouldIdent: true,
-				resolvedFiles: map[string]map[string]model.ResolvedFile{
-					"test.json": {
-						"test.json": {
-							Content: []byte(`{"key":"value"}`),
-						},
-					},
-				},
-				filename: "test.json",
-			},
-			want: map[string]model.ResolvedFile{
-				"test.json": {
-					Content: []byte(`{"key":"value"}`),
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{
-				shouldIdent:   tt.fields.shouldIdent,
-				resolvedFiles: tt.fields.resolvedFiles,
-			}
-			if got := p.GetResolvedFiles(tt.fields.filename); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
-			}
 		})
 	}
 }

--- a/pkg/parser/json/parser_test.go
+++ b/pkg/parser/json/parser_test.go
@@ -126,7 +126,8 @@ func TestJSON_StringifyContent(t *testing.T) {
 func TestParser_GetResolvedFiles(t *testing.T) {
 	type fields struct {
 		shouldIdent   bool
-		resolvedFiles map[string]model.ResolvedFile
+		resolvedFiles map[string]map[string]model.ResolvedFile
+		filename      string
 	}
 	tests := []struct {
 		name   string
@@ -137,11 +138,14 @@ func TestParser_GetResolvedFiles(t *testing.T) {
 			name: "test get resolved files",
 			fields: fields{
 				shouldIdent: true,
-				resolvedFiles: map[string]model.ResolvedFile{
+				resolvedFiles: map[string]map[string]model.ResolvedFile{
 					"test.json": {
-						Content: []byte(`{"key":"value"}`),
+						"test.json": {
+							Content: []byte(`{"key":"value"}`),
+						},
 					},
 				},
+				filename: "test.json",
 			},
 			want: map[string]model.ResolvedFile{
 				"test.json": {
@@ -156,7 +160,7 @@ func TestParser_GetResolvedFiles(t *testing.T) {
 				shouldIdent:   tt.fields.shouldIdent,
 				resolvedFiles: tt.fields.resolvedFiles,
 			}
-			if got := p.GetResolvedFiles(); !reflect.DeepEqual(got, tt.want) {
+			if got := p.GetResolvedFiles(tt.fields.filename); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -22,7 +22,9 @@ type kindParser interface {
 	GetCommentToken() string
 	SupportedExtensions() []string
 	SupportedTypes() map[string]bool
-	Parse(ctx context.Context, fileContent []byte, filename string, _ bool, _ int) ([]byte, []model.Document, []int, map[string]model.ResolvedFile, error)
+	Parse(ctx context.Context,
+		fileContent []byte,
+		filename string, _ bool, _ int) ([]byte, []model.Document, []int, map[string]model.ResolvedFile, error)
 	StringifyContent(content []byte) (string, error)
 }
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 
@@ -23,11 +22,8 @@ type kindParser interface {
 	GetCommentToken() string
 	SupportedExtensions() []string
 	SupportedTypes() map[string]bool
-	Parse(ctx context.Context, filePath string, fileContent []byte) ([]model.Document, []int, error)
-	Resolve(ctx context.Context, fileContent []byte, filename string, _ bool, _ int) ([]byte, error)
+	Parse(ctx context.Context, fileContent []byte, filename string, _ bool, _ int) ([]byte, []model.Document, []int, map[string]model.ResolvedFile, error)
 	StringifyContent(content []byte) (string, error)
-	GetResolvedFiles(filename string) map[string]model.ResolvedFile
-	Clone() any
 }
 
 // Builder is a representation of parsers that will be construct
@@ -143,20 +139,12 @@ func (c *Parser) Parse(
 	fileContent = utils.DecryptAnsibleVault(ctx, fileContent, os.Getenv("ANSIBLE_VAULT_PASSWORD_FILE"))
 
 	if c.isValidExtension(ctx, filePath) {
-		parser, ok := c.parsers.Clone().(kindParser)
-		if !ok {
-			return ParsedDocument{}, fmt.Errorf("invalid kindParser")
-		}
-		resolved, err := parser.Resolve(ctx, fileContent, filePath, openAPIResolveReferences, maxResolverDepth)
-		if err != nil {
-			return ParsedDocument{}, err
-		}
-		obj, igLines, err := parser.Parse(ctx, filePath, resolved)
+		resolved, obj, igLines, resolvedFiles, err := c.parsers.Parse(ctx, fileContent, filePath, openAPIResolveReferences, maxResolverDepth)
 		if err != nil {
 			return ParsedDocument{}, err
 		}
 
-		cont, err := parser.StringifyContent(fileContent)
+		cont, err := c.parsers.StringifyContent(fileContent)
 		if err != nil {
 			contextLogger.Error().Msgf("failed to stringify original content: %s", err)
 			cont = string(fileContent)
@@ -164,11 +152,11 @@ func (c *Parser) Parse(
 
 		return ParsedDocument{
 			Docs:          obj,
-			Kind:          parser.GetKind(),
+			Kind:          c.parsers.GetKind(),
 			Content:       cont,
 			IgnoreLines:   igLines,
 			CountLines:    bytes.Count(resolved, []byte{'\n'}) + 1,
-			ResolvedFiles: parser.GetResolvedFiles(filePath),
+			ResolvedFiles: resolvedFiles,
 			IsMinified:    isMinified,
 		}, nil
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -25,7 +25,7 @@ type kindParser interface {
 	Parse(ctx context.Context, filePath string, fileContent []byte) ([]model.Document, []int, error)
 	Resolve(ctx context.Context, fileContent []byte, filename string, _ bool, _ int) ([]byte, error)
 	StringifyContent(content []byte) (string, error)
-	GetResolvedFiles() map[string]model.ResolvedFile
+	GetResolvedFiles(filename string) map[string]model.ResolvedFile
 }
 
 // Builder is a representation of parsers that will be construct
@@ -162,7 +162,7 @@ func (c *Parser) Parse(
 			Content:       cont,
 			IgnoreLines:   igLines,
 			CountLines:    bytes.Count(resolved, []byte{'\n'}) + 1,
-			ResolvedFiles: c.parsers.GetResolvedFiles(),
+			ResolvedFiles: c.parsers.GetResolvedFiles(filePath),
 			IsMinified:    isMinified,
 		}, nil
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -26,6 +27,7 @@ type kindParser interface {
 	Resolve(ctx context.Context, fileContent []byte, filename string, _ bool, _ int) ([]byte, error)
 	StringifyContent(content []byte) (string, error)
 	GetResolvedFiles(filename string) map[string]model.ResolvedFile
+	Clone() any
 }
 
 // Builder is a representation of parsers that will be construct
@@ -141,16 +143,20 @@ func (c *Parser) Parse(
 	fileContent = utils.DecryptAnsibleVault(ctx, fileContent, os.Getenv("ANSIBLE_VAULT_PASSWORD_FILE"))
 
 	if c.isValidExtension(ctx, filePath) {
-		resolved, err := c.parsers.Resolve(ctx, fileContent, filePath, openAPIResolveReferences, maxResolverDepth)
+		parser, ok := c.parsers.Clone().(kindParser)
+		if !ok {
+			return ParsedDocument{}, fmt.Errorf("invalid kindParser")
+		}
+		resolved, err := parser.Resolve(ctx, fileContent, filePath, openAPIResolveReferences, maxResolverDepth)
 		if err != nil {
 			return ParsedDocument{}, err
 		}
-		obj, igLines, err := c.parsers.Parse(ctx, filePath, resolved)
+		obj, igLines, err := parser.Parse(ctx, filePath, resolved)
 		if err != nil {
 			return ParsedDocument{}, err
 		}
 
-		cont, err := c.parsers.StringifyContent(fileContent)
+		cont, err := parser.StringifyContent(fileContent)
 		if err != nil {
 			contextLogger.Error().Msgf("failed to stringify original content: %s", err)
 			cont = string(fileContent)
@@ -158,11 +164,11 @@ func (c *Parser) Parse(
 
 		return ParsedDocument{
 			Docs:          obj,
-			Kind:          c.parsers.GetKind(),
+			Kind:          parser.GetKind(),
 			Content:       cont,
 			IgnoreLines:   igLines,
 			CountLines:    bytes.Count(resolved, []byte{'\n'}) + 1,
-			ResolvedFiles: c.parsers.GetResolvedFiles(filePath),
+			ResolvedFiles: parser.GetResolvedFiles(filePath),
 			IsMinified:    isMinified,
 		}, nil
 	}

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -46,9 +45,8 @@ var DefaultConverted = func(ctx context.Context, file *hcl.File, inputVariables 
 }
 
 type converter struct {
-	bytes       []byte
-	inputVars   VariableMap
-	inputVarsMu sync.RWMutex
+	bytes     []byte
+	inputVars VariableMap
 }
 
 const (
@@ -231,12 +229,10 @@ func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, e
 	case *hclsyntax.RelativeTraversalExpr, *hclsyntax.IndexExpr:
 		return c.tryEvalExpression(expr)
 	case *hclsyntax.ConditionalExpr:
-		c.inputVarsMu.RLock()
 		expressionEvaluated, err := expr.Value(&hcl.EvalContext{
 			Variables: c.inputVars,
 			Functions: functions.TerraformFuncs,
 		})
-		c.inputVarsMu.RUnlock()
 		if err != nil {
 			return c.wrapExpr(expr)
 		}
@@ -351,11 +347,9 @@ func (c *converter) convertStringPart(expr hclsyntax.Expression) (string, error)
 		return c.tryEvalToString(expr)
 	default:
 		// try to evaluate with variables only (no functions)
-		c.inputVarsMu.RLock()
 		valueConverted, _ := expr.Value(&hcl.EvalContext{
 			Variables: c.inputVars,
 		})
-		c.inputVarsMu.RUnlock()
 		if valueConverted.Type().FriendlyName() == ctyFriendlyNameString {
 			return valueConverted.AsString(), nil
 		}
@@ -417,12 +411,10 @@ func (c *converter) convertTemplateFor(expr *hclsyntax.ForExpr) (string, error) 
 }
 
 func (c *converter) tryEvalExpression(expr hclsyntax.Expression) (interface{}, error) {
-	c.inputVarsMu.RLock()
 	val, _ := expr.Value(&hcl.EvalContext{
 		Variables: c.inputVars,
 		Functions: functions.TerraformFuncs,
 	})
-	c.inputVarsMu.RUnlock()
 	if !checkDynamicKnownTypes(val) {
 		return ctyjson.SimpleJSONValue{Value: val}, nil
 	}
@@ -430,12 +422,10 @@ func (c *converter) tryEvalExpression(expr hclsyntax.Expression) (interface{}, e
 }
 
 func (c *converter) tryEvalToString(expr hclsyntax.Expression) (string, error) {
-	c.inputVarsMu.RLock()
 	val, _ := expr.Value(&hcl.EvalContext{
 		Variables: c.inputVars,
 		Functions: functions.TerraformFuncs,
 	})
-	c.inputVarsMu.RUnlock()
 	if val.Type().FriendlyName() == ctyFriendlyNameString {
 		return val.AsString(), nil
 	}
@@ -448,16 +438,13 @@ func (c *converter) wrapExpr(expr hclsyntax.Expression) (string, error) {
 }
 
 func (c *converter) evalFunction(expression hclsyntax.Expression) (interface{}, error) {
-	c.inputVarsMu.RLock()
 	expressionEvaluated, err := expression.Value(&hcl.EvalContext{
 		Variables: c.inputVars,
 		Functions: functions.TerraformFuncs,
 	})
-	c.inputVarsMu.RUnlock()
 
 	if err != nil {
 		// Initialize inputVars if nil
-		c.inputVarsMu.Lock()
 		if c.inputVars == nil {
 			c.inputVars = make(VariableMap)
 		}
@@ -468,7 +455,6 @@ func (c *converter) evalFunction(expression hclsyntax.Expression) (interface{}, 
 				if strings.Contains(jsonPath, ".") {
 					jsonCtyValue, convertErr := createEntryInputVar(strings.Split(jsonPath, ".")[1:], jsonPath)
 					if convertErr != nil {
-						c.inputVarsMu.Unlock()
 						return c.wrapExpr(expression)
 					}
 					c.inputVars[rootKey] = jsonCtyValue
@@ -477,15 +463,12 @@ func (c *converter) evalFunction(expression hclsyntax.Expression) (interface{}, 
 				}
 			}
 		}
-		c.inputVarsMu.Unlock()
 
 		// Retry evaluation with updated variables
-		c.inputVarsMu.RLock()
 		expressionEvaluated, err = expression.Value(&hcl.EvalContext{
 			Variables: c.inputVars,
 			Functions: functions.TerraformFuncs,
 		})
-		c.inputVarsMu.RUnlock()
 
 		if err != nil {
 			return c.wrapExpr(expression)

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -54,7 +54,9 @@ func NewDefaultWithParams(terraformVarsPath string, sciInfo model.SCIInfo) *Pars
 }
 
 // Resolve - replace or modifies in-memory content before parsing
-func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename string, _ bool, _ int) (resolved []byte, vars converter.VariableMap, err error) {
+func (p *Parser) Resolve(ctx context.Context,
+	fileContent []byte,
+	filename string, _ bool, _ int) (resolved []byte, vars converter.VariableMap, err error) {
 	// handle panic during resolve process
 	defer func() {
 		if r := recover(); r != nil {
@@ -181,7 +183,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, path string,
 	documents []model.Document,
 	ignoreLines []int,
 	resolvedFiles map[string]model.ResolvedFile,
-	error error) {
+	err error) {
 	contextLogger := logger.FromContext(ctx)
 	resolved, inputVariables, err := p.Resolve(ctx, fileContent, path, resolveReferences, maxResolverDepth)
 	if err != nil {

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -7,7 +7,6 @@ package terraform
 
 import (
 	"context"
-	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -207,9 +206,6 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, path string,
 	}
 
 	linesToIgnore := comment.GetIgnoreLines(ignore, file.Body.(*hclsyntax.Body))
-
-	inputVarsCopy := make(converter.VariableMap, len(inputVariables))
-	maps.Copy(inputVarsCopy, inputVariables)
 
 	fc, parseErr := p.convertFunc(ctx, file, inputVariables)
 	json, err := addExtraInfo(ctx, []model.Document{fc}, path)

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -73,7 +73,7 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename strin
 	// Use base filename to ensure consistency between Resolve() and Parse() calls
 	baseFilename := filepath.Base(filename)
 	p.inputVarsMu.Lock()
-	p.inputVariables[baseFilename] = vars
+	p.inputVariables[filename] = vars
 	p.inputVarsMu.Unlock()
 
 	return fileContent, nil
@@ -207,10 +207,8 @@ func (p *Parser) Parse(ctx context.Context, path string, content []byte) ([]mode
 
 	linesToIgnore := comment.GetIgnoreLines(ignore, file.Body.(*hclsyntax.Body))
 
-	// Use base filename to ensure consistency between Resolve() and Parse() calls
-	baseFilename := filepath.Base(path)
 	p.inputVarsMu.RLock()
-	inputVars, ok := p.inputVariables[baseFilename]
+	inputVars, ok := p.inputVariables[path]
 	if !ok {
 		inputVars = make(converter.VariableMap)
 	}

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -185,7 +185,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, path string,
 	contextLogger := logger.FromContext(ctx)
 	resolved, inputVariables, err := p.Resolve(ctx, fileContent, path, resolveReferences, maxResolverDepth)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+		return nil, nil, nil, nil, err
 	}
 
 	file, diagnostics := hclsyntax.ParseConfig(resolved, filepath.Base(path), hcl.Pos{Byte: 0, Line: 1, Column: 1})
@@ -197,7 +197,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, path string,
 	}()
 	if diagnostics != nil && diagnostics.HasErrors() && len(diagnostics.Errs()) > 0 {
 		err := diagnostics.Errs()[0]
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+		return nil, nil, nil, nil, err
 	}
 
 	ignore, err := comment.ParseComments(resolved, path)

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -253,3 +253,11 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
 	return make(map[string]model.ResolvedFile)
 }
+
+func (p *Parser) Clone() any {
+	parser := NewDefaultWithParams(p.terraformVarsPath, p.sciInfo)
+	p.inputVarsMu.RLock()
+	defer p.inputVarsMu.RUnlock()
+	maps.Copy(parser.inputVariables, p.inputVariables)
+	return parser
+}

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -213,8 +213,10 @@ func (p *Parser) Parse(ctx context.Context, path string, content []byte) ([]mode
 		inputVars = make(converter.VariableMap)
 	}
 	p.inputVarsMu.RUnlock()
+	inputVarsCopy := make(converter.VariableMap, len(inputVars))
+	maps.Copy(inputVarsCopy, inputVars)
 
-	fc, parseErr := p.convertFunc(ctx, file, inputVars)
+	fc, parseErr := p.convertFunc(ctx, file, inputVarsCopy)
 	json, err := addExtraInfo(ctx, []model.Document{fc}, path)
 	if err != nil {
 		return json, []int{}, errors.Wrap(err, "failed terraform parse")

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -7,6 +7,7 @@ package terraform
 
 import (
 	"context"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -70,8 +71,6 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename strin
 	vars := getDataSourcePolicy(ctx, filepath.Dir(filename), inputVars)
 
 	// Store variables per filename to avoid race conditions between different files
-	// Use base filename to ensure consistency between Resolve() and Parse() calls
-	baseFilename := filepath.Base(filename)
 	p.inputVarsMu.Lock()
 	p.inputVariables[filename] = vars
 	p.inputVarsMu.Unlock()
@@ -251,6 +250,6 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 }
 
 // GetResolvedFiles returns the files that are resolved
-func (p *Parser) GetResolvedFiles() map[string]model.ResolvedFile {
+func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
 	return make(map[string]model.ResolvedFile)
 }

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -37,16 +36,13 @@ type Parser struct {
 	numOfRetries      int
 	terraformVarsPath string
 	sciInfo           model.SCIInfo
-	inputVariables    map[string]converter.VariableMap
-	inputVarsMu       sync.RWMutex
 }
 
 // NewDefault initializes a parser with Parser default values
 func NewDefault() *Parser {
 	return &Parser{
-		numOfRetries:   RetriesDefaultValue,
-		convertFunc:    converter.DefaultConverted,
-		inputVariables: make(map[string]converter.VariableMap),
+		numOfRetries: RetriesDefaultValue,
+		convertFunc:  converter.DefaultConverted,
 	}
 }
 
@@ -59,7 +55,7 @@ func NewDefaultWithParams(terraformVarsPath string, sciInfo model.SCIInfo) *Pars
 }
 
 // Resolve - replace or modifies in-memory content before parsing
-func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename string, _ bool, _ int) ([]byte, error) {
+func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename string, _ bool, _ int) (resolved []byte, vars converter.VariableMap, err error) {
 	// handle panic during resolve process
 	defer func() {
 		if r := recover(); r != nil {
@@ -68,14 +64,9 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename strin
 		}
 	}()
 	inputVars := getInputVariables(ctx, filepath.Dir(filename), string(fileContent), p.terraformVarsPath)
-	vars := getDataSourcePolicy(ctx, filepath.Dir(filename), inputVars)
+	vars = getDataSourcePolicy(ctx, filepath.Dir(filename), inputVars)
 
-	// Store variables per filename to avoid race conditions between different files
-	p.inputVarsMu.Lock()
-	p.inputVariables[filename] = vars
-	p.inputVarsMu.Unlock()
-
-	return fileContent, nil
+	return fileContent, vars, nil
 }
 
 func processContent(ctx context.Context, elements model.Document, content, path string) {
@@ -185,9 +176,20 @@ func parseFile(filename string, shouldReplaceDataSource bool) (*hcl.File, error)
 }
 
 // Parse execute parser for the content in a file
-func (p *Parser) Parse(ctx context.Context, path string, content []byte) ([]model.Document, []int, error) {
+func (p *Parser) Parse(ctx context.Context, fileContent []byte, path string,
+	resolveReferences bool, maxResolverDepth int) (
+	resolved []byte,
+	documents []model.Document,
+	ignoreLines []int,
+	resolvedFiles map[string]model.ResolvedFile,
+	error error) {
 	contextLogger := logger.FromContext(ctx)
-	file, diagnostics := hclsyntax.ParseConfig(content, filepath.Base(path), hcl.Pos{Byte: 0, Line: 1, Column: 1})
+	resolved, inputVariables, err := p.Resolve(ctx, fileContent, path, resolveReferences, maxResolverDepth)
+	if err != nil {
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+	}
+
+	file, diagnostics := hclsyntax.ParseConfig(resolved, filepath.Base(path), hcl.Pos{Byte: 0, Line: 1, Column: 1})
 	defer func() {
 		if r := recover(); r != nil {
 			errMessage := "Recovered from panic during parsing of file " + path
@@ -196,32 +198,26 @@ func (p *Parser) Parse(ctx context.Context, path string, content []byte) ([]mode
 	}()
 	if diagnostics != nil && diagnostics.HasErrors() && len(diagnostics.Errs()) > 0 {
 		err := diagnostics.Errs()[0]
-		return nil, []int{}, err
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
 	}
 
-	ignore, err := comment.ParseComments(content, path)
+	ignore, err := comment.ParseComments(resolved, path)
 	if err != nil {
 		contextLogger.Err(err).Msg("failed to parse comments")
 	}
 
 	linesToIgnore := comment.GetIgnoreLines(ignore, file.Body.(*hclsyntax.Body))
 
-	p.inputVarsMu.RLock()
-	inputVars, ok := p.inputVariables[path]
-	if !ok {
-		inputVars = make(converter.VariableMap)
-	}
-	p.inputVarsMu.RUnlock()
-	inputVarsCopy := make(converter.VariableMap, len(inputVars))
-	maps.Copy(inputVarsCopy, inputVars)
+	inputVarsCopy := make(converter.VariableMap, len(inputVariables))
+	maps.Copy(inputVarsCopy, inputVariables)
 
-	fc, parseErr := p.convertFunc(ctx, file, inputVarsCopy)
+	fc, parseErr := p.convertFunc(ctx, file, inputVariables)
 	json, err := addExtraInfo(ctx, []model.Document{fc}, path)
 	if err != nil {
-		return json, []int{}, errors.Wrap(err, "failed terraform parse")
+		return []byte{}, json, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(err, "failed terraform parse")
 	}
 
-	return json, linesToIgnore, errors.Wrap(parseErr, "failed terraform parse")
+	return resolved, json, linesToIgnore, resolvedFiles, errors.Wrap(parseErr, "failed terraform parse")
 }
 
 // SupportedExtensions returns Terraform extensions
@@ -247,17 +243,4 @@ func (p *Parser) GetCommentToken() string {
 // StringifyContent converts original content into string formatted version
 func (p *Parser) StringifyContent(content []byte) (string, error) {
 	return string(content), nil
-}
-
-// GetResolvedFiles returns the files that are resolved
-func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
-	return make(map[string]model.ResolvedFile)
-}
-
-func (p *Parser) Clone() any {
-	parser := NewDefaultWithParams(p.terraformVarsPath, p.sciInfo)
-	p.inputVarsMu.RLock()
-	defer p.inputVarsMu.RUnlock()
-	maps.Copy(parser.inputVariables, p.inputVariables)
-	return parser
 }

--- a/pkg/parser/terraform/terraform_test.go
+++ b/pkg/parser/terraform/terraform_test.go
@@ -8,12 +8,8 @@ package terraform
 import (
 	"context"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
-	"github.com/hashicorp/hcl/v2"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/stretchr/testify/require"
@@ -128,7 +124,7 @@ func TestParser_SupportedExtensions(t *testing.T) {
 func Test_Parser(t *testing.T) {
 	ctx := context.Background()
 	parser := NewDefault()
-	document, linesToIgnore, err := parser.Parse(ctx, "test.tf", []byte(have))
+	_, document, linesToIgnore, _, err := parser.Parse(ctx, []byte(have), "test.tf", true, 15)
 
 	require.Equal(t, []int{8, 9, 10, 11, 5, 4, 6}, linesToIgnore)
 	require.NoError(t, err)
@@ -137,7 +133,7 @@ func Test_Parser(t *testing.T) {
 	require.Contains(t, document[0]["resource"], "aws_s3_bucket")
 
 	// case where we fail to parse the file and a fatal error is thrown caught with recover
-	document, linesToIgnore, err = parser.Parse(ctx, "test.tf", []byte(conditionalValResource))
+	_, document, linesToIgnore, _, err = parser.Parse(ctx, []byte(conditionalValResource), "test.tf", true, 15)
 	require.NoError(t, err)
 	require.Len(t, document, 0)
 	require.Len(t, linesToIgnore, 0)
@@ -148,7 +144,7 @@ func Test_Parser(t *testing.T) {
 func Test_Count(t *testing.T) {
 	ctx := context.Background()
 	parser := NewDefault()
-	document, _, err := parser.Parse(ctx, "count.tf", []byte(count))
+	_, document, _, _, err := parser.Parse(ctx, []byte(count), "count.tf", true, 15)
 	require.NoError(t, err)
 	require.Len(t, document, 1)
 	require.Contains(t, document[0], "resource")
@@ -162,9 +158,9 @@ func Test_Parentheses_Expr(t *testing.T) {
 	parser := NewDefault()
 	// Call Resolve first to set up input variables
 	fullPath := filepath.FromSlash("../../../test/fixtures/test-tf-parentheses/parentheses.tf")
-	_, err := parser.Resolve(ctx, []byte(parentheses), fullPath, false, 0)
+	_, _, err := parser.Resolve(ctx, []byte(parentheses), fullPath, false, 0)
 	require.NoError(t, err)
-	document, _, err := parser.Parse(ctx, fullPath, []byte(parentheses))
+	_, document, _, _, err := parser.Parse(ctx, []byte(parentheses), fullPath, true, 15)
 	require.NoError(t, err)
 	require.Len(t, document, 1)
 	require.Contains(t, document[0], "data")
@@ -176,7 +172,7 @@ func Test_Parentheses_Expr(t *testing.T) {
 func Test_namelessResource(t *testing.T) {
 	ctx := context.Background()
 	parser := NewDefault()
-	document, _, err := parser.Parse(ctx, "namelessResource.tf", []byte(namelessResource))
+	_, document, _, _, err := parser.Parse(ctx, []byte(namelessResource), "namelessResource.tf", true, 15)
 	require.NoError(t, err)
 	require.Len(t, document, 1)
 	require.Contains(t, document[0], "resource")
@@ -192,7 +188,7 @@ func Test_Resolve(t *testing.T) {
 	ctx := context.Background()
 	parser := NewDefault()
 
-	resolved, err := parser.Resolve(ctx, []byte(have), "test.tf", true, 15)
+	_, resolved, err := parser.Resolve(ctx, []byte(have), "test.tf", true, 15)
 	require.NoError(t, err)
 	require.Equal(t, []byte(have), resolved)
 }
@@ -387,39 +383,6 @@ data "aws_iam_policy_document" "test_destination_policy" {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.want, strings.ReplaceAll(string(parsedFile.Bytes), "\r", ""))
-			}
-		})
-	}
-}
-
-func TestParser_GetResolvedFiles(t *testing.T) {
-	type fields struct {
-		convertFunc  Converter
-		numOfRetries int
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   map[string]model.ResolvedFile
-	}{
-		{
-			name: "Should get resolved files",
-			fields: fields{
-				convertFunc: func(ctx context.Context, file *hcl.File, inputVariables converter.VariableMap) (model.Document, error) {
-					return nil, nil
-				},
-			},
-			want: map[string]model.ResolvedFile{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{
-				convertFunc:  tt.fields.convertFunc,
-				numOfRetries: tt.fields.numOfRetries,
-			}
-			if got := p.GetResolvedFiles(tt.name); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/parser/terraform/terraform_test.go
+++ b/pkg/parser/terraform/terraform_test.go
@@ -188,7 +188,7 @@ func Test_Resolve(t *testing.T) {
 	ctx := context.Background()
 	parser := NewDefault()
 
-	_, resolved, err := parser.Resolve(ctx, []byte(have), "test.tf", true, 15)
+	resolved, _, err := parser.Resolve(ctx, []byte(have), "test.tf", true, 15)
 	require.NoError(t, err)
 	require.Equal(t, []byte(have), resolved)
 }

--- a/pkg/parser/terraform/terraform_test.go
+++ b/pkg/parser/terraform/terraform_test.go
@@ -418,7 +418,7 @@ func TestParser_GetResolvedFiles(t *testing.T) {
 				convertFunc:  tt.fields.convertFunc,
 				numOfRetries: tt.fields.numOfRetries,
 			}
-			if got := p.GetResolvedFiles(); !reflect.DeepEqual(got, tt.want) {
+			if got := p.GetResolvedFiles(tt.name); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/parser/terraform/terraform_test.go
+++ b/pkg/parser/terraform/terraform_test.go
@@ -161,9 +161,10 @@ func Test_Parentheses_Expr(t *testing.T) {
 	ctx := context.Background()
 	parser := NewDefault()
 	// Call Resolve first to set up input variables
-	_, err := parser.Resolve(ctx, []byte(parentheses), filepath.FromSlash("../../../test/fixtures/test-tf-parentheses/parentheses.tf"), false, 0)
+	fullPath := filepath.FromSlash("../../../test/fixtures/test-tf-parentheses/parentheses.tf")
+	_, err := parser.Resolve(ctx, []byte(parentheses), fullPath, false, 0)
 	require.NoError(t, err)
-	document, _, err := parser.Parse(ctx, "parentheses.tf", []byte(parentheses))
+	document, _, err := parser.Parse(ctx, fullPath, []byte(parentheses))
 	require.NoError(t, err)
 	require.Len(t, document, 1)
 	require.Contains(t, document[0], "data")

--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -22,6 +22,7 @@ import (
 
 // Parser defines a parser type
 type Parser struct {
+	ignore          *model.Ignore
 	resolvedFiles   map[string]map[string]model.ResolvedFile
 	resolvedFilesMu sync.RWMutex
 }
@@ -51,8 +52,7 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename strin
 
 // Parse parses yaml/yml file and returns it as a Document
 func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte) ([]model.Document, []int, error) {
-	// Create a context-local Ignore instance to avoid race conditions
-	model.NewIgnore.Reset()
+	p.ignore.Reset()
 	var documents []model.Document
 
 	// Parse all documents as nodes
@@ -68,7 +68,7 @@ func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte)
 			// Get the actual content (not the document wrapper)
 			contentNode := node.Content[0]
 			doc := model.Document{}
-			if err := doc.UnmarshalYAML(ctx, contentNode); err != nil {
+			if err := doc.UnmarshalYAML(ctx, contentNode, p.ignore); err != nil {
 				return nil, []int{}, errors.Wrap(err, "failed to unmarshal yaml")
 			}
 
@@ -82,7 +82,7 @@ func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte)
 		return nil, []int{}, errors.New("no documents found in yaml file")
 	}
 
-	linesToIgnore := model.NewIgnore.GetLines()
+	linesToIgnore := p.ignore.GetLines()
 
 	// UnmarshalYAML already adds line tracking, so we can use documents directly
 	return convertKeysToString(addExtraInfo(ctx, documents, filePath)), linesToIgnore, nil
@@ -235,5 +235,6 @@ func (p *Parser) Clone() any {
 	}
 	return &Parser{
 		resolvedFiles: p.resolvedFiles,
+		ignore:        &model.Ignore{},
 	}
 }

--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -48,7 +48,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 
 	resolved, resolvedFiles, err := p.Resolve(ctx, fileContent, filePath, resolveReferences, maxResolverDepth)
 	if err != nil {
-		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+		return nil, nil, nil, nil, err
 	}
 
 	ignore := &model.Ignore{}

--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -22,7 +22,7 @@ import (
 
 // Parser defines a parser type
 type Parser struct {
-	resolvedFiles   map[string]model.ResolvedFile
+	resolvedFiles   map[string]map[string]model.ResolvedFile
 	resolvedFilesMu sync.RWMutex
 }
 
@@ -35,7 +35,11 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename strin
 	resolved := res.Resolve(ctx, fileContent, filename, 0, maxResolverDepth, resolvedFilesCache, resolveReferences)
 
 	p.resolvedFilesMu.Lock()
-	p.resolvedFiles = res.ResolvedFiles
+	if p.resolvedFiles == nil {
+		p.resolvedFiles = make(map[string]map[string]model.ResolvedFile)
+	}
+
+	p.resolvedFiles[filename] = res.ResolvedFiles
 	p.resolvedFilesMu.Unlock()
 
 	if len(res.ResolvedFiles) == 0 {
@@ -213,10 +217,10 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 }
 
 // GetResolvedFiles returns resolved files
-func (p *Parser) GetResolvedFiles() map[string]model.ResolvedFile {
+func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
 	p.resolvedFilesMu.RLock()
 	defer p.resolvedFilesMu.RUnlock()
 	resolvedFiles := make(map[string]model.ResolvedFile, len(p.resolvedFiles))
-	maps.Copy(resolvedFiles, p.resolvedFiles)
+	maps.Copy(resolvedFiles, p.resolvedFiles[filename])
 	return resolvedFiles
 }

--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -3,13 +3,11 @@
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
  */
-package json
+package yaml
 
 import (
 	"bytes"
 	"context"
-	"maps"
-	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/utils"
@@ -22,40 +20,41 @@ import (
 
 // Parser defines a parser type
 type Parser struct {
-	resolvedFiles   map[string]map[string]model.ResolvedFile
-	resolvedFilesMu sync.RWMutex
 }
 
 // Resolve - replace or modifies in-memory content before parsing
 func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename string,
-	resolveReferences bool, maxResolverDepth int) ([]byte, error) {
+	resolveReferences bool, maxResolverDepth int) (resolved []byte, resolvedFiles map[string]model.ResolvedFile, err error) {
 	// Resolve files passed as arguments with file resolver (e.g. file://)
 	res := file.NewResolver(yaml.Unmarshal, yaml.Marshal, p.SupportedExtensions())
 	resolvedFilesCache := make(map[string]file.ResolvedFile)
-	resolved := res.Resolve(ctx, fileContent, filename, 0, maxResolverDepth, resolvedFilesCache, resolveReferences)
-
-	p.resolvedFilesMu.Lock()
-	if p.resolvedFiles == nil {
-		p.resolvedFiles = make(map[string]map[string]model.ResolvedFile)
-	}
-
-	p.resolvedFiles[filename] = res.ResolvedFiles
-	p.resolvedFilesMu.Unlock()
+	resolved = res.Resolve(ctx, fileContent, filename, 0, maxResolverDepth, resolvedFilesCache, resolveReferences)
 
 	if len(res.ResolvedFiles) == 0 {
-		return fileContent, nil
+		return fileContent, res.ResolvedFiles, nil
 	}
 
-	return resolved, nil
+	return resolved, res.ResolvedFiles, nil
 }
 
 // Parse parses yaml/yml file and returns it as a Document
-func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte) ([]model.Document, []int, error) {
+func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
+	resolveReferences bool, maxResolverDepth int) (
+	resolved []byte,
+	documents []model.Document,
+	ignoreLines []int,
+	resolvedFiles map[string]model.ResolvedFile,
+	error error) {
+
+	resolved, resolvedFiles, err := p.Resolve(ctx, fileContent, filePath, resolveReferences, maxResolverDepth)
+	if err != nil {
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, err
+	}
+
 	ignore := &model.Ignore{}
-	var documents []model.Document
 
 	// Parse all documents as nodes
-	dec := yaml.NewDecoder(bytes.NewReader(fileContent))
+	dec := yaml.NewDecoder(bytes.NewReader(resolved))
 	for {
 		var node yaml.Node
 		if err := dec.Decode(&node); err != nil {
@@ -68,7 +67,7 @@ func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte)
 			contentNode := node.Content[0]
 			doc := model.Document{}
 			if err := doc.UnmarshalYAML(ctx, contentNode, ignore); err != nil {
-				return nil, []int{}, errors.Wrap(err, "failed to unmarshal yaml")
+				return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(err, "failed to unmarshal yaml")
 			}
 
 			if len(doc) > 0 {
@@ -78,13 +77,13 @@ func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte)
 	}
 
 	if len(documents) == 0 {
-		return nil, []int{}, errors.New("no documents found in yaml file")
+		return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, errors.New("no documents found in yaml file")
 	}
 
 	linesToIgnore := ignore.GetLines()
 
 	// UnmarshalYAML already adds line tracking, so we can use documents directly
-	return convertKeysToString(addExtraInfo(ctx, documents, filePath)), linesToIgnore, nil
+	return resolved, convertKeysToString(addExtraInfo(ctx, documents, filePath)), linesToIgnore, resolvedFiles, nil
 }
 
 // convertKeysToString goes through every document to convert map[interface{}]interface{}
@@ -212,27 +211,4 @@ func (p *Parser) GetCommentToken() string {
 // StringifyContent converts original content into string formatted version
 func (p *Parser) StringifyContent(content []byte) (string, error) {
 	return string(content), nil
-}
-
-// GetResolvedFiles returns resolved files
-func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile {
-	p.resolvedFilesMu.RLock()
-	defer p.resolvedFilesMu.RUnlock()
-	resolvedFiles := make(map[string]model.ResolvedFile, len(p.resolvedFiles))
-	maps.Copy(resolvedFiles, p.resolvedFiles[filename])
-	return resolvedFiles
-}
-
-func (p *Parser) Clone() any {
-	p.resolvedFilesMu.RLock()
-	defer p.resolvedFilesMu.RUnlock()
-	resolvedFiles := make(map[string]map[string]model.ResolvedFile, len(p.resolvedFiles))
-	for filename, innerMap := range p.resolvedFiles {
-		innerCopy := make(map[string]model.ResolvedFile, len(innerMap))
-		maps.Copy(innerCopy, innerMap)
-		resolvedFiles[filename] = innerCopy
-	}
-	return &Parser{
-		resolvedFiles: p.resolvedFiles,
-	}
 }

--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -44,9 +44,8 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	documents []model.Document,
 	ignoreLines []int,
 	resolvedFiles map[string]model.ResolvedFile,
-	error error) {
-
-	resolved, resolvedFiles, err := p.Resolve(ctx, fileContent, filePath, resolveReferences, maxResolverDepth)
+	err error) {
+	resolved, resolvedFiles, err = p.Resolve(ctx, fileContent, filePath, resolveReferences, maxResolverDepth)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -52,7 +52,7 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename strin
 // Parse parses yaml/yml file and returns it as a Document
 func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte) ([]model.Document, []int, error) {
 	// Create a context-local Ignore instance to avoid race conditions
-	ctx = model.WithIgnore(ctx)
+	model.NewIgnore.Reset()
 	var documents []model.Document
 
 	// Parse all documents as nodes
@@ -82,8 +82,7 @@ func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte)
 		return nil, []int{}, errors.New("no documents found in yaml file")
 	}
 
-	ignore := ctx.Value(model.ContextKeyIgnore{}).(*model.Ignore)
-	linesToIgnore := ignore.GetLines()
+	linesToIgnore := model.NewIgnore.GetLines()
 
 	// UnmarshalYAML already adds line tracking, so we can use documents directly
 	return convertKeysToString(addExtraInfo(ctx, documents, filePath)), linesToIgnore, nil
@@ -223,4 +222,18 @@ func (p *Parser) GetResolvedFiles(filename string) map[string]model.ResolvedFile
 	resolvedFiles := make(map[string]model.ResolvedFile, len(p.resolvedFiles))
 	maps.Copy(resolvedFiles, p.resolvedFiles[filename])
 	return resolvedFiles
+}
+
+func (p *Parser) Clone() any {
+	p.resolvedFilesMu.RLock()
+	defer p.resolvedFilesMu.RUnlock()
+	resolvedFiles := make(map[string]map[string]model.ResolvedFile, len(p.resolvedFiles))
+	for filename, innerMap := range p.resolvedFiles {
+		innerCopy := make(map[string]model.ResolvedFile, len(innerMap))
+		maps.Copy(innerCopy, innerMap)
+		resolvedFiles[filename] = innerCopy
+	}
+	return &Parser{
+		resolvedFiles: p.resolvedFiles,
+	}
 }

--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -22,7 +22,6 @@ import (
 
 // Parser defines a parser type
 type Parser struct {
-	ignore          *model.Ignore
 	resolvedFiles   map[string]map[string]model.ResolvedFile
 	resolvedFilesMu sync.RWMutex
 }
@@ -52,7 +51,7 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename strin
 
 // Parse parses yaml/yml file and returns it as a Document
 func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte) ([]model.Document, []int, error) {
-	p.ignore.Reset()
+	ignore := &model.Ignore{}
 	var documents []model.Document
 
 	// Parse all documents as nodes
@@ -68,7 +67,7 @@ func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte)
 			// Get the actual content (not the document wrapper)
 			contentNode := node.Content[0]
 			doc := model.Document{}
-			if err := doc.UnmarshalYAML(ctx, contentNode, p.ignore); err != nil {
+			if err := doc.UnmarshalYAML(ctx, contentNode, ignore); err != nil {
 				return nil, []int{}, errors.Wrap(err, "failed to unmarshal yaml")
 			}
 
@@ -82,7 +81,7 @@ func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte)
 		return nil, []int{}, errors.New("no documents found in yaml file")
 	}
 
-	linesToIgnore := p.ignore.GetLines()
+	linesToIgnore := ignore.GetLines()
 
 	// UnmarshalYAML already adds line tracking, so we can use documents directly
 	return convertKeysToString(addExtraInfo(ctx, documents, filePath)), linesToIgnore, nil
@@ -235,6 +234,5 @@ func (p *Parser) Clone() any {
 	}
 	return &Parser{
 		resolvedFiles: p.resolvedFiles,
-		ignore:        &model.Ignore{},
 	}
 }

--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -47,7 +47,8 @@ func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename strin
 
 // Parse parses yaml/yml file and returns it as a Document
 func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte) ([]model.Document, []int, error) {
-	model.NewIgnore.Reset()
+	// Create a context-local Ignore instance to avoid race conditions
+	ctx = model.WithIgnore(ctx)
 	var documents []model.Document
 
 	// Parse all documents as nodes
@@ -77,7 +78,8 @@ func (p *Parser) Parse(ctx context.Context, filePath string, fileContent []byte)
 		return nil, []int{}, errors.New("no documents found in yaml file")
 	}
 
-	linesToIgnore := model.NewIgnore.GetLines()
+	ignore := ctx.Value(model.ContextKeyIgnore{}).(*model.Ignore)
+	linesToIgnore := ignore.GetLines()
 
 	// UnmarshalYAML already adds line tracking, so we can use documents directly
 	return convertKeysToString(addExtraInfo(ctx, documents, filePath)), linesToIgnore, nil

--- a/pkg/parser/yaml/parser_test.go
+++ b/pkg/parser/yaml/parser_test.go
@@ -3,14 +3,13 @@
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
  */
-package json
+package yaml
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -366,7 +365,7 @@ resources:
 	ctx := context.Background()
 	for idx, tt := range have {
 		t.Run(fmt.Sprintf("test_parse_case_%d", idx), func(t *testing.T) {
-			doc, linesToIgnore, err := p.Parse(ctx, "test.yaml", []byte(tt))
+			_, doc, linesToIgnore, _, err := p.Parse(ctx, []byte(tt), "test.yaml", true, 15)
 			if want[idx].wantErr {
 				require.Error(t, err)
 			} else {
@@ -396,7 +395,7 @@ func Test_Resolve(t *testing.T) {
 	`
 	parser := &Parser{}
 
-	resolved, err := parser.Resolve(ctx, []byte(have), "test.yaml", true, 15)
+	resolved, _, err := parser.Resolve(ctx, []byte(have), "test.yaml", true, 15)
 	require.NoError(t, err)
 	require.Equal(t, []byte(have), resolved)
 }
@@ -469,7 +468,7 @@ func TestModel_TestYamlParser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := Parser{}
-			got, _, err := parser.Parse(ctx, "", []byte(tt.sample))
+			_, got, _, _, err := parser.Parse(ctx, []byte(tt.sample), "", true, 15)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -530,47 +529,6 @@ martin2:
 			got, err := tt.fields.parser.StringifyContent(tt.args.content)
 			require.Equal(t, tt.wantErr, (err != nil))
 			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestParser_GetResolvedFiles(t *testing.T) {
-	type fields struct {
-		resolvedFiles map[string]map[string]model.ResolvedFile
-		filename      string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   map[string]model.ResolvedFile
-	}{
-		{
-			name: "test get resolved files",
-			fields: fields{
-				resolvedFiles: map[string]map[string]model.ResolvedFile{
-					"test": {
-						"test": {
-							Content: []byte(`1`),
-						},
-					},
-				},
-				filename: "test",
-			},
-			want: map[string]model.ResolvedFile{
-				"test": {
-					Content: []byte(`1`),
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{
-				resolvedFiles: tt.fields.resolvedFiles,
-			}
-			if got := p.GetResolvedFiles(tt.fields.filename); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
-			}
 		})
 	}
 }

--- a/pkg/parser/yaml/parser_test.go
+++ b/pkg/parser/yaml/parser_test.go
@@ -48,7 +48,9 @@ func TestParser_SupportedTypes(t *testing.T) {
 
 // TestParser_Parse tests the functions [Parse()] and all the methods called by them
 func TestParser_Parse(t *testing.T) { //nolint
-	p := &Parser{}
+	p := &Parser{
+		ignore: &model.Ignore{},
+	}
 	have := []string{`
 # dd-iac-scan ignore-block
 martin:
@@ -468,7 +470,9 @@ func TestModel_TestYamlParser(t *testing.T) {
 	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := Parser{}
+			parser := Parser{
+				ignore: &model.Ignore{},
+			}
 			got, _, err := parser.Parse(ctx, "", []byte(tt.sample))
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/parser/yaml/parser_test.go
+++ b/pkg/parser/yaml/parser_test.go
@@ -536,7 +536,8 @@ martin2:
 
 func TestParser_GetResolvedFiles(t *testing.T) {
 	type fields struct {
-		resolvedFiles map[string]model.ResolvedFile
+		resolvedFiles map[string]map[string]model.ResolvedFile
+		filename      string
 	}
 	tests := []struct {
 		name   string
@@ -546,11 +547,14 @@ func TestParser_GetResolvedFiles(t *testing.T) {
 		{
 			name: "test get resolved files",
 			fields: fields{
-				resolvedFiles: map[string]model.ResolvedFile{
+				resolvedFiles: map[string]map[string]model.ResolvedFile{
 					"test": {
-						Content: []byte(`1`),
+						"test": {
+							Content: []byte(`1`),
+						},
 					},
 				},
+				filename: "test",
 			},
 			want: map[string]model.ResolvedFile{
 				"test": {
@@ -564,7 +568,7 @@ func TestParser_GetResolvedFiles(t *testing.T) {
 			p := &Parser{
 				resolvedFiles: tt.fields.resolvedFiles,
 			}
-			if got := p.GetResolvedFiles(); !reflect.DeepEqual(got, tt.want) {
+			if got := p.GetResolvedFiles(tt.fields.filename); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetResolvedFiles() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/parser/yaml/parser_test.go
+++ b/pkg/parser/yaml/parser_test.go
@@ -48,9 +48,7 @@ func TestParser_SupportedTypes(t *testing.T) {
 
 // TestParser_Parse tests the functions [Parse()] and all the methods called by them
 func TestParser_Parse(t *testing.T) { //nolint
-	p := &Parser{
-		ignore: &model.Ignore{},
-	}
+	p := &Parser{}
 	have := []string{`
 # dd-iac-scan ignore-block
 martin:
@@ -470,9 +468,7 @@ func TestModel_TestYamlParser(t *testing.T) {
 	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := Parser{
-				ignore: &model.Ignore{},
-			}
+			parser := Parser{}
 			got, _, err := parser.Parse(ctx, "", []byte(tt.sample))
 			if tt.wantErr {
 				require.Error(t, err)


### PR DESCRIPTION
## Motivation

Two errors could be encountered:
- Scan crash because of a race condition
- Each different scan on the same folder could lead to a different number of vulnerabilities 

This is all because of shared variables across threads that should not be.

## Changes

- `ResolvedFiles` is now processed per file for Yaml and Json files
- Each thread ignores comments using its own ignore structure
- Terraform files' `InputVars` is now per `fullPath` to avoid issues on files having the same name


## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- [x] No errors on the ci
- [x] The scans on a single repo should always give the same number of findings


## Blast Radius

`iac-scanning`

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
