### PR TITLE
Implement hclsyntax.RelativeTraversalExpr in HCL parser

### DIFF
--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -54,6 +54,15 @@ func (e *Engine) ExpToString(ctx context.Context, expr hclsyntax.Expression) (st
 		return strings.Join(items, "."), nil
 	case *hclsyntax.IndexExpr:
 		return e.indexExprToString(ctx, t)
+	case *hclsyntax.RelativeTraversalExpr:
+		sourceStr, err := e.ExpToString(ctx, t.Source)
+		if err != nil {
+			return "", err
+		}
+		if len(t.Traversal) == 0 {
+			return sourceStr, nil
+		}
+		return sourceStr + relativeTraversalToString(t.Traversal), nil
 	}
 	err := fmt.Errorf("can't convert expression %T to string", expr)
 	contextLogger.Error().Msg(err.Error())
@@ -112,4 +121,27 @@ func evaluateScopeTraversalExpr(t hcl.Traversal) []string {
 		}
 	}
 	return items
+}
+
+// relativeTraversalToString formats a relative traversal (e.g. .attr or [0]) so that
+// TraverseAttr becomes ".name" and TraverseIndex becomes "[key]".
+func relativeTraversalToString(t hcl.Traversal) string {
+	var b strings.Builder
+	for _, step := range t {
+		switch s := step.(type) {
+		case hcl.TraverseAttr:
+			b.WriteString(".")
+			b.WriteString(s.Name)
+		case hcl.TraverseIndex:
+			b.WriteString("[")
+			switch s.Key.Type() {
+			case cty.Number:
+				b.WriteString(s.Key.AsBigFloat().String())
+			case cty.String:
+				b.WriteString(s.Key.AsString())
+			}
+			b.WriteString("]")
+		}
+	}
+	return b.String()
 }

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -91,6 +91,81 @@ func TestExpToString_IndexExpr(t *testing.T) {
 	})
 }
 
+func TestExpToString_RelativeTraversalExpr(t *testing.T) {
+	e := &Engine{}
+	ctx := context.Background()
+
+	t.Run("relative_traversal_after_index", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("list[var.i].name"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.RelativeTraversalExpr); !ok {
+			t.Fatalf("expected *hclsyntax.RelativeTraversalExpr, got %T", expr)
+		}
+
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "list[var.i].name"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("relative_traversal_multi_step", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("list[var.i].a.b"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.RelativeTraversalExpr); !ok {
+			t.Fatalf("expected *hclsyntax.RelativeTraversalExpr, got %T", expr)
+		}
+
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "list[var.i].a.b"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("relative_traversal_with_index_step", func(t *testing.T) {
+		// e.g. list[var.i][0] -> RelativeTraversalExpr(IndexExpr, [TraverseIndex(0)])
+		expr, diags := hclsyntax.ParseExpression([]byte("list[var.i][0]"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.RelativeTraversalExpr); !ok {
+			t.Fatalf("expected *hclsyntax.RelativeTraversalExpr, got %T", expr)
+		}
+
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "list[var.i][0]"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unsupported_source_propagates_error", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("tostring(var.x).attr"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.RelativeTraversalExpr); !ok {
+			t.Fatalf("expected *hclsyntax.RelativeTraversalExpr, got %T", expr)
+		}
+
+		_, err := e.ExpToString(ctx, expr)
+		if err == nil {
+			t.Error("ExpToString should return error for unsupported source type")
+		}
+	})
+}
+
 func TestExpToString_IndexExpr_edgeCases(t *testing.T) {
 	e := &Engine{}
 	ctx := context.Background()

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -47,6 +47,7 @@ const (
 	DefaultQueryDescriptionID   = "Undefined"
 	DefaultQueryURI             = "https://github.com/DataDog/datadog-iac-scanner/"
 	DefaultIssueType            = model.IssueTypeIncorrectValue
+	unresolvedPlaceholder       = "__UNRESOLVED__"
 
 	regoQuery = `result = data.Cx.CxPolicy`
 )
@@ -789,7 +790,7 @@ func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) { //nolint:go
 		for _, item := range e.Exprs {
 			v, err := expressionToAST(item)
 			if err != nil {
-				v = ast.String("__UNRESOLVED__")
+				v = ast.String(unresolvedPlaceholder)
 			}
 			terms = append(terms, ast.NewTerm(v))
 		}
@@ -809,7 +810,7 @@ func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) { //nolint:go
 			}
 			valVal, err := expressionToAST(item.ValueExpr)
 			if err != nil {
-				valVal = ast.String("__UNRESOLVED__")
+				valVal = ast.String(unresolvedPlaceholder)
 			}
 			obj.Insert(ast.NewTerm(strKey), ast.NewTerm(valVal))
 		}
@@ -822,11 +823,32 @@ func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) { //nolint:go
 		collV, err1 := expressionToAST(e.Collection)
 		keyV, err2 := expressionToAST(e.Key)
 		if err1 != nil || err2 != nil {
-			return ast.String("__UNRESOLVED__"), nil
+			return ast.String(unresolvedPlaceholder), nil
 		}
 		collStr := astValueToSimpleString(collV)
 		keyStr := astValueToSimpleString(keyV)
 		return ast.String(collStr + "[" + keyStr + "]"), nil
+
+	case *hclsyntax.RelativeTraversalExpr:
+		sourceVal, err := expressionToAST(e.Source)
+		if err != nil {
+			return ast.String(unresolvedPlaceholder), nil
+		}
+		sourceStr := astValueToSimpleString(sourceVal)
+		for _, step := range e.Traversal {
+			switch s := step.(type) {
+			case hcl.TraverseAttr:
+				sourceStr += "." + s.Name
+			case hcl.TraverseIndex:
+				switch s.Key.Type() {
+				case cty.Number:
+					sourceStr += "[" + s.Key.AsBigFloat().String() + "]"
+				case cty.String:
+					sourceStr += "[" + s.Key.AsString() + "]"
+				}
+			}
+		}
+		return ast.String(sourceStr), nil
 
 	default:
 		return ast.String("__UNSUPPORTED_EXPR__"), nil
@@ -835,7 +857,7 @@ func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) { //nolint:go
 
 func astValueToSimpleString(v ast.Value) string {
 	if v == nil {
-		return "__UNRESOLVED__"
+		return unresolvedPlaceholder
 	}
 	if s, ok := v.(ast.String); ok {
 		return string(s)

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/stretchr/testify/assert"
 
@@ -598,6 +600,72 @@ func (m *mockSource) GetQueryLibrary(ctx context.Context, platform string) (sour
 		LibraryCode:      embeddedLibrary,
 		LibraryInputData: "{}",
 	}, errGettingEmbeddedLibrary
+}
+
+func TestExpressionToAST_RelativeTraversalExpr(t *testing.T) {
+	t.Run("relative_traversal_after_index", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("list[var.i].name"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.RelativeTraversalExpr); !ok {
+			t.Fatalf("expected *hclsyntax.RelativeTraversalExpr, got %T", expr)
+		}
+
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+
+		got := val.String()
+		// IndexExpr resolves: Collection RootName="list", Key RootName="var" → "list[var]"
+		// Relative traversal appends ".name"
+		want := `"list[var].name"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("relative_traversal_multi_step", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("list[var.i].a.b"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.RelativeTraversalExpr); !ok {
+			t.Fatalf("expected *hclsyntax.RelativeTraversalExpr, got %T", expr)
+		}
+
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+
+		got := val.String()
+		want := `"list[var].a.b"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("unsupported_source_returns_gracefully", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("tostring(var.x).attr"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST should not return error, got: %v", err)
+		}
+
+		got := val.String()
+		// FunctionCallExpr is unsupported → source is "__UNSUPPORTED_EXPR__"
+		// Traversal appends ".attr"
+		want := `"__UNSUPPORTED_EXPR__.attr"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
 }
 
 func TestInspector_checkComment(t *testing.T) {

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -51,7 +51,10 @@ type converter struct {
 	inputVarsMu sync.RWMutex
 }
 
-const kicsLinesKey = "_kics_"
+const (
+	kicsLinesKey          = "_kics_"
+	ctyFriendlyNameString = "string"
+)
 
 func (c *converter) rangeSource(r hcl.Range) string {
 	return string(c.bytes[r.Start.Byte:r.End.Byte])
@@ -225,6 +228,17 @@ func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, e
 		return c.objectConsExpr(value)
 	case *hclsyntax.FunctionCallExpr:
 		return c.evalFunction(expr)
+	case *hclsyntax.RelativeTraversalExpr:
+		c.inputVarsMu.RLock()
+		expressionEvaluated, _ := expr.Value(&hcl.EvalContext{
+			Variables: c.inputVars,
+			Functions: functions.TerraformFuncs,
+		})
+		c.inputVarsMu.RUnlock()
+		if !checkDynamicKnownTypes(expressionEvaluated) {
+			return ctyjson.SimpleJSONValue{Value: expressionEvaluated}, nil
+		}
+		return c.wrapExpr(expr)
 	case *hclsyntax.ConditionalExpr:
 		c.inputVarsMu.RLock()
 		expressionEvaluated, err := expr.Value(&hcl.EvalContext{
@@ -352,6 +366,17 @@ func (c *converter) convertStringPart(expr hclsyntax.Expression) (string, error)
 		return c.convertTemplateFor(v.Tuple.(*hclsyntax.ForExpr))
 	case *hclsyntax.ParenthesesExpr:
 		return c.convertStringPart(v.Expression)
+	case *hclsyntax.RelativeTraversalExpr:
+		c.inputVarsMu.RLock()
+		valueConverted, _ := expr.Value(&hcl.EvalContext{
+			Variables: c.inputVars,
+			Functions: functions.TerraformFuncs,
+		})
+		c.inputVarsMu.RUnlock()
+		if valueConverted.Type().FriendlyName() == ctyFriendlyNameString {
+			return valueConverted.AsString(), nil
+		}
+		return c.wrapExpr(expr)
 	default:
 		// try to evaluate with variables
 		c.inputVarsMu.RLock()
@@ -359,7 +384,7 @@ func (c *converter) convertStringPart(expr hclsyntax.Expression) (string, error)
 			Variables: c.inputVars,
 		})
 		c.inputVarsMu.RUnlock()
-		if valueConverted.Type().FriendlyName() == "string" {
+		if valueConverted.Type().FriendlyName() == ctyFriendlyNameString {
 			return valueConverted.AsString(), nil
 		}
 		// treating as an embedded expression

--- a/pkg/parser/terraform/converter/default_test.go
+++ b/pkg/parser/terraform/converter/default_test.go
@@ -310,6 +310,81 @@ block "label_one" {
 	}
 }
 
+func TestRelativeTraversalExpr(t *testing.T) {
+	t.Run("jsondecode_with_traversal_resolves", func(t *testing.T) {
+		input := `
+block "test" {
+  host = jsondecode(var.json_data).host
+}
+`
+		ctx := context.Background()
+		file, diags := hclsyntax.ParseConfig([]byte(input), "testFileName", hcl.Pos{Byte: 0, Line: 1, Column: 1})
+		require.False(t, diags.HasErrors(), "parse error: %v", diags)
+
+		body, err := DefaultConverted(ctx, file, VariableMap{
+			"var": cty.ObjectVal(map[string]cty.Value{
+				"json_data": cty.StringVal(`{"host":"db.example.com"}`),
+			}),
+		})
+		require.NoError(t, err)
+
+		blockDoc := body["block"].(model.Document)["test"].(model.Document)
+		gotValue := ""
+		if token, ok := blockDoc["host"].(ctyjson.SimpleJSONValue); ok {
+			gotValue = token.Value.AsString()
+		} else if s, ok := blockDoc["host"].(string); ok {
+			gotValue = s
+		}
+		require.Equal(t, "db.example.com", gotValue)
+	})
+
+	t.Run("relative_traversal_without_vars_wraps_expression", func(t *testing.T) {
+		input := `
+block "test" {
+  host = jsondecode(var.json_data).host
+}
+`
+		ctx := context.Background()
+		file, diags := hclsyntax.ParseConfig([]byte(input), "testFileName", hcl.Pos{Byte: 0, Line: 1, Column: 1})
+		require.False(t, diags.HasErrors(), "parse error: %v", diags)
+
+		body, err := DefaultConverted(ctx, file, VariableMap{})
+		require.NoError(t, err)
+
+		blockDoc := body["block"].(model.Document)["test"].(model.Document)
+		gotValue := fmt.Sprintf("%v", blockDoc["host"])
+		// Without variables, the expression can't be fully evaluated and gets wrapped
+		require.Contains(t, gotValue, "jsondecode")
+	})
+
+	t.Run("relative_traversal_in_template", func(t *testing.T) {
+		input := `
+block "test" {
+  host = "prefix-${jsondecode(var.json_data).host}"
+}
+`
+		ctx := context.Background()
+		file, diags := hclsyntax.ParseConfig([]byte(input), "testFileName", hcl.Pos{Byte: 0, Line: 1, Column: 1})
+		require.False(t, diags.HasErrors(), "parse error: %v", diags)
+
+		body, err := DefaultConverted(ctx, file, VariableMap{
+			"var": cty.ObjectVal(map[string]cty.Value{
+				"json_data": cty.StringVal(`{"host":"db.example.com"}`),
+			}),
+		})
+		require.NoError(t, err)
+
+		blockDoc := body["block"].(model.Document)["test"].(model.Document)
+		gotValue := ""
+		if token, ok := blockDoc["host"].(ctyjson.SimpleJSONValue); ok {
+			gotValue = token.Value.AsString()
+		} else if s, ok := blockDoc["host"].(string); ok {
+			gotValue = s
+		}
+		require.Equal(t, "prefix-db.example.com", gotValue)
+	})
+}
+
 func TestEvalFunction(t *testing.T) { //nolint
 	type funcTest struct {
 		name    string

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -62,11 +62,14 @@ func isTerraformFile(filePath string) bool {
 	return strings.HasSuffix(strings.ToLower(filePath), ".tf")
 }
 
-const stringLocal = "local"
-const stringUnknown = "unknown"
-const stringPublic = "public"
-const stringRegistry = "registry"
-const stringPrivate = "private"
+const (
+	stringLocal           = "local"
+	stringUnknown         = "unknown"
+	stringPublic          = "public"
+	stringRegistry        = "registry"
+	stringPrivate         = "private"
+	unresolvedPlaceholder = "__UNRESOLVED__"
+)
 
 // nolint:gocyclo
 // ParseTerraformModules parses HCL content and extracts module source/version, resolving locals/variables if possible.
@@ -229,6 +232,8 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 				}
 			case *hclsyntax.ScopeTraversalExpr:
 				result.WriteString(resolveScopeTraversal(p, locals, vars))
+			case *hclsyntax.RelativeTraversalExpr:
+				result.WriteString(resolveExpr(p, locals, vars))
 			default:
 				result.WriteString("${UNSUPPORTED_TEMPLATE_EXPR}")
 			}
@@ -241,15 +246,43 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 	case *hclsyntax.FunctionCallExpr:
 		return resolveFunctionCall(e, locals, vars)
 
+	case *hclsyntax.RelativeTraversalExpr:
+		return resolveRelativeTraversalExpr(e, locals, vars)
+
 	default:
-		val, diag := expr.Value(nil)
-		if !diag.HasErrors() &&
-			val.Type().Equals(cty.String) &&
-			!val.IsNull() {
-			return val.AsString()
-		}
-		return "__UNRESOLVED__"
+		return resolveExprDefault(expr)
 	}
+}
+
+func resolveRelativeTraversalExpr(e *hclsyntax.RelativeTraversalExpr, locals, vars map[string]string) string {
+	sourceStr := resolveExpr(e.Source, locals, vars)
+	if strings.HasPrefix(sourceStr, "__") {
+		return unresolvedPlaceholder
+	}
+	for _, step := range e.Traversal {
+		switch s := step.(type) {
+		case hcl.TraverseAttr:
+			sourceStr += "." + s.Name
+		case hcl.TraverseIndex:
+			switch s.Key.Type() {
+			case cty.Number:
+				sourceStr += "[" + s.Key.AsBigFloat().String() + "]"
+			case cty.String:
+				sourceStr += "[" + s.Key.AsString() + "]"
+			}
+		}
+	}
+	return sourceStr
+}
+
+func resolveExprDefault(expr hclsyntax.Expression) string {
+	val, diag := expr.Value(nil)
+	if !diag.HasErrors() &&
+		val.Type().Equals(cty.String) &&
+		!val.IsNull() {
+		return val.AsString()
+	}
+	return unresolvedPlaceholder
 }
 
 func resolveScopeTraversal(expr *hclsyntax.ScopeTraversalExpr, locals, vars map[string]string) string {

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/require"
 )
 
@@ -401,6 +403,99 @@ func TestDetectModuleSourceTypeWithScope(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveExpr_RelativeTraversalExpr(t *testing.T) {
+	t.Run("function_call_source_with_traversal", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression(
+			[]byte(`format("%s", "value").suffix`),
+			"test.hcl", hcl.Pos{Line: 1, Column: 1},
+		)
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.RelativeTraversalExpr); !ok {
+			t.Fatalf("expected *hclsyntax.RelativeTraversalExpr, got %T", expr)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{})
+		want := "value.suffix"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+
+	t.Run("unresolved_source_short_circuits", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression(
+			[]byte("tostring(var.x).attr"),
+			"test.hcl", hcl.Pos{Line: 1, Column: 1},
+		)
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.RelativeTraversalExpr); !ok {
+			t.Fatalf("expected *hclsyntax.RelativeTraversalExpr, got %T", expr)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{})
+		if result != "__UNRESOLVED__" {
+			t.Errorf("resolveExpr = %q, want %q", result, "__UNRESOLVED__")
+		}
+	})
+
+	t.Run("in_template_expression", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression(
+			[]byte(`"prefix-${format("%s", "val").suffix}"`),
+			"test.hcl", hcl.Pos{Line: 1, Column: 1},
+		)
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{})
+		want := "prefix-val.suffix"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+
+	t.Run("multi_step_traversal", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression(
+			[]byte(`format("%s", "base").a.b`),
+			"test.hcl", hcl.Pos{Line: 1, Column: 1},
+		)
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.RelativeTraversalExpr); !ok {
+			t.Fatalf("expected *hclsyntax.RelativeTraversalExpr, got %T", expr)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{})
+		want := "base.a.b"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+
+	t.Run("traversal_with_index_step", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression(
+			[]byte(`format("%s", "base")[0].name`),
+			"test.hcl", hcl.Pos{Line: 1, Column: 1},
+		)
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.RelativeTraversalExpr); !ok {
+			t.Fatalf("expected *hclsyntax.RelativeTraversalExpr, got %T", expr)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{})
+		want := "base[0].name"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
 }
 
 func TestGetProviderFromResourceType(t *testing.T) {


### PR DESCRIPTION
## Motivation

Logs indicate that `hclsyntax.RelativeTraversalExpr` is not implemented in the parser, causing expressions like `jsondecode(var.config).host` or `list[var.i].name` to be unhandled across multiple dispatch sites.

## Changes

- Added `RelativeTraversalExpr` case to `ExpToString` in `pkg/builder/engine/engine.go`
- Added `RelativeTraversalExpr` case to `expressionToAST` in `pkg/engine/inspector.go`
- Added `RelativeTraversalExpr` case to `convertExpression` and `convertStringPart` in `pkg/parser/terraform/converter/default.go`
- Added `RelativeTraversalExpr` case to `resolveExpr` in `pkg/parser/terraform/modules/modules.go`
- Added 14 test cases covering happy paths, error propagation, template integration, and index traversal steps

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run the test suites for the modified packages:
```
go test ./pkg/builder/engine/ ./pkg/engine/ ./pkg/parser/terraform/converter/ ./pkg/parser/terraform/modules/ -v -count=1
```
Verify all `RelativeTraversalExpr` tests pass and no regressions in existing tests.

## Blast Radius

DataDog IaC Scanner only, HCL expression parsing/evaluation

## Additional Notes

I submit this contribution under the Apache-2.0 license.