### PR TITLE
Implement hclsyntax.FunctionCallExpr in HCL parser

### DIFF
--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -26,47 +26,72 @@ func (e *Engine) ExpToString(ctx context.Context, expr hclsyntax.Expression) (st
 	contextLogger := logger.FromContext(ctx)
 	switch t := expr.(type) {
 	case *hclsyntax.LiteralValueExpr:
-		s, err := ctyConvert.Convert(t.Val, cty.String)
-		if err != nil {
-			return "", err
-		}
-		return s.AsString(), nil
+		return e.expToStringLiteralValue(t)
 	case *hclsyntax.TemplateExpr:
-		if t.IsStringLiteral() {
-			v, err := t.Value(nil)
-			if err != nil {
-				return "", err
-			}
-			return v.AsString(), nil
-		}
-		builderString, err := e.buildString(ctx, t.Parts)
-		if err != nil {
-			return "", err
-		}
-
-		return builderString, nil
+		return e.expToStringTemplateExpr(ctx, t)
 	case *hclsyntax.TemplateWrapExpr:
 		return e.ExpToString(ctx, t.Wrapped)
 	case *hclsyntax.ObjectConsKeyExpr:
 		return e.ExpToString(ctx, t.Wrapped)
 	case *hclsyntax.ScopeTraversalExpr:
-		items := evaluateScopeTraversalExpr(t.Traversal)
-		return strings.Join(items, "."), nil
+		return e.expToStringScopeTraversal(t), nil
 	case *hclsyntax.IndexExpr:
 		return e.indexExprToString(ctx, t)
 	case *hclsyntax.RelativeTraversalExpr:
-		sourceStr, err := e.ExpToString(ctx, t.Source)
-		if err != nil {
-			return "", err
-		}
-		if len(t.Traversal) == 0 {
-			return sourceStr, nil
-		}
-		return sourceStr + relativeTraversalToString(t.Traversal), nil
+		return e.expToStringRelativeTraversal(ctx, t)
+	case *hclsyntax.FunctionCallExpr:
+		return e.expToStringFunctionCall(ctx, t)
 	}
 	err := fmt.Errorf("can't convert expression %T to string", expr)
 	contextLogger.Error().Msg(err.Error())
 	return "", err
+}
+
+func (e *Engine) expToStringLiteralValue(t *hclsyntax.LiteralValueExpr) (string, error) {
+	s, err := ctyConvert.Convert(t.Val, cty.String)
+	if err != nil {
+		return "", err
+	}
+	return s.AsString(), nil
+}
+
+func (e *Engine) expToStringTemplateExpr(ctx context.Context, t *hclsyntax.TemplateExpr) (string, error) {
+	if t.IsStringLiteral() {
+		v, err := t.Value(nil)
+		if err != nil {
+			return "", err
+		}
+		return v.AsString(), nil
+	}
+	return e.buildString(ctx, t.Parts)
+}
+
+func (e *Engine) expToStringScopeTraversal(t *hclsyntax.ScopeTraversalExpr) string {
+	items := evaluateScopeTraversalExpr(t.Traversal)
+	return strings.Join(items, ".")
+}
+
+func (e *Engine) expToStringRelativeTraversal(ctx context.Context, t *hclsyntax.RelativeTraversalExpr) (string, error) {
+	sourceStr, err := e.ExpToString(ctx, t.Source)
+	if err != nil {
+		return "", err
+	}
+	if len(t.Traversal) == 0 {
+		return sourceStr, nil
+	}
+	return sourceStr + relativeTraversalToString(t.Traversal), nil
+}
+
+func (e *Engine) expToStringFunctionCall(ctx context.Context, t *hclsyntax.FunctionCallExpr) (string, error) {
+	args := make([]string, 0, len(t.Args))
+	for _, arg := range t.Args {
+		s, err := e.ExpToString(ctx, arg)
+		if err != nil {
+			return "", err
+		}
+		args = append(args, s)
+	}
+	return t.Name + "(" + strings.Join(args, ", ") + ")", nil
 }
 
 func (e *Engine) buildString(ctx context.Context, parts []hclsyntax.Expression) (string, error) {

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -150,7 +150,7 @@ func TestExpToString_RelativeTraversalExpr(t *testing.T) {
 		}
 	})
 
-	t.Run("unsupported_source_propagates_error", func(t *testing.T) {
+	t.Run("function_call_source_now_resolves", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte("tostring(var.x).attr"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
 		if diags.HasErrors() {
 			t.Fatalf("parse failed: %v", diags)
@@ -159,9 +159,104 @@ func TestExpToString_RelativeTraversalExpr(t *testing.T) {
 			t.Fatalf("expected *hclsyntax.RelativeTraversalExpr, got %T", expr)
 		}
 
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "tostring(var.x).attr"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestExpToString_FunctionCallExpr(t *testing.T) {
+	e := &Engine{}
+	ctx := context.Background()
+
+	t.Run("simple_function_call", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`upper("hello")`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.FunctionCallExpr); !ok {
+			t.Fatalf("expected *hclsyntax.FunctionCallExpr, got %T", expr)
+		}
+
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "upper(hello)"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("function_call_with_multiple_args", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`format("%s-%s", var.a, var.b)`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.FunctionCallExpr); !ok {
+			t.Fatalf("expected *hclsyntax.FunctionCallExpr, got %T", expr)
+		}
+
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "format(%s-%s, var.a, var.b)"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("function_call_no_args", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`timestamp()`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.FunctionCallExpr); !ok {
+			t.Fatalf("expected *hclsyntax.FunctionCallExpr, got %T", expr)
+		}
+
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "timestamp()"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("nested_function_calls", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`upper(format("%s", var.x))`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.FunctionCallExpr); !ok {
+			t.Fatalf("expected *hclsyntax.FunctionCallExpr, got %T", expr)
+		}
+
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "upper(format(%s, var.x))"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unsupported_arg_propagates_error", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`upper(true ? "a" : "b")`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.FunctionCallExpr); !ok {
+			t.Fatalf("expected *hclsyntax.FunctionCallExpr, got %T", expr)
+		}
+
 		_, err := e.ExpToString(ctx, expr)
 		if err == nil {
-			t.Error("ExpToString should return error for unsupported source type")
+			t.Error("ExpToString should return error for unsupported argument type")
 		}
 	})
 }

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -850,6 +850,18 @@ func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) { //nolint:go
 		}
 		return ast.String(sourceStr), nil
 
+	case *hclsyntax.FunctionCallExpr:
+		args := make([]string, 0, len(e.Args))
+		for _, arg := range e.Args {
+			v, err := expressionToAST(arg)
+			if err != nil {
+				args = append(args, unresolvedPlaceholder)
+				continue
+			}
+			args = append(args, astValueToSimpleString(v))
+		}
+		return ast.String(e.Name + "(" + strings.Join(args, ", ") + ")"), nil
+
 	default:
 		return ast.String("__UNSUPPORTED_EXPR__"), nil
 	}

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -760,111 +760,125 @@ func parseJsonencodeHCL(ctx context.Context, input string) (ast.Value, error) {
 }
 
 // expressionToAST converts HCL expression to OPA ast.Value
-func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) { //nolint:gocyclo
+func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) {
 	switch e := expr.(type) {
 	case *hclsyntax.LiteralValueExpr:
 		return literalToAst(e)
-
 	case *hclsyntax.TemplateExpr:
-		result := ""
-		for _, part := range e.Parts {
-			switch p := part.(type) {
-			case *hclsyntax.LiteralValueExpr:
-				if p.Val.Type().Equals(cty.String) {
-					result += p.Val.AsString()
-				}
-			default:
-				result += "${...}"
-			}
-		}
-		return ast.String(result), nil
-
+		return expressionToASTTemplateExpr(e), nil
 	case *hclsyntax.TemplateWrapExpr:
 		return expressionToAST(e.Wrapped)
-
 	case *hclsyntax.ScopeTraversalExpr:
 		return ast.String(e.Traversal.RootName()), nil
-
 	case *hclsyntax.TupleConsExpr:
-		terms := []*ast.Term{}
-		for _, item := range e.Exprs {
-			v, err := expressionToAST(item)
-			if err != nil {
-				v = ast.String(unresolvedPlaceholder)
-			}
-			terms = append(terms, ast.NewTerm(v))
-		}
-		return ast.NewArray(terms...), nil
-
+		return expressionToASTTupleConsExpr(e), nil
 	case *hclsyntax.ObjectConsExpr:
-		obj := ast.NewObject()
-		for _, item := range e.Items {
-			keyExpr := normalizeKeyExpr(item.KeyExpr)
-			keyVal, err := expressionToAST(keyExpr)
-			if err != nil {
-				continue
-			}
-			strKey, ok := keyVal.(ast.String)
-			if !ok {
-				continue
-			}
-			valVal, err := expressionToAST(item.ValueExpr)
-			if err != nil {
-				valVal = ast.String(unresolvedPlaceholder)
-			}
-			obj.Insert(ast.NewTerm(strKey), ast.NewTerm(valVal))
-		}
-		return obj, nil
-
+		return expressionToASTObjectConsExpr(e), nil
 	case *hclsyntax.ObjectConsKeyExpr:
 		return expressionToAST(e.UnwrapExpression())
-
 	case *hclsyntax.IndexExpr:
-		collV, err1 := expressionToAST(e.Collection)
-		keyV, err2 := expressionToAST(e.Key)
-		if err1 != nil || err2 != nil {
-			return ast.String(unresolvedPlaceholder), nil
-		}
-		collStr := astValueToSimpleString(collV)
-		keyStr := astValueToSimpleString(keyV)
-		return ast.String(collStr + "[" + keyStr + "]"), nil
-
+		return expressionToASTIndexExpr(e), nil
 	case *hclsyntax.RelativeTraversalExpr:
-		sourceVal, err := expressionToAST(e.Source)
-		if err != nil {
-			return ast.String(unresolvedPlaceholder), nil
-		}
-		sourceStr := astValueToSimpleString(sourceVal)
-		for _, step := range e.Traversal {
-			switch s := step.(type) {
-			case hcl.TraverseAttr:
-				sourceStr += "." + s.Name
-			case hcl.TraverseIndex:
-				switch s.Key.Type() {
-				case cty.Number:
-					sourceStr += "[" + s.Key.AsBigFloat().String() + "]"
-				case cty.String:
-					sourceStr += "[" + s.Key.AsString() + "]"
-				}
-			}
-		}
-		return ast.String(sourceStr), nil
-
+		return expressionToASTRelativeTraversalExpr(e), nil
 	case *hclsyntax.FunctionCallExpr:
-		args := make([]string, 0, len(e.Args))
-		for _, arg := range e.Args {
-			v, err := expressionToAST(arg)
-			if err != nil {
-				args = append(args, unresolvedPlaceholder)
-				continue
-			}
-			args = append(args, astValueToSimpleString(v))
-		}
-		return ast.String(e.Name + "(" + strings.Join(args, ", ") + ")"), nil
-
+		return expressionToASTFunctionCallExpr(e), nil
 	default:
 		return ast.String("__UNSUPPORTED_EXPR__"), nil
 	}
+}
+
+func expressionToASTTemplateExpr(e *hclsyntax.TemplateExpr) ast.Value {
+	result := ""
+	for _, part := range e.Parts {
+		switch p := part.(type) {
+		case *hclsyntax.LiteralValueExpr:
+			if p.Val.Type().Equals(cty.String) {
+				result += p.Val.AsString()
+			}
+		default:
+			result += "${...}"
+		}
+	}
+	return ast.String(result)
+}
+
+func expressionToASTTupleConsExpr(e *hclsyntax.TupleConsExpr) ast.Value {
+	terms := make([]*ast.Term, 0, len(e.Exprs))
+	for _, item := range e.Exprs {
+		v, err := expressionToAST(item)
+		if err != nil {
+			v = ast.String(unresolvedPlaceholder)
+		}
+		terms = append(terms, ast.NewTerm(v))
+	}
+	return ast.NewArray(terms...)
+}
+
+func expressionToASTObjectConsExpr(e *hclsyntax.ObjectConsExpr) ast.Value {
+	obj := ast.NewObject()
+	for _, item := range e.Items {
+		keyExpr := normalizeKeyExpr(item.KeyExpr)
+		keyVal, err := expressionToAST(keyExpr)
+		if err != nil {
+			continue
+		}
+		strKey, ok := keyVal.(ast.String)
+		if !ok {
+			continue
+		}
+		valVal, err := expressionToAST(item.ValueExpr)
+		if err != nil {
+			valVal = ast.String(unresolvedPlaceholder)
+		}
+		obj.Insert(ast.NewTerm(strKey), ast.NewTerm(valVal))
+	}
+	return obj
+}
+
+func expressionToASTIndexExpr(e *hclsyntax.IndexExpr) ast.Value {
+	collV, err1 := expressionToAST(e.Collection)
+	keyV, err2 := expressionToAST(e.Key)
+	if err1 != nil || err2 != nil {
+		return ast.String(unresolvedPlaceholder)
+	}
+	collStr := astValueToSimpleString(collV)
+	keyStr := astValueToSimpleString(keyV)
+	return ast.String(collStr + "[" + keyStr + "]")
+}
+
+func expressionToASTRelativeTraversalExpr(e *hclsyntax.RelativeTraversalExpr) ast.Value {
+	sourceVal, err := expressionToAST(e.Source)
+	if err != nil {
+		return ast.String(unresolvedPlaceholder)
+	}
+	sourceStr := astValueToSimpleString(sourceVal)
+	for _, step := range e.Traversal {
+		switch s := step.(type) {
+		case hcl.TraverseAttr:
+			sourceStr += "." + s.Name
+		case hcl.TraverseIndex:
+			switch s.Key.Type() {
+			case cty.Number:
+				sourceStr += "[" + s.Key.AsBigFloat().String() + "]"
+			case cty.String:
+				sourceStr += "[" + s.Key.AsString() + "]"
+			}
+		}
+	}
+	return ast.String(sourceStr)
+}
+
+func expressionToASTFunctionCallExpr(e *hclsyntax.FunctionCallExpr) ast.Value {
+	args := make([]string, 0, len(e.Args))
+	for _, arg := range e.Args {
+		v, err := expressionToAST(arg)
+		if err != nil {
+			args = append(args, unresolvedPlaceholder)
+			continue
+		}
+		args = append(args, astValueToSimpleString(v))
+	}
+	return ast.String(e.Name + "(" + strings.Join(args, ", ") + ")")
 }
 
 func astValueToSimpleString(v ast.Value) string {

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -474,7 +474,7 @@ func TestShouldSkipFile(t *testing.T) {
 func TestInspector_DecodeQueryResults(t *testing.T) {
 
 	//context
-	contextToUSe := context.Background()
+	contextToUse := context.Background()
 
 	//build inspector
 	c := newInspectorInstance(t, []string{}, true)
@@ -492,7 +492,7 @@ func TestInspector_DecodeQueryResults(t *testing.T) {
 		{
 			name: "should_not_fail_when_timeout",
 			args: args{
-				queryContext: newQueryContext(contextToUSe),
+				queryContext: newQueryContext(contextToUse),
 				regoResult:   newResultset(),
 				timeDuration: "0s",
 			},
@@ -505,7 +505,7 @@ func TestInspector_DecodeQueryResults(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			//create a context with 0 second to timeout
 			timeoutDuration, _ := time.ParseDuration(tt.args.timeDuration)
-			myCtxTimeOut, cancel := context.WithTimeout(contextToUSe, timeoutDuration)
+			myCtxTimeOut, cancel := context.WithTimeout(contextToUse, timeoutDuration)
 			defer cancel()
 			result, err := c.DecodeQueryResults(ctx, &tt.args.queryContext, myCtxTimeOut, tt.args.regoResult, 57)
 			assert.Nil(t, err, "Error not as expected")

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -505,7 +505,8 @@ func TestInspector_DecodeQueryResults(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			//create a context with 0 second to timeout
 			timeoutDuration, _ := time.ParseDuration(tt.args.timeDuration)
-			myCtxTimeOut, _ := context.WithTimeout(contextToUSe, timeoutDuration)
+			myCtxTimeOut, cancel := context.WithTimeout(contextToUSe, timeoutDuration)
+			defer cancel()
 			result, err := c.DecodeQueryResults(ctx, &tt.args.queryContext, myCtxTimeOut, tt.args.regoResult, 57)
 			assert.Nil(t, err, "Error not as expected")
 			assert.Equal(t, 0, len(result), "Array size is not as expected")
@@ -647,7 +648,7 @@ func TestExpressionToAST_RelativeTraversalExpr(t *testing.T) {
 		}
 	})
 
-	t.Run("unsupported_source_returns_gracefully", func(t *testing.T) {
+	t.Run("function_call_source_now_resolves", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte("tostring(var.x).attr"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
 		if diags.HasErrors() {
 			t.Fatalf("parse failed: %v", diags)
@@ -659,9 +660,74 @@ func TestExpressionToAST_RelativeTraversalExpr(t *testing.T) {
 		}
 
 		got := val.String()
-		// FunctionCallExpr is unsupported → source is "__UNSUPPORTED_EXPR__"
-		// Traversal appends ".attr"
-		want := `"__UNSUPPORTED_EXPR__.attr"`
+		// FunctionCallExpr now resolves: tostring(var) where "var" is the root name
+		want := `"tostring(var).attr"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+}
+
+func TestExpressionToAST_FunctionCallExpr(t *testing.T) {
+	t.Run("simple_function_call", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`upper("hello")`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.FunctionCallExpr); !ok {
+			t.Fatalf("expected *hclsyntax.FunctionCallExpr, got %T", expr)
+		}
+
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+
+		got := val.String()
+		want := `"upper(hello)"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("function_call_with_multiple_args", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`format("%s", var.name)`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.FunctionCallExpr); !ok {
+			t.Fatalf("expected *hclsyntax.FunctionCallExpr, got %T", expr)
+		}
+
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+
+		got := val.String()
+		// ScopeTraversalExpr returns root name only
+		want := `"format(%s, var)"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("function_call_no_args", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`timestamp()`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.FunctionCallExpr); !ok {
+			t.Fatalf("expected *hclsyntax.FunctionCallExpr, got %T", expr)
+		}
+
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+
+		got := val.String()
+		want := `"timestamp()"`
 		if got != want {
 			t.Errorf("expressionToAST = %s, want %s", got, want)
 		}

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -366,7 +366,7 @@ func (c *converter) convertStringPart(expr hclsyntax.Expression) (string, error)
 		return c.convertTemplateFor(v.Tuple.(*hclsyntax.ForExpr))
 	case *hclsyntax.ParenthesesExpr:
 		return c.convertStringPart(v.Expression)
-	case *hclsyntax.RelativeTraversalExpr:
+	case *hclsyntax.RelativeTraversalExpr, *hclsyntax.FunctionCallExpr:
 		c.inputVarsMu.RLock()
 		valueConverted, _ := expr.Value(&hcl.EvalContext{
 			Variables: c.inputVars,

--- a/pkg/parser/terraform/converter/default_test.go
+++ b/pkg/parser/terraform/converter/default_test.go
@@ -385,6 +385,94 @@ block "test" {
 	})
 }
 
+func TestFunctionCallExprInStringPart(t *testing.T) {
+	t.Run("function_call_in_template_resolves", func(t *testing.T) {
+		input := `
+block "test" {
+  name = "prefix-${upper("hello")}"
+}
+`
+		ctx := context.Background()
+		file, diags := hclsyntax.ParseConfig([]byte(input), "testFileName", hcl.Pos{Byte: 0, Line: 1, Column: 1})
+		require.False(t, diags.HasErrors(), "parse error: %v", diags)
+
+		body, err := DefaultConverted(ctx, file, VariableMap{})
+		require.NoError(t, err)
+
+		blockDoc := body["block"].(model.Document)["test"].(model.Document)
+		gotValue := ""
+		if token, ok := blockDoc["name"].(ctyjson.SimpleJSONValue); ok {
+			gotValue = token.Value.AsString()
+		} else if s, ok := blockDoc["name"].(string); ok {
+			gotValue = s
+		}
+		require.Equal(t, "prefix-HELLO", gotValue)
+	})
+
+	t.Run("function_call_in_template_with_vars", func(t *testing.T) {
+		input := `
+block "test" {
+  name = "prefix-${upper(var.env)}"
+}
+`
+		ctx := context.Background()
+		file, diags := hclsyntax.ParseConfig([]byte(input), "testFileName", hcl.Pos{Byte: 0, Line: 1, Column: 1})
+		require.False(t, diags.HasErrors(), "parse error: %v", diags)
+
+		body, err := DefaultConverted(ctx, file, VariableMap{
+			"var": cty.ObjectVal(map[string]cty.Value{
+				"env": cty.StringVal("production"),
+			}),
+		})
+		require.NoError(t, err)
+
+		blockDoc := body["block"].(model.Document)["test"].(model.Document)
+		gotValue := ""
+		if token, ok := blockDoc["name"].(ctyjson.SimpleJSONValue); ok {
+			gotValue = token.Value.AsString()
+		} else if s, ok := blockDoc["name"].(string); ok {
+			gotValue = s
+		}
+		require.Equal(t, "prefix-PRODUCTION", gotValue)
+	})
+
+	t.Run("function_call_in_template_without_vars_wraps", func(t *testing.T) {
+		input := `
+block "test" {
+  name = "prefix-${upper(var.env)}"
+}
+`
+		ctx := context.Background()
+		file, diags := hclsyntax.ParseConfig([]byte(input), "testFileName", hcl.Pos{Byte: 0, Line: 1, Column: 1})
+		require.False(t, diags.HasErrors(), "parse error: %v", diags)
+
+		body, err := DefaultConverted(ctx, file, VariableMap{})
+		require.NoError(t, err)
+
+		blockDoc := body["block"].(model.Document)["test"].(model.Document)
+		gotValue := fmt.Sprintf("%v", blockDoc["name"])
+		require.Contains(t, gotValue, "upper")
+	})
+
+	t.Run("function_call_returning_non_string_wraps", func(t *testing.T) {
+		input := `
+block "test" {
+  name = "prefix-${length("hello")}"
+}
+`
+		ctx := context.Background()
+		file, diags := hclsyntax.ParseConfig([]byte(input), "testFileName", hcl.Pos{Byte: 0, Line: 1, Column: 1})
+		require.False(t, diags.HasErrors(), "parse error: %v", diags)
+
+		body, err := DefaultConverted(ctx, file, VariableMap{})
+		require.NoError(t, err)
+
+		blockDoc := body["block"].(model.Document)["test"].(model.Document)
+		gotValue := fmt.Sprintf("%v", blockDoc["name"])
+		require.Contains(t, gotValue, "length")
+	})
+}
+
 func TestEvalFunction(t *testing.T) { //nolint
 	type funcTest struct {
 		name    string

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -234,6 +234,8 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 				result.WriteString(resolveScopeTraversal(p, locals, vars))
 			case *hclsyntax.RelativeTraversalExpr:
 				result.WriteString(resolveExpr(p, locals, vars))
+			case *hclsyntax.FunctionCallExpr:
+				result.WriteString(resolveExpr(p, locals, vars))
 			default:
 				result.WriteString("${UNSUPPORTED_TEMPLATE_EXPR}")
 			}

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -232,9 +232,7 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 				}
 			case *hclsyntax.ScopeTraversalExpr:
 				result.WriteString(resolveScopeTraversal(p, locals, vars))
-			case *hclsyntax.RelativeTraversalExpr:
-				result.WriteString(resolveExpr(p, locals, vars))
-			case *hclsyntax.FunctionCallExpr:
+			case *hclsyntax.RelativeTraversalExpr, *hclsyntax.FunctionCallExpr:
 				result.WriteString(resolveExpr(p, locals, vars))
 			default:
 				result.WriteString("${UNSUPPORTED_TEMPLATE_EXPR}")

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -498,6 +498,100 @@ func TestResolveExpr_RelativeTraversalExpr(t *testing.T) {
 	})
 }
 
+func TestResolveExpr_FunctionCallExpr(t *testing.T) {
+	t.Run("format_function_resolves", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression(
+			[]byte(`format("%s/%s", var.base, var.path)`),
+			"test.hcl", hcl.Pos{Line: 1, Column: 1},
+		)
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.FunctionCallExpr); !ok {
+			t.Fatalf("expected *hclsyntax.FunctionCallExpr, got %T", expr)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{
+			"base": "./modules",
+			"path": "vpc",
+		})
+		want := "./modules/vpc"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+
+	t.Run("join_function_resolves", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression(
+			[]byte(`join("-", ["a", "b", "c"])`),
+			"test.hcl", hcl.Pos{Line: 1, Column: 1},
+		)
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.FunctionCallExpr); !ok {
+			t.Fatalf("expected *hclsyntax.FunctionCallExpr, got %T", expr)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{})
+		want := "a-b-c"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+
+	t.Run("unsupported_function_returns_sentinel", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression(
+			[]byte(`tostring(var.x)`),
+			"test.hcl", hcl.Pos{Line: 1, Column: 1},
+		)
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.FunctionCallExpr); !ok {
+			t.Fatalf("expected *hclsyntax.FunctionCallExpr, got %T", expr)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{})
+		want := "__UNSUPPORTED_FUNC_tostring__"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+
+	t.Run("function_call_in_template_expression", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression(
+			[]byte(`"prefix-${format("%s", "value")}"`),
+			"test.hcl", hcl.Pos{Line: 1, Column: 1},
+		)
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{})
+		want := "prefix-value"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+
+	t.Run("unsupported_function_in_template_returns_sentinel", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression(
+			[]byte(`"prefix-${tostring(var.x)}"`),
+			"test.hcl", hcl.Pos{Line: 1, Column: 1},
+		)
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{})
+		want := "prefix-__UNSUPPORTED_FUNC_tostring__"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+}
+
 func TestGetProviderFromResourceType(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
> [!TIP]
> This PR is best reviewed commit by commit.

## Motivation

Logs showed that `hclsyntax.FunctionCallExpr` was not handled in several HCL expression dispatch sites, so expressions like `format("%s", var.x)` or `upper(var.env)` in templates and rule evaluation were failing or falling back to unsupported placeholders. This PR adds explicit handling wherever it was missing so that function calls are supported consistently across the parser.

## Changes

- `ExpToString` in engine.go : handle `FunctionCallExpr` by recursing on each argument and returning `funcname(arg1, arg2, ...)`.
- `expressionToAST` in inspector.go: handle `FunctionCallExpr` by recursing on arguments and producing a string representation for Rego 
- `convertStringPart` in default.go: evaluate `FunctionCallExpr` with `functions.TerraformFuncs` in the eval context (previously evaluated without functions, so function calls in templates failed)
- `resolveExpr` template sub-switch in modules.go: add explicit `FunctionCallExpr` case delegating to `resolveExpr` (and thus `resolveFunctionCall`).
- Remove cyclomatic exception from expressionToAST
- Added tests for these

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run unit tests for `pkg/builder/engine`, `pkg/engine`, `pkg/parser/terraform/converter`, and `pkg/parser/terraform/modules`. Optionally scan Terraform configs that use function calls in attributes or templates (e.g. `format(...)`, `upper(...)`, `join(...)`) and confirm no regressions and that values resolve as expected.

## Blast Radius

DataDog IaC Scanner only: HCL parsing and rule evaluation for Terraform

I submit this contribution under the Apache-2.0 license.