### PR TITLE
Create an experimental flag for parallel file parsing

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -73,6 +73,12 @@ var scanAction = &cli.Command{
 			Usage:   "a list of platform types to scan",
 			Value:   GetSupportedPlatforms(),
 		},
+		&cli.BoolFlag{
+			Name:   "x-parallelparsing",
+			Hidden: true,
+			Usage:  "(experimental, will be removed soon) parse files in parallel",
+			Value:  false,
+		},
 	},
 	Action: runScan,
 }
@@ -128,7 +134,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		ExcludePlatform:   []string{""},
 		PayloadPath:       payloadPath,
 		SCIInfo:           model.SCIInfo{RunType: "ci", RepositoryCommitInfo: *repoInfo},
-		FlagEvaluator:     featureflags.NewLocalEvaluator(),
+		FlagEvaluator:     getFeatureFlagEvaluator(c),
 		ExcludeCategories: config.ExcludeCategories,
 		ExcludeQueries:    append(c.StringSlice("exclude-queries"), config.ExcludeQueries...),
 		ExcludeResults:    config.ExcludeResults,
@@ -334,4 +340,10 @@ func selectPlatforms(platforms []string) []string {
 		}
 	}
 	return out
+}
+
+func getFeatureFlagEvaluator(c *cli.Command) featureflags.FlagEvaluator {
+	overrides := map[string]bool{}
+	overrides[featureflags.IaCEnableKicsParallelFileParsing] = c.Bool("x-parallelparsing")
+	return featureflags.NewLocalEvaluatorWithOverrides(overrides)
 }


### PR DESCRIPTION
## Motivation

We want to control whether this option is enabled, and we want it disabled by default.

## Changes

Added a flag and a function to generate feature flag overrides depending on the flags.

## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Tell the reviewer how they can make sure the PR is indeed working as intended. Tell them what they should be looking for.

## Blast Radius

What services will this change impact. Is it only DataDog IaC Scanner, internal services, the documentation or anything else?

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
