### PR TITLE
HCL expression handling: consistency and refactor

### DIFF
--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -44,43 +44,11 @@ func (e *Engine) ExpToString(ctx context.Context, expr hclsyntax.Expression) (st
 	case *hclsyntax.FunctionCallExpr:
 		return e.expToStringFunctionCall(ctx, t)
 	case *hclsyntax.ConditionalExpr:
-		condStr, err := e.ExpToString(ctx, t.Condition)
-		if err != nil {
-			return "", err
-		}
-		trueStr, err := e.ExpToString(ctx, t.TrueResult)
-		if err != nil {
-			return "", err
-		}
-		falseStr, err := e.ExpToString(ctx, t.FalseResult)
-		if err != nil {
-			return "", err
-		}
-		return condStr + " ? " + trueStr + " : " + falseStr, nil
+		return e.expToStringConditionalExpr(ctx, t)
 	case *hclsyntax.TupleConsExpr:
-		parts := make([]string, 0, len(t.Exprs))
-		for _, ex := range t.Exprs {
-			s, err := e.ExpToString(ctx, ex)
-			if err != nil {
-				return "", err
-			}
-			parts = append(parts, s)
-		}
-		return "[" + strings.Join(parts, ", ") + "]", nil
+		return e.expToStringTupleConsExpr(ctx, t)
 	case *hclsyntax.ObjectConsExpr:
-		parts := make([]string, 0, len(t.Items))
-		for _, item := range t.Items {
-			keyStr, err := e.ExpToString(ctx, item.KeyExpr)
-			if err != nil {
-				return "", err
-			}
-			valStr, err := e.ExpToString(ctx, item.ValueExpr)
-			if err != nil {
-				return "", err
-			}
-			parts = append(parts, keyStr+": "+valStr)
-		}
-		return "{" + strings.Join(parts, ", ") + "}", nil
+		return e.expToStringObjectConsExpr(ctx, t)
 	}
 	err := fmt.Errorf("can't convert expression %T to string", expr)
 	contextLogger.Error().Msg(err.Error())
@@ -132,6 +100,50 @@ func (e *Engine) expToStringFunctionCall(ctx context.Context, t *hclsyntax.Funct
 		args = append(args, s)
 	}
 	return t.Name + "(" + strings.Join(args, ", ") + ")", nil
+}
+
+func (e *Engine) expToStringConditionalExpr(ctx context.Context, t *hclsyntax.ConditionalExpr) (string, error) {
+	condStr, err := e.ExpToString(ctx, t.Condition)
+	if err != nil {
+		return "", err
+	}
+	trueStr, err := e.ExpToString(ctx, t.TrueResult)
+	if err != nil {
+		return "", err
+	}
+	falseStr, err := e.ExpToString(ctx, t.FalseResult)
+	if err != nil {
+		return "", err
+	}
+	return condStr + " ? " + trueStr + " : " + falseStr, nil
+}
+
+func (e *Engine) expToStringTupleConsExpr(ctx context.Context, t *hclsyntax.TupleConsExpr) (string, error) {
+	parts := make([]string, 0, len(t.Exprs))
+	for _, ex := range t.Exprs {
+		s, err := e.ExpToString(ctx, ex)
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, s)
+	}
+	return "[" + strings.Join(parts, ", ") + "]", nil
+}
+
+func (e *Engine) expToStringObjectConsExpr(ctx context.Context, t *hclsyntax.ObjectConsExpr) (string, error) {
+	parts := make([]string, 0, len(t.Items))
+	for _, item := range t.Items {
+		keyStr, err := e.ExpToString(ctx, item.KeyExpr)
+		if err != nil {
+			return "", err
+		}
+		valStr, err := e.ExpToString(ctx, item.ValueExpr)
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, keyStr+": "+valStr)
+	}
+	return "{" + strings.Join(parts, ", ") + "}", nil
 }
 
 func (e *Engine) buildString(ctx context.Context, parts []hclsyntax.Expression) (string, error) {

--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -31,6 +31,8 @@ func (e *Engine) ExpToString(ctx context.Context, expr hclsyntax.Expression) (st
 		return e.expToStringTemplateExpr(ctx, t)
 	case *hclsyntax.TemplateWrapExpr:
 		return e.ExpToString(ctx, t.Wrapped)
+	case *hclsyntax.ParenthesesExpr:
+		return e.ExpToString(ctx, t.Expression)
 	case *hclsyntax.ObjectConsKeyExpr:
 		return e.ExpToString(ctx, t.Wrapped)
 	case *hclsyntax.ScopeTraversalExpr:

--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -43,6 +43,20 @@ func (e *Engine) ExpToString(ctx context.Context, expr hclsyntax.Expression) (st
 		return e.expToStringRelativeTraversal(ctx, t)
 	case *hclsyntax.FunctionCallExpr:
 		return e.expToStringFunctionCall(ctx, t)
+	case *hclsyntax.ConditionalExpr:
+		condStr, err := e.ExpToString(ctx, t.Condition)
+		if err != nil {
+			return "", err
+		}
+		trueStr, err := e.ExpToString(ctx, t.TrueResult)
+		if err != nil {
+			return "", err
+		}
+		falseStr, err := e.ExpToString(ctx, t.FalseResult)
+		if err != nil {
+			return "", err
+		}
+		return condStr + " ? " + trueStr + " : " + falseStr, nil
 	}
 	err := fmt.Errorf("can't convert expression %T to string", expr)
 	contextLogger.Error().Msg(err.Error())

--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -57,6 +57,30 @@ func (e *Engine) ExpToString(ctx context.Context, expr hclsyntax.Expression) (st
 			return "", err
 		}
 		return condStr + " ? " + trueStr + " : " + falseStr, nil
+	case *hclsyntax.TupleConsExpr:
+		parts := make([]string, 0, len(t.Exprs))
+		for _, ex := range t.Exprs {
+			s, err := e.ExpToString(ctx, ex)
+			if err != nil {
+				return "", err
+			}
+			parts = append(parts, s)
+		}
+		return "[" + strings.Join(parts, ", ") + "]", nil
+	case *hclsyntax.ObjectConsExpr:
+		parts := make([]string, 0, len(t.Items))
+		for _, item := range t.Items {
+			keyStr, err := e.ExpToString(ctx, item.KeyExpr)
+			if err != nil {
+				return "", err
+			}
+			valStr, err := e.ExpToString(ctx, item.ValueExpr)
+			if err != nil {
+				return "", err
+			}
+			parts = append(parts, keyStr+": "+valStr)
+		}
+		return "{" + strings.Join(parts, ", ") + "}", nil
 	}
 	err := fmt.Errorf("can't convert expression %T to string", expr)
 	contextLogger.Error().Msg(err.Error())

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -247,11 +247,11 @@ func TestExpToString_ObjectConsExpr(t *testing.T) {
 		t.Fatalf("ExpToString error: %v", err)
 	}
 	// Key order may vary; check it contains both key-value pairs
-	if !strings.Contains(got, "a: var.x") && !strings.Contains(got, "var.x") {
-		t.Errorf("ExpToString = %q, expected to contain a and var.x", got)
+	if !strings.Contains(got, "a: var.x") {
+		t.Errorf("ExpToString = %q, expected to contain a: var.x", got)
 	}
-	if !strings.Contains(got, "b: y") && !strings.Contains(got, "y") {
-		t.Errorf("ExpToString = %q, expected to contain b and y", got)
+	if !strings.Contains(got, "b: y") {
+		t.Errorf("ExpToString = %q, expected to contain b: y", got)
 	}
 	if !strings.HasPrefix(got, "{") || !strings.HasSuffix(got, "}") {
 		t.Errorf("ExpToString = %q, expected to be wrapped in {}", got)

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -207,6 +207,30 @@ func TestExpToString_ParenthesesExpr(t *testing.T) {
 	})
 }
 
+func TestExpToString_ConditionalExpr(t *testing.T) {
+	e := &Engine{}
+	ctx := context.Background()
+
+	t.Run("returns_condition_true_false_string", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`var.enabled ? "yes" : "no"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.ConditionalExpr); !ok {
+			t.Fatalf("expected *hclsyntax.ConditionalExpr, got %T", expr)
+		}
+
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		want := "var.enabled ? yes : no"
+		if got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+}
+
 func TestExpToString_FunctionCallExpr(t *testing.T) {
 	e := &Engine{}
 	ctx := context.Background()
@@ -284,7 +308,8 @@ func TestExpToString_FunctionCallExpr(t *testing.T) {
 	})
 
 	t.Run("unsupported_arg_propagates_error", func(t *testing.T) {
-		expr, diags := hclsyntax.ParseExpression([]byte(`upper(true ? "a" : "b")`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		// Use tuple as argument; TupleConsExpr is not handled by ExpToString
+		expr, diags := hclsyntax.ParseExpression([]byte(`upper([1, 2])`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
 		if diags.HasErrors() {
 			t.Fatalf("parse failed: %v", diags)
 		}

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -169,6 +169,44 @@ func TestExpToString_RelativeTraversalExpr(t *testing.T) {
 	})
 }
 
+func TestExpToString_ParenthesesExpr(t *testing.T) {
+	e := &Engine{}
+	ctx := context.Background()
+
+	t.Run("unwraps_to_inner_expression", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("(var.x)"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.ParenthesesExpr); !ok {
+			t.Fatalf("expected *hclsyntax.ParenthesesExpr, got %T", expr)
+		}
+
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "var.x"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("nested_parentheses_unwrap", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("((var.a))"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "var.a"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+}
+
 func TestExpToString_FunctionCallExpr(t *testing.T) {
 	e := &Engine{}
 	ctx := context.Background()

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -8,6 +8,7 @@ package engine
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -207,6 +208,56 @@ func TestExpToString_ParenthesesExpr(t *testing.T) {
 	})
 }
 
+func TestExpToString_TupleConsExpr(t *testing.T) {
+	e := &Engine{}
+	ctx := context.Background()
+
+	expr, diags := hclsyntax.ParseExpression([]byte(`[var.a, "b", 1]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse failed: %v", diags)
+	}
+	if _, ok := expr.(*hclsyntax.TupleConsExpr); !ok {
+		t.Fatalf("expected *hclsyntax.TupleConsExpr, got %T", expr)
+	}
+
+	got, err := e.ExpToString(ctx, expr)
+	if err != nil {
+		t.Fatalf("ExpToString error: %v", err)
+	}
+	want := "[var.a, b, 1]"
+	if got != want {
+		t.Errorf("ExpToString = %q, want %q", got, want)
+	}
+}
+
+func TestExpToString_ObjectConsExpr(t *testing.T) {
+	e := &Engine{}
+	ctx := context.Background()
+
+	expr, diags := hclsyntax.ParseExpression([]byte(`{a = var.x, b = "y"}`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse failed: %v", diags)
+	}
+	if _, ok := expr.(*hclsyntax.ObjectConsExpr); !ok {
+		t.Fatalf("expected *hclsyntax.ObjectConsExpr, got %T", expr)
+	}
+
+	got, err := e.ExpToString(ctx, expr)
+	if err != nil {
+		t.Fatalf("ExpToString error: %v", err)
+	}
+	// Key order may vary; check it contains both key-value pairs
+	if !strings.Contains(got, "a: var.x") && !strings.Contains(got, "var.x") {
+		t.Errorf("ExpToString = %q, expected to contain a and var.x", got)
+	}
+	if !strings.Contains(got, "b: y") && !strings.Contains(got, "y") {
+		t.Errorf("ExpToString = %q, expected to contain b and y", got)
+	}
+	if !strings.HasPrefix(got, "{") || !strings.HasSuffix(got, "}") {
+		t.Errorf("ExpToString = %q, expected to be wrapped in {}", got)
+	}
+}
+
 func TestExpToString_ConditionalExpr(t *testing.T) {
 	e := &Engine{}
 	ctx := context.Background()
@@ -308,8 +359,8 @@ func TestExpToString_FunctionCallExpr(t *testing.T) {
 	})
 
 	t.Run("unsupported_arg_propagates_error", func(t *testing.T) {
-		// Use tuple as argument; TupleConsExpr is not handled by ExpToString
-		expr, diags := hclsyntax.ParseExpression([]byte(`upper([1, 2])`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		// Use for expression as argument; ForExpr is not handled by ExpToString
+		expr, diags := hclsyntax.ParseExpression([]byte(`upper([for i in [1,2] : i])`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
 		if diags.HasErrors() {
 			t.Fatalf("parse failed: %v", diags)
 		}

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -768,6 +768,8 @@ func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) {
 		return expressionToASTTemplateExpr(e), nil
 	case *hclsyntax.TemplateWrapExpr:
 		return expressionToAST(e.Wrapped)
+	case *hclsyntax.ParenthesesExpr:
+		return expressionToAST(e.Expression)
 	case *hclsyntax.ScopeTraversalExpr:
 		return ast.String(e.Traversal.RootName()), nil
 	case *hclsyntax.TupleConsExpr:

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -784,6 +784,11 @@ func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) {
 		return expressionToASTRelativeTraversalExpr(e), nil
 	case *hclsyntax.FunctionCallExpr:
 		return expressionToASTFunctionCallExpr(e), nil
+	case *hclsyntax.ConditionalExpr:
+		condV, _ := expressionToAST(e.Condition)
+		trueV, _ := expressionToAST(e.TrueResult)
+		falseV, _ := expressionToAST(e.FalseResult)
+		return ast.String(astValueToSimpleString(condV) + " ? " + astValueToSimpleString(trueV) + " : " + astValueToSimpleString(falseV)), nil
 	default:
 		return ast.String("__UNSUPPORTED_EXPR__"), nil
 	}

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -785,10 +785,7 @@ func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) {
 	case *hclsyntax.FunctionCallExpr:
 		return expressionToASTFunctionCallExpr(e), nil
 	case *hclsyntax.ConditionalExpr:
-		condV, _ := expressionToAST(e.Condition)
-		trueV, _ := expressionToAST(e.TrueResult)
-		falseV, _ := expressionToAST(e.FalseResult)
-		return ast.String(astValueToSimpleString(condV) + " ? " + astValueToSimpleString(trueV) + " : " + astValueToSimpleString(falseV)), nil
+		return expressionToASTConditionalExpr(e), nil
 	default:
 		return ast.String("__UNSUPPORTED_EXPR__"), nil
 	}
@@ -873,6 +870,13 @@ func expressionToASTRelativeTraversalExpr(e *hclsyntax.RelativeTraversalExpr) as
 		}
 	}
 	return ast.String(sourceStr)
+}
+
+func expressionToASTConditionalExpr(e *hclsyntax.ConditionalExpr) ast.Value {
+	condV, _ := expressionToAST(e.Condition)
+	trueV, _ := expressionToAST(e.TrueResult)
+	falseV, _ := expressionToAST(e.FalseResult)
+	return ast.String(astValueToSimpleString(condV) + " ? " + astValueToSimpleString(trueV) + " : " + astValueToSimpleString(falseV))
 }
 
 func expressionToASTFunctionCallExpr(e *hclsyntax.FunctionCallExpr) ast.Value {

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -707,6 +707,28 @@ func TestExpressionToAST_ParenthesesExpr(t *testing.T) {
 	})
 }
 
+func TestExpressionToAST_ConditionalExpr(t *testing.T) {
+	t.Run("returns_condition_true_false_string", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`true ? "a" : "b"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.ConditionalExpr); !ok {
+			t.Fatalf("expected *hclsyntax.ConditionalExpr, got %T", expr)
+		}
+
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		got := val.String()
+		want := `"true ? a : b"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+}
+
 func TestExpressionToAST_FunctionCallExpr(t *testing.T) {
 	t.Run("simple_function_call", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte(`upper("hello")`), "test.hcl", hcl.Pos{Line: 1, Column: 1})

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -668,6 +668,45 @@ func TestExpressionToAST_RelativeTraversalExpr(t *testing.T) {
 	})
 }
 
+func TestExpressionToAST_ParenthesesExpr(t *testing.T) {
+	t.Run("unwraps_to_inner_expression", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("(var.x)"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.ParenthesesExpr); !ok {
+			t.Fatalf("expected *hclsyntax.ParenthesesExpr, got %T", expr)
+		}
+
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		got := val.String()
+		want := `"var"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("nested_parentheses_unwrap", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("((1))"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		got := val.String()
+		want := `1`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+}
+
 func TestExpressionToAST_FunctionCallExpr(t *testing.T) {
 	t.Run("simple_function_call", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte(`upper("hello")`), "test.hcl", hcl.Pos{Line: 1, Column: 1})

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -228,28 +228,8 @@ func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, e
 		return c.objectConsExpr(value)
 	case *hclsyntax.FunctionCallExpr:
 		return c.evalFunction(expr)
-	case *hclsyntax.RelativeTraversalExpr:
-		c.inputVarsMu.RLock()
-		expressionEvaluated, _ := expr.Value(&hcl.EvalContext{
-			Variables: c.inputVars,
-			Functions: functions.TerraformFuncs,
-		})
-		c.inputVarsMu.RUnlock()
-		if !checkDynamicKnownTypes(expressionEvaluated) {
-			return ctyjson.SimpleJSONValue{Value: expressionEvaluated}, nil
-		}
-		return c.wrapExpr(expr)
-	case *hclsyntax.IndexExpr:
-		c.inputVarsMu.RLock()
-		expressionEvaluated, _ := expr.Value(&hcl.EvalContext{
-			Variables: c.inputVars,
-			Functions: functions.TerraformFuncs,
-		})
-		c.inputVarsMu.RUnlock()
-		if !checkDynamicKnownTypes(expressionEvaluated) {
-			return ctyjson.SimpleJSONValue{Value: expressionEvaluated}, nil
-		}
-		return c.wrapExpr(expr)
+	case *hclsyntax.RelativeTraversalExpr, *hclsyntax.IndexExpr:
+		return c.tryEvalExpression(expr)
 	case *hclsyntax.ConditionalExpr:
 		c.inputVarsMu.RLock()
 		expressionEvaluated, err := expr.Value(&hcl.EvalContext{
@@ -262,17 +242,7 @@ func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, e
 		}
 		return ctyjson.SimpleJSONValue{Value: expressionEvaluated}, nil
 	default:
-		// try to evaluate with variables and functions
-		c.inputVarsMu.RLock()
-		valueConverted, _ := expr.Value(&hcl.EvalContext{
-			Variables: c.inputVars,
-			Functions: functions.TerraformFuncs,
-		})
-		c.inputVarsMu.RUnlock()
-		if !checkDynamicKnownTypes(valueConverted) {
-			return ctyjson.SimpleJSONValue{Value: valueConverted}, nil
-		}
-		return c.wrapExpr(expr)
+		return c.tryEvalExpression(expr)
 	}
 }
 
@@ -377,30 +347,10 @@ func (c *converter) convertStringPart(expr hclsyntax.Expression) (string, error)
 		return c.convertTemplateFor(v.Tuple.(*hclsyntax.ForExpr))
 	case *hclsyntax.ParenthesesExpr:
 		return c.convertStringPart(v.Expression)
-	case *hclsyntax.IndexExpr:
-		c.inputVarsMu.RLock()
-		valueConverted, _ := expr.Value(&hcl.EvalContext{
-			Variables: c.inputVars,
-			Functions: functions.TerraformFuncs,
-		})
-		c.inputVarsMu.RUnlock()
-		if valueConverted.Type().FriendlyName() == ctyFriendlyNameString {
-			return valueConverted.AsString(), nil
-		}
-		return c.wrapExpr(expr)
-	case *hclsyntax.RelativeTraversalExpr, *hclsyntax.FunctionCallExpr:
-		c.inputVarsMu.RLock()
-		valueConverted, _ := expr.Value(&hcl.EvalContext{
-			Variables: c.inputVars,
-			Functions: functions.TerraformFuncs,
-		})
-		c.inputVarsMu.RUnlock()
-		if valueConverted.Type().FriendlyName() == ctyFriendlyNameString {
-			return valueConverted.AsString(), nil
-		}
-		return c.wrapExpr(expr)
+	case *hclsyntax.IndexExpr, *hclsyntax.RelativeTraversalExpr, *hclsyntax.FunctionCallExpr:
+		return c.tryEvalToString(expr)
 	default:
-		// try to evaluate with variables
+		// try to evaluate with variables only (no functions)
 		c.inputVarsMu.RLock()
 		valueConverted, _ := expr.Value(&hcl.EvalContext{
 			Variables: c.inputVars,
@@ -409,7 +359,6 @@ func (c *converter) convertStringPart(expr hclsyntax.Expression) (string, error)
 		if valueConverted.Type().FriendlyName() == ctyFriendlyNameString {
 			return valueConverted.AsString(), nil
 		}
-		// treating as an embedded expression
 		return c.wrapExpr(expr)
 	}
 }
@@ -465,6 +414,32 @@ func (c *converter) convertTemplateFor(expr *hclsyntax.ForExpr) (string, error) 
 	builder.Reset()
 	builder = nil
 	return s, nil
+}
+
+func (c *converter) tryEvalExpression(expr hclsyntax.Expression) (interface{}, error) {
+	c.inputVarsMu.RLock()
+	val, _ := expr.Value(&hcl.EvalContext{
+		Variables: c.inputVars,
+		Functions: functions.TerraformFuncs,
+	})
+	c.inputVarsMu.RUnlock()
+	if !checkDynamicKnownTypes(val) {
+		return ctyjson.SimpleJSONValue{Value: val}, nil
+	}
+	return c.wrapExpr(expr)
+}
+
+func (c *converter) tryEvalToString(expr hclsyntax.Expression) (string, error) {
+	c.inputVarsMu.RLock()
+	val, _ := expr.Value(&hcl.EvalContext{
+		Variables: c.inputVars,
+		Functions: functions.TerraformFuncs,
+	})
+	c.inputVarsMu.RUnlock()
+	if val.Type().FriendlyName() == ctyFriendlyNameString {
+		return val.AsString(), nil
+	}
+	return c.wrapExpr(expr)
 }
 
 func (c *converter) wrapExpr(expr hclsyntax.Expression) (string, error) {

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -239,6 +239,17 @@ func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, e
 			return ctyjson.SimpleJSONValue{Value: expressionEvaluated}, nil
 		}
 		return c.wrapExpr(expr)
+	case *hclsyntax.IndexExpr:
+		c.inputVarsMu.RLock()
+		expressionEvaluated, _ := expr.Value(&hcl.EvalContext{
+			Variables: c.inputVars,
+			Functions: functions.TerraformFuncs,
+		})
+		c.inputVarsMu.RUnlock()
+		if !checkDynamicKnownTypes(expressionEvaluated) {
+			return ctyjson.SimpleJSONValue{Value: expressionEvaluated}, nil
+		}
+		return c.wrapExpr(expr)
 	case *hclsyntax.ConditionalExpr:
 		c.inputVarsMu.RLock()
 		expressionEvaluated, err := expr.Value(&hcl.EvalContext{
@@ -366,6 +377,17 @@ func (c *converter) convertStringPart(expr hclsyntax.Expression) (string, error)
 		return c.convertTemplateFor(v.Tuple.(*hclsyntax.ForExpr))
 	case *hclsyntax.ParenthesesExpr:
 		return c.convertStringPart(v.Expression)
+	case *hclsyntax.IndexExpr:
+		c.inputVarsMu.RLock()
+		valueConverted, _ := expr.Value(&hcl.EvalContext{
+			Variables: c.inputVars,
+			Functions: functions.TerraformFuncs,
+		})
+		c.inputVarsMu.RUnlock()
+		if valueConverted.Type().FriendlyName() == ctyFriendlyNameString {
+			return valueConverted.AsString(), nil
+		}
+		return c.wrapExpr(expr)
 	case *hclsyntax.RelativeTraversalExpr, *hclsyntax.FunctionCallExpr:
 		c.inputVarsMu.RLock()
 		valueConverted, _ := expr.Value(&hcl.EvalContext{

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -249,6 +249,20 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 				result.WriteString("[")
 				result.WriteString(resolveExpr(p.Key, locals, vars))
 				result.WriteString("]")
+			case *hclsyntax.TupleConsExpr:
+				parts := make([]string, 0, len(p.Exprs))
+				for _, ex := range p.Exprs {
+					parts = append(parts, resolveExpr(ex, locals, vars))
+				}
+				result.WriteString("[" + strings.Join(parts, ", ") + "]")
+			case *hclsyntax.ObjectConsExpr:
+				parts := make([]string, 0, len(p.Items))
+				for _, item := range p.Items {
+					keyStr := resolveExpr(item.KeyExpr, locals, vars)
+					valStr := resolveExpr(item.ValueExpr, locals, vars)
+					parts = append(parts, keyStr+": "+valStr)
+				}
+				result.WriteString("{" + strings.Join(parts, ", ") + "}")
 			default:
 				result.WriteString("${UNSUPPORTED_TEMPLATE_EXPR}")
 			}
@@ -280,6 +294,22 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 		collStr := resolveExpr(e.Collection, locals, vars)
 		keyStr := resolveExpr(e.Key, locals, vars)
 		return collStr + "[" + keyStr + "]"
+
+	case *hclsyntax.TupleConsExpr:
+		parts := make([]string, 0, len(e.Exprs))
+		for _, ex := range e.Exprs {
+			parts = append(parts, resolveExpr(ex, locals, vars))
+		}
+		return "[" + strings.Join(parts, ", ") + "]"
+
+	case *hclsyntax.ObjectConsExpr:
+		parts := make([]string, 0, len(e.Items))
+		for _, item := range e.Items {
+			keyStr := resolveExpr(item.KeyExpr, locals, vars)
+			valStr := resolveExpr(item.ValueExpr, locals, vars)
+			parts = append(parts, keyStr+": "+valStr)
+		}
+		return "{" + strings.Join(parts, ", ") + "}"
 
 	default:
 		return resolveExprDefault(expr)

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -217,57 +217,10 @@ func getFileContent(file model.FileMetadata) string {
 func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) string {
 	switch e := expr.(type) {
 	case *hclsyntax.LiteralValueExpr:
-		if e.Val.Type().Equals(cty.String) {
-			return e.Val.AsString()
-		}
-		return "__NON_STRING_LITERAL__"
+		return resolveLiteralValueExpr(e)
 
 	case *hclsyntax.TemplateExpr:
-		var result strings.Builder
-		for _, part := range e.Parts {
-			switch p := part.(type) {
-			case *hclsyntax.LiteralValueExpr:
-				if p.Val.Type().Equals(cty.String) {
-					result.WriteString(p.Val.AsString())
-				}
-			case *hclsyntax.ScopeTraversalExpr:
-				result.WriteString(resolveScopeTraversal(p, locals, vars))
-			case *hclsyntax.RelativeTraversalExpr, *hclsyntax.FunctionCallExpr:
-				result.WriteString(resolveExpr(p, locals, vars))
-			case *hclsyntax.ParenthesesExpr:
-				result.WriteString(resolveExpr(p, locals, vars))
-			case *hclsyntax.TemplateWrapExpr:
-				result.WriteString(resolveExpr(p.Wrapped, locals, vars))
-			case *hclsyntax.ConditionalExpr:
-				result.WriteString(resolveExpr(p.Condition, locals, vars))
-				result.WriteString(" ? ")
-				result.WriteString(resolveExpr(p.TrueResult, locals, vars))
-				result.WriteString(" : ")
-				result.WriteString(resolveExpr(p.FalseResult, locals, vars))
-			case *hclsyntax.IndexExpr:
-				result.WriteString(resolveExpr(p.Collection, locals, vars))
-				result.WriteString("[")
-				result.WriteString(resolveExpr(p.Key, locals, vars))
-				result.WriteString("]")
-			case *hclsyntax.TupleConsExpr:
-				parts := make([]string, 0, len(p.Exprs))
-				for _, ex := range p.Exprs {
-					parts = append(parts, resolveExpr(ex, locals, vars))
-				}
-				result.WriteString("[" + strings.Join(parts, ", ") + "]")
-			case *hclsyntax.ObjectConsExpr:
-				parts := make([]string, 0, len(p.Items))
-				for _, item := range p.Items {
-					keyStr := resolveExpr(item.KeyExpr, locals, vars)
-					valStr := resolveExpr(item.ValueExpr, locals, vars)
-					parts = append(parts, keyStr+": "+valStr)
-				}
-				result.WriteString("{" + strings.Join(parts, ", ") + "}")
-			default:
-				result.WriteString("${UNSUPPORTED_TEMPLATE_EXPR}")
-			}
-		}
-		return result.String()
+		return resolveTemplateExpr(e, locals, vars)
 
 	case *hclsyntax.ScopeTraversalExpr:
 		return resolveScopeTraversal(e, locals, vars)
@@ -314,6 +267,21 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 	default:
 		return resolveExprDefault(expr)
 	}
+}
+
+func resolveLiteralValueExpr(e *hclsyntax.LiteralValueExpr) string {
+	if e.Val.Type().Equals(cty.String) {
+		return e.Val.AsString()
+	}
+	return "__NON_STRING_LITERAL__"
+}
+
+func resolveTemplateExpr(e *hclsyntax.TemplateExpr, locals, vars map[string]string) string {
+	var result strings.Builder
+	for _, part := range e.Parts {
+		result.WriteString(resolveExpr(part, locals, vars))
+	}
+	return result.String()
 }
 
 func resolveRelativeTraversalExpr(e *hclsyntax.RelativeTraversalExpr, locals, vars map[string]string) string {

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -236,6 +236,8 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 				result.WriteString(resolveExpr(p, locals, vars))
 			case *hclsyntax.ParenthesesExpr:
 				result.WriteString(resolveExpr(p, locals, vars))
+			case *hclsyntax.TemplateWrapExpr:
+				result.WriteString(resolveExpr(p.Wrapped, locals, vars))
 			default:
 				result.WriteString("${UNSUPPORTED_TEMPLATE_EXPR}")
 			}
@@ -244,6 +246,9 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 
 	case *hclsyntax.ScopeTraversalExpr:
 		return resolveScopeTraversal(e, locals, vars)
+
+	case *hclsyntax.TemplateWrapExpr:
+		return resolveExpr(e.Wrapped, locals, vars)
 
 	case *hclsyntax.FunctionCallExpr:
 		return resolveFunctionCall(e, locals, vars)

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -234,6 +234,8 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 				result.WriteString(resolveScopeTraversal(p, locals, vars))
 			case *hclsyntax.RelativeTraversalExpr, *hclsyntax.FunctionCallExpr:
 				result.WriteString(resolveExpr(p, locals, vars))
+			case *hclsyntax.ParenthesesExpr:
+				result.WriteString(resolveExpr(p, locals, vars))
 			default:
 				result.WriteString("${UNSUPPORTED_TEMPLATE_EXPR}")
 			}
@@ -248,6 +250,9 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 
 	case *hclsyntax.RelativeTraversalExpr:
 		return resolveRelativeTraversalExpr(e, locals, vars)
+
+	case *hclsyntax.ParenthesesExpr:
+		return resolveExpr(e.Expression, locals, vars)
 
 	default:
 		return resolveExprDefault(expr)

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -238,6 +238,12 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 				result.WriteString(resolveExpr(p, locals, vars))
 			case *hclsyntax.TemplateWrapExpr:
 				result.WriteString(resolveExpr(p.Wrapped, locals, vars))
+			case *hclsyntax.ConditionalExpr:
+				result.WriteString(resolveExpr(p.Condition, locals, vars))
+				result.WriteString(" ? ")
+				result.WriteString(resolveExpr(p.TrueResult, locals, vars))
+				result.WriteString(" : ")
+				result.WriteString(resolveExpr(p.FalseResult, locals, vars))
 			default:
 				result.WriteString("${UNSUPPORTED_TEMPLATE_EXPR}")
 			}
@@ -258,6 +264,12 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 
 	case *hclsyntax.ParenthesesExpr:
 		return resolveExpr(e.Expression, locals, vars)
+
+	case *hclsyntax.ConditionalExpr:
+		condStr := resolveExpr(e.Condition, locals, vars)
+		trueStr := resolveExpr(e.TrueResult, locals, vars)
+		falseStr := resolveExpr(e.FalseResult, locals, vars)
+		return condStr + " ? " + trueStr + " : " + falseStr
 
 	default:
 		return resolveExprDefault(expr)

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -244,6 +244,11 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 				result.WriteString(resolveExpr(p.TrueResult, locals, vars))
 				result.WriteString(" : ")
 				result.WriteString(resolveExpr(p.FalseResult, locals, vars))
+			case *hclsyntax.IndexExpr:
+				result.WriteString(resolveExpr(p.Collection, locals, vars))
+				result.WriteString("[")
+				result.WriteString(resolveExpr(p.Key, locals, vars))
+				result.WriteString("]")
 			default:
 				result.WriteString("${UNSUPPORTED_TEMPLATE_EXPR}")
 			}
@@ -270,6 +275,11 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 		trueStr := resolveExpr(e.TrueResult, locals, vars)
 		falseStr := resolveExpr(e.FalseResult, locals, vars)
 		return condStr + " ? " + trueStr + " : " + falseStr
+
+	case *hclsyntax.IndexExpr:
+		collStr := resolveExpr(e.Collection, locals, vars)
+		keyStr := resolveExpr(e.Key, locals, vars)
+		return collStr + "[" + keyStr + "]"
 
 	default:
 		return resolveExprDefault(expr)

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -560,6 +560,38 @@ func TestResolveExpr_TemplateWrapExpr(t *testing.T) {
 	})
 }
 
+func TestResolveExpr_IndexExpr(t *testing.T) {
+	t.Run("main_switch_resolves_collection_and_key", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("var.list[var.i]"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.IndexExpr); !ok {
+			t.Fatalf("expected *hclsyntax.IndexExpr, got %T", expr)
+		}
+
+		vars := map[string]string{"list": "items", "i": "0"}
+		result := resolveExpr(expr, map[string]string{}, vars)
+		want := "items[0]"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+
+	t.Run("in_template_expression", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`"${var.map[var.k]}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{"map": "m", "k": "key"})
+		want := "m[key]"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+}
+
 func TestResolveExpr_ConditionalExpr(t *testing.T) {
 	t.Run("main_switch_resolves_condition_true_false", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte(`var.enabled ? var.yes : var.no`), "test.hcl", hcl.Pos{Line: 1, Column: 1})

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -529,6 +529,37 @@ func TestResolveExpr_ParenthesesExpr(t *testing.T) {
 	})
 }
 
+func TestResolveExpr_TemplateWrapExpr(t *testing.T) {
+	t.Run("main_switch_unwraps_and_resolves", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`"${var.source}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.TemplateWrapExpr); !ok {
+			t.Fatalf("expected TemplateWrapExpr, got %T", expr)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{"source": "./local/module"})
+		want := "./local/module"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+
+	t.Run("in_template_expression", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`"prefix-${var.x}-suffix"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{"x": "value"})
+		want := "prefix-value-suffix"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+}
+
 func TestResolveExpr_FunctionCallExpr(t *testing.T) {
 	t.Run("format_function_resolves", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression(

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -560,6 +560,38 @@ func TestResolveExpr_TemplateWrapExpr(t *testing.T) {
 	})
 }
 
+func TestResolveExpr_ConditionalExpr(t *testing.T) {
+	t.Run("main_switch_resolves_condition_true_false", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`var.enabled ? var.yes : var.no`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.ConditionalExpr); !ok {
+			t.Fatalf("expected *hclsyntax.ConditionalExpr, got %T", expr)
+		}
+
+		vars := map[string]string{"enabled": "true", "yes": "./module-a", "no": "./module-b"}
+		result := resolveExpr(expr, map[string]string{}, vars)
+		want := "true ? ./module-a : ./module-b"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+
+	t.Run("in_template_expression", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`"${var.flag ? var.a : var.b}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{"flag": "x", "a": "first", "b": "second"})
+		want := "x ? first : second"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+}
+
 func TestResolveExpr_FunctionCallExpr(t *testing.T) {
 	t.Run("format_function_resolves", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression(

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -498,6 +498,37 @@ func TestResolveExpr_RelativeTraversalExpr(t *testing.T) {
 	})
 }
 
+func TestResolveExpr_ParenthesesExpr(t *testing.T) {
+	t.Run("main_switch_unwraps_and_resolves", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("(var.source)"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.ParenthesesExpr); !ok {
+			t.Fatalf("expected *hclsyntax.ParenthesesExpr, got %T", expr)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{"source": "./modules/vpc"})
+		want := "./modules/vpc"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+
+	t.Run("in_template_expression", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`"prefix-${(var.x)}-suffix"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+
+		result := resolveExpr(expr, map[string]string{}, map[string]string{"x": "value"})
+		want := "prefix-value-suffix"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+}
+
 func TestResolveExpr_FunctionCallExpr(t *testing.T) {
 	t.Run("format_function_resolves", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression(

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -560,6 +560,44 @@ func TestResolveExpr_TemplateWrapExpr(t *testing.T) {
 	})
 }
 
+func TestResolveExpr_TupleConsExpr(t *testing.T) {
+	t.Run("main_switch_resolves_elements", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`[var.a, var.b]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.TupleConsExpr); !ok {
+			t.Fatalf("expected *hclsyntax.TupleConsExpr, got %T", expr)
+		}
+
+		vars := map[string]string{"a": "x", "b": "y"}
+		result := resolveExpr(expr, map[string]string{}, vars)
+		want := "[x, y]"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+}
+
+func TestResolveExpr_ObjectConsExpr(t *testing.T) {
+	t.Run("main_switch_resolves_keys_and_values", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`{k = var.v}`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.ObjectConsExpr); !ok {
+			t.Fatalf("expected *hclsyntax.ObjectConsExpr, got %T", expr)
+		}
+
+		vars := map[string]string{"v": "resolved"}
+		result := resolveExpr(expr, map[string]string{}, vars)
+		want := "{k: resolved}"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+}
+
 func TestResolveExpr_IndexExpr(t *testing.T) {
 	t.Run("main_switch_resolves_collection_and_key", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte("var.list[var.i]"), "test.hcl", hcl.Pos{Line: 1, Column: 1})


### PR DESCRIPTION
> [!TIP]
> This PR is best reviewed commit by commit.

## Motivation

Expression handling was inconsistent across the four places we switch on HCL expression types (engine, inspector, modules, converter). Some types were handled in some spots and fell through to default or error in others. This PR fixes the gaps and refactors the resulting code.

## Changes

- Handle ParenthesesExpr, TemplateWrapExpr, ConditionalExpr, IndexExpr, TupleConsExpr, and ObjectConsExpr everywhere they were missing (unwrap or string form as appropriate).
- Modules: template parts now go through resolveExpr instead of a duplicated inner switch.
- Engine / inspector / converter: extracted helpers for composite expressions and shared eval logic (tryEvalExpression, tryEvalToString) so the switches stay readable.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

`go test ./pkg/builder/engine/ ./pkg/engine/ ./pkg/parser/terraform/modules/ ./pkg/parser/terraform/converter/`

## Blast Radius

IaC Scanner only, parser and rule engine paths that walk HCL expressions.

I submit this contribution under the Apache-2.0 license.