### PR TITLE
HCL expressions central package refactor

### DIFF
--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/hclexpr"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -24,17 +25,12 @@ type Engine struct {
 // ExpToString converts an expression into a string
 func (e *Engine) ExpToString(ctx context.Context, expr hclsyntax.Expression) (string, error) {
 	contextLogger := logger.FromContext(ctx)
+	expr = hclexpr.Unwrap(expr)
 	switch t := expr.(type) {
 	case *hclsyntax.LiteralValueExpr:
 		return e.expToStringLiteralValue(t)
 	case *hclsyntax.TemplateExpr:
 		return e.expToStringTemplateExpr(ctx, t)
-	case *hclsyntax.TemplateWrapExpr:
-		return e.ExpToString(ctx, t.Wrapped)
-	case *hclsyntax.ParenthesesExpr:
-		return e.ExpToString(ctx, t.Expression)
-	case *hclsyntax.ObjectConsKeyExpr:
-		return e.ExpToString(ctx, t.Wrapped)
 	case *hclsyntax.ScopeTraversalExpr:
 		return e.expToStringScopeTraversal(t), nil
 	case *hclsyntax.IndexExpr:

--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -24,31 +24,49 @@ type Engine struct {
 
 // ExpToString converts an expression into a string
 func (e *Engine) ExpToString(ctx context.Context, expr hclsyntax.Expression) (string, error) {
-	contextLogger := logger.FromContext(ctx)
-	expr = hclexpr.Unwrap(expr)
-	switch t := expr.(type) {
-	case *hclsyntax.LiteralValueExpr:
-		return e.expToStringLiteralValue(t)
-	case *hclsyntax.TemplateExpr:
-		return e.expToStringTemplateExpr(ctx, t)
-	case *hclsyntax.ScopeTraversalExpr:
-		return e.expToStringScopeTraversal(t), nil
-	case *hclsyntax.IndexExpr:
-		return e.indexExprToString(ctx, t)
-	case *hclsyntax.RelativeTraversalExpr:
-		return e.expToStringRelativeTraversal(ctx, t)
-	case *hclsyntax.FunctionCallExpr:
-		return e.expToStringFunctionCall(ctx, t)
-	case *hclsyntax.ConditionalExpr:
-		return e.expToStringConditionalExpr(ctx, t)
-	case *hclsyntax.TupleConsExpr:
-		return e.expToStringTupleConsExpr(ctx, t)
-	case *hclsyntax.ObjectConsExpr:
-		return e.expToStringObjectConsExpr(ctx, t)
-	}
-	err := fmt.Errorf("can't convert expression %T to string", expr)
-	contextLogger.Error().Msg(err.Error())
-	return "", err
+	return hclexpr.Dispatch(expr, &engineVisitor{e: e, ctx: ctx})
+}
+
+// engineVisitor implements hclexpr.Visitor[string] for ExpToString.
+type engineVisitor struct {
+	e   *Engine
+	ctx context.Context
+}
+
+func (v *engineVisitor) VisitLiteralValue(e *hclsyntax.LiteralValueExpr) (string, error) {
+	return v.e.expToStringLiteralValue(e)
+}
+func (v *engineVisitor) VisitTemplateExpr(e *hclsyntax.TemplateExpr) (string, error) {
+	return v.e.expToStringTemplateExpr(v.ctx, e)
+}
+func (v *engineVisitor) VisitScopeTraversal(e *hclsyntax.ScopeTraversalExpr) (string, error) {
+	return v.e.expToStringScopeTraversal(e), nil
+}
+func (v *engineVisitor) VisitIndexExpr(e *hclsyntax.IndexExpr) (string, error) {
+	return v.e.indexExprToString(v.ctx, e)
+}
+func (v *engineVisitor) VisitRelativeTraversal(e *hclsyntax.RelativeTraversalExpr) (string, error) {
+	return v.e.expToStringRelativeTraversal(v.ctx, e)
+}
+func (v *engineVisitor) VisitFunctionCall(e *hclsyntax.FunctionCallExpr) (string, error) {
+	return v.e.expToStringFunctionCall(v.ctx, e)
+}
+func (v *engineVisitor) VisitConditional(e *hclsyntax.ConditionalExpr) (string, error) {
+	return v.e.expToStringConditionalExpr(v.ctx, e)
+}
+func (v *engineVisitor) VisitTupleCons(e *hclsyntax.TupleConsExpr) (string, error) {
+	return v.e.expToStringTupleConsExpr(v.ctx, e)
+}
+func (v *engineVisitor) VisitObjectCons(e *hclsyntax.ObjectConsExpr) (string, error) {
+	return v.e.expToStringObjectConsExpr(v.ctx, e)
+}
+func (v *engineVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (string, error) {
+	return "", fmt.Errorf("can't convert expression %T to string", e)
+}
+func (v *engineVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
+	log := logger.FromContext(v.ctx)
+	log.Error().Msgf("can't convert expression %T to string", e)
+	return "", fmt.Errorf("can't convert expression %T to string", e)
 }
 
 func (e *Engine) expToStringLiteralValue(t *hclsyntax.LiteralValueExpr) (string, error) {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/detector/terraform"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
+	"github.com/DataDog/datadog-iac-scanner/pkg/hclexpr"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
@@ -761,23 +762,18 @@ func parseJsonencodeHCL(ctx context.Context, input string) (ast.Value, error) {
 
 // expressionToAST converts HCL expression to OPA ast.Value
 func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) {
+	expr = hclexpr.Unwrap(expr)
 	switch e := expr.(type) {
 	case *hclsyntax.LiteralValueExpr:
 		return literalToAst(e)
 	case *hclsyntax.TemplateExpr:
 		return expressionToASTTemplateExpr(e), nil
-	case *hclsyntax.TemplateWrapExpr:
-		return expressionToAST(e.Wrapped)
-	case *hclsyntax.ParenthesesExpr:
-		return expressionToAST(e.Expression)
 	case *hclsyntax.ScopeTraversalExpr:
 		return ast.String(scopeTraversalPath(e.Traversal)), nil
 	case *hclsyntax.TupleConsExpr:
 		return expressionToASTTupleConsExpr(e), nil
 	case *hclsyntax.ObjectConsExpr:
 		return expressionToASTObjectConsExpr(e), nil
-	case *hclsyntax.ObjectConsKeyExpr:
-		return expressionToAST(e.UnwrapExpression())
 	case *hclsyntax.IndexExpr:
 		return expressionToASTIndexExpr(e), nil
 	case *hclsyntax.RelativeTraversalExpr:
@@ -946,12 +942,7 @@ func literalToAst(expr *hclsyntax.LiteralValueExpr) (ast.Value, error) {
 }
 
 func normalizeKeyExpr(expr hclsyntax.Expression) hclsyntax.Expression {
-	switch e := expr.(type) {
-	case *hclsyntax.TemplateWrapExpr:
-		return normalizeKeyExpr(e.Wrapped)
-	case *hclsyntax.ParenthesesExpr:
-		return normalizeKeyExpr(e.Expression)
-	}
+	expr = hclexpr.Unwrap(expr)
 
 	v := reflect.ValueOf(expr)
 	if v.Kind() == reflect.Ptr && !v.IsNil() {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -771,7 +771,7 @@ func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) {
 	case *hclsyntax.ParenthesesExpr:
 		return expressionToAST(e.Expression)
 	case *hclsyntax.ScopeTraversalExpr:
-		return ast.String(e.Traversal.RootName()), nil
+		return ast.String(scopeTraversalPath(e.Traversal)), nil
 	case *hclsyntax.TupleConsExpr:
 		return expressionToASTTupleConsExpr(e), nil
 	case *hclsyntax.ObjectConsExpr:
@@ -890,6 +890,26 @@ func expressionToASTFunctionCallExpr(e *hclsyntax.FunctionCallExpr) ast.Value {
 		args = append(args, astValueToSimpleString(v))
 	}
 	return ast.String(e.Name + "(" + strings.Join(args, ", ") + ")")
+}
+
+func scopeTraversalPath(t hcl.Traversal) string {
+	items := make([]string, 0, len(t))
+	for _, part := range t {
+		switch step := part.(type) {
+		case hcl.TraverseAttr:
+			items = append(items, step.Name)
+		case hcl.TraverseRoot:
+			items = append(items, step.Name)
+		case hcl.TraverseIndex:
+			switch step.Key.Type() {
+			case cty.Number:
+				items = append(items, step.Key.AsBigFloat().String())
+			case cty.String:
+				items = append(items, step.Key.AsString())
+			}
+		}
+	}
+	return strings.Join(items, ".")
 }
 
 func astValueToSimpleString(v ast.Value) string {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -762,29 +762,44 @@ func parseJsonencodeHCL(ctx context.Context, input string) (ast.Value, error) {
 
 // expressionToAST converts HCL expression to OPA ast.Value
 func expressionToAST(expr hclsyntax.Expression) (ast.Value, error) {
-	expr = hclexpr.Unwrap(expr)
-	switch e := expr.(type) {
-	case *hclsyntax.LiteralValueExpr:
-		return literalToAst(e)
-	case *hclsyntax.TemplateExpr:
-		return expressionToASTTemplateExpr(e), nil
-	case *hclsyntax.ScopeTraversalExpr:
-		return ast.String(scopeTraversalPath(e.Traversal)), nil
-	case *hclsyntax.TupleConsExpr:
-		return expressionToASTTupleConsExpr(e), nil
-	case *hclsyntax.ObjectConsExpr:
-		return expressionToASTObjectConsExpr(e), nil
-	case *hclsyntax.IndexExpr:
-		return expressionToASTIndexExpr(e), nil
-	case *hclsyntax.RelativeTraversalExpr:
-		return expressionToASTRelativeTraversalExpr(e), nil
-	case *hclsyntax.FunctionCallExpr:
-		return expressionToASTFunctionCallExpr(e), nil
-	case *hclsyntax.ConditionalExpr:
-		return expressionToASTConditionalExpr(e), nil
-	default:
-		return ast.String("__UNSUPPORTED_EXPR__"), nil
-	}
+	return hclexpr.Dispatch(expr, &inspectorExprVisitor{})
+}
+
+// inspectorExprVisitor implements hclexpr.Visitor[ast.Value] for expressionToAST.
+type inspectorExprVisitor struct{}
+
+func (v *inspectorExprVisitor) VisitLiteralValue(e *hclsyntax.LiteralValueExpr) (ast.Value, error) {
+	return literalToAst(e)
+}
+func (v *inspectorExprVisitor) VisitTemplateExpr(e *hclsyntax.TemplateExpr) (ast.Value, error) {
+	return expressionToASTTemplateExpr(e), nil
+}
+func (v *inspectorExprVisitor) VisitScopeTraversal(e *hclsyntax.ScopeTraversalExpr) (ast.Value, error) {
+	return ast.String(scopeTraversalPath(e.Traversal)), nil
+}
+func (v *inspectorExprVisitor) VisitIndexExpr(e *hclsyntax.IndexExpr) (ast.Value, error) {
+	return expressionToASTIndexExpr(e), nil
+}
+func (v *inspectorExprVisitor) VisitRelativeTraversal(e *hclsyntax.RelativeTraversalExpr) (ast.Value, error) {
+	return expressionToASTRelativeTraversalExpr(e), nil
+}
+func (v *inspectorExprVisitor) VisitFunctionCall(e *hclsyntax.FunctionCallExpr) (ast.Value, error) {
+	return expressionToASTFunctionCallExpr(e), nil
+}
+func (v *inspectorExprVisitor) VisitConditional(e *hclsyntax.ConditionalExpr) (ast.Value, error) {
+	return expressionToASTConditionalExpr(e), nil
+}
+func (v *inspectorExprVisitor) VisitTupleCons(e *hclsyntax.TupleConsExpr) (ast.Value, error) {
+	return expressionToASTTupleConsExpr(e), nil
+}
+func (v *inspectorExprVisitor) VisitObjectCons(e *hclsyntax.ObjectConsExpr) (ast.Value, error) {
+	return expressionToASTObjectConsExpr(e), nil
+}
+func (v *inspectorExprVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (ast.Value, error) {
+	return ast.String("__UNSUPPORTED_EXPR__"), nil
+}
+func (v *inspectorExprVisitor) VisitDefault(e hclsyntax.Expression) (ast.Value, error) {
+	return ast.String("__UNSUPPORTED_EXPR__"), nil
 }
 
 func expressionToASTTemplateExpr(e *hclsyntax.TemplateExpr) ast.Value {
@@ -897,11 +912,14 @@ func scopeTraversalPath(t hcl.Traversal) string {
 		case hcl.TraverseRoot:
 			items = append(items, step.Name)
 		case hcl.TraverseIndex:
+			if len(items) == 0 {
+				items = append(items, "")
+			}
 			switch step.Key.Type() {
 			case cty.Number:
-				items = append(items, step.Key.AsBigFloat().String())
+				items[len(items)-1] += "[" + step.Key.AsBigFloat().String() + "]"
 			case cty.String:
-				items = append(items, step.Key.AsString())
+				items[len(items)-1] += "[" + step.Key.AsString() + "]"
 			}
 		}
 	}

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -791,6 +791,42 @@ func TestExpressionToAST_FunctionCallExpr(t *testing.T) {
 	})
 }
 
+func TestExpressionToAST_ScopeTraversalWithIndex(t *testing.T) {
+	t.Run("numeric_index_uses_brackets", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("var.list[0]"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		got := val.String()
+		want := `"var.list[0]"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("string_index_uses_brackets", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`var.map["key"]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		got := val.String()
+		want := `"var.map[key]"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+}
+
 func TestInspector_checkComment(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -619,9 +619,7 @@ func TestExpressionToAST_RelativeTraversalExpr(t *testing.T) {
 		}
 
 		got := val.String()
-		// IndexExpr resolves: Collection RootName="list", Key RootName="var" → "list[var]"
-		// Relative traversal appends ".name"
-		want := `"list[var].name"`
+		want := `"list[var.i].name"`
 		if got != want {
 			t.Errorf("expressionToAST = %s, want %s", got, want)
 		}
@@ -642,7 +640,7 @@ func TestExpressionToAST_RelativeTraversalExpr(t *testing.T) {
 		}
 
 		got := val.String()
-		want := `"list[var].a.b"`
+		want := `"list[var.i].a.b"`
 		if got != want {
 			t.Errorf("expressionToAST = %s, want %s", got, want)
 		}
@@ -660,8 +658,7 @@ func TestExpressionToAST_RelativeTraversalExpr(t *testing.T) {
 		}
 
 		got := val.String()
-		// FunctionCallExpr now resolves: tostring(var) where "var" is the root name
-		want := `"tostring(var).attr"`
+		want := `"tostring(var.x).attr"`
 		if got != want {
 			t.Errorf("expressionToAST = %s, want %s", got, want)
 		}
@@ -683,7 +680,7 @@ func TestExpressionToAST_ParenthesesExpr(t *testing.T) {
 			t.Fatalf("expressionToAST error: %v", err)
 		}
 		got := val.String()
-		want := `"var"`
+		want := `"var.x"`
 		if got != want {
 			t.Errorf("expressionToAST = %s, want %s", got, want)
 		}
@@ -766,8 +763,7 @@ func TestExpressionToAST_FunctionCallExpr(t *testing.T) {
 		}
 
 		got := val.String()
-		// ScopeTraversalExpr returns root name only
-		want := `"format(%s, var)"`
+		want := `"format(%s, var.name)"`
 		if got != want {
 			t.Errorf("expressionToAST = %s, want %s", got, want)
 		}

--- a/pkg/hclexpr/dispatch_test.go
+++ b/pkg/hclexpr/dispatch_test.go
@@ -1,0 +1,164 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package hclexpr
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// recordingVisitor records which Visit* method was called.
+type recordingVisitor struct {
+	called string
+}
+
+func (r *recordingVisitor) VisitLiteralValue(_ *hclsyntax.LiteralValueExpr) (string, error) {
+	r.called = "LiteralValue"
+	return r.called, nil
+}
+func (r *recordingVisitor) VisitTemplateExpr(_ *hclsyntax.TemplateExpr) (string, error) {
+	r.called = "TemplateExpr"
+	return r.called, nil
+}
+func (r *recordingVisitor) VisitScopeTraversal(_ *hclsyntax.ScopeTraversalExpr) (string, error) {
+	r.called = "ScopeTraversal"
+	return r.called, nil
+}
+func (r *recordingVisitor) VisitIndexExpr(_ *hclsyntax.IndexExpr) (string, error) {
+	r.called = "IndexExpr"
+	return r.called, nil
+}
+func (r *recordingVisitor) VisitRelativeTraversal(_ *hclsyntax.RelativeTraversalExpr) (string, error) {
+	r.called = "RelativeTraversal"
+	return r.called, nil
+}
+func (r *recordingVisitor) VisitFunctionCall(_ *hclsyntax.FunctionCallExpr) (string, error) {
+	r.called = "FunctionCall"
+	return r.called, nil
+}
+func (r *recordingVisitor) VisitConditional(_ *hclsyntax.ConditionalExpr) (string, error) {
+	r.called = "Conditional"
+	return r.called, nil
+}
+func (r *recordingVisitor) VisitTupleCons(_ *hclsyntax.TupleConsExpr) (string, error) {
+	r.called = "TupleCons"
+	return r.called, nil
+}
+func (r *recordingVisitor) VisitObjectCons(_ *hclsyntax.ObjectConsExpr) (string, error) {
+	r.called = "ObjectCons"
+	return r.called, nil
+}
+func (r *recordingVisitor) VisitTemplateJoin(_ *hclsyntax.TemplateJoinExpr) (string, error) {
+	r.called = "TemplateJoin"
+	return r.called, nil
+}
+func (r *recordingVisitor) VisitDefault(_ hclsyntax.Expression) (string, error) {
+	r.called = "Default"
+	return r.called, nil
+}
+
+func TestDispatch(t *testing.T) {
+	parse := func(t *testing.T, src string) hclsyntax.Expression {
+		t.Helper()
+		expr, diags := hclsyntax.ParseExpression([]byte(src), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse %q failed: %v", src, diags)
+		}
+		return expr
+	}
+
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"LiteralValue", `42`, "LiteralValue"},
+		{"ScopeTraversal", `var.x`, "ScopeTraversal"},
+		{"TemplateExpr", `"hello ${var.x} world"`, "TemplateExpr"},
+		{"IndexExpr", `list[var.i]`, "IndexExpr"},
+		{"RelativeTraversal", `list[var.i].name`, "RelativeTraversal"},
+		{"FunctionCall", `upper("x")`, "FunctionCall"},
+		{"Conditional", `true ? 1 : 2`, "Conditional"},
+		{"TupleCons", `[1, 2]`, "TupleCons"},
+		{"ObjectCons", `{a = 1}`, "ObjectCons"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := parse(t, tt.src)
+			v := &recordingVisitor{}
+			got, err := Dispatch[string](expr, v)
+			if err != nil {
+				t.Fatalf("Dispatch error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Dispatch returned %q, want %q", got, tt.want)
+			}
+			if v.called != tt.want {
+				t.Errorf("visitor called %q, want %q", v.called, tt.want)
+			}
+		})
+	}
+}
+
+func TestDispatch_UnwrapsBeforeDispatch(t *testing.T) {
+	parse := func(t *testing.T, src string) hclsyntax.Expression {
+		t.Helper()
+		expr, diags := hclsyntax.ParseExpression([]byte(src), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse %q failed: %v", src, diags)
+		}
+		return expr
+	}
+
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"TemplateWrapExpr_unwraps", `"${var.x}"`, "ScopeTraversal"},
+		{"ParenthesesExpr_unwraps", `(var.x)`, "ScopeTraversal"},
+		{"nested_unwrap", `"${(var.x)}"`, "ScopeTraversal"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := parse(t, tt.src)
+			v := &recordingVisitor{}
+			got, err := Dispatch[string](expr, v)
+			if err != nil {
+				t.Fatalf("Dispatch error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Dispatch returned %q, want %q", got, tt.want)
+			}
+			if v.called != tt.want {
+				t.Errorf("visitor called %q, want %q", v.called, tt.want)
+			}
+		})
+	}
+}
+
+func TestDispatch_UnknownExprType(t *testing.T) {
+	expr, diags := hclsyntax.ParseExpression([]byte(`[for x in var.list : x]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse failed: %v", diags)
+	}
+
+	v := &recordingVisitor{}
+	got, err := Dispatch[string](expr, v)
+	if err != nil {
+		t.Fatalf("Dispatch error: %v", err)
+	}
+	if got != "Default" {
+		t.Errorf("Dispatch returned %q, want %q", got, "Default")
+	}
+	if v.called != "Default" {
+		t.Errorf("visitor called %q, want %q", v.called, "Default")
+	}
+}

--- a/pkg/hclexpr/unwrap.go
+++ b/pkg/hclexpr/unwrap.go
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package hclexpr
+
+import (
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// Unwrap returns the inner expression for wrapper types (TemplateWrapExpr,
+// ParenthesesExpr, ObjectConsKeyExpr). For other expression types, returns expr unchanged.
+// Callers can use this before their own type switch so wrapper handling is centralized.
+func Unwrap(expr hclsyntax.Expression) hclsyntax.Expression {
+	switch e := expr.(type) {
+	case *hclsyntax.TemplateWrapExpr:
+		return Unwrap(e.Wrapped)
+	case *hclsyntax.ParenthesesExpr:
+		return Unwrap(e.Expression)
+	case *hclsyntax.ObjectConsKeyExpr:
+		return Unwrap(e.Wrapped)
+	default:
+		return expr
+	}
+}

--- a/pkg/hclexpr/unwrap_test.go
+++ b/pkg/hclexpr/unwrap_test.go
@@ -1,0 +1,60 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package hclexpr
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func TestUnwrap(t *testing.T) {
+	t.Run("TemplateWrapExpr", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`"${var.x}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		got := Unwrap(expr)
+		if _, ok := got.(*hclsyntax.ScopeTraversalExpr); !ok {
+			t.Errorf("Unwrap(TemplateWrapExpr) = %T, want *hclsyntax.ScopeTraversalExpr", got)
+		}
+	})
+
+	t.Run("ParenthesesExpr", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("(var.x)"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		got := Unwrap(expr)
+		if _, ok := got.(*hclsyntax.ScopeTraversalExpr); !ok {
+			t.Errorf("Unwrap(ParenthesesExpr) = %T, want *hclsyntax.ScopeTraversalExpr", got)
+		}
+	})
+
+	t.Run("nested_wrappers", func(t *testing.T) {
+		// "${(var.x)}" parses as TemplateWrapExpr wrapping ParenthesesExpr wrapping ScopeTraversalExpr
+		expr, diags := hclsyntax.ParseExpression([]byte(`"${(var.x)}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		got := Unwrap(expr)
+		if _, ok := got.(*hclsyntax.ScopeTraversalExpr); !ok {
+			t.Errorf("Unwrap(TemplateWrap(Parentheses(ScopeTraversal))) = %T, want *hclsyntax.ScopeTraversalExpr", got)
+		}
+	})
+
+	t.Run("non_wrapper_unchanged", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte("var.x"), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		got := Unwrap(expr)
+		if got != expr {
+			t.Errorf("Unwrap(ScopeTraversalExpr) should return same expr, got %T", got)
+		}
+	})
+}

--- a/pkg/hclexpr/visitor.go
+++ b/pkg/hclexpr/visitor.go
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package hclexpr
+
+import (
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// Visitor is the interface for handling each HCL expression type in one place.
+// Implement this interface for each dispatch site (engine, inspector, modules, converter).
+// Adding a new expression type: add a method here and a case in Dispatch below.
+type Visitor[T any] interface {
+	VisitLiteralValue(e *hclsyntax.LiteralValueExpr) (T, error)
+	VisitTemplateExpr(e *hclsyntax.TemplateExpr) (T, error)
+	VisitScopeTraversal(e *hclsyntax.ScopeTraversalExpr) (T, error)
+	VisitIndexExpr(e *hclsyntax.IndexExpr) (T, error)
+	VisitRelativeTraversal(e *hclsyntax.RelativeTraversalExpr) (T, error)
+	VisitFunctionCall(e *hclsyntax.FunctionCallExpr) (T, error)
+	VisitConditional(e *hclsyntax.ConditionalExpr) (T, error)
+	VisitTupleCons(e *hclsyntax.TupleConsExpr) (T, error)
+	VisitObjectCons(e *hclsyntax.ObjectConsExpr) (T, error)
+	VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (T, error)
+	VisitDefault(e hclsyntax.Expression) (T, error)
+}
+
+// Dispatch unwraps expr then dispatches to the appropriate Visitor method.
+// Add new expression types here and to the Visitor interface so all sites stay in sync.
+func Dispatch[T any](expr hclsyntax.Expression, v Visitor[T]) (T, error) {
+	expr = Unwrap(expr)
+	switch e := expr.(type) {
+	case *hclsyntax.LiteralValueExpr:
+		return v.VisitLiteralValue(e)
+	case *hclsyntax.TemplateExpr:
+		return v.VisitTemplateExpr(e)
+	case *hclsyntax.ScopeTraversalExpr:
+		return v.VisitScopeTraversal(e)
+	case *hclsyntax.IndexExpr:
+		return v.VisitIndexExpr(e)
+	case *hclsyntax.RelativeTraversalExpr:
+		return v.VisitRelativeTraversal(e)
+	case *hclsyntax.FunctionCallExpr:
+		return v.VisitFunctionCall(e)
+	case *hclsyntax.ConditionalExpr:
+		return v.VisitConditional(e)
+	case *hclsyntax.TupleConsExpr:
+		return v.VisitTupleCons(e)
+	case *hclsyntax.ObjectConsExpr:
+		return v.VisitObjectCons(e)
+	case *hclsyntax.TemplateJoinExpr:
+		return v.VisitTemplateJoin(e)
+	default:
+		return v.VisitDefault(expr)
+	}
+}

--- a/pkg/hclexpr/visitor_test.go
+++ b/pkg/hclexpr/visitor_test.go
@@ -86,11 +86,21 @@ func TestDispatch(t *testing.T) {
 		{"Conditional", `true ? 1 : 2`, "Conditional"},
 		{"TupleCons", `[1, 2]`, "TupleCons"},
 		{"ObjectCons", `{a = 1}`, "ObjectCons"},
+		{"TemplateJoin", ``, "TemplateJoin"}, // no parseable src; expr built in loop below
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			expr := parse(t, tt.src)
+			var expr hclsyntax.Expression
+			if tt.name == "TemplateJoin" {
+				forExpr, diags := hclsyntax.ParseExpression([]byte(`[for x in var.list : x]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+				if diags.HasErrors() {
+					t.Fatalf("parse for-expr failed: %v", diags)
+				}
+				expr = &hclsyntax.TemplateJoinExpr{Tuple: forExpr}
+			} else {
+				expr = parse(t, tt.src)
+			}
 			v := &recordingVisitor{}
 			got, err := Dispatch[string](expr, v)
 			if err != nil {

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/hclexpr"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/functions"
@@ -204,16 +205,12 @@ func (c *converter) convertBlock(ctx context.Context, block *hclsyntax.Block, ou
 }
 
 func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, error) {
-	// assume it is hcl syntax (because, um, it is)
+	expr = hclexpr.Unwrap(expr)
 	switch value := expr.(type) {
 	case *hclsyntax.LiteralValueExpr:
 		return ctyjson.SimpleJSONValue{Value: value.Val}, nil
 	case *hclsyntax.TemplateExpr:
 		return c.convertTemplate(value)
-	case *hclsyntax.TemplateWrapExpr:
-		return c.convertExpression(value.Wrapped)
-	case *hclsyntax.ParenthesesExpr:
-		return c.convertExpression(value.Expression)
 	case *hclsyntax.TupleConsExpr:
 		list := make([]interface{}, 0)
 		for _, ex := range value.Exprs {
@@ -328,6 +325,7 @@ func (c *converter) convertTemplate(t *hclsyntax.TemplateExpr) (string, error) {
 }
 
 func (c *converter) convertStringPart(expr hclsyntax.Expression) (string, error) {
+	expr = hclexpr.Unwrap(expr)
 	switch v := expr.(type) {
 	case *hclsyntax.LiteralValueExpr:
 		s, err := ctyconvert.Convert(v.Val, cty.String)
@@ -337,14 +335,10 @@ func (c *converter) convertStringPart(expr hclsyntax.Expression) (string, error)
 		return s.AsString(), nil
 	case *hclsyntax.TemplateExpr:
 		return c.convertTemplate(v)
-	case *hclsyntax.TemplateWrapExpr:
-		return c.convertStringPart(v.Wrapped)
 	case *hclsyntax.ConditionalExpr:
 		return c.convertTemplateConditional(v)
 	case *hclsyntax.TemplateJoinExpr:
 		return c.convertTemplateFor(v.Tuple.(*hclsyntax.ForExpr))
-	case *hclsyntax.ParenthesesExpr:
-		return c.convertStringPart(v.Expression)
 	case *hclsyntax.IndexExpr, *hclsyntax.RelativeTraversalExpr, *hclsyntax.FunctionCallExpr:
 		return c.tryEvalToString(expr)
 	default:

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -205,40 +205,61 @@ func (c *converter) convertBlock(ctx context.Context, block *hclsyntax.Block, ou
 }
 
 func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, error) {
-	expr = hclexpr.Unwrap(expr)
-	switch value := expr.(type) {
-	case *hclsyntax.LiteralValueExpr:
-		return ctyjson.SimpleJSONValue{Value: value.Val}, nil
-	case *hclsyntax.TemplateExpr:
-		return c.convertTemplate(value)
-	case *hclsyntax.TupleConsExpr:
-		list := make([]interface{}, 0)
-		for _, ex := range value.Exprs {
-			elem, err := c.convertExpression(ex)
-			if err != nil {
-				return nil, err
-			}
-			list = append(list, elem)
-		}
-		return list, nil
-	case *hclsyntax.ObjectConsExpr:
-		return c.objectConsExpr(value)
-	case *hclsyntax.FunctionCallExpr:
-		return c.evalFunction(expr)
-	case *hclsyntax.RelativeTraversalExpr, *hclsyntax.IndexExpr:
-		return c.tryEvalExpression(expr)
-	case *hclsyntax.ConditionalExpr:
-		expressionEvaluated, err := expr.Value(&hcl.EvalContext{
-			Variables: c.inputVars,
-			Functions: functions.TerraformFuncs,
-		})
-		if err != nil {
-			return c.wrapExpr(expr)
-		}
-		return ctyjson.SimpleJSONValue{Value: expressionEvaluated}, nil
-	default:
-		return c.tryEvalExpression(expr)
+	return hclexpr.Dispatch(expr, &converterExprVisitor{c: c})
+}
+
+// converterExprVisitor implements hclexpr.Visitor[interface{}] for convertExpression.
+type converterExprVisitor struct {
+	c *converter
+}
+
+func (v *converterExprVisitor) VisitLiteralValue(e *hclsyntax.LiteralValueExpr) (interface{}, error) {
+	return ctyjson.SimpleJSONValue{Value: e.Val}, nil
+}
+func (v *converterExprVisitor) VisitTemplateExpr(e *hclsyntax.TemplateExpr) (interface{}, error) {
+	return v.c.convertTemplate(e)
+}
+func (v *converterExprVisitor) VisitScopeTraversal(e *hclsyntax.ScopeTraversalExpr) (interface{}, error) {
+	return v.c.tryEvalExpression(e)
+}
+func (v *converterExprVisitor) VisitIndexExpr(e *hclsyntax.IndexExpr) (interface{}, error) {
+	return v.c.tryEvalExpression(e)
+}
+func (v *converterExprVisitor) VisitRelativeTraversal(e *hclsyntax.RelativeTraversalExpr) (interface{}, error) {
+	return v.c.tryEvalExpression(e)
+}
+func (v *converterExprVisitor) VisitFunctionCall(e *hclsyntax.FunctionCallExpr) (interface{}, error) {
+	return v.c.evalFunction(e)
+}
+func (v *converterExprVisitor) VisitConditional(e *hclsyntax.ConditionalExpr) (interface{}, error) {
+	val, err := e.Value(&hcl.EvalContext{
+		Variables: v.c.inputVars,
+		Functions: functions.TerraformFuncs,
+	})
+	if err != nil {
+		return v.c.wrapExpr(e)
 	}
+	return ctyjson.SimpleJSONValue{Value: val}, nil
+}
+func (v *converterExprVisitor) VisitTupleCons(e *hclsyntax.TupleConsExpr) (interface{}, error) {
+	list := make([]interface{}, 0, len(e.Exprs))
+	for _, ex := range e.Exprs {
+		elem, err := v.c.convertExpression(ex)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, elem)
+	}
+	return list, nil
+}
+func (v *converterExprVisitor) VisitObjectCons(e *hclsyntax.ObjectConsExpr) (interface{}, error) {
+	return v.c.objectConsExpr(e)
+}
+func (v *converterExprVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (interface{}, error) {
+	return v.c.tryEvalExpression(e)
+}
+func (v *converterExprVisitor) VisitDefault(e hclsyntax.Expression) (interface{}, error) {
+	return v.c.tryEvalExpression(e)
 }
 
 func checkValue(val cty.Value) bool {
@@ -325,32 +346,54 @@ func (c *converter) convertTemplate(t *hclsyntax.TemplateExpr) (string, error) {
 }
 
 func (c *converter) convertStringPart(expr hclsyntax.Expression) (string, error) {
-	expr = hclexpr.Unwrap(expr)
-	switch v := expr.(type) {
-	case *hclsyntax.LiteralValueExpr:
-		s, err := ctyconvert.Convert(v.Val, cty.String)
-		if err != nil {
-			return "", err
-		}
-		return s.AsString(), nil
-	case *hclsyntax.TemplateExpr:
-		return c.convertTemplate(v)
-	case *hclsyntax.ConditionalExpr:
-		return c.convertTemplateConditional(v)
-	case *hclsyntax.TemplateJoinExpr:
-		return c.convertTemplateFor(v.Tuple.(*hclsyntax.ForExpr))
-	case *hclsyntax.IndexExpr, *hclsyntax.RelativeTraversalExpr, *hclsyntax.FunctionCallExpr:
-		return c.tryEvalToString(expr)
-	default:
-		// try to evaluate with variables only (no functions)
-		valueConverted, _ := expr.Value(&hcl.EvalContext{
-			Variables: c.inputVars,
-		})
-		if valueConverted.Type().FriendlyName() == ctyFriendlyNameString {
-			return valueConverted.AsString(), nil
-		}
-		return c.wrapExpr(expr)
+	return hclexpr.Dispatch(expr, &converterStringPartVisitor{c: c})
+}
+
+// converterStringPartVisitor implements hclexpr.Visitor[string] for convertStringPart.
+type converterStringPartVisitor struct {
+	c *converter
+}
+
+func (v *converterStringPartVisitor) VisitLiteralValue(e *hclsyntax.LiteralValueExpr) (string, error) {
+	s, err := ctyconvert.Convert(e.Val, cty.String)
+	if err != nil {
+		return "", err
 	}
+	return s.AsString(), nil
+}
+func (v *converterStringPartVisitor) VisitTemplateExpr(e *hclsyntax.TemplateExpr) (string, error) {
+	return v.c.convertTemplate(e)
+}
+func (v *converterStringPartVisitor) VisitScopeTraversal(e *hclsyntax.ScopeTraversalExpr) (string, error) {
+	return v.c.tryEvalToString(e)
+}
+func (v *converterStringPartVisitor) VisitIndexExpr(e *hclsyntax.IndexExpr) (string, error) {
+	return v.c.tryEvalToString(e)
+}
+func (v *converterStringPartVisitor) VisitRelativeTraversal(e *hclsyntax.RelativeTraversalExpr) (string, error) {
+	return v.c.tryEvalToString(e)
+}
+func (v *converterStringPartVisitor) VisitFunctionCall(e *hclsyntax.FunctionCallExpr) (string, error) {
+	return v.c.tryEvalToString(e)
+}
+func (v *converterStringPartVisitor) VisitConditional(e *hclsyntax.ConditionalExpr) (string, error) {
+	return v.c.convertTemplateConditional(e)
+}
+func (v *converterStringPartVisitor) VisitTupleCons(e *hclsyntax.TupleConsExpr) (string, error) {
+	return v.c.tryEvalToString(e)
+}
+func (v *converterStringPartVisitor) VisitObjectCons(e *hclsyntax.ObjectConsExpr) (string, error) {
+	return v.c.tryEvalToString(e)
+}
+func (v *converterStringPartVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (string, error) {
+	return v.c.convertTemplateFor(e.Tuple.(*hclsyntax.ForExpr))
+}
+func (v *converterStringPartVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
+	val, _ := e.Value(&hcl.EvalContext{Variables: v.c.inputVars})
+	if val.Type().FriendlyName() == ctyFriendlyNameString {
+		return val.AsString(), nil
+	}
+	return v.c.wrapExpr(e)
 }
 
 func (c *converter) convertTemplateConditional(expr *hclsyntax.ConditionalExpr) (string, error) {

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -212,6 +212,8 @@ func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, e
 		return c.convertTemplate(value)
 	case *hclsyntax.TemplateWrapExpr:
 		return c.convertExpression(value.Wrapped)
+	case *hclsyntax.ParenthesesExpr:
+		return c.convertExpression(value.Expression)
 	case *hclsyntax.TupleConsExpr:
 		list := make([]interface{}, 0)
 		for _, ex := range value.Exprs {

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/hclexpr"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/hashicorp/hcl/v2"
@@ -215,6 +216,7 @@ func getFileContent(file model.FileMetadata) string {
 
 // resolveExpr evaluates HCL expressions using known locals and vars
 func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) string {
+	expr = hclexpr.Unwrap(expr)
 	switch e := expr.(type) {
 	case *hclsyntax.LiteralValueExpr:
 		return resolveLiteralValueExpr(e)
@@ -225,17 +227,11 @@ func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) stri
 	case *hclsyntax.ScopeTraversalExpr:
 		return resolveScopeTraversal(e, locals, vars)
 
-	case *hclsyntax.TemplateWrapExpr:
-		return resolveExpr(e.Wrapped, locals, vars)
-
 	case *hclsyntax.FunctionCallExpr:
 		return resolveFunctionCall(e, locals, vars)
 
 	case *hclsyntax.RelativeTraversalExpr:
 		return resolveRelativeTraversalExpr(e, locals, vars)
-
-	case *hclsyntax.ParenthesesExpr:
-		return resolveExpr(e.Expression, locals, vars)
 
 	case *hclsyntax.ConditionalExpr:
 		condStr := resolveExpr(e.Condition, locals, vars)
@@ -317,7 +313,13 @@ func resolveExprDefault(expr hclsyntax.Expression) string {
 
 func resolveScopeTraversal(expr *hclsyntax.ScopeTraversalExpr, locals, vars map[string]string) string {
 	traversal := expr.Traversal
-	if len(traversal) < 2 {
+	if len(traversal) == 0 {
+		return "__INVALID_TRAVERSAL__"
+	}
+	if len(traversal) == 1 {
+		if root, ok := traversal[0].(hcl.TraverseRoot); ok {
+			return root.Name
+		}
 		return "__INVALID_TRAVERSAL__"
 	}
 

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -216,53 +216,62 @@ func getFileContent(file model.FileMetadata) string {
 
 // resolveExpr evaluates HCL expressions using known locals and vars
 func resolveExpr(expr hclsyntax.Expression, locals, vars map[string]string) string {
-	expr = hclexpr.Unwrap(expr)
-	switch e := expr.(type) {
-	case *hclsyntax.LiteralValueExpr:
-		return resolveLiteralValueExpr(e)
+	s, _ := hclexpr.Dispatch(expr, &resolveExprVisitor{locals: locals, vars: vars})
+	return s
+}
 
-	case *hclsyntax.TemplateExpr:
-		return resolveTemplateExpr(e, locals, vars)
+// resolveExprVisitor implements hclexpr.Visitor[string] for resolveExpr.
+type resolveExprVisitor struct {
+	locals, vars map[string]string
+}
 
-	case *hclsyntax.ScopeTraversalExpr:
-		return resolveScopeTraversal(e, locals, vars)
-
-	case *hclsyntax.FunctionCallExpr:
-		return resolveFunctionCall(e, locals, vars)
-
-	case *hclsyntax.RelativeTraversalExpr:
-		return resolveRelativeTraversalExpr(e, locals, vars)
-
-	case *hclsyntax.ConditionalExpr:
-		condStr := resolveExpr(e.Condition, locals, vars)
-		trueStr := resolveExpr(e.TrueResult, locals, vars)
-		falseStr := resolveExpr(e.FalseResult, locals, vars)
-		return condStr + " ? " + trueStr + " : " + falseStr
-
-	case *hclsyntax.IndexExpr:
-		collStr := resolveExpr(e.Collection, locals, vars)
-		keyStr := resolveExpr(e.Key, locals, vars)
-		return collStr + "[" + keyStr + "]"
-
-	case *hclsyntax.TupleConsExpr:
-		parts := make([]string, 0, len(e.Exprs))
-		for _, ex := range e.Exprs {
-			parts = append(parts, resolveExpr(ex, locals, vars))
-		}
-		return "[" + strings.Join(parts, ", ") + "]"
-
-	case *hclsyntax.ObjectConsExpr:
-		parts := make([]string, 0, len(e.Items))
-		for _, item := range e.Items {
-			keyStr := resolveExpr(item.KeyExpr, locals, vars)
-			valStr := resolveExpr(item.ValueExpr, locals, vars)
-			parts = append(parts, keyStr+": "+valStr)
-		}
-		return "{" + strings.Join(parts, ", ") + "}"
-
-	default:
-		return resolveExprDefault(expr)
+func (v *resolveExprVisitor) VisitLiteralValue(e *hclsyntax.LiteralValueExpr) (string, error) {
+	return resolveLiteralValueExpr(e), nil
+}
+func (v *resolveExprVisitor) VisitTemplateExpr(e *hclsyntax.TemplateExpr) (string, error) {
+	return resolveTemplateExpr(e, v.locals, v.vars), nil
+}
+func (v *resolveExprVisitor) VisitScopeTraversal(e *hclsyntax.ScopeTraversalExpr) (string, error) {
+	return resolveScopeTraversal(e, v.locals, v.vars), nil
+}
+func (v *resolveExprVisitor) VisitIndexExpr(e *hclsyntax.IndexExpr) (string, error) {
+	collStr := resolveExpr(e.Collection, v.locals, v.vars)
+	keyStr := resolveExpr(e.Key, v.locals, v.vars)
+	return collStr + "[" + keyStr + "]", nil
+}
+func (v *resolveExprVisitor) VisitRelativeTraversal(e *hclsyntax.RelativeTraversalExpr) (string, error) {
+	return resolveRelativeTraversalExpr(e, v.locals, v.vars), nil
+}
+func (v *resolveExprVisitor) VisitFunctionCall(e *hclsyntax.FunctionCallExpr) (string, error) {
+	return resolveFunctionCall(e, v.locals, v.vars), nil
+}
+func (v *resolveExprVisitor) VisitConditional(e *hclsyntax.ConditionalExpr) (string, error) {
+	condStr := resolveExpr(e.Condition, v.locals, v.vars)
+	trueStr := resolveExpr(e.TrueResult, v.locals, v.vars)
+	falseStr := resolveExpr(e.FalseResult, v.locals, v.vars)
+	return condStr + " ? " + trueStr + " : " + falseStr, nil
+}
+func (v *resolveExprVisitor) VisitTupleCons(e *hclsyntax.TupleConsExpr) (string, error) {
+	parts := make([]string, 0, len(e.Exprs))
+	for _, ex := range e.Exprs {
+		parts = append(parts, resolveExpr(ex, v.locals, v.vars))
 	}
+	return "[" + strings.Join(parts, ", ") + "]", nil
+}
+func (v *resolveExprVisitor) VisitObjectCons(e *hclsyntax.ObjectConsExpr) (string, error) {
+	parts := make([]string, 0, len(e.Items))
+	for _, item := range e.Items {
+		keyStr := resolveExpr(item.KeyExpr, v.locals, v.vars)
+		valStr := resolveExpr(item.ValueExpr, v.locals, v.vars)
+		parts = append(parts, keyStr+": "+valStr)
+	}
+	return "{" + strings.Join(parts, ", ") + "}", nil
+}
+func (v *resolveExprVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (string, error) {
+	return resolveExprDefault(e), nil
+}
+func (v *resolveExprVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
+	return resolveExprDefault(e), nil
 }
 
 func resolveLiteralValueExpr(e *hclsyntax.LiteralValueExpr) string {

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -64,12 +64,13 @@ func isTerraformFile(filePath string) bool {
 }
 
 const (
-	stringLocal           = "local"
-	stringUnknown         = "unknown"
-	stringPublic          = "public"
-	stringRegistry        = "registry"
-	stringPrivate         = "private"
-	unresolvedPlaceholder = "__UNRESOLVED__"
+	stringLocal                 = "local"
+	stringUnknown               = "unknown"
+	stringPublic                = "public"
+	stringRegistry              = "registry"
+	stringPrivate               = "private"
+	unresolvedPlaceholder       = "__UNRESOLVED__"
+	invalidTraversalPlaceholder = "__INVALID_TRAVERSAL__"
 )
 
 // nolint:gocyclo
@@ -323,13 +324,13 @@ func resolveExprDefault(expr hclsyntax.Expression) string {
 func resolveScopeTraversal(expr *hclsyntax.ScopeTraversalExpr, locals, vars map[string]string) string {
 	traversal := expr.Traversal
 	if len(traversal) == 0 {
-		return "__INVALID_TRAVERSAL__"
+		return invalidTraversalPlaceholder
 	}
 	if len(traversal) == 1 {
 		if root, ok := traversal[0].(hcl.TraverseRoot); ok {
 			return root.Name
 		}
-		return "__INVALID_TRAVERSAL__"
+		return invalidTraversalPlaceholder
 	}
 
 	root := traversal[0].(hcl.TraverseRoot).Name


### PR DESCRIPTION
> [!TIP]
> This PR is best reviewed commit by commit.

## Motivation

Adding or changing an HCL expression type required updating four separate type switches (engine, inspector, modules, converter), which caused drift and bugs. This PR introduces a single `Visitor` + `Dispatch` and central `Unwrap` so all expression handling goes through one place and stays in sync.

## Changes

- Add `pkg/hclexpr`: `Visitor[T]` interface, `Dispatch(expr, visitor)`, and `Unwrap(expr)` for TemplateWrapExpr, ParenthesesExpr, ObjectConsKeyExpr.
- Migrate engine, inspector, modules, and converter to use `hclexpr.Dispatch` + Unwrap instead of local type switches.
- Add ParenthesesExpr unwrap in converter `convertExpression`.
- Fix ScopeTraversalExpr in inspector to return full traversal path (not only root name).

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run `go test ./pkg/hclexpr/... ./pkg/builder/engine/... ./pkg/engine/... ./pkg/parser/terraform/...`. Terraform scans with expressions (traversals, templates, index, conditional, etc.) should behave as before; inspector findings that depend on full traversal paths should be correct.

## Blast Radius

DataDog IaC Scanner only (HCL expression handling in engine, inspector, modules, converter).

## Additional Notes

Stacked on top of `chakib.hamie/hcl_expr_consistency_and_refactor`. Refactor only.

I submit this contribution under the Apache-2.0 license.
