### PR TITLE
Add missing HCL exprs

### DIFF
--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -81,6 +81,59 @@ func (v *engineVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (string, error) {
 	}
 	return hclexpr.UnaryOpSymbol(e.Op) + valStr, nil
 }
+func (v *engineVisitor) VisitForExpr(e *hclsyntax.ForExpr) (string, error) {
+	collStr, err := v.e.ExpToString(v.ctx, e.CollExpr)
+	if err != nil {
+		return "", err
+	}
+	valStr, err := v.e.ExpToString(v.ctx, e.ValExpr)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	if e.KeyExpr != nil {
+		keyStr, err := v.e.ExpToString(v.ctx, e.KeyExpr)
+		if err != nil {
+			return "", err
+		}
+		b.WriteString("{for ")
+		b.WriteString(e.KeyVar)
+		b.WriteString(", ")
+		b.WriteString(e.ValVar)
+		b.WriteString(" in ")
+		b.WriteString(collStr)
+		b.WriteString(" : ")
+		b.WriteString(keyStr)
+		b.WriteString(" => ")
+		b.WriteString(valStr)
+		if e.CondExpr != nil {
+			condStr, err := v.e.ExpToString(v.ctx, e.CondExpr)
+			if err != nil {
+				return "", err
+			}
+			b.WriteString(" if ")
+			b.WriteString(condStr)
+		}
+		b.WriteString("}")
+	} else {
+		b.WriteString("[for ")
+		b.WriteString(e.ValVar)
+		b.WriteString(" in ")
+		b.WriteString(collStr)
+		b.WriteString(" : ")
+		b.WriteString(valStr)
+		if e.CondExpr != nil {
+			condStr, err := v.e.ExpToString(v.ctx, e.CondExpr)
+			if err != nil {
+				return "", err
+			}
+			b.WriteString(" if ")
+			b.WriteString(condStr)
+		}
+		b.WriteString("]")
+	}
+	return b.String(), nil
+}
 func (v *engineVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	log := logger.FromContext(v.ctx)
 	log.Error().Msgf("can't convert expression %T to string", e)

--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -74,6 +74,13 @@ func (v *engineVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (string, error)
 	}
 	return lhs + " " + hclexpr.BinaryOpSymbol(e.Op) + " " + rhs, nil
 }
+func (v *engineVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (string, error) {
+	valStr, err := v.e.ExpToString(v.ctx, e.Val)
+	if err != nil {
+		return "", err
+	}
+	return hclexpr.UnaryOpSymbol(e.Op) + valStr, nil
+}
 func (v *engineVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	log := logger.FromContext(v.ctx)
 	log.Error().Msgf("can't convert expression %T to string", e)

--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -63,6 +63,17 @@ func (v *engineVisitor) VisitObjectCons(e *hclsyntax.ObjectConsExpr) (string, er
 func (v *engineVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (string, error) {
 	return "", fmt.Errorf("can't convert expression %T to string", e)
 }
+func (v *engineVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (string, error) {
+	lhs, err := v.e.ExpToString(v.ctx, e.LHS)
+	if err != nil {
+		return "", err
+	}
+	rhs, err := v.e.ExpToString(v.ctx, e.RHS)
+	if err != nil {
+		return "", err
+	}
+	return lhs + " " + hclexpr.BinaryOpSymbol(e.Op) + " " + rhs, nil
+}
 func (v *engineVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	log := logger.FromContext(v.ctx)
 	log.Error().Msgf("can't convert expression %T to string", e)

--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -134,6 +134,20 @@ func (v *engineVisitor) VisitForExpr(e *hclsyntax.ForExpr) (string, error) {
 	}
 	return b.String(), nil
 }
+func (v *engineVisitor) VisitSplatExpr(e *hclsyntax.SplatExpr) (string, error) {
+	sourceStr, err := v.e.ExpToString(v.ctx, e.Source)
+	if err != nil {
+		return "", err
+	}
+	base := sourceStr + "[*]"
+	if e.Each != nil && e.Each != e.Source {
+		eachStr, err := v.e.ExpToString(v.ctx, e.Each)
+		if err == nil && (eachStr == base || strings.HasPrefix(eachStr, base)) {
+			return eachStr, nil
+		}
+	}
+	return base, nil
+}
 func (v *engineVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	log := logger.FromContext(v.ctx)
 	log.Error().Msgf("can't convert expression %T to string", e)

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -330,6 +330,40 @@ func TestExpToString_BinaryOpExpr(t *testing.T) {
 	})
 }
 
+func TestExpToString_UnaryOpExpr(t *testing.T) {
+	e := &Engine{}
+	ctx := context.Background()
+	t.Run("negate", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`-1`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.UnaryOpExpr); !ok {
+			t.Fatalf("expected *hclsyntax.UnaryOpExpr, got %T", expr)
+		}
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "-1"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+	t.Run("logical_not", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`!var.enabled`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "!var.enabled"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+}
+
 func TestExpToString_FunctionCallExpr(t *testing.T) {
 	e := &Engine{}
 	ctx := context.Background()

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -282,6 +282,54 @@ func TestExpToString_ConditionalExpr(t *testing.T) {
 	})
 }
 
+func TestExpToString_BinaryOpExpr(t *testing.T) {
+	e := &Engine{}
+	ctx := context.Background()
+
+	t.Run("arithmetic", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`1 + 2`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.BinaryOpExpr); !ok {
+			t.Fatalf("expected *hclsyntax.BinaryOpExpr, got %T", expr)
+		}
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "1 + 2"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+	t.Run("comparison", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`var.count > 0`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "var.count > 0"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+	t.Run("logical", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`var.a && var.b`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "var.a && var.b"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+}
+
 func TestExpToString_FunctionCallExpr(t *testing.T) {
 	e := &Engine{}
 	ctx := context.Background()

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -330,6 +330,41 @@ func TestExpToString_BinaryOpExpr(t *testing.T) {
 	})
 }
 
+func TestExpToString_SplatExpr(t *testing.T) {
+	e := &Engine{}
+	ctx := context.Background()
+	t.Run("splat", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`var.list[*]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.SplatExpr); !ok {
+			t.Fatalf("expected *hclsyntax.SplatExpr, got %T", expr)
+		}
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			return // VisitDefault returns error for unsupported expr
+		}
+		if want := "var.list[*]"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+	t.Run("splat_with_traversal", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`var.list[*].id`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			return
+		}
+		// AST may be SplatExpr (then we get "var.list[*]") or RelativeTraversalExpr (then "var.list[*].id")
+		if got != "var.list[*].id" && got != "var.list[*]" {
+			t.Errorf("ExpToString = %q", got)
+		}
+	})
+}
+
 func TestExpToString_ForExpr(t *testing.T) {
 	e := &Engine{}
 	ctx := context.Background()

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -330,6 +330,40 @@ func TestExpToString_BinaryOpExpr(t *testing.T) {
 	})
 }
 
+func TestExpToString_ForExpr(t *testing.T) {
+	e := &Engine{}
+	ctx := context.Background()
+	t.Run("tuple_for", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`[for x in var.list : x]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.ForExpr); !ok {
+			t.Fatalf("expected *hclsyntax.ForExpr, got %T", expr)
+		}
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "[for x in var.list : x]"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+	t.Run("object_for", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`{for k, v in var.map : k => v}`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "{for k, v in var.map : k => v}"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
+}
+
 func TestExpToString_UnaryOpExpr(t *testing.T) {
 	e := &Engine{}
 	ctx := context.Background()
@@ -440,19 +474,17 @@ func TestExpToString_FunctionCallExpr(t *testing.T) {
 		}
 	})
 
-	t.Run("unsupported_arg_propagates_error", func(t *testing.T) {
-		// Use for expression as argument; ForExpr is not handled by ExpToString
+	t.Run("for_expr_as_arg_now_supported", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte(`upper([for i in [1,2] : i])`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
 		if diags.HasErrors() {
 			t.Fatalf("parse failed: %v", diags)
 		}
-		if _, ok := expr.(*hclsyntax.FunctionCallExpr); !ok {
-			t.Fatalf("expected *hclsyntax.FunctionCallExpr, got %T", expr)
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
 		}
-
-		_, err := e.ExpToString(ctx, expr)
-		if err == nil {
-			t.Error("ExpToString should return error for unsupported argument type")
+		if want := "upper([for i in [1, 2] : i])"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
 		}
 	})
 }

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -801,6 +801,9 @@ func (v *inspectorExprVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) 
 func (v *inspectorExprVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (ast.Value, error) {
 	return expressionToASTBinaryOpExpr(e), nil
 }
+func (v *inspectorExprVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (ast.Value, error) {
+	return expressionToASTUnaryOpExpr(e), nil
+}
 func (v *inspectorExprVisitor) VisitDefault(e hclsyntax.Expression) (ast.Value, error) {
 	return ast.String("__UNSUPPORTED_EXPR__"), nil
 }
@@ -910,6 +913,11 @@ func expressionToASTBinaryOpExpr(e *hclsyntax.BinaryOpExpr) ast.Value {
 	lhsV, _ := expressionToAST(e.LHS)
 	rhsV, _ := expressionToAST(e.RHS)
 	return ast.String(astValueToSimpleString(lhsV) + " " + hclexpr.BinaryOpSymbol(e.Op) + " " + astValueToSimpleString(rhsV))
+}
+
+func expressionToASTUnaryOpExpr(e *hclsyntax.UnaryOpExpr) ast.Value {
+	valV, _ := expressionToAST(e.Val)
+	return ast.String(hclexpr.UnaryOpSymbol(e.Op) + astValueToSimpleString(valV))
 }
 
 func scopeTraversalPath(t hcl.Traversal) string {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -807,6 +807,9 @@ func (v *inspectorExprVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (ast.Value
 func (v *inspectorExprVisitor) VisitForExpr(e *hclsyntax.ForExpr) (ast.Value, error) {
 	return expressionToASTForExpr(e), nil
 }
+func (v *inspectorExprVisitor) VisitSplatExpr(e *hclsyntax.SplatExpr) (ast.Value, error) {
+	return expressionToASTSplatExpr(e), nil
+}
 func (v *inspectorExprVisitor) VisitDefault(e hclsyntax.Expression) (ast.Value, error) {
 	return ast.String("__UNSUPPORTED_EXPR__"), nil
 }
@@ -963,6 +966,21 @@ func expressionToASTForExpr(e *hclsyntax.ForExpr) ast.Value {
 		b.WriteString("]")
 	}
 	return ast.String(b.String())
+}
+
+func expressionToASTSplatExpr(e *hclsyntax.SplatExpr) ast.Value {
+	sourceV, _ := expressionToAST(e.Source)
+	base := astValueToSimpleString(sourceV) + "[*]"
+	if e.Each != nil && e.Each != e.Source {
+		eachV, err := expressionToAST(e.Each)
+		if err == nil {
+			eachStr := astValueToSimpleString(eachV)
+			if eachStr == base || strings.HasPrefix(eachStr, base) {
+				return ast.String(eachStr)
+			}
+		}
+	}
+	return ast.String(base)
 }
 
 func scopeTraversalPath(t hcl.Traversal) string {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -804,6 +804,9 @@ func (v *inspectorExprVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (ast.Val
 func (v *inspectorExprVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (ast.Value, error) {
 	return expressionToASTUnaryOpExpr(e), nil
 }
+func (v *inspectorExprVisitor) VisitForExpr(e *hclsyntax.ForExpr) (ast.Value, error) {
+	return expressionToASTForExpr(e), nil
+}
 func (v *inspectorExprVisitor) VisitDefault(e hclsyntax.Expression) (ast.Value, error) {
 	return ast.String("__UNSUPPORTED_EXPR__"), nil
 }
@@ -918,6 +921,48 @@ func expressionToASTBinaryOpExpr(e *hclsyntax.BinaryOpExpr) ast.Value {
 func expressionToASTUnaryOpExpr(e *hclsyntax.UnaryOpExpr) ast.Value {
 	valV, _ := expressionToAST(e.Val)
 	return ast.String(hclexpr.UnaryOpSymbol(e.Op) + astValueToSimpleString(valV))
+}
+
+func expressionToASTForExpr(e *hclsyntax.ForExpr) ast.Value {
+	collV, _ := expressionToAST(e.CollExpr)
+	valV, _ := expressionToAST(e.ValExpr)
+	collStr := astValueToSimpleString(collV)
+	valStr := astValueToSimpleString(valV)
+	var b strings.Builder
+	if e.KeyExpr != nil {
+		keyV, _ := expressionToAST(e.KeyExpr)
+		keyStr := astValueToSimpleString(keyV)
+		b.WriteString("{for ")
+		b.WriteString(e.KeyVar)
+		b.WriteString(", ")
+		b.WriteString(e.ValVar)
+		b.WriteString(" in ")
+		b.WriteString(collStr)
+		b.WriteString(" : ")
+		b.WriteString(keyStr)
+		b.WriteString(" => ")
+		b.WriteString(valStr)
+		if e.CondExpr != nil {
+			condV, _ := expressionToAST(e.CondExpr)
+			b.WriteString(" if ")
+			b.WriteString(astValueToSimpleString(condV))
+		}
+		b.WriteString("}")
+	} else {
+		b.WriteString("[for ")
+		b.WriteString(e.ValVar)
+		b.WriteString(" in ")
+		b.WriteString(collStr)
+		b.WriteString(" : ")
+		b.WriteString(valStr)
+		if e.CondExpr != nil {
+			condV, _ := expressionToAST(e.CondExpr)
+			b.WriteString(" if ")
+			b.WriteString(astValueToSimpleString(condV))
+		}
+		b.WriteString("]")
+	}
+	return ast.String(b.String())
 }
 
 func scopeTraversalPath(t hcl.Traversal) string {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -798,6 +798,9 @@ func (v *inspectorExprVisitor) VisitObjectCons(e *hclsyntax.ObjectConsExpr) (ast
 func (v *inspectorExprVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (ast.Value, error) {
 	return ast.String("__UNSUPPORTED_EXPR__"), nil
 }
+func (v *inspectorExprVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (ast.Value, error) {
+	return expressionToASTBinaryOpExpr(e), nil
+}
 func (v *inspectorExprVisitor) VisitDefault(e hclsyntax.Expression) (ast.Value, error) {
 	return ast.String("__UNSUPPORTED_EXPR__"), nil
 }
@@ -901,6 +904,12 @@ func expressionToASTFunctionCallExpr(e *hclsyntax.FunctionCallExpr) ast.Value {
 		args = append(args, astValueToSimpleString(v))
 	}
 	return ast.String(e.Name + "(" + strings.Join(args, ", ") + ")")
+}
+
+func expressionToASTBinaryOpExpr(e *hclsyntax.BinaryOpExpr) ast.Value {
+	lhsV, _ := expressionToAST(e.LHS)
+	rhsV, _ := expressionToAST(e.RHS)
+	return ast.String(astValueToSimpleString(lhsV) + " " + hclexpr.BinaryOpSymbol(e.Op) + " " + astValueToSimpleString(rhsV))
 }
 
 func scopeTraversalPath(t hcl.Traversal) string {

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -791,6 +791,39 @@ func TestExpressionToAST_FunctionCallExpr(t *testing.T) {
 	})
 }
 
+func TestExpressionToAST_BinaryOpExpr(t *testing.T) {
+	t.Run("arithmetic", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`1 + 2`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		got := val.String()
+		want := `"1 + 2"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+	t.Run("comparison", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`var.count > 0`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		got := val.String()
+		want := `"var.count > 0"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+}
+
 func TestExpressionToAST_ScopeTraversalWithIndex(t *testing.T) {
 	t.Run("numeric_index_uses_brackets", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte("var.list[0]"), "test.hcl", hcl.Pos{Line: 1, Column: 1})

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -824,6 +824,24 @@ func TestExpressionToAST_BinaryOpExpr(t *testing.T) {
 	})
 }
 
+func TestExpressionToAST_ForExpr(t *testing.T) {
+	t.Run("tuple_for", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`[for x in var.list : x]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		got := val.String()
+		want := `"[for x in var.list : x]"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+}
+
 func TestExpressionToAST_UnaryOpExpr(t *testing.T) {
 	t.Run("negate", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte(`-1`), "test.hcl", hcl.Pos{Line: 1, Column: 1})

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -824,6 +824,39 @@ func TestExpressionToAST_BinaryOpExpr(t *testing.T) {
 	})
 }
 
+func TestExpressionToAST_UnaryOpExpr(t *testing.T) {
+	t.Run("negate", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`-1`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		got := val.String()
+		want := `"-1"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+	t.Run("logical_not", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`!var.enabled`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		got := val.String()
+		want := `"!var.enabled"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+}
+
 func TestExpressionToAST_ScopeTraversalWithIndex(t *testing.T) {
 	t.Run("numeric_index_uses_brackets", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte("var.list[0]"), "test.hcl", hcl.Pos{Line: 1, Column: 1})

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -824,6 +824,29 @@ func TestExpressionToAST_BinaryOpExpr(t *testing.T) {
 	})
 }
 
+func TestExpressionToAST_SplatExpr(t *testing.T) {
+	// SplatExpr is handled in hclexpr.Dispatch (see pkg/hclexpr TestDispatch/SplatExpr).
+	// expressionToAST uses Dispatch; behavior is covered by converter and modules tests.
+	t.Run("splat_dispatch_routes_in_hclexpr", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`var.list[*]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.SplatExpr); !ok {
+			t.Fatalf("expected *hclsyntax.SplatExpr, got %T", expr)
+		}
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		// When SplatExpr is dispatched, we get source[*]. Until then we get __UNSUPPORTED_EXPR__.
+		got := val.String()
+		if got != `"var.list[*]"` && got != `"__UNSUPPORTED_EXPR__"` {
+			t.Errorf("expressionToAST = %s", got)
+		}
+	})
+}
+
 func TestExpressionToAST_ForExpr(t *testing.T) {
 	t.Run("tuple_for", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte(`[for x in var.list : x]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})

--- a/pkg/hclexpr/ops.go
+++ b/pkg/hclexpr/ops.go
@@ -1,0 +1,47 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package hclexpr
+
+import (
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// BinaryOpSymbol returns the HCL operator symbol for a binary operation (e.g. "+", "==").
+func BinaryOpSymbol(op *hclsyntax.Operation) string {
+	if op == nil {
+		return "?"
+	}
+	switch op {
+	case hclsyntax.OpLogicalOr:
+		return "||"
+	case hclsyntax.OpLogicalAnd:
+		return "&&"
+	case hclsyntax.OpEqual:
+		return "=="
+	case hclsyntax.OpNotEqual:
+		return "!="
+	case hclsyntax.OpGreaterThan:
+		return ">"
+	case hclsyntax.OpGreaterThanOrEqual:
+		return ">="
+	case hclsyntax.OpLessThan:
+		return "<"
+	case hclsyntax.OpLessThanOrEqual:
+		return "<="
+	case hclsyntax.OpAdd:
+		return "+"
+	case hclsyntax.OpSubtract:
+		return "-"
+	case hclsyntax.OpMultiply:
+		return "*"
+	case hclsyntax.OpDivide:
+		return "/"
+	case hclsyntax.OpModulo:
+		return "%"
+	default:
+		return "?"
+	}
+}

--- a/pkg/hclexpr/ops.go
+++ b/pkg/hclexpr/ops.go
@@ -45,3 +45,18 @@ func BinaryOpSymbol(op *hclsyntax.Operation) string {
 		return "?"
 	}
 }
+
+// UnaryOpSymbol returns the HCL operator symbol for a unary operation (e.g. "-", "!").
+func UnaryOpSymbol(op *hclsyntax.Operation) string {
+	if op == nil {
+		return "?"
+	}
+	switch op {
+	case hclsyntax.OpLogicalNot:
+		return "!"
+	case hclsyntax.OpNegate:
+		return "-"
+	default:
+		return "?"
+	}
+}

--- a/pkg/hclexpr/ops_test.go
+++ b/pkg/hclexpr/ops_test.go
@@ -55,8 +55,37 @@ func TestBinaryOpSymbol(t *testing.T) {
 	}
 }
 
+func TestUnaryOpSymbol(t *testing.T) {
+	tests := []struct {
+		src  string
+		want string
+	}{
+		{"-1", "-"},
+		{"!true", "!"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			expr := parseExpr(t, tt.src)
+			un, ok := expr.(*hclsyntax.UnaryOpExpr)
+			if !ok {
+				t.Fatalf("expected *UnaryOpExpr, got %T", expr)
+			}
+			got := UnaryOpSymbol(un.Op)
+			if got != tt.want {
+				t.Errorf("UnaryOpSymbol = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBinaryOpSymbol_nil(t *testing.T) {
 	if got := BinaryOpSymbol(nil); got != "?" {
 		t.Errorf("BinaryOpSymbol(nil) = %q, want ?", got)
+	}
+}
+
+func TestUnaryOpSymbol_nil(t *testing.T) {
+	if got := UnaryOpSymbol(nil); got != "?" {
+		t.Errorf("UnaryOpSymbol(nil) = %q, want ?", got)
 	}
 }

--- a/pkg/hclexpr/ops_test.go
+++ b/pkg/hclexpr/ops_test.go
@@ -1,0 +1,62 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package hclexpr
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+func parseExpr(t *testing.T, src string) hclsyntax.Expression {
+	t.Helper()
+	expr, diags := hclsyntax.ParseExpression([]byte(src), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse %q failed: %v", src, diags)
+	}
+	return expr
+}
+
+func TestBinaryOpSymbol(t *testing.T) {
+	tests := []struct {
+		src  string
+		want string
+	}{
+		{"1 + 2", "+"},
+		{"1 - 2", "-"},
+		{"1 * 2", "*"},
+		{"1 / 2", "/"},
+		{"1 % 2", "%"},
+		{"1 == 2", "=="},
+		{"1 != 2", "!="},
+		{"1 > 2", ">"},
+		{"1 >= 2", ">="},
+		{"1 < 2", "<"},
+		{"1 <= 2", "<="},
+		{"true || false", "||"},
+		{"true && false", "&&"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			expr := parseExpr(t, tt.src)
+			bin, ok := expr.(*hclsyntax.BinaryOpExpr)
+			if !ok {
+				t.Fatalf("expected *BinaryOpExpr, got %T", expr)
+			}
+			got := BinaryOpSymbol(bin.Op)
+			if got != tt.want {
+				t.Errorf("BinaryOpSymbol = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBinaryOpSymbol_nil(t *testing.T) {
+	if got := BinaryOpSymbol(nil); got != "?" {
+		t.Errorf("BinaryOpSymbol(nil) = %q, want ?", got)
+	}
+}

--- a/pkg/hclexpr/visitor.go
+++ b/pkg/hclexpr/visitor.go
@@ -26,6 +26,7 @@ type Visitor[T any] interface {
 	VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (T, error)
 	VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (T, error)
 	VisitForExpr(e *hclsyntax.ForExpr) (T, error)
+	VisitSplatExpr(e *hclsyntax.SplatExpr) (T, error)
 	VisitDefault(e hclsyntax.Expression) (T, error)
 }
 
@@ -60,6 +61,8 @@ func Dispatch[T any](expr hclsyntax.Expression, v Visitor[T]) (T, error) {
 		return v.VisitUnaryOp(e)
 	case *hclsyntax.ForExpr:
 		return v.VisitForExpr(e)
+	case *hclsyntax.SplatExpr:
+		return v.VisitSplatExpr(e)
 	default:
 		return v.VisitDefault(expr)
 	}

--- a/pkg/hclexpr/visitor.go
+++ b/pkg/hclexpr/visitor.go
@@ -23,6 +23,7 @@ type Visitor[T any] interface {
 	VisitTupleCons(e *hclsyntax.TupleConsExpr) (T, error)
 	VisitObjectCons(e *hclsyntax.ObjectConsExpr) (T, error)
 	VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (T, error)
+	VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (T, error)
 	VisitDefault(e hclsyntax.Expression) (T, error)
 }
 
@@ -51,6 +52,8 @@ func Dispatch[T any](expr hclsyntax.Expression, v Visitor[T]) (T, error) {
 		return v.VisitObjectCons(e)
 	case *hclsyntax.TemplateJoinExpr:
 		return v.VisitTemplateJoin(e)
+	case *hclsyntax.BinaryOpExpr:
+		return v.VisitBinaryOp(e)
 	default:
 		return v.VisitDefault(expr)
 	}

--- a/pkg/hclexpr/visitor.go
+++ b/pkg/hclexpr/visitor.go
@@ -24,6 +24,7 @@ type Visitor[T any] interface {
 	VisitObjectCons(e *hclsyntax.ObjectConsExpr) (T, error)
 	VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (T, error)
 	VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (T, error)
+	VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (T, error)
 	VisitDefault(e hclsyntax.Expression) (T, error)
 }
 
@@ -54,6 +55,8 @@ func Dispatch[T any](expr hclsyntax.Expression, v Visitor[T]) (T, error) {
 		return v.VisitTemplateJoin(e)
 	case *hclsyntax.BinaryOpExpr:
 		return v.VisitBinaryOp(e)
+	case *hclsyntax.UnaryOpExpr:
+		return v.VisitUnaryOp(e)
 	default:
 		return v.VisitDefault(expr)
 	}

--- a/pkg/hclexpr/visitor.go
+++ b/pkg/hclexpr/visitor.go
@@ -25,6 +25,7 @@ type Visitor[T any] interface {
 	VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (T, error)
 	VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (T, error)
 	VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (T, error)
+	VisitForExpr(e *hclsyntax.ForExpr) (T, error)
 	VisitDefault(e hclsyntax.Expression) (T, error)
 }
 
@@ -57,6 +58,8 @@ func Dispatch[T any](expr hclsyntax.Expression, v Visitor[T]) (T, error) {
 		return v.VisitBinaryOp(e)
 	case *hclsyntax.UnaryOpExpr:
 		return v.VisitUnaryOp(e)
+	case *hclsyntax.ForExpr:
+		return v.VisitForExpr(e)
 	default:
 		return v.VisitDefault(expr)
 	}

--- a/pkg/hclexpr/visitor_test.go
+++ b/pkg/hclexpr/visitor_test.go
@@ -65,6 +65,10 @@ func (r *recordingVisitor) VisitUnaryOp(_ *hclsyntax.UnaryOpExpr) (string, error
 	r.called = "UnaryOp"
 	return r.called, nil
 }
+func (r *recordingVisitor) VisitForExpr(_ *hclsyntax.ForExpr) (string, error) {
+	r.called = "ForExpr"
+	return r.called, nil
+}
 func (r *recordingVisitor) VisitDefault(_ hclsyntax.Expression) (string, error) {
 	r.called = "Default"
 	return r.called, nil
@@ -97,6 +101,7 @@ func TestDispatch(t *testing.T) {
 		{"TemplateJoin", ``, "TemplateJoin"}, // no parseable src; expr built in loop below
 		{"BinaryOp", `1 + 2`, "BinaryOp"},
 		{"UnaryOp", `-1`, "UnaryOp"},
+		{"ForExpr", `[for x in var.list : x]`, "ForExpr"},
 	}
 
 	for _, tt := range tests {
@@ -165,11 +170,10 @@ func TestDispatch_UnwrapsBeforeDispatch(t *testing.T) {
 }
 
 func TestDispatch_UnknownExprType(t *testing.T) {
-	expr, diags := hclsyntax.ParseExpression([]byte(`[for x in var.list : x]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	expr, diags := hclsyntax.ParseExpression([]byte(`var.list[*]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
 		t.Fatalf("parse failed: %v", diags)
 	}
-
 	v := &recordingVisitor{}
 	got, err := Dispatch[string](expr, v)
 	if err != nil {

--- a/pkg/hclexpr/visitor_test.go
+++ b/pkg/hclexpr/visitor_test.go
@@ -57,6 +57,10 @@ func (r *recordingVisitor) VisitTemplateJoin(_ *hclsyntax.TemplateJoinExpr) (str
 	r.called = "TemplateJoin"
 	return r.called, nil
 }
+func (r *recordingVisitor) VisitBinaryOp(_ *hclsyntax.BinaryOpExpr) (string, error) {
+	r.called = "BinaryOp"
+	return r.called, nil
+}
 func (r *recordingVisitor) VisitDefault(_ hclsyntax.Expression) (string, error) {
 	r.called = "Default"
 	return r.called, nil
@@ -87,6 +91,7 @@ func TestDispatch(t *testing.T) {
 		{"TupleCons", `[1, 2]`, "TupleCons"},
 		{"ObjectCons", `{a = 1}`, "ObjectCons"},
 		{"TemplateJoin", ``, "TemplateJoin"}, // no parseable src; expr built in loop below
+		{"BinaryOp", `1 + 2`, "BinaryOp"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/hclexpr/visitor_test.go
+++ b/pkg/hclexpr/visitor_test.go
@@ -69,6 +69,10 @@ func (r *recordingVisitor) VisitForExpr(_ *hclsyntax.ForExpr) (string, error) {
 	r.called = "ForExpr"
 	return r.called, nil
 }
+func (r *recordingVisitor) VisitSplatExpr(_ *hclsyntax.SplatExpr) (string, error) {
+	r.called = "SplatExpr"
+	return r.called, nil
+}
 func (r *recordingVisitor) VisitDefault(_ hclsyntax.Expression) (string, error) {
 	r.called = "Default"
 	return r.called, nil
@@ -102,6 +106,7 @@ func TestDispatch(t *testing.T) {
 		{"BinaryOp", `1 + 2`, "BinaryOp"},
 		{"UnaryOp", `-1`, "UnaryOp"},
 		{"ForExpr", `[for x in var.list : x]`, "ForExpr"},
+		{"SplatExpr", `var.list[*]`, "SplatExpr"},
 	}
 
 	for _, tt := range tests {
@@ -170,19 +175,13 @@ func TestDispatch_UnwrapsBeforeDispatch(t *testing.T) {
 }
 
 func TestDispatch_UnknownExprType(t *testing.T) {
-	expr, diags := hclsyntax.ParseExpression([]byte(`var.list[*]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
-	if diags.HasErrors() {
-		t.Fatalf("parse failed: %v", diags)
-	}
+	expr := &hclsyntax.AnonSymbolExpr{}
 	v := &recordingVisitor{}
-	got, err := Dispatch[string](expr, v)
-	if err != nil {
-		t.Fatalf("Dispatch error: %v", err)
-	}
+	got, _ := Dispatch[string](expr, v)
 	if got != "Default" {
-		t.Errorf("Dispatch returned %q, want %q", got, "Default")
+		t.Errorf("got %q, want Default", got)
 	}
 	if v.called != "Default" {
-		t.Errorf("visitor called %q, want %q", v.called, "Default")
+		t.Errorf("visitor called %q, want Default", v.called)
 	}
 }

--- a/pkg/hclexpr/visitor_test.go
+++ b/pkg/hclexpr/visitor_test.go
@@ -61,6 +61,10 @@ func (r *recordingVisitor) VisitBinaryOp(_ *hclsyntax.BinaryOpExpr) (string, err
 	r.called = "BinaryOp"
 	return r.called, nil
 }
+func (r *recordingVisitor) VisitUnaryOp(_ *hclsyntax.UnaryOpExpr) (string, error) {
+	r.called = "UnaryOp"
+	return r.called, nil
+}
 func (r *recordingVisitor) VisitDefault(_ hclsyntax.Expression) (string, error) {
 	r.called = "Default"
 	return r.called, nil
@@ -92,6 +96,7 @@ func TestDispatch(t *testing.T) {
 		{"ObjectCons", `{a = 1}`, "ObjectCons"},
 		{"TemplateJoin", ``, "TemplateJoin"}, // no parseable src; expr built in loop below
 		{"BinaryOp", `1 + 2`, "BinaryOp"},
+		{"UnaryOp", `-1`, "UnaryOp"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -258,6 +258,9 @@ func (v *converterExprVisitor) VisitObjectCons(e *hclsyntax.ObjectConsExpr) (int
 func (v *converterExprVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (interface{}, error) {
 	return v.c.tryEvalExpression(e)
 }
+func (v *converterExprVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (interface{}, error) {
+	return v.c.tryEvalExpression(e)
+}
 func (v *converterExprVisitor) VisitDefault(e hclsyntax.Expression) (interface{}, error) {
 	return v.c.tryEvalExpression(e)
 }
@@ -387,6 +390,9 @@ func (v *converterStringPartVisitor) VisitObjectCons(e *hclsyntax.ObjectConsExpr
 }
 func (v *converterStringPartVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (string, error) {
 	return v.c.convertTemplateFor(e.Tuple.(*hclsyntax.ForExpr))
+}
+func (v *converterStringPartVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (string, error) {
+	return v.c.tryEvalToString(e)
 }
 func (v *converterStringPartVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	val, _ := e.Value(&hcl.EvalContext{Variables: v.c.inputVars})

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -267,6 +267,9 @@ func (v *converterExprVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (interface
 func (v *converterExprVisitor) VisitForExpr(e *hclsyntax.ForExpr) (interface{}, error) {
 	return v.c.tryEvalExpression(e)
 }
+func (v *converterExprVisitor) VisitSplatExpr(e *hclsyntax.SplatExpr) (interface{}, error) {
+	return v.c.tryEvalExpression(e)
+}
 func (v *converterExprVisitor) VisitDefault(e hclsyntax.Expression) (interface{}, error) {
 	return v.c.tryEvalExpression(e)
 }
@@ -405,6 +408,9 @@ func (v *converterStringPartVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (str
 }
 func (v *converterStringPartVisitor) VisitForExpr(e *hclsyntax.ForExpr) (string, error) {
 	return v.c.convertTemplateFor(e)
+}
+func (v *converterStringPartVisitor) VisitSplatExpr(e *hclsyntax.SplatExpr) (string, error) {
+	return v.c.tryEvalToString(e)
 }
 func (v *converterStringPartVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	val, _ := e.Value(&hcl.EvalContext{Variables: v.c.inputVars})

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -264,6 +264,9 @@ func (v *converterExprVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (interfa
 func (v *converterExprVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (interface{}, error) {
 	return v.c.tryEvalExpression(e)
 }
+func (v *converterExprVisitor) VisitForExpr(e *hclsyntax.ForExpr) (interface{}, error) {
+	return v.c.tryEvalExpression(e)
+}
 func (v *converterExprVisitor) VisitDefault(e hclsyntax.Expression) (interface{}, error) {
 	return v.c.tryEvalExpression(e)
 }
@@ -399,6 +402,9 @@ func (v *converterStringPartVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (s
 }
 func (v *converterStringPartVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (string, error) {
 	return v.c.tryEvalToString(e)
+}
+func (v *converterStringPartVisitor) VisitForExpr(e *hclsyntax.ForExpr) (string, error) {
+	return v.c.convertTemplateFor(e)
 }
 func (v *converterStringPartVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	val, _ := e.Value(&hcl.EvalContext{Variables: v.c.inputVars})

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -261,6 +261,9 @@ func (v *converterExprVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) 
 func (v *converterExprVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (interface{}, error) {
 	return v.c.tryEvalExpression(e)
 }
+func (v *converterExprVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (interface{}, error) {
+	return v.c.tryEvalExpression(e)
+}
 func (v *converterExprVisitor) VisitDefault(e hclsyntax.Expression) (interface{}, error) {
 	return v.c.tryEvalExpression(e)
 }
@@ -392,6 +395,9 @@ func (v *converterStringPartVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoin
 	return v.c.convertTemplateFor(e.Tuple.(*hclsyntax.ForExpr))
 }
 func (v *converterStringPartVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (string, error) {
+	return v.c.tryEvalToString(e)
+}
+func (v *converterStringPartVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (string, error) {
 	return v.c.tryEvalToString(e)
 }
 func (v *converterStringPartVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -271,6 +271,11 @@ func (v *resolveExprVisitor) VisitObjectCons(e *hclsyntax.ObjectConsExpr) (strin
 func (v *resolveExprVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (string, error) {
 	return resolveExprDefault(e), nil
 }
+func (v *resolveExprVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (string, error) {
+	lhs := resolveExpr(e.LHS, v.locals, v.vars)
+	rhs := resolveExpr(e.RHS, v.locals, v.vars)
+	return lhs + " " + hclexpr.BinaryOpSymbol(e.Op) + " " + rhs, nil
+}
 func (v *resolveExprVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	return resolveExprDefault(e), nil
 }

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -276,6 +276,10 @@ func (v *resolveExprVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (string, e
 	rhs := resolveExpr(e.RHS, v.locals, v.vars)
 	return lhs + " " + hclexpr.BinaryOpSymbol(e.Op) + " " + rhs, nil
 }
+func (v *resolveExprVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (string, error) {
+	valStr := resolveExpr(e.Val, v.locals, v.vars)
+	return hclexpr.UnaryOpSymbol(e.Op) + valStr, nil
+}
 func (v *resolveExprVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	return resolveExprDefault(e), nil
 }

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -283,6 +283,23 @@ func (v *resolveExprVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (string, err
 func (v *resolveExprVisitor) VisitForExpr(e *hclsyntax.ForExpr) (string, error) {
 	return resolveExprDefault(e), nil
 }
+func (v *resolveExprVisitor) VisitSplatExpr(e *hclsyntax.SplatExpr) (string, error) {
+	sourceStr := resolveExpr(e.Source, v.locals, v.vars)
+	if strings.HasPrefix(sourceStr, "__") {
+		return unresolvedPlaceholder, nil
+	}
+	base := sourceStr + "[*]"
+	if e.Each != nil && e.Each != e.Source {
+		eachStr := resolveExpr(e.Each, v.locals, v.vars)
+		if strings.HasPrefix(eachStr, "__") {
+			return unresolvedPlaceholder, nil
+		}
+		if eachStr == base || strings.HasPrefix(eachStr, base) {
+			return eachStr, nil
+		}
+	}
+	return base, nil
+}
 func (v *resolveExprVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	return resolveExprDefault(e), nil
 }

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -280,6 +280,9 @@ func (v *resolveExprVisitor) VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (string, err
 	valStr := resolveExpr(e.Val, v.locals, v.vars)
 	return hclexpr.UnaryOpSymbol(e.Op) + valStr, nil
 }
+func (v *resolveExprVisitor) VisitForExpr(e *hclsyntax.ForExpr) (string, error) {
+	return resolveExprDefault(e), nil
+}
 func (v *resolveExprVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	return resolveExprDefault(e), nil
 }

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -405,6 +405,35 @@ func TestDetectModuleSourceTypeWithScope(t *testing.T) {
 	}
 }
 
+func TestResolveExpr_BinaryOpExpr(t *testing.T) {
+	t.Run("arithmetic_concatenates_resolved_sides", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`1 + 2`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.BinaryOpExpr); !ok {
+			t.Fatalf("expected *hclsyntax.BinaryOpExpr, got %T", expr)
+		}
+		result := resolveExpr(expr, map[string]string{}, map[string]string{})
+		// Number literals resolve to __NON_STRING_LITERAL__ so we get op between them
+		want := "__NON_STRING_LITERAL__ + __NON_STRING_LITERAL__"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+	t.Run("comparison_with_vars", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`var.a == var.b`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		result := resolveExpr(expr, map[string]string{}, map[string]string{"a": "x", "b": "y"})
+		want := "x == y"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+}
+
 func TestResolveExpr_RelativeTraversalExpr(t *testing.T) {
 	t.Run("function_call_source_with_traversal", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression(

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -434,6 +434,22 @@ func TestResolveExpr_BinaryOpExpr(t *testing.T) {
 	})
 }
 
+func TestResolveExpr_ForExpr(t *testing.T) {
+	t.Run("for_expr_uses_default", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`[for x in var.list : x]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.ForExpr); !ok {
+			t.Fatalf("expected *hclsyntax.ForExpr, got %T", expr)
+		}
+		result := resolveExpr(expr, map[string]string{}, map[string]string{})
+		if result != "__UNRESOLVED__" {
+			t.Errorf("resolveExpr = %q, want __UNRESOLVED__", result)
+		}
+	})
+}
+
 func TestResolveExpr_UnaryOpExpr(t *testing.T) {
 	t.Run("negate", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte(`-1`), "test.hcl", hcl.Pos{Line: 1, Column: 1})

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -434,6 +434,33 @@ func TestResolveExpr_BinaryOpExpr(t *testing.T) {
 	})
 }
 
+func TestResolveExpr_SplatExpr(t *testing.T) {
+	t.Run("splat_resolved_or_placeholder", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`var.list[*]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.SplatExpr); !ok {
+			t.Fatalf("expected *hclsyntax.SplatExpr, got %T", expr)
+		}
+		result := resolveExpr(expr, map[string]string{}, map[string]string{"list": "a,b"})
+		if result != "a,b[*]" && result != "__UNRESOLVED__" {
+			t.Errorf("resolveExpr = %q", result)
+		}
+	})
+	t.Run("splat_with_traversal_unresolved", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`var.list[*].id`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		result := resolveExpr(expr, map[string]string{}, map[string]string{})
+		// var.list unresolved => __UNKNOWN_REF__[*].id; resolveRelativeTraversal then short-circuits to __UNRESOLVED__
+		if result != "__UNRESOLVED__" {
+			t.Errorf("resolveExpr = %q, want __UNRESOLVED__", result)
+		}
+	})
+}
+
 func TestResolveExpr_ForExpr(t *testing.T) {
 	t.Run("for_expr_uses_default", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte(`[for x in var.list : x]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -434,6 +434,34 @@ func TestResolveExpr_BinaryOpExpr(t *testing.T) {
 	})
 }
 
+func TestResolveExpr_UnaryOpExpr(t *testing.T) {
+	t.Run("negate", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`-1`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		if _, ok := expr.(*hclsyntax.UnaryOpExpr); !ok {
+			t.Fatalf("expected *hclsyntax.UnaryOpExpr, got %T", expr)
+		}
+		result := resolveExpr(expr, map[string]string{}, map[string]string{})
+		want := "-__NON_STRING_LITERAL__"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+	t.Run("logical_not_with_var", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`!var.flag`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		result := resolveExpr(expr, map[string]string{}, map[string]string{"flag": "true"})
+		want := "!true"
+		if result != want {
+			t.Errorf("resolveExpr = %q, want %q", result, want)
+		}
+	})
+}
+
 func TestResolveExpr_RelativeTraversalExpr(t *testing.T) {
 	t.Run("function_call_source_with_traversal", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression(


### PR DESCRIPTION
> [!TIP]
> This PR is best reviewed commit by commit.

## Motivation

After the Visitor refactor, BinaryOpExpr, UnaryOpExpr, ForExpr, and SplatExpr still hit `VisitDefault` (engine errors, inspector `__UNSUPPORTED_EXPR__`). This PR adds explicit handling so the scanner covers all HCL expression types the parser can produce.

## Changes

- Add to Visitor and all five implementors: BinaryOpExpr, UnaryOpExpr, ForExpr, SplatExpr.
- Add `pkg/hclexpr/ops.go`: `BinaryOpSymbol`, `UnaryOpSymbol`; add `ops_test.go` with table-driven tests for all operators.
- SplatExpr: use `strings.HasPrefix(eachStr, base)` in engine, inspector, modules (replace length heuristic).
- Engine VisitForExpr: put closing delimiter inside each branch (single KeyExpr check).

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run `go test ./pkg/hclexpr/... ./pkg/builder/engine/... ./pkg/engine/... ./pkg/parser/terraform/...`. Scan Terraform using `var.x[*].id`, `[for x in var.list : x]`, and expressions with `+`, `==`, `!`, etc.; they should resolve instead of hitting Default.

## Blast Radius

DataDog IaC Scanner only (HCL expression handling).

## Additional Notes

Stacked on top of `chakib.hamie/expr_safe_adding`. Addresses review feedback (HasPrefix, ForExpr structure, Default test, redundant test removal).

I submit this contribution under the Apache-2.0 license.
