### PR TITLE
Replace n/a resourceType and resourceName with meaningful values

### DIFF
--- a/assets/queries/ansible/config/allow_unsafe_lookups_enabled_in_defaults/query.rego
+++ b/assets/queries/ansible/config/allow_unsafe_lookups_enabled_in_defaults/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceName": "defaults",
-		"resourceType": "n/a",
+		"resourceType": "ansible_config",
 		"searchKey": "defaults.allow_unsafe_lookups",
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "allow_unsafe_lookups should be set to 'False'",

--- a/assets/queries/ansible/config/communication_over_http_in_defaults/query.rego
+++ b/assets/queries/ansible/config/communication_over_http_in_defaults/query.rego
@@ -11,8 +11,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "ansible_config",
+		"resourceName": "galaxy",
 		"searchKey": "[galaxy].server",
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'server' from galaxy group should be accessed via the HTTPS protocol",

--- a/assets/queries/ansible/config/logging_of_sensitive_data_in_defaults/query.rego
+++ b/assets/queries/ansible/config/logging_of_sensitive_data_in_defaults/query.rego
@@ -11,8 +11,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": "defaults",
 		"issueType": "IncorrectValue",
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "ansible_config",
+		"resourceName": "defaults",
 		"keyExpectedValue": "no_log should be defined and set to 'true'",
 		"keyActualValue": "no_log is not defined",
 	}
@@ -27,8 +27,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": "defaults.no_log",
 		"issueType": "IncorrectValue",
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "ansible_config",
+		"resourceName": "defaults",
 		"keyExpectedValue": "no_log should be set to 'true'",
 		"keyActualValue": "no_log is set to 'false'",
 	}

--- a/assets/queries/ansible/config/privilege_escalation_using_become_plugin_in_defaults/query.rego
+++ b/assets/queries/ansible/config/privilege_escalation_using_become_plugin_in_defaults/query.rego
@@ -11,8 +11,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "ansible_config",
+		"resourceName": "defaults",
 		"searchKey": "defaults.become_user",
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'become' should be defined and set to 'true'",
@@ -28,8 +28,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "ansible_config",
+		"resourceName": "defaults",
 		"searchKey": "defaults.become",
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'become' should be set to 'true'",

--- a/assets/queries/ansible/general/privilege_escalation_using_become_plugin/query.rego
+++ b/assets/queries/ansible/general/privilege_escalation_using_become_plugin/query.rego
@@ -10,8 +10,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "ansible_playbook",
+		"resourceName": playbook.become_user,
 		"searchKey": "become",
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'become' should be defined and set to 'true' in order to perform an action with %s", [playbook.become_user]),
@@ -26,8 +26,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "ansible_playbook",
+		"resourceName": playbook.become_user,
 		"searchKey": sprintf("become_user={{%s}}", [playbook.become_user]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'become' should be defined and set to 'true' in order to perform an action with %s", [playbook.become_user]),
@@ -42,8 +42,8 @@ CxPolicy[result] {
 
     result := {
 		"documentId": id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "ansible_task",
+		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.become_user={{%s}}.become", [task.name, task.become_user]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'become' should be to 'true' in order to perform an action with %s", [task.become_user]),
@@ -58,8 +58,8 @@ CxPolicy[result] {
 
     result := {
 		"documentId": id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
+		"resourceType": "ansible_task",
+		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.become_user={{%s}}", [task.name, task.become_user]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'become' should be defined and set to 'true' in order to perform an action with %s", [task.become_user]),

--- a/assets/queries/ansible/hosts/ansible_tower_exposed_to_internet/query.rego
+++ b/assets/queries/ansible/hosts/ansible_tower_exposed_to_internet/query.rego
@@ -11,8 +11,8 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[id].id,
 		"hostname": "tower",
-		"resourceName": "children",
-		"resourceType": "n/a",
+		"resourceName": "tower",
+		"resourceType": "ansible_inventory",
 		"searchKey": "all.children.tower.hosts",
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Ansible Tower IP should be private",


### PR DESCRIPTION
## Motivation

Avoid reporting `n/a` for resourceType and resourceName on Ansible findings so findings have real values for these important fields and is consistent with the other rules

## Changes

- **Config rules** (4): `resourceType` = `ansible_config`, `resourceName` = section (`defaults`, `galaxy`).
- **Hosts** (ansible_tower_exposed_to_internet): `resourceType` = `ansible_inventory`, `resourceName` = `tower`.
- **General** (privilege_escalation_using_become_plugin): playbook-level → `ansible_playbook` + `become_user`; task-level → `ansible_task` + `task.name`.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary.
- [x] All new and existing tests pass.

## QA Instruction

`go test ./test/... -run TestQueries -count=1`

## Blast Radius

Datadog IaC Scanner (Ansible query output only).

I submit this contribution under the Apache-2.0 license.