### PR TITLE
Ansible normalize resourceType

### DIFF
--- a/assets/queries/ansible/general/risky_file_permissions/query.rego
+++ b/assets/queries/ansible/general/risky_file_permissions/query.rego
@@ -73,7 +73,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": id,
-		"resourceType": modules[m],
+		"resourceType": m,
 		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, m]),
 		"issueType": "IncorrectValue",

--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
@@ -168,6 +169,12 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 		overrideKey = s.(string)
 	}
 
+	platform := getStringFromMap(ctx, "platform", "", overrideKey, vObj, &logWithFields)
+	resourceType := PtrStringToString(mustMapKeyToString(ctx, vObj, "resourceType"))
+	if strings.EqualFold(platform, "ansible") {
+		resourceType = utils.NormalizeAnsibleResourceType(resourceType)
+	}
+
 	queryID := getStringFromMap(ctx, "id", DefaultQueryID, overrideKey, vObj, &logWithFields)
 
 	severity := getResolvedSeverity(ctx, vObj, &logWithFields, overrideKey, useOldSeverities)
@@ -195,7 +202,7 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 		Description:     getStringFromMap(ctx, "descriptionText", "", overrideKey, vObj, &logWithFields),
 		DescriptionID:   getStringFromMap(ctx, "descriptionID", DefaultQueryDescriptionID, overrideKey, vObj, &logWithFields),
 		Severity:        severity,
-		Platform:        getStringFromMap(ctx, "platform", "", overrideKey, vObj, &logWithFields),
+		Platform:        platform,
 		CWE:             getStringFromMap(ctx, "cwe", "", overrideKey, vObj, &logWithFields),
 		Line:            linesVulne.Line,
 		VulnerabilityLocation: model.ResourceLocation{
@@ -207,7 +214,7 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 			End:   linesVulne.RemediationLocation.End,
 		},
 		VulnLines:             linesVulne.VulnLines,
-		ResourceType:          PtrStringToString(mustMapKeyToString(ctx, vObj, "resourceType")),
+		ResourceType:          resourceType,
 		ResourceName:          PtrStringToString(mustMapKeyToString(ctx, vObj, "resourceName")),
 		IssueType:             issueType,
 		SearchKey:             searchKey,

--- a/pkg/scan/utils_test.go
+++ b/pkg/scan/utils_test.go
@@ -129,7 +129,7 @@ func Test_GetTotalFiles(t *testing.T) {
 		{
 			name:           "count utils folder files",
 			paths:          []string{filepath.Join("..", "..", "pkg", "utils")},
-			expectedOutput: 16,
+			expectedOutput: 18,
 		},
 		{
 			name:           "count analyzer folder files",
@@ -139,7 +139,7 @@ func Test_GetTotalFiles(t *testing.T) {
 		{
 			name:           "count analyzer and utils folder files",
 			paths:          []string{filepath.Join("..", "..", "pkg", "analyzer"), filepath.Join("..", "..", "pkg", "utils")},
-			expectedOutput: 18,
+			expectedOutput: 20,
 		},
 		{
 			name:           "count invalid folder",

--- a/pkg/utils/ansible_resource_type.go
+++ b/pkg/utils/ansible_resource_type.go
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package utils
+
+import "strings"
+
+// NormalizeAnsibleResourceType returns the Ansible content name (last segment after ".") from a
+// fully qualified collection name (FQCN) or short name. Used so that rego rules can output
+// either "community.aws.ec2_instance" or "ec2_instance" and we consistently expose "ec2_instance".
+// If resourceType has no ".", it is returned unchanged.
+func NormalizeAnsibleResourceType(resourceType string) string {
+	if idx := strings.LastIndex(resourceType, "."); idx != -1 {
+		return resourceType[idx+1:]
+	}
+	return resourceType
+}

--- a/pkg/utils/ansible_resource_type_test.go
+++ b/pkg/utils/ansible_resource_type_test.go
@@ -1,0 +1,82 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeAnsibleResourceType(t *testing.T) {
+	tests := []struct {
+		name        string
+		resourceType string
+		want        string
+	}{
+		{
+			name:        "FQCN community.aws returns last segment",
+			resourceType: "community.aws.ec2_instance",
+			want:        "ec2_instance",
+		},
+		{
+			name:        "FQCN ansible.builtin returns last segment",
+			resourceType: "ansible.builtin.user",
+			want:        "user",
+		},
+		{
+			name:        "FQCN azure.azcollection returns last segment",
+			resourceType: "azure.azcollection.azure_rm_aks",
+			want:        "azure_rm_aks",
+		},
+		{
+			name:        "FQCN google.cloud returns last segment",
+			resourceType: "google.cloud.gcp_compute_firewall",
+			want:        "gcp_compute_firewall",
+		},
+		{
+			name:        "short name with no dot is unchanged",
+			resourceType: "ec2_instance",
+			want:        "ec2_instance",
+		},
+		{
+			name:        "conceptual type with no dot is unchanged",
+			resourceType: "ansible_config",
+			want:        "ansible_config",
+		},
+		{
+			name:        "ansible_playbook unchanged",
+			resourceType: "ansible_playbook",
+			want:        "ansible_playbook",
+		},
+		{
+			name:        "ansible_task unchanged",
+			resourceType: "ansible_task",
+			want:        "ansible_task",
+		},
+		{
+			name:        "community.aws.aws_kms to aws_kms",
+			resourceType: "community.aws.aws_kms",
+			want:        "aws_kms",
+		},
+		{
+			name:        "installer module FQCN to short name",
+			resourceType: "community.general.apt",
+			want:        "apt",
+		},
+		{
+			name:        "empty string unchanged",
+			resourceType: "",
+			want:        "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeAnsibleResourceType(tt.resourceType)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Ansible rules reported inconsistent or wrong `resourceType` values: (1) risky_file_permissions used the map value (boolean) instead of the module name; (2) rules output either FQCN (e.g. `community.aws.ec2_instance`) or short name (`ec2_instance`) depending on the set. We fix the bug and normalize Ansible resourceType in Go so all findings expose the content name (last segment after `.`) without changing every rego rule.

## Changes

- **Fix risky_file_permissions:** Third CxPolicy block used `resourceType: modules[m]` (map value = boolean), which means it reports true/false for the resourceType haha. Now uses `m` (module name).
- **Normalize Ansible resourceType in Go:** Added `utils.NormalizeAnsibleResourceType(resourceType)` (returns last segment after `.`, or unchanged if no dot). In `vulnerability_builder.go`, when platform is Ansible we normalize before setting `ResourceType`. Rego rules are unchanged; normalization is applied once at build time. Includes unit tests for the util.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run scanner on Ansible playbooks; confirm findings show `resourceType` as short names (e.g. `ec2_instance`, `user`, `ansible_config`) not FQCNs. Run `go test ./pkg/utils/ -run TestNormalizeAnsibleResourceType` and `go test ./pkg/engine/...`.

## Blast Radius

Ansible findings only: `ResourceType` field in vulnerability model (and thus in SARIF, storage, API). No rego changes; no other platforms affected.

## Additional Notes

I submit this contribution under the Apache-2.0 license.