### PR TITLE
Skip non-Terraform files in module generation

### DIFF
--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -555,6 +555,11 @@ func generateEquivalentMap(ctx context.Context, modulePath string) (map[string]M
 			continue
 		}
 
+		if !isTerraformFile(entry.Name()) {
+			contextLogger.Debug().Msgf("Skipping non-Terraform file: %s", path)
+			continue
+		}
+
 		contents, err := os.ReadFile(filepath.Clean(path))
 		if err != nil {
 			contextLogger.Error().Msgf("Failed to read file: %s", path)


### PR DESCRIPTION
## Motivation

`generateEquivalentMap` reads all files in a module directory to extract resource blocks, but it was not filtering by file extension. Non-HCL files (e.g. `README.md`) would be passed to `hclwrite.ParseConfig`, causing parse errors like:

```
error parsing input Terraform block in file .../README.md: Invalid character; The "`" character is not valid.
```

## Changes

- Added an `isTerraformFile()` check in `generateEquivalentMap` to skip non-`.tf` files before attempting HCL parsing, consistent with how `ParseTerraformModules` and `getDataSourcePolicy` already handle file filtering.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run the scanner against a Terraform module directory that contains non-`.tf` files (e.g. `README.md` with markdown backticks). The parse error should no longer occur.

## Blast Radius

DataDog IaC Scanner only, Terraform module parsing.

## Additional Notes

No tests added, `isTerraformFile()` is already covered, and this is a straightforward guard clause. Existing tests pass.

I submit this contribution under the Apache-2.0 license.