### PR TITLE
Create release files without version number

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,8 @@ builds:
 
 archives:
   - ids: [datadog-iac-scanner]
+    # Like the default template, but without version number
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 \"v1\") }}{{ .Amd64 }}{{ end }}"
     format_overrides:
       - goos: windows
         formats: [zip]


### PR DESCRIPTION
## Motivation

This makes it easier for CI as the latest release file URL will always be the same. Otherwise, our scripts need to do GitHub API calls to determine the URL.

## Changes

Used a custom file name template that's like the default template with version number removed.

## Author Checklist

- [X] I have reviewed my own PR.
- [X] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [X] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Executed `goreleaser release --snapshot` and got this:

```
  • archives
    • archiving                                      name=dist/datadog-iac-scanner_windows_amd64.zip
    • archiving                                      name=dist/datadog-iac-scanner_darwin_arm64.tar.gz
    • archiving                                      name=dist/datadog-iac-scanner_linux_amd64.tar.gz
    • archiving                                      name=dist/datadog-iac-scanner_linux_arm64.tar.gz
```

## Blast Radius

What services will this change impact. Is it only DataDog IaC Scanner, internal services, the documentation or anything else?

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
