### PR TITLE
Do not include the version number in the checksum file's name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,6 +37,10 @@ archives:
     files:
       - LICENSE
 
+checksum:
+  name_template: "{{ .ProjectName }}_checksums.txt"
+  algorithm: sha256
+
 changelog:
   use: github-native
 


### PR DESCRIPTION
## Motivation

In https://github.com/DataDog/datadog-iac-scanner/pull/34 I removed the version numbers from the release files, but didn't realize I needed to do the same for the checksums file. This PR fixes that.

## Changes

Added a `checksums` section with an updated file name template and explicit SHA256 algorithm.

## Author Checklist

- [X] I have reviewed my own PR.
- [X] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [X] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

After executing `goreleaser release --snapshot --clean`:

```
% cat dist/datadog-iac-scanner_checksums.txt
8e5b70c6047070f79f9e0dc2496ae1aff2204a1e4d241058cc32ba7b41cae335  datadog-iac-scanner_darwin_arm64.tar.gz
e5c52ac841b137c08c06328b50a836c7fa5a91e927055b68bff1385c69755b0f  datadog-iac-scanner_linux_amd64.tar.gz
964ec4769bba79cde8dda03f1c9c2d2d88ee06104e77ca57d204cb91bce3a8b1  datadog-iac-scanner_linux_arm64.tar.gz
166ddc98e17cfb4722369ee832018380e5135fa19c055d91031e3624b106645e  datadog-iac-scanner_windows_amd64.zip
```

## Blast Radius

What services will this change impact. Is it only DataDog IaC Scanner, internal services, the documentation or anything else?

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
