### PR TITLE
Ansible resourceName: align with module identifiers and manifest

### DIFF
--- a/assets/queries/ansible/aws/alb_listening_on_http/query.rego
+++ b/assets/queries/ansible/aws/alb_listening_on_http/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(applicationLb, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.listeners.Protocol=%s", [task.name, modules[m], applicationLb.listeners[index].Protocol]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'aws_elb_application_lb' Protocol should be 'HTTP'",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(applicationLb, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.listeners", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'aws_elb_application_lb' Protocol should be 'HTTP'",

--- a/assets/queries/ansible/aws/ami_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/ami_not_encrypted/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2Ami, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "ec2_ami.device_mapping.device_name.encrypted should be set to true",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2Ami, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.device_mapping.encrypted", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ec2_ami.device_mapping.encrypted should be set to true",

--- a/assets/queries/ansible/aws/ami_shared_with_multiple_accounts/query.rego
+++ b/assets/queries/ansible/aws/ami_shared_with_multiple_accounts/query.rego
@@ -5,15 +5,15 @@ import data.generic.ansible as ansLib
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
 	modules := {"amazon.aws.ec2_ami", "ec2_ami"}
-	ac2_ami := task[modules[m]]
-	ansLib.checkState(ac2_ami)
+	ec2Ami := task[modules[m]]
+	ansLib.checkState(ec2Ami)
 
-	amiIsShared(ac2_ami.launch_permissions)
+	amiIsShared(ec2Ami.launch_permissions)
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2Ami, "image_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.launch_permissions", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ec2_ami.launch_permissions just allows one user to launch the AMI",

--- a/assets/queries/ansible/aws/api_gateway_endpoint_config_is_not_private/query.rego
+++ b/assets/queries/ansible/aws/api_gateway_endpoint_config_is_not_private/query.rego
@@ -5,15 +5,15 @@ import data.generic.ansible as ansLib
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
 	modules := {"community.aws.aws_api_gateway", "aws_api_gateway"}
-	redshiftCluster := task[modules[m]]
-	ansLib.checkState(redshiftCluster)
+	apiGateway := task[modules[m]]
+	ansLib.checkState(apiGateway)
 
-	redshiftCluster.endpoint_type != "PRIVATE"
+	apiGateway.endpoint_type != "PRIVATE"
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(apiGateway, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.endpoint_type", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'aws_api_gateway.endpoint_type' should be set to 'PRIVATE'",

--- a/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/query.rego
+++ b/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/query.rego
@@ -6,15 +6,15 @@ import data.generic.common as common_lib
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
 	modules := {"community.aws.cloudwatchlogs_log_group", "cloudwatchlogs_log_group"}
-	awsApiGateway := task[modules[m]]
-	ansLib.checkState(awsApiGateway)
+	logGroup := task[modules[m]]
+	ansLib.checkState(logGroup)
 
-	not common_lib.valid_key(awsApiGateway, "log_group_name")
+	not common_lib.valid_key(logGroup, "log_group_name")
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(logGroup, "log_group_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "cloudwatchlogs_log_grouptracing_enabled should contain log_group_name",

--- a/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/query.rego
+++ b/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/query.rego
@@ -19,7 +19,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(apiGateway, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.%s", [task.name, modules[m], content_info.attribute]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s.%s' should have an authorizer set", [modules[m], content_info.attribute]),
@@ -40,7 +40,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(apiGateway, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.swagger_text", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s.swagger_text' should have an authorizer set", [modules[m]]),
@@ -59,7 +59,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(apiGateway, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s' should have swagger_file, swagger_text or swagger_dict set", [modules[m]]),

--- a/assets/queries/ansible/aws/api_gateway_without_ssl_certificate/query.rego
+++ b/assets/queries/ansible/aws/api_gateway_without_ssl_certificate/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(api_gateway, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_api_gateway.validate_certs should be set",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(api_gateway, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.validate_certs", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "aws_api_gateway.validate_certs should be set to yes",

--- a/assets/queries/ansible/aws/api_gateway_without_waf/query.rego
+++ b/assets/queries/ansible/aws/api_gateway_without_waf/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(api, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "API Gateway Stage should be associated with a Web Application Firewall",

--- a/assets/queries/ansible/aws/api_gateway_xray_disabled/query.rego
+++ b/assets/queries/ansible/aws/api_gateway_xray_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(tracing, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_api_gateway.tracing_enabled should be defined",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(tracing, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.tracing_enabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "aws_api_gateway.tracing_enabled should be true",

--- a/assets/queries/ansible/aws/authentication_without_mfa/query.rego
+++ b/assets/queries/ansible/aws/authentication_without_mfa/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(sts_assume_role, "role_arn", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"searchValue": attributes[j],
 		"issueType": "MissingAttribute",

--- a/assets/queries/ansible/aws/auto_scaling_group_with_no_associated_elb/query.rego
+++ b/assets/queries/ansible/aws/auto_scaling_group_with_no_associated_elb/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(resource, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.load_balancers should be set and not empty", [modules[m]]),
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(resource, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.load_balancers", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.load_balancers should not be empty", [modules[m]]),

--- a/assets/queries/ansible/aws/automatic_minor_upgrades_disabled/query.rego
+++ b/assets/queries/ansible/aws/automatic_minor_upgrades_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(rds_instance, "db_instance_identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.auto_minor_version_upgrade", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "rds_instance.auto_minor_version_upgrade should be true",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(rds_instance, "db_instance_identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "rds_instance.auto_minor_version_upgrade should be set",

--- a/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/query.rego
+++ b/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(batch_job_definition, "job_definition_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.privileged", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{%s}}.privileged should be set to 'false' or not set", [task.name, modules[m]]),

--- a/assets/queries/ansible/aws/ca_certificate_identifier_is_outdated/query.rego
+++ b/assets/queries/ansible/aws/ca_certificate_identifier_is_outdated/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(rds_instance, "db_instance_identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "rds_instance.ca_certificate_identifier should be defined",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(rds_instance, "db_instance_identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.ca_certificate_identifier", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "rds_instance.ca_certificate_identifier should equal to 'rds-ca-2019'",

--- a/assets/queries/ansible/aws/cdn_configuration_is_missing/query.rego
+++ b/assets/queries/ansible/aws/cdn_configuration_is_missing/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudfront_distribution, "distribution_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"searchValue": "enabled",
 		"issueType": "MissingAttribute",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudfront_distribution, "distribution_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.enabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{%s}}.enabled should be set to 'true'", [task.name, modules[m]]),
@@ -55,7 +55,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudfront_distribution, "distribution_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"searchValue": "origins",
 		"issueType": "MissingAttribute",

--- a/assets/queries/ansible/aws/certificate_has_expired/query.rego
+++ b/assets/queries/ansible/aws/certificate_has_expired/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": "community.aws.aws_acm",
-		"resourceName": task.name,
+		"resourceName": object.get(acm, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.community.aws.aws_acm.certificate", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'community.aws.aws_acm.certificate' should not have expired",

--- a/assets/queries/ansible/aws/certificate_rsa_key_bytes_lower_than_256/query.rego
+++ b/assets/queries/ansible/aws/certificate_rsa_key_bytes_lower_than_256/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
         "resourceType": "community.aws.aws_acm",
-		"resourceName": task.name,
+		"resourceName": object.get(acm, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.community.aws.aws_acm.certificate", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'community.aws.aws_acm.certificate' should use a RSA key with a length equal to or higher than 256 bytes",

--- a/assets/queries/ansible/aws/cloudfront_logging_disabled/query.rego
+++ b/assets/queries/ansible/aws/cloudfront_logging_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudfront, "distribution_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "cloudfront_distribution.logging should be defined",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudfront, "distribution_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.logging.enabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "cloudfront_distribution.logging.enabled should be true",

--- a/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/query.rego
+++ b/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudfront, "distribution_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "cloudfront_distribution.viewer_certificate should be defined",
@@ -36,7 +36,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudfront, "distribution_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.viewer_certificate.minimum_protocol_version", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{%s}}.viewer_certificate.minimum_protocol_version' should be TLSv1.2_x", [task.name, modules[m]]),

--- a/assets/queries/ansible/aws/cloudfront_without_waf/query.rego
+++ b/assets/queries/ansible/aws/cloudfront_without_waf/query.rego
@@ -5,15 +5,15 @@ import data.generic.ansible as ansLib
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
 	modules := {"community.aws.cloudfront_distribution", "cloudfront_distribution"}
-	redshiftCluster := task[modules[m]]
-	ansLib.checkState(redshiftCluster)
+	cloudfront := task[modules[m]]
+	ansLib.checkState(cloudfront)
 
-	not redshiftCluster.web_acl_id
+	not cloudfront.web_acl_id
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudfront, "distribution_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "cloudfront_distribution.web_acl_id should be defined",

--- a/assets/queries/ansible/aws/cloudtrail_log_file_validation_disabled/query.rego
+++ b/assets/queries/ansible/aws/cloudtrail_log_file_validation_disabled/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudtrail, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "cloudtrail.enable_log_file_validation or cloudtrail.log_file_validation_enabled should be defined",
@@ -37,7 +37,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudtrail, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.%s", [task.name, modules[m], attr]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("cloudtrail.%s should be set to true or yes", [attr]),

--- a/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/query.rego
+++ b/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudtrail, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "cloudtrail.kms_key_id should be set",

--- a/assets/queries/ansible/aws/cloudtrail_logging_disabled/query.rego
+++ b/assets/queries/ansible/aws/cloudtrail_logging_disabled/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudtrail, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.enable_logging", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "cloudtrail.enable_logging should be true",

--- a/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/query.rego
+++ b/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudtrail, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.is_multi_region_trail", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "cloudtrail.is_multi_region_trail should be true",
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudtrail, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "cloudtrail.is_multi_region_trail should be defined and set to true",

--- a/assets/queries/ansible/aws/cloudtrail_not_integrated_with_cloudwatch/query.rego
+++ b/assets/queries/ansible/aws/cloudtrail_not_integrated_with_cloudwatch/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudtrail, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"searchValue": properties[p],
 		"issueType": "MissingAttribute",

--- a/assets/queries/ansible/aws/cloudtrail_sns_topic_name_undefined/query.rego
+++ b/assets/queries/ansible/aws/cloudtrail_sns_topic_name_undefined/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "cloudtrail.sns_topic_name should be set",
@@ -32,7 +32,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.sns_topic_name", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "cloudtrail.sns_topic_name should be set",

--- a/assets/queries/ansible/aws/cloudwatch_without_retention_period_specified/query.rego
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_period_specified/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudwatchlogs_log_group, "log_group_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "cloudwatchlogs_log_group.retention should be set",
@@ -36,7 +36,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudwatchlogs_log_group, "log_group_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.retention", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "cloudwatchlogs_log_group.retention should be set and valid",

--- a/assets/queries/ansible/aws/cmk_is_unusable/query.rego
+++ b/assets/queries/ansible/aws/cmk_is_unusable/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": "community.aws.aws_kms",
-		"resourceName": task.name,
+		"resourceName": object.get(kms, "alias", task.name),
 		"searchKey": sprintf("name={{%s}}.{{community.aws.aws_kms}}.enabled", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.aws_kms.enabled should be set to true",
@@ -30,7 +30,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": "community.aws.aws_kms",
-		"resourceName": task.name,
+		"resourceName": object.get(kms, "alias", task.name),
 		"searchKey": sprintf("name={{%s}}.{{community.aws.aws_kms}}.pending_window", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.aws_kms.pending_window should be undefined",

--- a/assets/queries/ansible/aws/cmk_rotation_disabled/query.rego
+++ b/assets/queries/ansible/aws/cmk_rotation_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": "community.aws.aws_kms",
-		"resourceName": task.name,
+		"resourceName": object.get(kms, "alias", task.name),
 		"searchKey": sprintf("name={{%s}}.{{community.aws.aws_kms}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.aws_kms.enable_key_rotation should be set",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": "community.aws.aws_kms",
-		"resourceName": task.name,
+		"resourceName": object.get(kms, "alias", task.name),
 		"searchKey": sprintf("name={{%s}}.{{community.aws.aws_kms}}.enable_key_rotation", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.aws_kms.enable_key_rotation should be set to true",

--- a/assets/queries/ansible/aws/codebuild_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/codebuild_not_encrypted/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(aws_codebuild, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_codebuild.encryption_key should be set",

--- a/assets/queries/ansible/aws/config_configuration_aggregator_to_all_regions_disabled/query.rego
+++ b/assets/queries/ansible/aws/config_configuration_aggregator_to_all_regions_disabled/query.rego
@@ -6,16 +6,16 @@ modules := {"community.aws.aws_config_aggregator", "aws_config_aggregator"}
 
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
-	cloudwatchlogs := task[modules[m]]
-	ansLib.checkState(cloudwatchlogs)
+	configAggregator := task[modules[m]]
+	ansLib.checkState(configAggregator)
 	fields := ["account_sources", "organization_source"]
 
-	not ansLib.isAnsibleTrue(cloudwatchlogs[fields[f]].all_aws_regions)
+	not ansLib.isAnsibleTrue(configAggregator[fields[f]].all_aws_regions)
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(configAggregator, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.%s.all_aws_regions", [task.name, modules[m], fields[f]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'aws_config_aggregator.%s' should have all_aws_regions set to true", [fields[f]]),

--- a/assets/queries/ansible/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/query.rego
+++ b/assets/queries/ansible/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/query.rego
@@ -25,7 +25,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(iamRole, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.assume_role_policy_document", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "assume_role_policy_document should not contain ':root",

--- a/assets/queries/ansible/aws/db_instance_storage_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/db_instance_storage_not_encrypted/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "db_instance_identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "rds_instance.storage_encrypted should be set to true",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "db_instance_identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.storage_encrypted", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "rds_instance.storage_encrypted should be set to true",

--- a/assets/queries/ansible/aws/db_security_group_open_to_large_scope/query.rego
+++ b/assets/queries/ansible/aws/db_security_group_open_to_large_scope/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules.cidr_ip", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'ec2_group.rules.cidr_ip' should be one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]",

--- a/assets/queries/ansible/aws/db_security_group_with_public_scope/query.rego
+++ b/assets/queries/ansible/aws/db_security_group_with_public_scope/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules.cidr_ip", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'ec2_group.rules.cidr_ip' should be one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]",
@@ -37,7 +37,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules_egress.cidr_ip", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'ec2_group.rules_egress.cidr_ip' should be one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]",

--- a/assets/queries/ansible/aws/default_security_groups_with_unrestricted_traffic/query.rego
+++ b/assets/queries/ansible/aws/default_security_groups_with_unrestricted_traffic/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(group, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.%s", [task.name, modules[m], searchKey]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("ec2_group.%s should not contain the value '%s'", [errorPath, errorValue]),

--- a/assets/queries/ansible/aws/ebs_volume_encryption_disabled/query.rego
+++ b/assets/queries/ansible/aws/ebs_volume_encryption_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_vol, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.encrypted", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ec2_vol.encrypted should be enabled",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_vol, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "ec2_vol.encrypted should be defined",

--- a/assets/queries/ansible/aws/ec2_group_has_public_interface/query.rego
+++ b/assets/queries/ansible/aws/ec2_group_has_public_interface/query.rego
@@ -21,7 +21,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules.%s", [task.name, modules[m], cidr]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'ec2_group.rules.%s' should not be %s", [cidr, cidrValue]),

--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/query.rego
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.assign_public_ip", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ec2.assign_public_ip should be set to false, 'no' or undefined",
@@ -39,7 +39,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_launch_template, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.network_interfaces.associate_public_ip_address", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ec2_launch_template.network_interfaces.associate_public_ip_address should be set to false, 'no' or undefined",
@@ -61,7 +61,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.network.assign_public_ip", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ec2_instance.network.assign_public_ip should be set to false, 'no' or undefined",

--- a/assets/queries/ansible/aws/ec2_instance_using_default_security_group/query.rego
+++ b/assets/queries/ansible/aws/ec2_instance_using_default_security_group/query.rego
@@ -19,7 +19,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.%s", [task.name, modules[m], sgs[s]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s' should not be using default security group", [sgs[s]]),
@@ -44,7 +44,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.%s", [task.name, modules[m], sgs[s]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s' should not be using default security group", [sgs[s]]),

--- a/assets/queries/ansible/aws/ec2_instance_using_default_vpc/query.rego
+++ b/assets/queries/ansible/aws/ec2_instance_using_default_vpc/query.rego
@@ -26,7 +26,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.vpc_subnet_id", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'vpc_subnet_id' should not be associated with a default VPC",

--- a/assets/queries/ansible/aws/ec2_not_ebs_optimized/query.rego
+++ b/assets/queries/ansible/aws/ec2_not_ebs_optimized/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "ec2 to have ebs_optimized set to true.",
@@ -37,7 +37,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.ebs_optimized", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ec2 to have ebs_optimized set to true.",

--- a/assets/queries/ansible/aws/ecr_image_tag_not_immutable/query.rego
+++ b/assets/queries/ansible/aws/ecr_image_tag_not_immutable/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ecs_ecr, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "ecs_ecr.image_tag_mutability should be set ",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ecs_ecr, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.image_tag_mutability", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ecs_ecr.image_tag_mutability should be set to 'immutable'",

--- a/assets/queries/ansible/aws/ecr_repository_is_publicly_accessible/query.rego
+++ b/assets/queries/ansible/aws/ecr_repository_is_publicly_accessible/query.rego
@@ -20,7 +20,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudwatchlogs, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ecs_ecr.policy.Principal should not equal to '*'",

--- a/assets/queries/ansible/aws/ecs_service_admin_role_is_present/query.rego
+++ b/assets/queries/ansible/aws/ecs_service_admin_role_is_present/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ecs, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.role", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ecs_service.role should not be an admin role",

--- a/assets/queries/ansible/aws/ecs_service_without_running_tasks/query.rego
+++ b/assets/queries/ansible/aws/ecs_service_without_running_tasks/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ecs_service, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.deployment_configuration should be defined", [modules[m]]),
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ecs_service, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.deployment_configuration", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.deployment_configuration should have at least 1 task running", [modules[m]]),

--- a/assets/queries/ansible/aws/ecs_services_assigned_with_public_ip_address/query.rego
+++ b/assets/queries/ansible/aws/ecs_services_assigned_with_public_ip_address/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ecs_service, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.network_configuration.assign_public_ip", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s.network_configuration.assign_public_ip' should be set to false (default value is false)", [modules[m]]),

--- a/assets/queries/ansible/aws/ecs_task_definition_network_mode_not_recommended/query.rego
+++ b/assets/queries/ansible/aws/ecs_task_definition_network_mode_not_recommended/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ecs_taskdefinition, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.network_mode", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'ecs_taskdefinition.network_mode' should be set to 'awsvpc'",

--- a/assets/queries/ansible/aws/efs_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/efs_not_encrypted/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(efs, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "efs.encrypt should be set to true",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(efs, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.encrypt", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "efs.encrypt should be set to true",

--- a/assets/queries/ansible/aws/efs_without_kms/query.rego
+++ b/assets/queries/ansible/aws/efs_without_kms/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(efs, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "efs.kms_key_id should be set",

--- a/assets/queries/ansible/aws/efs_without_tags/query.rego
+++ b/assets/queries/ansible/aws/efs_without_tags/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(efs, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("name={{%s}}.{{%s}}.tags should be set", [task.name, modules[m]]),

--- a/assets/queries/ansible/aws/elasticache_using_default_port/query.rego
+++ b/assets/queries/ansible/aws/elasticache_using_default_port/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(elasticache, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.cache_port", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'cache_port' should not be set to %d", [enginePort]),

--- a/assets/queries/ansible/aws/elasticache_without_vpc/query.rego
+++ b/assets/queries/ansible/aws/elasticache_without_vpc/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(elasticache, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'cache_subnet_group' should be defined and not null",

--- a/assets/queries/ansible/aws/elasticsearch_with_https_disabled/query.rego
+++ b/assets/queries/ansible/aws/elasticsearch_with_https_disabled/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(elasticsearch, "domain_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.domain_endpoint_options.enforce_https", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{%s}}.domain_endpoint_options.enforce_https should be set to 'true'", [task.name, modules[m]]),
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(elasticsearch, "domain_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.domain_endpoint_options", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("name={{%s}}.{{%s}}.domain_endpoint_options.enforce_https should be defined and set to 'true'", [task.name, modules[m]]),
@@ -54,7 +54,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(elasticsearch, "domain_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("name={{%s}}.{{%s}}.domain_endpoint_options.enforce_https should be defined and set to 'true'", [task.name, modules[m]]),

--- a/assets/queries/ansible/aws/elb_using_insecure_protocols/query.rego
+++ b/assets/queries/ansible/aws/elb_using_insecure_protocols/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(elb, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.listeners should be defined", [modules[m]]),
@@ -36,7 +36,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(elb, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.listeners.%s", [task.name, modules[m], j]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.listeners.SslPolicy should be defined", [modules[m]]),
@@ -54,7 +54,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(elb, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.listeners.%s", [task.name, modules[m], j]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.listeners.SslPolicy is a secure protocol", [modules[m]]),

--- a/assets/queries/ansible/aws/elb_using_weak_ciphers/query.rego
+++ b/assets/queries/ansible/aws/elb_using_weak_ciphers/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(elb, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.listeners should be defined", [modules[m]]),
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(elb, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.listeners.%s", [task.name, modules[m], j]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.listeners.SslPolicy should be defined", [modules[m]]),
@@ -52,7 +52,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(elb, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.listeners.%s", [task.name, modules[m], j]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.listeners.SslPolicy should not be a weak cipher", [modules[m]]),

--- a/assets/queries/ansible/aws/hardcoded_aws_access_key/query.rego
+++ b/assets/queries/ansible/aws/hardcoded_aws_access_key/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.user_data", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'ec2_instance.user_data' shouldn't contain access key",
@@ -32,7 +32,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.user_data", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'ec2_instance.user_data' shouldn't contain access key",

--- a/assets/queries/ansible/aws/hardcoded_aws_access_key_in_lambda/query.rego
+++ b/assets/queries/ansible/aws/hardcoded_aws_access_key_in_lambda/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(lambda, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.aws_access_key", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "lambda.aws_access_key should not be in plaintext",

--- a/assets/queries/ansible/aws/http_port_open_to_internet/query.rego
+++ b/assets/queries/ansible/aws/http_port_open_to_internet/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_group, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("ec2_group.rules[%d] shouldn't open the http port (80)", [index]),

--- a/assets/queries/ansible/aws/iam_access_key_is_exposed/query.rego
+++ b/assets/queries/ansible/aws/iam_access_key_is_exposed/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(iamuser, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.access_key_state", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "iam.name should be 'root' for an active access key",

--- a/assets/queries/ansible/aws/iam_database_auth_not_enabled/query.rego
+++ b/assets/queries/ansible/aws/iam_database_auth_not_enabled/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(rds_instance, "db_instance_identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.enable_iam_database_authentication", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "rds_instance.enable_iam_database_authentication should be enabled",
@@ -36,7 +36,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(rds_instance, "db_instance_identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "rds_instance.enable_iam_database_authentication should be defined",

--- a/assets/queries/ansible/aws/iam_group_without_users/query.rego
+++ b/assets/queries/ansible/aws/iam_group_without_users/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
     result := {
         "documentId": id,
         "resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(iam_group, "name", task.name),
         "searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
         "issueType": "MissingAttribute",
         "keyExpectedValue": sprintf("%s.users should be defined and not null", [modules[m]]),

--- a/assets/queries/ansible/aws/iam_policies_attached_to_user/query.rego
+++ b/assets/queries/ansible/aws/iam_policies_attached_to_user/query.rego
@@ -5,15 +5,15 @@ import data.generic.ansible as ansLib
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
 	modules := {"community.aws.iam_policy", "iam_policy"}
-	awsApiGateway := task[modules[m]]
-	ansLib.checkState(awsApiGateway)
+	iamPolicy := task[modules[m]]
+	ansLib.checkState(iamPolicy)
 
-	lower(awsApiGateway.iam_type) == "user"
+	lower(iamPolicy.iam_type) == "user"
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(iamPolicy, "policy_name", object.get(iamPolicy, "iam_name", task.name)),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.iam_type", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "iam_policy.iam_type should be configured with group or role",

--- a/assets/queries/ansible/aws/iam_policies_with_full_privileges/query.rego
+++ b/assets/queries/ansible/aws/iam_policies_with_full_privileges/query.rego
@@ -6,10 +6,10 @@ import data.generic.common as common_lib
 CxPolicy[result] {
 	task := ans_lib.tasks[id][t]
 	modules := {"community.aws.iam_managed_policy", "iam_managed_policy"}
-	awsApiGateway := task[modules[m]]
-	ans_lib.checkState(awsApiGateway)
+	iamPolicy := task[modules[m]]
+	ans_lib.checkState(iamPolicy)
 
-	st := common_lib.get_statement(common_lib.get_policy(awsApiGateway.policy))
+	st := common_lib.get_statement(common_lib.get_policy(iamPolicy.policy))
 	statement := st[_]
 
 	common_lib.is_allow_effect(statement)
@@ -19,7 +19,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(iamPolicy, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "iam_managed_policy.policy.Statement.Action should not contain '*'",

--- a/assets/queries/ansible/aws/iam_policy_grants_assumerole_permission_across_all_services/query.rego
+++ b/assets/queries/ansible/aws/iam_policy_grants_assumerole_permission_across_all_services/query.rego
@@ -7,10 +7,10 @@ modules := {"community.aws.iam_managed_policy", "iam_managed_policy"}
 
 CxPolicy[result] {
 	task := ans_lib.tasks[id][t]
-	awsApiGateway := task[modules[m]]
-	ans_lib.checkState(awsApiGateway)
+	iamPolicy := task[modules[m]]
+	ans_lib.checkState(iamPolicy)
 
-	st := common_lib.get_statement(common_lib.get_policy(awsApiGateway.policy))
+	st := common_lib.get_statement(common_lib.get_policy(iamPolicy.policy))
 	statement := st[_]
 
 	common_lib.is_allow_effect(statement)
@@ -20,7 +20,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(iamPolicy, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "iam_managed_policy.policy.Statement.Principal.AWS should not contain '*'",

--- a/assets/queries/ansible/aws/iam_policy_grants_full_permissions/query.rego
+++ b/assets/queries/ansible/aws/iam_policy_grants_full_permissions/query.rego
@@ -7,10 +7,10 @@ modules := {"community.aws.iam_managed_policy", "iam_managed_policy"}
 
 CxPolicy[result] {
 	task := ans_lib.tasks[id][t]
-	awsApiGateway := task[modules[m]]
-	ans_lib.checkState(awsApiGateway)
+	iamPolicy := task[modules[m]]
+	ans_lib.checkState(iamPolicy)
 
-	st := common_lib.get_statement(common_lib.get_policy(awsApiGateway.policy))
+	st := common_lib.get_statement(common_lib.get_policy(iamPolicy.policy))
 	statement := st[_]
 
 	common_lib.is_allow_effect(statement)
@@ -20,7 +20,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(iamPolicy, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement.Resource' and 'policy.Statement.Action' should no be equal to '*'",

--- a/assets/queries/ansible/aws/iam_role_allows_all_principals_to_assume/query.rego
+++ b/assets/queries/ansible/aws/iam_role_allows_all_principals_to_assume/query.rego
@@ -7,10 +7,10 @@ modules := {"community.aws.iam_managed_policy", "iam_managed_policy"}
 
 CxPolicy[result] {
 	task := ans_lib.tasks[id][t]
-	awsApiGateway := task[modules[m]]
-	ans_lib.checkState(awsApiGateway)
+	iamPolicy := task[modules[m]]
+	ans_lib.checkState(iamPolicy)
 
-	policy := common_lib.get_policy(common_lib.get_policy(awsApiGateway.policy))
+	policy := common_lib.get_policy(common_lib.get_policy(iamPolicy.policy))
 	st := common_lib.get_statement(policy)
 	statement := st[_]
 
@@ -22,7 +22,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(iamPolicy, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "iam_managed_policy.policy.Statement.Principal.AWS should not contain ':root",

--- a/assets/queries/ansible/aws/instance_uses_metadata_service_IMDSv1/query.rego
+++ b/assets/queries/ansible/aws/instance_uses_metadata_service_IMDSv1/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(resource, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"searchLine": common_lib.build_search_line(["playbooks", t, modules[m]], []),
 		"issueType": "MissingAttribute",
@@ -40,7 +40,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(resource, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.metadata_options.http_tokens", [task.name, modules[m]]),
 		"searchLine": common_lib.build_search_line(["playbooks", t, modules[m], "metadata_options", "http_tokens"], []),
 		"issueType": "IncorrectValue",
@@ -62,7 +62,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(resource, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.metadata_options", [task.name, modules[m]]),
 		"searchLine": common_lib.build_search_line(["playbooks", t, modules[m], "metadata_options"], []),
 		"issueType": "MissingAttribute",

--- a/assets/queries/ansible/aws/instance_with_no_vpc/query.rego
+++ b/assets/queries/ansible/aws/instance_with_no_vpc/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.vpc_subnet_id should be set", [modules[m]]),

--- a/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/query.rego
+++ b/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(kinesis_stream, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "kinesis_stream.encryption_type should be set",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(kinesis_stream, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "kinesis_stream.encryption_state should be set",
@@ -51,7 +51,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(kinesis_stream, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.encryption_state", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "kinesis_stream.encryption_state should be set to enabled",
@@ -69,7 +69,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(kinesis_stream, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.encryption_type", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "kinesis_stream.encryption_type should be set and not NONE",
@@ -88,7 +88,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(kinesis_stream, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "kinesis_stream.key_id should be set",

--- a/assets/queries/ansible/aws/kms_key_with_full_permissions/query.rego
+++ b/assets/queries/ansible/aws/kms_key_with_full_permissions/query.rego
@@ -20,7 +20,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(aws_kms, "alias", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "aws_kms.policy should not have wildcard in 'Action' and 'Principal'",
@@ -40,7 +40,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(aws_kms, "alias", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'policy' should be undefined or null",

--- a/assets/queries/ansible/aws/lambda_function_without_tags/query.rego
+++ b/assets/queries/ansible/aws/lambda_function_without_tags/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(lambda, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("name={{%s}}.{{%s}}.tags should be defined", [task.name, modules[m]]),

--- a/assets/queries/ansible/aws/lambda_functions_without_x-ray_tracing/query.rego
+++ b/assets/queries/ansible/aws/lambda_functions_without_x-ray_tracing/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(lambda, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "lambda.tracing_mode should be set",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(lambda, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.tracing_mode", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "lambda.tracing_mode should be set to 'Active'",

--- a/assets/queries/ansible/aws/lambda_permission_misconfigured/query.rego
+++ b/assets/queries/ansible/aws/lambda_permission_misconfigured/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(lambda, "function_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.action", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{%s}}.action should be 'lambda:InvokeFunction'", [task.name, modules[m]]),

--- a/assets/queries/ansible/aws/lambda_permission_principal_is_wildcard/query.rego
+++ b/assets/queries/ansible/aws/lambda_permission_principal_is_wildcard/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(lambda, "function_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.principal", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{%s}}.principal shouldn't contain a wildcard", [task.name, modules[m]]),

--- a/assets/queries/ansible/aws/launch_configuration_is_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/launch_configuration_is_not_encrypted/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_lc, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "ec2_lc.volumes should be set",
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_lc, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.volumes", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("ec2_lc.volumes[%d].encrypted should be set", [j]),
@@ -54,7 +54,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_lc, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.volumes", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("ec2_lc.volumes[%d].encrypted should be set to true or yes", [j]),

--- a/assets/queries/ansible/aws/no_stack_policy/query.rego
+++ b/assets/queries/ansible/aws/no_stack_policy/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudformation, "stack_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "cloudformation.stack_policy should be set",

--- a/assets/queries/ansible/aws/public_lambda_via_api_gateway/query.rego
+++ b/assets/queries/ansible/aws/public_lambda_via_api_gateway/query.rego
@@ -5,17 +5,17 @@ import data.generic.ansible as ansLib
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
 	modules := {"community.aws.lambda_policy", "lambda_policy"}
-	lambda := task[modules[m]]
-	ansLib.checkState(lambda)
+	lambdaPolicy := task[modules[m]]
+	ansLib.checkState(lambdaPolicy)
 
-	lambdaAction(lambda.action)
-	principalAllowAPIGateway(lambda.principal)
-	re_match("/\\*/\\*$", lambda.source_arn)
+	lambdaAction(lambdaPolicy.action)
+	principalAllowAPIGateway(lambdaPolicy.principal)
+	re_match("/\\*/\\*$", lambdaPolicy.source_arn)
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": object.get(lambda, "function_name", task.name),
+		"resourceName": object.get(lambdaPolicy, "function_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.source_arn", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "lambda_policy.source_arn should not equal to '/*/*'",

--- a/assets/queries/ansible/aws/public_lambda_via_api_gateway/query.rego
+++ b/assets/queries/ansible/aws/public_lambda_via_api_gateway/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(lambda, "function_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.source_arn", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "lambda_policy.source_arn should not equal to '/*/*'",

--- a/assets/queries/ansible/aws/public_port_wide/query.rego
+++ b/assets/queries/ansible/aws/public_port_wide/query.rego
@@ -20,7 +20,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_group, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("ec2_group.rules[%d] shouldn't have public port wide", [index]),
@@ -44,7 +44,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_group, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("ec2_group.rules[%d] shouldn't have public port wide", [index]),

--- a/assets/queries/ansible/aws/rds_associated_with_public_subnet/query.rego
+++ b/assets/queries/ansible/aws/rds_associated_with_public_subnet/query.rego
@@ -13,11 +13,11 @@ options := {"db_subnet_group_name", "subnet_group"}
 
 CxPolicy[result] {
 	task := ans_lib.tasks[id][t]
-	instance := task[rds[r]]
-	ans_lib.checkState(instance)
+	rds_instance := task[rds[r]]
+	ans_lib.checkState(rds_instance)
 
 	# get subnet group name
-	subnetGroupName := instance[options[o]]
+	subnetGroupName := rds_instance[options[o]]
 
 	# get subnet group
 	tk := ans_lib.tasks[_][_]
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": rds[r],
-		"resourceName": object.get(instance, "db_instance_identifier", task.name),
+		"resourceName": object.get(rds_instance, "db_instance_identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.%s", [task.name, rds[r], options[o]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "RDS should not be running in a public subnet",

--- a/assets/queries/ansible/aws/rds_associated_with_public_subnet/query.rego
+++ b/assets/queries/ansible/aws/rds_associated_with_public_subnet/query.rego
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": rds[r],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "db_instance_identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.%s", [task.name, rds[r], options[o]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "RDS should not be running in a public subnet",

--- a/assets/queries/ansible/aws/rds_db_instance_publicly_accessible/query.rego
+++ b/assets/queries/ansible/aws/rds_db_instance_publicly_accessible/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(rds_instance, "db_instance_identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.publicly_accessible", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.publicly_accessible should be false", [modules[m]]),

--- a/assets/queries/ansible/aws/rds_using_default_port/query.rego
+++ b/assets/queries/ansible/aws/rds_using_default_port/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "db_instance_identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.port", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'port' should not be set to %d", [enginePort]),

--- a/assets/queries/ansible/aws/rds_with_backup_disabled/query.rego
+++ b/assets/queries/ansible/aws/rds_with_backup_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "db_instance_identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.backup_retention_period", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "rds_instance should have the property 'backup_retention_period' greater than 0",

--- a/assets/queries/ansible/aws/redis_not_compliant/query.rego
+++ b/assets/queries/ansible/aws/redis_not_compliant/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(elasticache, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.cache_engine_version", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "elasticache.cache_engine_version should be compliant with the AWS PCI DSS requirements",

--- a/assets/queries/ansible/aws/redshift_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/redshift_not_encrypted/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(redshiftCluster, "identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "redshift.encrypted should be set to true",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(redshiftCluster, "identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.encrypted", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "redshift.encrypted should be set to true",

--- a/assets/queries/ansible/aws/redshift_publicly_accessible/query.rego
+++ b/assets/queries/ansible/aws/redshift_publicly_accessible/query.rego
@@ -5,13 +5,13 @@ import data.generic.ansible as ansLib
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
 	modules := ["redshift", "community.aws.redshift"]
-
-	ansLib.isAnsibleTrue(task[modules[m]].publicly_accessible)
+	redshift := task[modules[m]]
+	ansLib.isAnsibleTrue(redshift.publicly_accessible)
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(redshift, "identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.publicly_accessible", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "redshift.publicly_accessible should be set to false",

--- a/assets/queries/ansible/aws/redshift_using_default_port/query.rego
+++ b/assets/queries/ansible/aws/redshift_using_default_port/query.rego
@@ -7,12 +7,13 @@ CxPolicy[result] {
 	task := ans_lib.tasks[id][t]
 	modules := {"redshift", "community.aws.redshift"}
 
-	task[modules[m]].port == 5439
+	redshift := task[modules[m]]
+	redshift.port == 5439
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(redshift, "identifier", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.port", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "redshift.port should not be set to 5439",

--- a/assets/queries/ansible/aws/remote_desktop_port_open/query.rego
+++ b/assets/queries/ansible/aws/remote_desktop_port_open/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_group, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ec2_group.rules shouldn't open the remote desktop port (3389)",

--- a/assets/queries/ansible/aws/root_account_has_active_access_keys/query.rego
+++ b/assets/queries/ansible/aws/root_account_has_active_access_keys/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(iam, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "iam should not be active for a root account",

--- a/assets/queries/ansible/aws/route53_record_undefined/query.rego
+++ b/assets/queries/ansible/aws/route53_record_undefined/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(route53, "record", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "route53.value should be defined or not null",

--- a/assets/queries/ansible/aws/s3_bucket_access_to_any_principal/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_access_to_any_principal/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(s3_bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "s3_bucket.policy.Statement shouldn't make the bucket accessible to all AWS Accounts",

--- a/assets/queries/ansible/aws/s3_bucket_acl_allows_read_to_all_users/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_acl_allows_read_to_all_users/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(s3, "bucket", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.permission", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "aws_s3 should not have read access for all user groups",

--- a/assets/queries/ansible/aws/s3_bucket_acl_allows_read_to_any_authenticated_user/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_acl_allows_read_to_any_authenticated_user/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(s3, "bucket", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.permission", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "aws_s3 should not have read access for all authenticated users",

--- a/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
@@ -20,7 +20,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("s3_bucket[%s] should not allow Delete Action From All Principals", [bucket.name]),

--- a/assets/queries/ansible/aws/s3_bucket_allows_get_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_get_action_from_all_principals/query.rego
@@ -20,7 +20,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("s3_bucket[%s] should not allow Get Action From All Principals", [bucket.name]),

--- a/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
@@ -20,7 +20,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("s3_bucket[%s] should not allow List Action From All Principals", [bucket.name]),

--- a/assets/queries/ansible/aws/s3_bucket_allows_put_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_put_action_from_all_principals/query.rego
@@ -20,7 +20,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("s3_bucket[%s] should not allow Put Action From All Principals", [bucket.name]),

--- a/assets/queries/ansible/aws/s3_bucket_logging_disabled/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_logging_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.debug_botocore_endpoint_logs", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "s3_bucket.debug_botocore_endpoint_logs should be true",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "s3_bucket.debug_botocore_endpoint_logs should be defined",

--- a/assets/queries/ansible/aws/s3_bucket_with_all_permissions/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_with_all_permissions/query.rego
@@ -21,7 +21,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(s3_bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement' should not allow all actions to all principal",

--- a/assets/queries/ansible/aws/s3_bucket_with_public_access/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_with_public_access/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(aws_s3, "bucket", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.permission", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "aws_s3.permission shouldn't allow public access",

--- a/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cors, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%d] should not allow all methods, all headers or several origins", [modules[m], c]),

--- a/assets/queries/ansible/aws/s3_bucket_without_server-side_encryption/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_without_server-side_encryption/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(s3_bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.encryption", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "s3_bucket.encryption should not be 'none'",

--- a/assets/queries/ansible/aws/s3_bucket_without_versioning/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_without_versioning/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "s3_bucket should have versioning set to true",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.versioning", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "s3_bucket should have versioning set to true",

--- a/assets/queries/ansible/aws/secure_ciphers_disabled/query.rego
+++ b/assets/queries/ansible/aws/secure_ciphers_disabled/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudfront_distribution, "distribution_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.viewer_certificate.minimum_protocol_version", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "cloudfront_distribution.viewer_certificate.minimum_protocol_version should be TLSv1.1 or TLSv1.2",

--- a/assets/queries/ansible/aws/security_group_ingress_not_restricted/query.rego
+++ b/assets/queries/ansible/aws/security_group_ingress_not_restricted/query.rego
@@ -21,7 +21,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_group, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("ec2_group.rules[%d] should be restricted", [index]),

--- a/assets/queries/ansible/aws/security_group_with_unrestricted_access_to_ssh/query.rego
+++ b/assets/queries/ansible/aws/security_group_with_unrestricted_access_to_ssh/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_group, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("ec2_group.rules[%d] SSH' (Port:22) should not be public", [index]),

--- a/assets/queries/ansible/aws/ses_policy_with_allowed_iam_actions/query.rego
+++ b/assets/queries/ansible/aws/ses_policy_with_allowed_iam_actions/query.rego
@@ -20,7 +20,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(sesPolicy, "identity", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy' should not allow IAM actions to all principals",

--- a/assets/queries/ansible/aws/sns_topic_is_publicly_accessible/query.rego
+++ b/assets/queries/ansible/aws/sns_topic_is_publicly_accessible/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(snsTopicCommunity, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "sns_topic.policy.Statement shouldn't contain '*' for an AWS Principal",

--- a/assets/queries/ansible/aws/sql_analysis_services_port_2383_is_publicly_accessible/query.rego
+++ b/assets/queries/ansible/aws/sql_analysis_services_port_2383_is_publicly_accessible/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_group, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("ec2_group.rules[%d] shouldn't open the SQL analysis services port (2383)", [index]),

--- a/assets/queries/ansible/aws/sqs_policy_allows_all_actions/query.rego
+++ b/assets/queries/ansible/aws/sqs_policy_allows_all_actions/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(sqsPolicy, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "sqs_queue.policy.Statement should not contain Action equal to '*'",

--- a/assets/queries/ansible/aws/sqs_policy_with_public_access/query.rego
+++ b/assets/queries/ansible/aws/sqs_policy_with_public_access/query.rego
@@ -20,7 +20,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(sqsPolicy, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "sqs_queue.policy.Principal should not equal to '*'",

--- a/assets/queries/ansible/aws/sqs_queue_exposed/query.rego
+++ b/assets/queries/ansible/aws/sqs_queue_exposed/query.rego
@@ -19,7 +19,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(sqs_queue, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "sqs_queue.policy.Principal shouldn't get the queue publicly accessible",

--- a/assets/queries/ansible/aws/sqs_with_sse_disabled/query.rego
+++ b/assets/queries/ansible/aws/sqs_with_sse_disabled/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(sqsQueue, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.kms_master_key_id", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'kms_master_key_id' should be set",

--- a/assets/queries/ansible/aws/stack_notifications_disabled/query.rego
+++ b/assets/queries/ansible/aws/stack_notifications_disabled/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudformation, "stack_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "cloudformation.notification_arns should be set",

--- a/assets/queries/ansible/aws/stack_retention_disabled/query.rego
+++ b/assets/queries/ansible/aws/stack_retention_disabled/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudformation_stack_set, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "cloudformation_stack_set.purge_stacks should be set",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudformation_stack_set, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.purge_stacks", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "cloudformation_stack_set.purge_stacks should be set to false",

--- a/assets/queries/ansible/aws/stack_without_template/query.rego
+++ b/assets/queries/ansible/aws/stack_without_template/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudformation, "stack_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s has template, template_body or template_url set", [modules[m]]),
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudformation, "stack_name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s should not have more than one of the attributes template, template_body and template_url set", [modules[m]]),

--- a/assets/queries/ansible/aws/unknown_port_exposed_to_internet/query.rego
+++ b/assets/queries/ansible/aws/unknown_port_exposed_to_internet/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_group, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("ec2_group.rules[%d] port_range should not contain unknown ports and should not be exposed to the entire Internet", [index]),

--- a/assets/queries/ansible/aws/unrestricted_security_group_ingress/query.rego
+++ b/assets/queries/ansible/aws/unrestricted_security_group_ingress/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(group, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.%s", [task.name, modules[m], searchKey]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("ec2_group.%s should not contain the value '%s'", [errorPath, errorValue]),

--- a/assets/queries/ansible/aws/user_data_contains_encoded_private_key/query.rego
+++ b/assets/queries/ansible/aws/user_data_contains_encoded_private_key/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ec2_lc, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.user_data", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ec2_lc.user_data should not contain RSA Private Key",

--- a/assets/queries/ansible/aws/viewer_protocol_policy_allows_http/query.rego
+++ b/assets/queries/ansible/aws/viewer_protocol_policy_allows_http/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudfront_distribution, "distribution_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.%s.viewer_protocol_policy", [task.name, modules[m], fields[f]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("cloudfront_distribution.%s.viewer_protocol_policy should be 'https-only' or 'redirect-to-https'", [fields[f]]),

--- a/assets/queries/ansible/aws/vulnerable_default_ssl_certificate/query.rego
+++ b/assets/queries/ansible/aws/vulnerable_default_ssl_certificate/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudfront, "distribution_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.viewer_certificate.cloudfront_default_certificate", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Attribute 'cloudfront_default_certificate' should be 'false' or not defined",
@@ -39,7 +39,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cloudfront, "distribution_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.viewer_certificate", [task.name, modules[m]]),
 		"searchValue": attr,
 		"issueType": "MissingAttribute",

--- a/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/query.rego
+++ b/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(sqlserver, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_sqlserver.ad_user should be defined",

--- a/assets/queries/ansible/azure/admin_user_enabled_for_container_registry/query.rego
+++ b/assets/queries/ansible/azure/admin_user_enabled_for_container_registry/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(containerReg, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.admin_user_enabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_containerregistry.admin_user_enabled should be false or undefined (defaults to false)",

--- a/assets/queries/ansible/azure/aks_monitoring_logging_disabled/query.rego
+++ b/assets/queries/ansible/azure/aks_monitoring_logging_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(aks, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_aks.addon should be set",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(aks, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.addon", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_aks.addon.monitoring should be set",
@@ -53,7 +53,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(aks, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.addon.monitoring", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("azure_rm_aks.addon.monitoring.%s should be set", [attr]),
@@ -71,7 +71,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(aks, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.addon.monitoring.enabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_aks.addon.monitoring.enabled should be set to 'yes' or 'false'",

--- a/assets/queries/ansible/azure/aks_network_policy_misconfigured/query.rego
+++ b/assets/queries/ansible/azure/aks_network_policy_misconfigured/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(aks, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.network_profile.network_policy", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Azure AKS cluster network policy should be either 'calico' or 'azure'",
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(aks, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Azure AKS cluster network profile should be defined",
@@ -52,7 +52,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(aks, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Azure AKS cluster network policy should be defined",

--- a/assets/queries/ansible/azure/aks_rbac_disabled/query.rego
+++ b/assets/queries/ansible/azure/aks_rbac_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(aks, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_aks.enable_rbac should be defined",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(aks, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.enable_rbac", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_aks.enable_rbac should be set to 'yes' or 'true'",

--- a/assets/queries/ansible/azure/azure_container_registry_with_no_locks/query.rego
+++ b/assets/queries/ansible/azure/azure_container_registry_with_no_locks/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(containerRegistry, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s' should be referenced by an existing lock", [modules[m]]),

--- a/assets/queries/ansible/azure/azure_instance_using_basic_authentication/query.rego
+++ b/assets/queries/ansible/azure/azure_instance_using_basic_authentication/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "azure_rm_virtualmachine",
 		"resourceName": vm.name,
-		"searchKey": sprintf("azure_rm_virtualmachine[%s].ssh_public_keys", [vm.name]),
+		"searchKey": sprintf("name={{%s}}.azure_rm_virtualmachine", [input.document[i].playbooks[k].name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'azure_rm_virtualmachine[%s]' should be using SSH keys for authentication", [vm.name]),
 		"keyActualValue": sprintf("'azure_rm_virtualmachine[%s]' is using username and password for authentication", [vm.name]),

--- a/assets/queries/ansible/azure/azure_instance_using_basic_authentication/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/azure_instance_using_basic_authentication/test/positive_expected_result.json
@@ -2,7 +2,7 @@
   {
     "queryName": "Azure Instance Using Basic Authentication",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive.yaml"
   }
 ]

--- a/assets/queries/ansible/azure/cosmosdb_account_ip_range_filter_not_set/query.rego
+++ b/assets/queries/ansible/azure/cosmosdb_account_ip_range_filter_not_set/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cosmosdbaccount, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'azurerm_cosmosdb_account.ip_range_filter' should be defined",

--- a/assets/queries/ansible/azure/cosmosdb_account_without_tags/query.rego
+++ b/assets/queries/ansible/azure/cosmosdb_account_without_tags/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cosmosdbaccount, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.tags", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_cosmosdbaccount.tags should be defined",

--- a/assets/queries/ansible/azure/default_azure_storage_account_network_access_is_too_permissive/query.rego
+++ b/assets/queries/ansible/azure/default_azure_storage_account_network_access_is_too_permissive/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
     result := {
 		"documentId": id,
 		"resourceType": modules[index],
-		"resourceName": task.name,
+		"resourceName": object.get(storageAccount, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[index]]),
 		"issueType": issue.issueType,
 		"keyExpectedValue": issue.kev,

--- a/assets/queries/ansible/azure/firewall_rule_allows_too_many_hosts_to_access_redis_cache/query.rego
+++ b/assets/queries/ansible/azure/firewall_rule_allows_too_many_hosts_to_access_redis_cache/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.start_ip_address", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_rediscachefirewallrule.start_ip_address and end_ip_address should allow up to 255 hosts",

--- a/assets/queries/ansible/azure/key_vault_soft_delete_is_disabled/query.rego
+++ b/assets/queries/ansible/azure/key_vault_soft_delete_is_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(keyvault, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.enable_soft_delete", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_keyvault.enable_soft_delete should be true",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(keyvault, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_keyvault.enable_soft_delete should be defined",

--- a/assets/queries/ansible/azure/log_retention_is_not_set/query.rego
+++ b/assets/queries/ansible/azure/log_retention_is_not_set/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(postgresql_configuration, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.value", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_postgresqlconfiguration.value should equal to 'on'",

--- a/assets/queries/ansible/azure/monitoring_log_profile_without_all_activities/query.rego
+++ b/assets/queries/ansible/azure/monitoring_log_profile_without_all_activities/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(azureMonitor, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.categories", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_monitorlogprofile.categories should have all categories, Write, Action and Delete",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(azureMonitor, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_monitorlogprofile.categories should be defined",

--- a/assets/queries/ansible/azure/mysql_ssl_connection_disabled/query.rego
+++ b/assets/queries/ansible/azure/mysql_ssl_connection_disabled/query.rego
@@ -7,15 +7,15 @@ modules := {"azure.azcollection.azure_rm_mysqlserver", "azure_rm_mysqlserver"}
 
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
-	storageAccount := task[modules[m]]
-	ansLib.checkState(storageAccount)
+	mysqlServer := task[modules[m]]
+	ansLib.checkState(mysqlServer)
 
-	not common_lib.valid_key(storageAccount, "enforce_ssl")
+	not common_lib.valid_key(mysqlServer, "enforce_ssl")
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(mysqlServer, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_mysqlserver should have enforce_ssl set to true",
@@ -25,15 +25,15 @@ CxPolicy[result] {
 
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
-	storageAccount := task[modules[m]]
-	ansLib.checkState(storageAccount)
+	mysqlServer := task[modules[m]]
+	ansLib.checkState(mysqlServer)
 
-	not ansLib.isAnsibleTrue(storageAccount.enforce_ssl)
+	not ansLib.isAnsibleTrue(mysqlServer.enforce_ssl)
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(mysqlServer, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.enforce_ssl", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_mysqlserver should have enforce_ssl set to true",

--- a/assets/queries/ansible/azure/postgresql_log_checkpoints_disabled/query.rego
+++ b/assets/queries/ansible/azure/postgresql_log_checkpoints_disabled/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(pgConfig, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.value", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_postgresqlconfiguration.value should be 'ON' when name is 'log_checkpoints'",

--- a/assets/queries/ansible/azure/postgresql_log_connections_not_set/query.rego
+++ b/assets/queries/ansible/azure/postgresql_log_connections_not_set/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(pgConfig, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.value", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_postgresqlconfiguration.value should be 'ON' when name is 'log_connections'",

--- a/assets/queries/ansible/azure/postgresql_log_disconnections_not_set/query.rego
+++ b/assets/queries/ansible/azure/postgresql_log_disconnections_not_set/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(pgConfig, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.value", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_postgresqlconfiguration.value should be 'ON' when name is 'log_disconnections'",

--- a/assets/queries/ansible/azure/postgresql_log_duration_not_set/query.rego
+++ b/assets/queries/ansible/azure/postgresql_log_duration_not_set/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(pgConfig, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.value", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_postgresqlconfiguration.value should be 'ON' for 'log_duration'",

--- a/assets/queries/ansible/azure/postgresql_server_without_connection_throttling/query.rego
+++ b/assets/queries/ansible/azure/postgresql_server_without_connection_throttling/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(pgConfig, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.value", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_postgresqlconfiguration.value should be 'ON' when name is 'connection_throttling'",

--- a/assets/queries/ansible/azure/public_storage_account/query.rego
+++ b/assets/queries/ansible/azure/public_storage_account/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(storageaccount, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.network_acls.default_action", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_storageaccount.network_acls.default_action should not be set",
@@ -37,7 +37,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(storageaccount, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.network_acls.ip_rules", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_storageaccount.network_acls.default_action should be set to 'Deny' and azure_rm_storageaccount.network_acls.ip_rules should not contain value '0.0.0.0/0' ",

--- a/assets/queries/ansible/azure/redis_cache_allows_non_ssl_connections/query.rego
+++ b/assets/queries/ansible/azure/redis_cache_allows_non_ssl_connections/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.enable_non_ssl_port", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_rediscache.enable_non_ssl_port should be set to false or undefined",

--- a/assets/queries/ansible/azure/redis_entirely_accessible/query.rego
+++ b/assets/queries/ansible/azure/redis_entirely_accessible/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(firewall_rule, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.start_ip_address", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_rediscachefirewallrule start_ip and end_ip should not equal to '0.0.0.0'",

--- a/assets/queries/ansible/azure/redis_publicly_accessible/query.rego
+++ b/assets/queries/ansible/azure/redis_publicly_accessible/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(firewall_rule, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.start_ip_address", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_rediscachefirewallrule ip range should be private",

--- a/assets/queries/ansible/azure/role_definition_allows_custom_role_creation/query.rego
+++ b/assets/queries/ansible/azure/role_definition_allows_custom_role_creation/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(roleDefinition, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.permissions.actions", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.permissions[%d].actions should not allow custom role creation", [modules[m], p]),

--- a/assets/queries/ansible/azure/security_group_is_not_configured/query.rego
+++ b/assets/queries/ansible/azure/security_group_is_not_configured/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(subnet, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_subnet.security_group should be defined and not null",
@@ -36,7 +36,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(subnet, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.%s", [task.name, modules[m], fields[f]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("azure_rm_subnet.%s should not be empty", [fields[f]]),

--- a/assets/queries/ansible/azure/sensitive_port_is_exposed_to_entire_network/query.rego
+++ b/assets/queries/ansible/azure/sensitive_port_is_exposed_to_entire_network/query.rego
@@ -27,7 +27,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(securitygroup, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules.name={{%s}}.destination_port_range", [task.name, modules[m], resource.name]),
 		"searchValue": sprintf("%s,%d", [protocol, portNumber]),
 		"issueType": "IncorrectValue",

--- a/assets/queries/ansible/azure/small_activity_log_retention_period/query.rego
+++ b/assets/queries/ansible/azure/small_activity_log_retention_period/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(azureMonitor, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.retention_policy.enabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_monitorlogprofile.retention_policy.enabled should be true or yes",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(azureMonitor, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.retention_policy.days", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_monitorlogprofile.retention_policy.days should be greater than or equal to 365 days or 0 (indefinitely)",
@@ -53,7 +53,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(azureMonitor, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_monitorlogprofile.retention_policy should be defined",

--- a/assets/queries/ansible/azure/sql_server_ingress_from_any_ip/query.rego
+++ b/assets/queries/ansible/azure/sql_server_ingress_from_any_ip/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(fwRule, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.end_ip_address", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_sqlfirewallrule should allow all IPs",

--- a/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/query.rego
+++ b/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ad, "app_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.ad_user", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_ad_serviceprincipal.ad_user should be neither empty nor null",
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(ad, "app_id", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.ad_user", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_ad_serviceprincipal.ad_user should not be predictable",

--- a/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/query.rego
+++ b/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(server, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.admin_username", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_sqlserver.admin_username should not be empty",
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(server, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.admin_username", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_sqlserver.admin_username should not be predictable",

--- a/assets/queries/ansible/azure/ssl_enforce_is_disabled/query.rego
+++ b/assets/queries/ansible/azure/ssl_enforce_is_disabled/query.rego
@@ -7,15 +7,15 @@ modules := {"azure.azcollection.azure_rm_postgresqlserver", "azure_rm_postgresql
 
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
-	storageAccount := task[modules[m]]
-	ansLib.checkState(storageAccount)
+	postgresqlServer := task[modules[m]]
+	ansLib.checkState(postgresqlServer)
 
-	not common_lib.valid_key(storageAccount, "enforce_ssl")
+	not common_lib.valid_key(postgresqlServer, "enforce_ssl")
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(postgresqlServer, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_postgresqlserver should have enforce_ssl set to true",
@@ -25,15 +25,15 @@ CxPolicy[result] {
 
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
-	storageAccount := task[modules[m]]
-	ansLib.checkState(storageAccount)
+	postgresqlServer := task[modules[m]]
+	ansLib.checkState(postgresqlServer)
 
-	not ansLib.isAnsibleTrue(storageAccount.enforce_ssl)
+	not ansLib.isAnsibleTrue(postgresqlServer.enforce_ssl)
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(postgresqlServer, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.enforce_ssl", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_postgresqlserver should have enforce_ssl set to true",

--- a/assets/queries/ansible/azure/storage_account_not_forcing_https/query.rego
+++ b/assets/queries/ansible/azure/storage_account_not_forcing_https/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[index],
-		"resourceName": task.name,
+		"resourceName": object.get(storageAccount, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[index]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_storageaccount.https_only should be defined",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[index],
-		"resourceName": task.name,
+		"resourceName": object.get(storageAccount, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.https_only", [task.name, modules[index]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_storageaccount should have https_only set to true",

--- a/assets/queries/ansible/azure/storage_account_not_using_latest_tls_encryption_version/query.rego
+++ b/assets/queries/ansible/azure/storage_account_not_using_latest_tls_encryption_version/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(storage, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_storageaccount.minimum_tls_version should be defined",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(storage, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.minimum_tls_version", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_storageaccount should be using the latest version of TLS encryption",

--- a/assets/queries/ansible/azure/storage_container_is_publicly_accessible/query.rego
+++ b/assets/queries/ansible/azure/storage_container_is_publicly_accessible/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(storageblob, "container", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.public_access", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_storageblob.public_access should not be set",

--- a/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/query.rego
+++ b/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(storageaccount, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.network_acls.bypass", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_storageaccount.network_acls.bypass should not be set or contain 'AzureServices'",

--- a/assets/queries/ansible/azure/unrestricted_sql_server_acess/query.rego
+++ b/assets/queries/ansible/azure/unrestricted_sql_server_acess/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(rule, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "The difference between the value of azure_rm_sqlfirewallrule end_ip_address and start_ip_address should be less than 256",

--- a/assets/queries/ansible/azure/vm_not_attached_to_network/query.rego
+++ b/assets/queries/ansible/azure/vm_not_attached_to_network/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 		"documentId": id,
 		"resourceType": modules[m],
 		"resourceName": task.name,
-		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
+		"searchKey": sprintf("name={{%s}}.azure_rm_virtualmachine", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_virtualmachine.network_interface_names should be defined",
 		"keyActualValue": "azure_rm_virtualmachine.network_interface_names is undefined",

--- a/assets/queries/ansible/azure/vm_not_attached_to_network/query.rego
+++ b/assets/queries/ansible/azure/vm_not_attached_to_network/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(virtualmachine, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.azure_rm_virtualmachine", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_virtualmachine.network_interface_names should be defined",

--- a/assets/queries/ansible/azure/waf_is_disabled_for_azure_application_gateway/query.rego
+++ b/assets/queries/ansible/azure/waf_is_disabled_for_azure_application_gateway/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(appgateway, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.sku.tier", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_appgateway.sku.tier should be 'waf' or 'waf_v2'",

--- a/assets/queries/ansible/azure/web_app_accepting_traffic_other_than_https/query.rego
+++ b/assets/queries/ansible/azure/web_app_accepting_traffic_other_than_https/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(webapp, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.https_only", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_webapp.https_only should be set to true or 'yes'",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(webapp, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_webapp.https_only should be defined",

--- a/assets/queries/ansible/gcp/bigquery_dataset_is_public/query.rego
+++ b/assets/queries/ansible/gcp/bigquery_dataset_is_public/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(bigquery_dataset, "name", object.get(object.get(bigquery_dataset, "dataset_reference", {}), "dataset_id", task.name)),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.access", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_bigquery_dataset.access.special_group should not equal to 'allAuthenticatedUsers'",

--- a/assets/queries/ansible/gcp/client_certificate_disabled/query.rego
+++ b/assets/queries/ansible/gcp/client_certificate_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_cluster.master_auth should be defined",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.master_auth", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_cluster.master_auth.client_certificate_config should be defined",
@@ -51,7 +51,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.master_auth.client_certificate_config.issue_client_certificate", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_container_cluster.master_auth.password should be true",

--- a/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/query.rego
+++ b/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(managed_zone, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_dns_managed_zone.dnssec_config should be defined",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(managed_zone, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.dnssec_config", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_dns_managed_zone.dnssec_config.state should be defined",
@@ -51,7 +51,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(managed_zone, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.dnssec_config.state", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_dns_managed_zone.dnssec_config.state should equal to 'on'",

--- a/assets/queries/ansible/gcp/cloud_sql_instance_with_contained_database_authentication_on/query.rego
+++ b/assets/queries/ansible/gcp/cloud_sql_instance_with_contained_database_authentication_on/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.settings.database_flags", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "cloud_gcp_sql_instance.settings.database_flags should be correct",

--- a/assets/queries/ansible/gcp/cloud_sql_instance_with_cross_db_ownership_chaining_on/query.rego
+++ b/assets/queries/ansible/gcp/cloud_sql_instance_with_cross_db_ownership_chaining_on/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.settings.database_flags", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{cloud_gcp_sql_instance}}.settings.database_flags should be correct",

--- a/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/query.rego
+++ b/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_storage_bucket.default_object_acl should be defined",
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.acl.entity", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_storage_bucket.acl.entity should not be 'allUsers' or 'allAuthenticatedUsers'",
@@ -53,7 +53,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.default_object_acl.entity", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_storage_bucket.default_object_acl.entity should not be 'allUsers' or 'allAuthenticatedUsers'",

--- a/assets/queries/ansible/gcp/cloud_storage_bucket_logging_not_enabled/query.rego
+++ b/assets/queries/ansible/gcp/cloud_storage_bucket_logging_not_enabled/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(storage_bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_storage_bucket.logging should be defined",

--- a/assets/queries/ansible/gcp/cloud_storage_bucket_versioning_disabled/query.rego
+++ b/assets/queries/ansible/gcp/cloud_storage_bucket_versioning_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(storage_bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_storage_bucket.versioning should be defined",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(storage_bucket, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.versioning.enabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_storage_bucket.versioning.enabled should be true",

--- a/assets/queries/ansible/gcp/cluster_labels_disabled/query.rego
+++ b/assets/queries/ansible/gcp/cluster_labels_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s should be defined and not null", [modules[m]]),
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.resource_labels", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s should not be empty", [modules[m]]),

--- a/assets/queries/ansible/gcp/cluster_master_authentication_disabled/query.rego
+++ b/assets/queries/ansible/gcp/cluster_master_authentication_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_cluster.master_auth should be defined and not null",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.master_auth", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("gcp_container_cluster.master_auth.%s should be defined and not null", [field]),
@@ -55,7 +55,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.master_auth.%s", [task.name, modules[m], fields[f]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("gcp_container_cluster.master_auth.%s should not be empty", [field]),

--- a/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/query.rego
+++ b/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(compute_instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.network_interfaces.access_configs", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_compute_instance.network_interfaces.access_configs should not be defined",

--- a/assets/queries/ansible/gcp/cos_node_image_not_used/query.rego
+++ b/assets/queries/ansible/gcp/cos_node_image_not_used/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(gcp_container, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.config.image_type", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_container_node_pool.config.image_type should start with 'COS'",

--- a/assets/queries/ansible/gcp/disk_encryption_disabled/query.rego
+++ b/assets/queries/ansible/gcp/disk_encryption_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(disk, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_compute_disk.disk_encryption_key should be defined and not null",
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(disk, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.disk_encryption_key", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_compute_disk.disk_encryption_key.raw_key or gcp_compute_disk.disk_encryption_key.kms_key_name should be defined and not null",
@@ -52,7 +52,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(disk, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.disk_encryption_key.%s", [task.name, modules[m], key]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("gcp_compute_disk.disk_encryption_key.%s should not be empty", [key]),

--- a/assets/queries/ansible/gcp/dnssec_using_rsasha1/query.rego
+++ b/assets/queries/ansible/gcp/dnssec_using_rsasha1/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(dns, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.dnssec_config.defaultKeySpecs.algorithm", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_dns_managed_zone.dnssec_config.defaultKeySpecs.algorithm should not equal to 'rsasha1'",

--- a/assets/queries/ansible/gcp/gke_basic_authentication_enabled/query.rego
+++ b/assets/queries/ansible/gcp/gke_basic_authentication_enabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_cluster.master_auth should be defined",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.master_auth", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("gcp_container_cluster.master_auth.%s should be defined", [fields[f]]),
@@ -55,7 +55,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.master_auth.%s", [task.name, modules[m], fields[f]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("gcp_container_cluster.master_auth.%s should be empty", [fields[f]]),

--- a/assets/queries/ansible/gcp/gke_legacy_authorization_enabled/query.rego
+++ b/assets/queries/ansible/gcp/gke_legacy_authorization_enabled/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.legacy_abac.enabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_container_cluster.legacy_abac.enabled should be set to false",

--- a/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/query.rego
+++ b/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(container_cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_cluster.master_authorized_networks_config should be defined",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(container_cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.master_authorized_networks_config", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_cluster.master_authorized_networks_config.enabled should be defined",
@@ -51,7 +51,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(container_cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.master_authorized_networks_config.enabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_container_cluster.master_authorized_networks_config.enabled should be true",

--- a/assets/queries/ansible/gcp/gke_using_default_service_account/query.rego
+++ b/assets/queries/ansible/gcp/gke_using_default_service_account/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(container_cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.node_config", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'service_account' should not be default",
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(container_cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.node_config.service_account", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'service_account' should not be default",

--- a/assets/queries/ansible/gcp/google_compute_network_using_default_firewall_rule/query.rego
+++ b/assets/queries/ansible/gcp/google_compute_network_using_default_firewall_rule/query.rego
@@ -21,7 +21,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modulesCompute[m],
-		"resourceName": tk.name,
+		"resourceName": object.get(computeNetwork, "name", tk.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [tk.name, modulesCompute[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s' should not be using a default firewall rule", [modulesCompute[m]]),

--- a/assets/queries/ansible/gcp/google_compute_network_using_firewall_allows_port_range/query.rego
+++ b/assets/queries/ansible/gcp/google_compute_network_using_firewall_allows_port_range/query.rego
@@ -23,7 +23,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modulesCompute[m],
-		"resourceName": tk.name,
+		"resourceName": object.get(computeNetwork, "name", tk.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [tk.name, modulesCompute[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s' should not be using a firewall rule that allows access to port range", [modulesCompute[m]]),

--- a/assets/queries/ansible/gcp/google_compute_network_using_firewall_rule_allows_all_ports/query.rego
+++ b/assets/queries/ansible/gcp/google_compute_network_using_firewall_rule_allows_all_ports/query.rego
@@ -22,7 +22,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modulesCompute[m],
-		"resourceName": tk.name,
+		"resourceName": object.get(computeNetwork, "name", tk.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [tk.name, modulesCompute[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s' should not be using a firewall rule that allows access to all ports", [modulesCompute[m]]),

--- a/assets/queries/ansible/gcp/google_compute_ssl_policy_weak_cipher_in_use/query.rego
+++ b/assets/queries/ansible/gcp/google_compute_ssl_policy_weak_cipher_in_use/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(policy, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_compute_ssl_policy has min_tls_version should be set to 'TLS_1_2'",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(policy, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.min_tls_version", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_compute_ssl_policy.min_tls_version has min_tls_version should be set to 'TLS_1_2'",

--- a/assets/queries/ansible/gcp/google_compute_subnetwork_with_private_google_access_disabled/query.rego
+++ b/assets/queries/ansible/gcp/google_compute_subnetwork_with_private_google_access_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(subnetwork, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.private_ip_google_access should be defined and not null", [modules[m]]),
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(subnetwork, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.private_ip_google_access", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue":  sprintf("%s.private_ip_google_access should be set to yes", [modules[m]]),

--- a/assets/queries/ansible/gcp/google_container_node_pool_auto_repair_disabled/query.rego
+++ b/assets/queries/ansible/gcp/google_container_node_pool_auto_repair_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(gcpContainer, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_node_pool.management should be defined",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(gcpContainer, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.management.auto_repair", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_container_node_pool.management.auto_repair should be set to true",

--- a/assets/queries/ansible/gcp/high_google_kms_crypto_key_rotation_period/query.rego
+++ b/assets/queries/ansible/gcp/high_google_kms_crypto_key_rotation_period/query.rego
@@ -7,15 +7,15 @@ modules := {"google.cloud.gcp_kms_crypto_key", "gcp_kms_crypto_key"}
 
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
-	gcpTopic := task[modules[m]]
-	ansLib.checkState(gcpTopic)
+	cryptoKey := task[modules[m]]
+	ansLib.checkState(cryptoKey)
 
-	not common_lib.valid_key(gcpTopic, "rotation_period")
+	not common_lib.valid_key(cryptoKey, "rotation_period")
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cryptoKey, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_kms_crypto_key.rotation_period should be defined with a value less or equal to 7776000",
@@ -25,16 +25,16 @@ CxPolicy[result] {
 
 CxPolicy[result] {
 	task := ansLib.tasks[id][t]
-	gcpTopic := task[modules[m]]
-	ansLib.checkState(gcpTopic)
+	cryptoKey := task[modules[m]]
+	ansLib.checkState(cryptoKey)
 
-	rotationPeriod := substring(gcpTopic.rotation_period, 0, count(gcpTopic.rotation_period) - 1)
+	rotationPeriod := substring(cryptoKey.rotation_period, 0, count(cryptoKey.rotation_period) - 1)
 	to_number(rotationPeriod) > 7776000
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cryptoKey, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rotation_period", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_kms_crypto_key.rotation_period should be less or equal to 7776000",

--- a/assets/queries/ansible/gcp/ip_aliasing_disabled/query.rego
+++ b/assets/queries/ansible/gcp/ip_aliasing_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_cluster.ip_allocation_policy should be defined",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.ip_allocation_policy", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_cluster.ip_allocation_policy.use_ip_aliases should be set to true",
@@ -51,7 +51,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.ip_allocation_policy.use_ip_aliases", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_container_cluster.ip_allocation_policy.use_ip_aliases should be true",

--- a/assets/queries/ansible/gcp/ip_forwarding_enabled/query.rego
+++ b/assets/queries/ansible/gcp/ip_forwarding_enabled/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.can_ip_forward", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_compute_instance.can_ip_forward should be set to false",

--- a/assets/queries/ansible/gcp/mysql_instance_with_local_infile_on/query.rego
+++ b/assets/queries/ansible/gcp/mysql_instance_with_local_infile_on/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.settings.database_flags", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "cloud_gcp_sql_instance.settings.database_flags should be correct",

--- a/assets/queries/ansible/gcp/network_policy_disabled/query.rego
+++ b/assets/queries/ansible/gcp/network_policy_disabled/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"searchValue": field,
 		"issueType": "MissingAttribute",
@@ -37,7 +37,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.addons_config", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_cluster.addons_config.network_policy_config should be defined",
@@ -56,7 +56,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.network_policy.enabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_container_cluster.network_policy.enabled should be true",
@@ -76,7 +76,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.addons_config.network_policy_config.disabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_container_cluster.addons_config.network_policy_config.disabled should be set to false",

--- a/assets/queries/ansible/gcp/node_auto_upgrade_disabled/query.rego
+++ b/assets/queries/ansible/gcp/node_auto_upgrade_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(container_task, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_node_pool.management should be defined",
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(container_task, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.management", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_node_pool.management.auto_upgrade should be defined",
@@ -53,7 +53,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(container_task, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.management.auto_upgrade", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_container_node_pool.management.auto_upgrade should be true",

--- a/assets/queries/ansible/gcp/oslogin_is_disabled_for_vm_instance/query.rego
+++ b/assets/queries/ansible/gcp/oslogin_is_disabled_for_vm_instance/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.metadata.enable-oslogin", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_compute_instance.metadata.enable-oslogin should be true",

--- a/assets/queries/ansible/gcp/postgresql_log_checkpoints_flag_not_set_to_on/query.rego
+++ b/assets/queries/ansible/gcp/postgresql_log_checkpoints_flag_not_set_to_on/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(gcp_task, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_sql_instance.settings.databaseFlags should be defined",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(gcp_task, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.settings.databaseFlags", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_sql_instance.settings.databaseFlags should have 'log_checkpoints' flag set to 'on'",

--- a/assets/queries/ansible/gcp/postgresql_log_connections_disabled/query.rego
+++ b/assets/queries/ansible/gcp/postgresql_log_connections_disabled/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(gcp_task, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_sql_instance.settings.databaseFlags should be defined",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(gcp_task, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.settings.databaseFlags", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_sql_instance.settings.databaseFlags should have 'log_connections' flag set to 'on'",

--- a/assets/queries/ansible/gcp/postgresql_logging_of_temporary_files_disabled/query.rego
+++ b/assets/queries/ansible/gcp/postgresql_logging_of_temporary_files_disabled/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.settings.database_flags", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_sql_instance.settings.database_flags should set the log_temp_files to 0",

--- a/assets/queries/ansible/gcp/postgresql_misconfigured_log_messages_flag/query.rego
+++ b/assets/queries/ansible/gcp/postgresql_misconfigured_log_messages_flag/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.settings.database_flags.log_min_messages", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_sql_instance.settings.database_flags should set 'log_min_messages' to a valid value",

--- a/assets/queries/ansible/gcp/postgresql_misconfigured_logging_duration_flag/query.rego
+++ b/assets/queries/ansible/gcp/postgresql_misconfigured_logging_duration_flag/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.settings.database_flags", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_sql_instance.settings.database_flags should set the log_min_duration_statement to -1",

--- a/assets/queries/ansible/gcp/private_cluster_disabled/query.rego
+++ b/assets/queries/ansible/gcp/private_cluster_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_cluster.private_cluster_config should be defined",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.private_cluster_config", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("gcp_container_cluster.private_cluster_config.%s should be defined", [fields[f]]),
@@ -54,7 +54,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.private_cluster_config.%s", [task.name, modules[m], fields[f]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("gcp_container_cluster.private_cluster_config.%s should be true", [fields[f]]),

--- a/assets/queries/ansible/gcp/project_wide_ssh_keys_are_enabled_in_vm_instances/query.rego
+++ b/assets/queries/ansible/gcp/project_wide_ssh_keys_are_enabled_in_vm_instances/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.metadata.block-project-ssh-keys", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_compute_instance.metadata.block-project-ssh-keys should be true",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.metadata", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_compute_instance.metadata.block-project-ssh-keys should be set to true",
@@ -53,7 +53,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_compute_instance.metadata should be set",

--- a/assets/queries/ansible/gcp/rdp_access_is_not_restricted/query.rego
+++ b/assets/queries/ansible/gcp/rdp_access_is_not_restricted/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.allowed.ip_protocol=%s.ports", [task.name, modules[m], allowed[k].ip_protocol]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("gcp_compute_firewall.allowed.ip_protocol=%s.ports shouldn't contain RDP port (3389) with unrestricted ingress traffic", [allowed[k].ip_protocol]),

--- a/assets/queries/ansible/gcp/serial_ports_enabled_for_vm_instances/query.rego
+++ b/assets/queries/ansible/gcp/serial_ports_enabled_for_vm_instances/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.metadata.serial-port-enable", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_compute_instance.metadata.serial-port-enable should be undefined or set to false",

--- a/assets/queries/ansible/gcp/shielded_vm_disabled/query.rego
+++ b/assets/queries/ansible/gcp/shielded_vm_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_compute_instance.shielded_instance_config should be defined",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.shielded_instance_config", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("gcp_compute_instance.shielded_instance_config.%s should be defined", [attributes[j]]),
@@ -54,7 +54,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.shielded_instance_config.%s", [task.name, modules[m], attributes[j]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("gcp_compute_instance.shielded_instance_config.%s should be true", [attributes[j]]),

--- a/assets/queries/ansible/gcp/sql_db_instance_backup_disabled/query.rego
+++ b/assets/queries/ansible/gcp/sql_db_instance_backup_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}%s", [task.name, modules[m], path.defined]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("gcp_sql_instance.%s should be defined", [path.undefined]),
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.settings.backup_configuration.enabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_sql_instance.settings.backup_configuration.require_ssl should be true",

--- a/assets/queries/ansible/gcp/sql_db_instance_is_publicly_accessible/query.rego
+++ b/assets/queries/ansible/gcp/sql_db_instance_is_publicly_accessible/query.rego
@@ -19,7 +19,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.settings.ip_configuration.authorized_networks.name={{%s}}.value", [task.name, modules[m], network]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("gcp_sql_instance.settings.ip_configuration.authorized_networks.name={{%s}}.value address should be trusted", [network]),
@@ -39,7 +39,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.settings.ip_configuration.ipv4_enabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_sql_instance.settings.ip_configuration.ipv4_enabled should be disabled when there are no authorized networks",
@@ -57,7 +57,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.settings", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_sql_instance.settings.ip_configuration should be defined and allow only trusted networks",

--- a/assets/queries/ansible/gcp/sql_db_instance_with_ssl_disabled/query.rego
+++ b/assets/queries/ansible/gcp/sql_db_instance_with_ssl_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(sql_instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}%s", [task.name, modules[m], path.defined]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("gcp_sql_instance.%s should be defined", [path.undefined]),
@@ -33,7 +33,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(sql_instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.settings.ip_configuration.require_ssl", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_sql_instance.settings.ip_configuration.require_ssl should be true",

--- a/assets/queries/ansible/gcp/ssh_access_is_not_restricted/query.rego
+++ b/assets/queries/ansible/gcp/ssh_access_is_not_restricted/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.allowed.ip_protocol=%s.ports", [task.name, modules[m], allowed[k].ip_protocol]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("gcp_compute_firewall.allowed.ip_protocol=%s.ports shouldn't contain SSH port (22) with unrestricted ingress traffic", [allowed[k].ip_protocol]),

--- a/assets/queries/ansible/gcp/stackdriver_logging_disabled/query.rego
+++ b/assets/queries/ansible/gcp/stackdriver_logging_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_cluster.logging_service should be defined",
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.logging_service", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_container_cluster.logging_service should not be 'none'",

--- a/assets/queries/ansible/gcp/stackdriver_monitoring_disabled/query.rego
+++ b/assets/queries/ansible/gcp/stackdriver_monitoring_disabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_container_cluster.monitoring_service should be defined",
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(cluster, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.monitoring_service", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_container_cluster.monitoring_service should not be 'none'",

--- a/assets/queries/ansible/gcp/using_default_service_account/query.rego
+++ b/assets/queries/ansible/gcp/using_default_service_account/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "gcp_compute_instance.service_account_email should be defined",
@@ -37,7 +37,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.service_account_email", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_compute_instance.service_account_email should not be empty",
@@ -59,7 +59,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.service_account_email", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_compute_instance.service_account_email should be an email",
@@ -79,7 +79,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(instance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.service_account_email", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_compute_instance.service_account_email should not be a default Google Compute Engine service account",

--- a/assets/queries/ansible/gcp/vm_with_full_cloud_access/query.rego
+++ b/assets/queries/ansible/gcp/vm_with_full_cloud_access/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(taskComputeInstance, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.service_accounts", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "gcp_compute_instance.service_accounts.scopes should not contain 'cloud-platform'",

--- a/assets/queries/ansible/general/communication_over_http/query.rego
+++ b/assets/queries/ansible/general/communication_over_http/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(builtin_uri, "url", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.url", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "ansible.builtin.uri.url should be accessed via the HTTPS protocol",

--- a/assets/queries/ansible/general/insecure_relative_path_resolution/query.rego
+++ b/assets/queries/ansible/general/insecure_relative_path_resolution/query.rego
@@ -23,7 +23,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": m,
-		"resourceName": task.name,
+		"resourceName": object.get(copyOrTemplate, "dest", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.src", [task.name, m]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.src should not be a relative path", [m]),

--- a/assets/queries/ansible/general/logging_of_sensitive_data/query.rego
+++ b/assets/queries/ansible/general/logging_of_sensitive_data/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": id,
-		"resourceName": task.name,
+		"resourceName": object.get(action, "name", task.name),
 		"resourceType": "ansible.builtin.user",
 		"searchKey": sprintf("name={{%s}}", [task.name]),
 		"issueType": "MissingAttribute",
@@ -32,7 +32,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": id,
-		"resourceName": task.name,
+		"resourceName": object.get(action, "name", task.name),
 		"resourceType": "ansible.builtin.user",
 		"searchKey": sprintf("name={{%s}}.no_log", [task.name]),
 		"issueType": "IncorrectValue",

--- a/assets/queries/ansible/general/privilege_escalation_using_become_plugin/query.rego
+++ b/assets/queries/ansible/general/privilege_escalation_using_become_plugin/query.rego
@@ -43,7 +43,7 @@ CxPolicy[result] {
     result := {
 		"documentId": id,
 		"resourceType": "ansible_task",
-		"resourceName": task.name,
+		"resourceName": object.get(task, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.become_user={{%s}}.become", [task.name, task.become_user]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'become' should be to 'true' in order to perform an action with %s", [task.become_user]),
@@ -59,7 +59,7 @@ CxPolicy[result] {
     result := {
 		"documentId": id,
 		"resourceType": "ansible_task",
-		"resourceName": task.name,
+		"resourceName": object.get(task, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.become_user={{%s}}", [task.name, task.become_user]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'become' should be defined and set to 'true' in order to perform an action with %s", [task.become_user]),

--- a/assets/queries/ansible/general/risky_file_permissions/query.rego
+++ b/assets/queries/ansible/general/risky_file_permissions/query.rego
@@ -38,12 +38,12 @@ CxPolicy[result] {
 	not common_lib.valid_key(action, "recurse")
     not file_module(action, modules[m])
     
-    not common_lib.valid_key(action, "mode")
+	not common_lib.valid_key(action, "mode")
 
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": object.get(action, "dest", task.name),
+		"resourceName": object.get(action, "dest", object.get(action, "path", task.name)),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("All the permissions set in %s about creating files/directories", [modules[m]]),

--- a/assets/queries/ansible/general/risky_file_permissions/query.rego
+++ b/assets/queries/ansible/general/risky_file_permissions/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": m,
-		"resourceName": task.name,
+		"resourceName": object.get(action, "dest", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, m]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s does not allow setting 'preserve' value for 'mode' key", [m]),
@@ -43,7 +43,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(action, "dest", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("All the permissions set in %s about creating files/directories", [modules[m]]),
@@ -74,7 +74,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": m,
-		"resourceName": task.name,
+		"resourceName": object.get(action, "path", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, m]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s 'create' key should set to 'false' or 'mode' key should be defined", [m]),

--- a/assets/queries/ansible/general/unpinned_package_version/query.rego
+++ b/assets/queries/ansible/general/unpinned_package_version/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": ansLib.installer_modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(package_installer, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.state", [task.name, ansLib.installer_modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "State's task when installing a package should not be defined as 'latest' or should have set 'update_only' to 'true'",
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": id,
 		"resourceType": ansLib.installer_modules[m],
-		"resourceName": task.name,
+		"resourceName": object.get(package_installer, "name", task.name),
 		"searchKey": sprintf("name={{%s}}.{{%s}}.state", [task.name, ansLib.installer_modules[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "State's task when installing a package should not be defined as 'latest' or should have set 'update_only' to 'true'",


### PR DESCRIPTION
## Motivation

Ansible findings should report the **resource identifier** (e.g. bucket name, `db_instance_identifier`) instead of only the task name, so users can locate the exact resource in their playbooks. This PR ensures every Ansible rule that sets `resourceName` uses the correct module identifier from official Ansible docs, and keeps the manifest and verification doc in sync.

## Changes

- Two rules were reporting wrong searchKeys, making the findings being dropped because no resource lines reported
- Corrected identifier fields and variable names where they didn’t match Ansible module parameters (e.g. `aws_s3` → `bucket`, `opensearch` → `domain_name`, `iam_policy` → `policy_name`/`iam_name`, `iam_managed_policy` variable renames, account-scoped IAM password policy → `task.name` only).`cos_node_image_not_used` → `gcp_container_node_pool`; added config/hosts rules with literal identifiers).

## Author Checklist

- [x] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- Run a scan on the Ansible samples of the rules and generate SARIF. In the output, confirm that reported `resourceName` values match the real identifiers from the example tasks (e.g. bucket name, `db_instance_identifier`, task name where appropriate).
- Review the diff to ensure only intended Rego identifier fields, manifest rows, and verification doc updates are changed.

## Blast Radius

Ansible query results only: `resourceName` in findings may change to the real resource id (e.g. bucket name) where it was previously wrong or task-only. No API or scanner behavior change beyond that.

## Additional Notes

I submit this contribution under the Apache-2.0 license.
