### PR TITLE
Fix Terraform rules dropping findings (invalid resource location)

### DIFF
--- a/assets/queries/terraform/alicloud/rds_instance_log_disconnections_disabled/query.rego
+++ b/assets/queries/terraform/alicloud/rds_instance_log_disconnections_disabled/query.rego
@@ -4,10 +4,9 @@ import data.generic.common as common_lib
 import data.generic.terraform as tf_lib
 
 CxPolicy[result] {
-	some i
 	resource := input.document[i].resource.alicloud_db_instance[name].parameters
-    resource[parameter].name == "log_disconnections"
-    resource[parameter].value == "OFF"
+	resource[parameter].name == "log_disconnections"
+	resource[parameter].value == "OFF"
 
 	result := {
 		"documentId": input.document[i].id,
@@ -27,7 +26,6 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	some i
 	resource := input.document[i].resource.alicloud_db_instance[name]
 	common_lib.valid_key(resource, "parameters")
 	not has_log_disconn(resource)
@@ -50,7 +48,6 @@ has_log_disconn(resource){
 }
 
 CxPolicy[result] {
-	some i
 	resource := input.document[i].resource.alicloud_db_instance[name]
 	not common_lib.valid_key(resource, "parameters")
 
@@ -58,10 +55,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "alicloud_db_instance",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("alicloud_db_instance[%s]]", [name]),
+		"searchKey": sprintf("alicloud_db_instance[%s]", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "'log_disconnections' parameter should be defined and value should be 'ON' in parametes array",
-		"keyActualValue": "'log_disconnections' parameter is not defined in parametes array",
+		"keyExpectedValue": "'log_disconnections' parameter should be defined and value should be 'ON' in parameters array",
+		"keyActualValue": "'log_disconnections' parameter is not defined in parameters array",
 		"searchLine": common_lib.build_search_line(["resource", "alicloud_db_instance", name], []),
 		"remediation": "parameters = [{\n\tname = \"log_disconnections\"\n\tvalue = \"ON\"\n\t}]",
 		"remediationType": "addition",

--- a/assets/queries/terraform/alicloud/rds_instance_log_duration_disabled/query.rego
+++ b/assets/queries/terraform/alicloud/rds_instance_log_duration_disabled/query.rego
@@ -4,10 +4,9 @@ import data.generic.common as common_lib
 import data.generic.terraform as tf_lib
 
 CxPolicy[result] {
-	some i
 	resource := input.document[i].resource.alicloud_db_instance[name].parameters
-    resource[parameter].name == "log_duration"
-    resource[parameter].value == "OFF"
+	resource[parameter].name == "log_duration"
+	resource[parameter].value == "OFF"
 
 	result := {
 		"documentId": input.document[i].id,
@@ -27,7 +26,6 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	some i
 	resource := input.document[i].resource.alicloud_db_instance[name]
 	common_lib.valid_key(resource, "parameters")
 	not has_log_duration(resource)
@@ -50,7 +48,6 @@ has_log_duration(resource){
 }
 
 CxPolicy[result] {
-	some i
 	resource := input.document[i].resource.alicloud_db_instance[name]
 	not common_lib.valid_key(resource, "parameters")
 
@@ -58,7 +55,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "alicloud_db_instance",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("alicloud_db_instance[%s]]", [name]),
+		"searchKey": sprintf("alicloud_db_instance[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'log_duration' parameter should be defined and value should be 'ON' in parameters array",
 		"keyActualValue": "'log_duration' parameter is not defined in parameters array",

--- a/assets/queries/terraform/azure/default_azure_storage_account_network_access_is_too_permissive/query.rego
+++ b/assets/queries/terraform/azure/default_azure_storage_account_network_access_is_too_permissive/query.rego
@@ -11,7 +11,8 @@ CxPolicy[result] {
 	res1 := publicNetworkAccessEnabled(resource)
 	res2 := aclsDefaultActionAllow(networkRules.rules)
 
-	issue := prepare_issue(res1, res2, var0, networkRules.type, networkRules.key)
+	same_doc := docs_match(networkRules.docId, input.document[i].id)
+	issue := prepare_issue(res1, res2, var0, networkRules.type, networkRules.key, same_doc)
 
 	result := {
 		"documentId": input.document[i].id,
@@ -27,8 +28,8 @@ CxPolicy[result] {
 	}
 }
 
-prepare_issue(res1, res2, resource_id, rules_type, rules_key) = issue {
-    res1 == "not defined"
+prepare_issue(res1, res2, resource_id, rules_type, rules_key, same_doc) = issue {
+	res1 == "not defined"
 	res2 == "not defined"
 	issue := {
 		"kav": "azurerm_storage_account.public_network_access_enabled is not set (default is 'true')",
@@ -40,8 +41,8 @@ prepare_issue(res1, res2, resource_id, rules_type, rules_key) = issue {
 		"remediationType": "addition",
 	}
 } else = issue {
-    res1 == "enabled"
-    issue := {
+	res1 == "enabled"
+	issue := {
 		"kav": "azurerm_storage_account.public_network_access_enabled set to 'true'",
 		"kev": "azurerm_storage_account.public_network_access_enabled should be set to 'false'",
 		"searchLine": common_lib.build_search_line(["resource", "azurerm_storage_account", resource_id, "public_network_access_enabled"], []),
@@ -54,9 +55,9 @@ prepare_issue(res1, res2, resource_id, rules_type, rules_key) = issue {
 		"remediationType": "replacement",
 	}
 } else = issue {
-    res2 == "allow"
-    rules_type == "inline"
-    issue := {
+	res2 == "allow"
+	rules_type == "inline"
+	issue := {
 		"kav": "azurerm_storage_account.network_rules.default_action is set to 'Allow'",
 		"kev": "azurerm_storage_account.network_rules.default_action should be set to 'Deny'",
 		"issueType": "IncorrectValue",
@@ -64,14 +65,15 @@ prepare_issue(res1, res2, resource_id, rules_type, rules_key) = issue {
 			"before": "Allow",
 			"after": "Deny",
 		}),
-        "searchLine": common_lib.build_search_line(["resource", "azurerm_storage_account", resource_id, "network_rules", "default_action"], []),
-        "searchKey": sprintf("azurerm_storage_account[%s].network_rules.default_action", [resource_id]),
-        "remediationType": "replacement",
+		"searchLine": common_lib.build_search_line(["resource", "azurerm_storage_account", resource_id, "network_rules", "default_action"], []),
+		"searchKey": sprintf("azurerm_storage_account[%s].network_rules.default_action", [resource_id]),
+		"remediationType": "replacement",
 	}
 } else = issue {
-    res2 == "allow"
-    rules_type == "object"
-    issue := {
+	res2 == "allow"
+	rules_type == "object"
+	same_doc == true
+	issue := {
 		"kav": "azurerm_storage_account_network_rules.default_action is set to 'Allow'",
 		"kev": "azurerm_storage_account_network_rules.default_action should be set to 'Deny'",
 		"issueType": "IncorrectValue",
@@ -79,36 +81,52 @@ prepare_issue(res1, res2, resource_id, rules_type, rules_key) = issue {
 			"before": "Allow",
 			"after": "Deny",
 		}),
-        "searchLine": common_lib.build_search_line(["resource", "azurerm_storage_account_network_rules", rules_key, "default_action"], []),
-        "searchKey": sprintf("azurerm_storage_account_network_rules[%s].default_action", [rules_key]),
-        "remediationType": "replacement",
+		"searchLine": common_lib.build_search_line(["resource", "azurerm_storage_account_network_rules", rules_key, "default_action"], []),
+		"searchKey": sprintf("azurerm_storage_account_network_rules[%s].default_action", [rules_key]),
+		"remediationType": "replacement",
+	}
+} else = issue {
+	res2 == "allow"
+	rules_type == "object"
+	same_doc == false
+	issue := {
+		"kav": "azurerm_storage_account_network_rules.default_action is set to 'Allow' (defined in a separate resource)",
+		"kev": "azurerm_storage_account_network_rules.default_action should be set to 'Deny'",
+		"issueType": "IncorrectValue",
+		"searchLine": common_lib.build_search_line(["resource", "azurerm_storage_account", resource_id], []),
+		"searchKey": sprintf("azurerm_storage_account[%s]", [resource_id]),
+		"remediation": "",
+		"remediationType": "",
 	}
 }
 
 get_network_rules(storage_account, storage_account_name) = rules {
-	networkRules := input.document[i].resource.azurerm_storage_account_network_rules[var1]
-    networkRules.storage_account_id == sprintf("${azurerm_storage_account.%s.id}", [storage_account_name])
-    rules := {
-        "rules": object.union(networkRules, {"name": var1}),
-        "type": "object",
-        "key": var1
-    }
+	networkRules := input.document[j].resource.azurerm_storage_account_network_rules[var1]
+	networkRules.storage_account_id == sprintf("${azurerm_storage_account.%s.id}", [storage_account_name])
+	rules := {
+		"rules": object.union(networkRules, {"name": var1}),
+		"type": "object",
+		"key": var1,
+		"docId": input.document[j].id,
+	}
 } else = rules {
 	rules := {
-	    "rules": storage_account.network_rules,
-	    "type": "inline",
-	    "key": null
-    }
+		"rules": storage_account.network_rules,
+		"type": "inline",
+		"key": null,
+		"docId": null,
+	}
 } else = rules {
 	rules := {
-	    "rules": null,
-	    "type": null,
-	    "key": null
+		"rules": null,
+		"type": null,
+		"key": null,
+		"docId": null,
 	}
 }
 
 publicNetworkAccessEnabled(sa) = reason {
-    not has_key(sa, "public_network_access_enabled")
+	not has_key(sa, "public_network_access_enabled")
 	reason := "not defined"
 } else = reason {
 	sa.public_network_access_enabled == true
@@ -116,17 +134,21 @@ publicNetworkAccessEnabled(sa) = reason {
 }
 
 aclsDefaultActionAllow(network_rules) = reason {
-    not has_key(network_rules, "default_action")
-    reason := "not defined"
+	not has_key(network_rules, "default_action")
+	reason := "not defined"
 } else = reason {
-    is_null(network_rules)
-    reason := "not defined"
+	is_null(network_rules)
+	reason := "not defined"
 } else = reason {
-    has_key(network_rules, "default_action")
-    lower(network_rules.default_action) == "allow"
-    reason := "allow"
+	has_key(network_rules, "default_action")
+	lower(network_rules.default_action) == "allow"
+	reason := "allow"
 }
 
 has_key(x, k) {
 	_ = x[k]
 }
+
+docs_match(a, b) = true {
+	a == b
+} else = false

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -477,7 +477,13 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 			resourceLocation := vulnerability.ResourceLocation
 
 			if resourceLocation.Start.Line < 1 || resourceLocation.End.Line < 1 {
-				contextLogger.Warn().Msgf("Invalid resource location for file %s", issue.Files[idx].FileName)
+				contextLogger.Error().
+					Str("file", vulnerability.FileName).
+					Str("query_name", issue.QueryName).
+					Str("resource_type", resourceType).
+					Str("resource_name", resourceName).
+					Str("platform", issue.Platform).
+					Msg("Invalid resource location for file")
 				continue
 			}
 


### PR DESCRIPTION
## Motivation

Findings with invalid resource location (e.g. when the Terraform detector cannot resolve the rego `searchKey` to a block) are dropped when building the SARIF report (`pkg/report/model/sarif.go`). When that happens we only logged a generic warning, which made it hard to see which query/file was affected. In addition, some Terraform rego rules were emitting `searchKey` values that the detector cannot resolve, causing those findings to be dropped. This PR improves observability and corrects the affected rego rules so findings are no longer dropped.

## Changes

- When a finding has invalid resource location, log at **Error** level with structured fields (`file`, `query_name`, `resource_type`, `resource_name`, `platform`) instead of a single Warn message. The finding is still skipped for SARIF as before.

- **Terraform rego fixes (so findings get a valid location and are not dropped):**
  - **alicloud/rds_instance_log_disconnections_disabled**: Removed redundant `some i`; fixed typo in `searchKey` (`alicloud_db_instance[%s]]` → `alicloud_db_instance[%s]`); fixed "parametes" → "parameters" in expected/actual value strings; indentation cleanup.
  - **alicloud/rds_instance_log_duration_disabled**: Removed redundant `some i`; fixed typo in `searchKey` (`alicloud_db_instance[%s]]` → `alicloud_db_instance[%s]`); indentation cleanup.
  - **azure/default_azure_storage_account_network_access_is_too_permissive**: When network rules are defined in a **separate** `azurerm_storage_account_network_rules` resource, the previous `searchKey` (`azurerm_storage_account_network_rules[rules_key].default_action`) could not be resolved by the detector, so findings were dropped. The rule now distinguishes same-document vs cross-document network rules (`same_doc` via `docs_match`). For the object case when the rules block is in a **different** document, the rule now emits a resolvable `searchKey` pointing at the storage account (`azurerm_storage_account[resource_id]`) so the finding is no longer dropped; message and remediation are adjusted for that case. Formatting/indentation normalized.

## Author Checklist

- [x] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. Run a Terraform scan that triggers the Azure "default storage account network access" rule with a separate `azurerm_storage_account_network_rules` resource (e.g. under `assets/queries/terraform/azure/default_azure_storage_account_network_access_is_too_permissive/test/` or `public_storage_account/test/`).
2. Confirm the finding appears in the SARIF output with a valid location (no "Invalid resource location" error in logs).
3. Run scans that trigger the Alicloud RDS log rules and confirm findings still appear with correct locations and messages.

Or just review the code as in essence nothing semantically has changed too much

## Blast Radius

Behaviour change: better error logging when a finding is dropped for invalid resource location; Terraform rego fixes ensure more findings (Alicloud RDS + Azure storage account network access in certain cases) are no longer dropped and appear in SARIF.

## Additional Notes

I submit this contribution under the Apache-2.0 license.
