### PR TITLE
[Helm] Location dropped issue

### DIFF
--- a/pkg/detector/helm/helm_detect.go
+++ b/pkg/detector/helm/helm_detect.go
@@ -71,11 +71,14 @@ func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata
 	// Since we are only looking at keys we can ignore the second value passed through '=' and '[]'
 	for _, key := range strings.Split(sanitizedSubstring, ".") {
 		substr1, _ := detector.GenerateSubstrings(ctx, key, extractedString, lines, curLineRes.lineRes)
-		curLineRes, start, end = curLineRes.detectCurrentLine(lines, fmt.Sprintf("%s:", substr1), "", true, file.IDInfo, helmID)
+		var iterStart, iterEnd model.ResourceLine
+		curLineRes, iterStart, iterEnd = curLineRes.detectCurrentLine(lines, fmt.Sprintf("%s:", substr1), "", true, file.IDInfo, helmID)
 
 		if curLineRes.breakRes {
 			break
 		}
+		start = iterStart
+		end = iterEnd
 	}
 
 	// Look at dupHistory to see if the last element was duplicate, if so
@@ -148,15 +151,15 @@ func (d detectCurlLine) detectCurrentLine(lines []string, str1,
 		if str1 != "" && str2 != "" {
 			if strings.Contains(lines[i], str1) && strings.Contains(lines[i], str2) {
 				distances[i] = levenshtein.ComputeDistance(detector.ExtractLineFragment(lines[i], str2, byKey), str2)
-				starts[i] = model.ResourceLine{Line: i, Col: 0}
-				ends[i] = model.ResourceLine{Line: i, Col: len(lines[i])}
+				starts[i] = model.ResourceLine{Line: i + 1, Col: 0}
+				ends[i] = model.ResourceLine{Line: i + 1, Col: len(lines[i])}
 			}
 		} else if str1 != "" {
 			if strings.Contains(lines[i], str1) {
 				distances[i] = levenshtein.ComputeDistance(
 					detector.ExtractLineFragment(strings.TrimSpace(lines[i]), str1, byKey), str1)
-				starts[i] = model.ResourceLine{Line: i, Col: 0}
-				ends[i] = model.ResourceLine{Line: i, Col: len(lines[i])}
+				starts[i] = model.ResourceLine{Line: i + 1, Col: 0}
+				ends[i] = model.ResourceLine{Line: i + 1, Col: len(lines[i])}
 			}
 		}
 	}

--- a/pkg/detector/helm/helm_detect_test.go
+++ b/pkg/detector/helm/helm_detect_test.go
@@ -57,6 +57,20 @@ spec:
     restartPolicy: Never
 `
 
+var OriginalDataPartialMatch = `# KICS_HELM_ID_0:
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          securityContext: {}
+          image: nginx
+`
+
 var OriginalData3 = `# KICS_HELM_ID_0:
 apiVersion: v1
 kind: Pod
@@ -135,11 +149,11 @@ func TestEngine_detectHelmLine(t *testing.T) { //nolint
 				ResolvedFile:          "test-connection.yaml",
 				VulnerablilityLocation: model.ResourceLocation{
 					Start: model.ResourceLine{
-						Line: 10,
+						Line: 11,
 						Col:  0,
 					},
 					End: model.ResourceLine{
-						Line: 10,
+						Line: 11,
 						Col:  13,
 					},
 				},
@@ -178,11 +192,11 @@ func TestEngine_detectHelmLine(t *testing.T) { //nolint
 				ResolvedFile:          "test-dup_values.yaml",
 				VulnerablilityLocation: model.ResourceLocation{
 					Start: model.ResourceLine{
-						Line: 10,
+						Line: 11,
 						Col:  0,
 					},
 					End: model.ResourceLine{
-						Line: 10,
+						Line: 11,
 						Col:  13,
 					},
 				},
@@ -218,12 +232,52 @@ func TestEngine_detectHelmLine(t *testing.T) { //nolint
 				ResolvedFile:          "test-dups.yaml",
 				VulnerablilityLocation: model.ResourceLocation{
 					Start: model.ResourceLine{
-						Line: 27,
+						Line: 28,
 						Col:  0,
 					},
 					End: model.ResourceLine{
-						Line: 27,
+						Line: 28,
 						Col:  13,
+					},
+				},
+			},
+		},
+		{
+			name: "test_preserve_location_when_final_key_missing",
+			args: args{
+				file: &model.FileMetadata{
+					ID:                "1",
+					ScanID:            "console",
+					Document:          model.Document{},
+					Kind:              model.KindHELM,
+					FilePath:          "deployment.yaml",
+					HelmID:            "# KICS_HELM_ID_0",
+					OriginalData:      OriginalDataPartialMatch,
+					LinesOriginalData: utils.SplitLines(OriginalDataPartialMatch),
+					Content:           ``,
+				},
+				searchKey:     "KICS_HELM_ID_0.spec.template.spec.containers.securityContext.runAsNonRoot",
+				logWithFields: &zerolog.Logger{},
+				outputLines:   1,
+			},
+			want: model.VulnerabilityLines{
+				Line: 10,
+				VulnLines: &[]model.CodeLine{
+					{
+						Position: 10,
+						Line:     "          securityContext: {}",
+					},
+				},
+				LineWithVulnerability: "          securityContext",
+				ResolvedFile:          "deployment.yaml",
+				VulnerablilityLocation: model.ResourceLocation{
+					Start: model.ResourceLine{
+						Line: 11,
+						Col:  0,
+					},
+					End: model.ResourceLine{
+						Line: 11,
+						Col:  29,
 					},
 				},
 			},


### PR DESCRIPTION
## Motivation

When scanning Helm charts, findings were dropped with **"Invalid resource location for file"** and never appeared in the report. This happened for templates where the finding was about **missing** configuration (e.g. `containers_running_as_root`): the line detector walks the search key path (e.g. `spec.template.spec.containers.securityContext.runAsNonRoot`), and when the **last** key part does not exist(securityContext for eg.) in the template it returned a zeroed location. The SARIF builder then rejected those findings (`Start.Line < 1`).

## Changes

- In `pkg/detector/helm/helm_detect.go`, only update `start`/`end` when the current key part is found. When the final part of the search key is missing (e.g. `runAsNonRoot`), we now keep the last valid location (e.g. the `securityContext:` line) instead of zeroing it, so the finding is no longer dropped.
- Use `Line: i + 1` in `detectCurrentLine` so locations pass SARIF validation (`Start.Line >= 1`) and match the rest of the pipeline for Helm

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [x] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. Run the scanner on a repo that contains any Helm chart where findings target missing keys, e.g. `securityContext.runAsNonRoot`.
2. **Before the fix:** Such findings would log "Invalid resource location for file" and not appear in the SARIF report.
3. **After the fix:** Findings appear in the report with a valid location (file + line) pointing to the last matched key (e.g. the `securityContext:` line).
4. Run `go test ./pkg/detector/helm/... -v` and confirm all tests pass.

## Blast Radius

- **DataDog IaC Scanner only.** Helm line detection and SARIF report generation for Helm charts

## Additional Notes

I submit this contribution under the Apache-2.0 license.