### PR TITLE
[CICD Coverage #3] Other rules

### DIFF
--- a/assets/queries/cicd/github/anonymous_definition/metadata.json
+++ b/assets/queries/cicd/github/anonymous_definition/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "a1b2c3d4-e5f6-47a8-b9c0-d1e2f3a4b5c6",
+  "queryName": "Anonymous definition",
+  "severity": "LOW",
+  "category": "Best Practices",
+  "descriptionText": "Unnamed workflows and jobs reduce traceability and slow down auditing, monitoring, and incident response because run logs and alerts become harder to identify and correlate.\n\nCheck GitHub Actions workflow YAML: the top-level `name` property must be defined and non-empty, and each standard job under `jobs` should include a non-empty `name` property. Workflows missing a top-level `name` or jobs without `name` will be flagged.\n\nThis rule applies to normal jobs. Reusable or composite actions may be treated differently by some tools, so ensure each visible job has a clear `name`. Use concise, descriptive names so runs and failures are immediately recognizable.\n\nSecure example:\n\n```yaml\nname: CI — Build and Test\n\non:\n  push:\n    branches: [ main ]\n\njobs:\n  build:\n    name: Build\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v3\n```",
+  "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/cicd/github/anonymous_definition",
+  "platform": "CICD",
+  "descriptionID": "a1b2c3d4",
+  "cloudProvider": "common",
+  "providerUrl": "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#name",
+  "cwe": "710"
+}

--- a/assets/queries/cicd/github/anonymous_definition/query.rego
+++ b/assets/queries/cicd/github/anonymous_definition/query.rego
@@ -1,0 +1,40 @@
+package Cx
+
+import data.generic.common as common_lib
+
+# Check for workflow without a name
+CxPolicy[result] {
+	doc := input.document[i]
+	doc.jobs
+	not object.get(doc, "name", false)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": "on",
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Workflow should have a name defined",
+		"keyActualValue": "Workflow does not have a name defined",
+		"searchLine": common_lib.build_search_line(["name"], []),
+		"resourceType": "github_action",
+		"resourceName": "anonymous_workflow"
+	}
+}
+
+# Check for jobs without names
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	not object.get(job, "name", false)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s", [j]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("Job '%s' should have a name defined", [j]),
+		"keyActualValue": sprintf("Job '%s' does not have a name defined", [j]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "name"], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}

--- a/assets/queries/cicd/github/anonymous_definition/test/negative.yaml
+++ b/assets/queries/cicd/github/anonymous_definition/test/negative.yaml
@@ -1,0 +1,13 @@
+name: Valid Workflow with Names
+on: push
+
+jobs:
+  build:
+    name: Build Job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run tests
+        run: npm test

--- a/assets/queries/cicd/github/anonymous_definition/test/positive.yaml
+++ b/assets/queries/cicd/github/anonymous_definition/test/positive.yaml
@@ -1,0 +1,9 @@
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: npm test

--- a/assets/queries/cicd/github/anonymous_definition/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/anonymous_definition/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "Anonymous definition",
+    "severity": "LOW",
+    "line": 1
+  },
+  {
+    "queryName": "Anonymous definition",
+    "severity": "LOW",
+    "line": 4
+  }
+]

--- a/assets/queries/cicd/github/concurrency_limits/metadata.json
+++ b/assets/queries/cicd/github/concurrency_limits/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "f6a7b8c9-d0e1-42f3-a4b5-c6d7e8f9a0b1",
+  "queryName": "Concurrency limits",
+  "severity": "LOW",
+  "category": "Best Practices",
+  "descriptionText": "Workflows and jobs without proper concurrency controls can lead to redundant, overlapping runs that waste CI/CD compute, increase queue times, and slow feedback for developers when commits or PR updates happen frequently. Configure the `concurrency` setting with `cancel-in-progress: true` so GitHub cancels in-progress runs for the same concurrency group instead of running duplicates.\n\nIn workflow YAML, the `concurrency` property must be an object containing a `group` and `cancel-in-progress: true`. This rule flags workflows or jobs that omit `concurrency` or use a bare string value, which lacks `cancel-in-progress`. Reusable-only workflows should not manage concurrency themselves. Their callers should define concurrency to avoid deadlocks and premature cancellations.\n\nSecure configuration example:\n\n```yaml\nconcurrency:\n  group: ${{ github.workflow }}-${{ github.ref }}\n  cancel-in-progress: true\n```",
+  "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/cicd/github/concurrency_limits",
+  "platform": "CICD",
+  "descriptionID": "f6a7b8c9",
+  "cloudProvider": "common",
+  "cwe": "400",
+  "providerUrl": "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency"
+}

--- a/assets/queries/cicd/github/concurrency_limits/query.rego
+++ b/assets/queries/cicd/github/concurrency_limits/query.rego
@@ -1,0 +1,118 @@
+package Cx
+
+import data.generic.common as common_lib
+
+# Check if workflow is reusable-only (only has workflow_call trigger)
+is_reusable_only(doc) {
+	string_trigger(doc)
+}
+
+is_reusable_only(doc) {
+	only_workflow_call(doc)
+}
+
+string_trigger(doc) {
+	doc.on == "workflow_call"
+}
+
+only_workflow_call(doc) {
+	count(doc.on) == 1
+	doc.on[_] == "workflow_call"
+}
+
+only_workflow_call(doc) {
+	count(doc.on) == 1
+	doc.on[key]
+	key == "workflow_call"
+}
+
+# Check if concurrency is bare (string only, no cancel-in-progress)
+is_bare_concurrency(concurrency) {
+	is_string(concurrency)
+}
+
+is_bare_concurrency(concurrency) {
+	is_object(concurrency)
+	concurrency.group
+	not object.get(concurrency, "cancel-in-progress", false)
+}
+
+# Workflow-level concurrency check
+CxPolicy[result] {
+	doc := input.document[i]
+
+	# Skip reusable-only workflows
+	not is_reusable_only(doc)
+
+	# Check workflow has bare concurrency
+	concurrency := doc.concurrency
+	is_bare_concurrency(concurrency)
+	doc_name := object.get(doc, "name", sprintf("document", []))
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": "concurrency",
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Workflow concurrency should include cancel-in-progress",
+		"keyActualValue": "Workflow concurrency is missing cancel-in-progress",
+		"searchLine": common_lib.build_search_line(["concurrency"], []),
+		"resourceType": "github_action",
+		"resourceName": doc_name
+	}
+}
+
+# Job-level concurrency check when workflow has no concurrency
+CxPolicy[result] {
+	doc := input.document[i]
+
+	# Skip reusable-only workflows
+	not is_reusable_only(doc)
+
+	# Workflow has no concurrency
+	not doc.concurrency
+
+	# Check job has bare concurrency
+	job := doc.jobs[j]
+	concurrency := job.concurrency
+	is_bare_concurrency(concurrency)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.concurrency", [j]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("Job '%s' concurrency should include cancel-in-progress", [j]),
+		"keyActualValue": sprintf("Job '%s' concurrency is missing cancel-in-progress", [j]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "concurrency"], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}
+
+# Job-level missing concurrency check when workflow has no concurrency
+CxPolicy[result] {
+	doc := input.document[i]
+
+	# Skip reusable-only workflows
+	not is_reusable_only(doc)
+
+	# Workflow has no concurrency
+	not doc.concurrency
+
+	# Job has no concurrency
+	job := doc.jobs[j]
+	not job.concurrency
+
+	# Skip reusable workflow calls (they should be managed by the caller)
+	not job.uses
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s", [j]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Workflow or job should have concurrency limits defined",
+		"keyActualValue": "Missing concurrency setting",
+		"searchLine": common_lib.build_search_line(["jobs", j], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}

--- a/assets/queries/cicd/github/concurrency_limits/test/negative.yaml
+++ b/assets/queries/cicd/github/concurrency_limits/test/negative.yaml
@@ -1,0 +1,54 @@
+# Workflow with proper concurrency control
+name: Workflow with Concurrency Control
+on: pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+---
+# Reusable workflow (should be skipped)
+name: Reusable Workflow
+on: workflow_call
+
+concurrency:
+  group: reusable-${{ github.ref }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm build
+---
+# Job-level concurrency with cancel-in-progress
+name: Job Level Concurrency
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: test-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+---
+# Reusable workflow call (should be skipped)
+name: Workflow Calling Reusable
+on: push
+
+concurrency:
+  group: caller-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  call-reusable:
+    uses: ./.github/workflows/reusable.yml

--- a/assets/queries/cicd/github/concurrency_limits/test/positive.yaml
+++ b/assets/queries/cicd/github/concurrency_limits/test/positive.yaml
@@ -1,0 +1,37 @@
+name: Workflow without Cancel in Progress
+on: pull_request
+
+# Workflow-level concurrency without cancel-in-progress
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+---
+# Job-level concurrency without cancel-in-progress
+name: Job Level Concurrency
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: test-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+---
+# Missing concurrency at both levels
+name: No Concurrency
+on: pull_request
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm run deploy

--- a/assets/queries/cicd/github/concurrency_limits/test/positive2.yaml
+++ b/assets/queries/cicd/github/concurrency_limits/test/positive2.yaml
@@ -1,0 +1,12 @@
+# String-based concurrency (bare string, no cancel-in-progress)
+name: String Concurrency
+on: push
+
+concurrency: ci-${{ github.ref }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm build

--- a/assets/queries/cicd/github/concurrency_limits/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/concurrency_limits/test/positive_expected_result.json
@@ -1,0 +1,23 @@
+[
+  {
+    "queryName": "Concurrency limits",
+    "severity": "LOW",
+    "line": 5
+  },
+  {
+    "queryName": "Concurrency limits",
+    "severity": "LOW",
+    "line": 22
+  },
+  {
+    "queryName": "Concurrency limits",
+    "severity": "LOW",
+    "line": 33
+  },
+  {
+    "queryName": "Concurrency limits",
+    "severity": "LOW",
+    "line": 5,
+    "fileName": "positive2.yaml"
+  }
+]

--- a/assets/queries/cicd/github/dependabot_cooldown/metadata.json
+++ b/assets/queries/cicd/github/dependabot_cooldown/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "f2a3b4c5-d6e7-48f9-a0b1-c2d3e4f5a6b7",
+  "queryName": "Dependabot cooldown",
+  "severity": "MEDIUM",
+  "category": "Best Practices",
+  "descriptionText": "Dependabot updates must include an adequate cooldown period to avoid excessive automated pull requests that can overwhelm maintainers and consume CI/CD resources.\n\nIn GitHub Dependabot configuration files (`.github/dependabot.yml`), each `updates` entry should define `cooldown.default-days` and set it to at least 7. If the `cooldown` block is missing or `default-days` is absent, Dependabot treats it as 0 (no cooldown) and will be flagged. Values less than the configured minimum (7 days by default) are also flagged. Fixes can add or increase `default-days` to 7.\n\nSecure configuration example:\n\n```yaml\nupdates:\n  - package-ecosystem: pip\n    directory: /\n    cooldown:\n      default-days: 7\n```",
+  "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/cicd/github/dependabot_cooldown",
+  "platform": "CICD",
+  "descriptionID": "f2a3b4c5",
+  "cloudProvider": "common",
+  "cwe": "400",
+  "providerUrl": "https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown"
+}

--- a/assets/queries/cicd/github/dependabot_cooldown/query.rego
+++ b/assets/queries/cicd/github/dependabot_cooldown/query.rego
@@ -1,0 +1,77 @@
+package Cx
+
+import data.generic.common as common_lib
+
+# Default minimum cooldown days
+default_min_cooldown_days := 7
+
+# Check for missing cooldown configuration entirely
+CxPolicy[result] {
+	doc := input.document[i]
+
+	# Iterate through each update configuration
+	update := doc.updates[idx]
+
+	# Check if cooldown is missing
+	not update.cooldown
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("updates[%d]", [idx]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Dependabot update should have cooldown configuration",
+		"keyActualValue": "Missing cooldown configuration",
+		"searchLine": common_lib.build_search_line(["updates", idx], []),
+		"resourceType": "dependabot_update",
+		"resourceName": sprintf("update-%d", [idx])
+	}
+}
+
+# Check for cooldown block present but missing default-days
+CxPolicy[result] {
+	doc := input.document[i]
+
+	# Iterate through each update configuration
+	update := doc.updates[idx]
+
+	# Check if cooldown exists but default-days is missing
+	cooldown := update.cooldown
+	not cooldown["default-days"]
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("updates[%d].cooldown", [idx]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Cooldown configuration should have default-days set",
+		"keyActualValue": "No default-days configured in cooldown",
+		"searchLine": common_lib.build_search_line(["updates", idx, "cooldown"], []),
+		"resourceType": "dependabot_update",
+		"resourceName": sprintf("update-%d", [idx])
+	}
+}
+
+# Check for insufficient default-days value
+CxPolicy[result] {
+	doc := input.document[i]
+
+	# Iterate through each update configuration
+	update := doc.updates[idx]
+
+	# Check if cooldown exists and default-days is less than threshold
+	cooldown := update.cooldown
+	default_days := cooldown["default-days"]
+
+	# Check if default-days is less than minimum (7 days)
+	default_days < default_min_cooldown_days
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("updates[%d].cooldown.default-days={{%d}}", [idx, default_days]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Cooldown default-days should be at least %d", [default_min_cooldown_days]),
+		"keyActualValue": sprintf("Insufficient default-days configured: %d (less than %d)", [default_days, default_min_cooldown_days]),
+		"searchLine": common_lib.build_search_line(["updates", idx, "cooldown", "default-days"], []),
+		"resourceType": "dependabot_update",
+		"resourceName": sprintf("update-%d", [idx])
+	}
+}

--- a/assets/queries/cicd/github/dependabot_cooldown/test/negative.yaml
+++ b/assets/queries/cicd/github/dependabot_cooldown/test/negative.yaml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Valid: Exactly at threshold (7 days)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+
+  # Valid: Above threshold (14 days)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 14
+
+  # Valid: Well above threshold (30 days)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 30
+
+  # Valid: With additional cooldown settings
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 10
+      dependency-type: "production"

--- a/assets/queries/cicd/github/dependabot_cooldown/test/positive.yaml
+++ b/assets/queries/cicd/github/dependabot_cooldown/test/positive.yaml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # Issue 1: Insufficient default-days (3 < 7)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 3
+
+  # Issue 2: Missing cooldown configuration entirely
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Issue 3: Cooldown exists but default-days is missing
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown: {}
+
+  # Issue 4: Another insufficient default-days (0)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 0

--- a/assets/queries/cicd/github/dependabot_cooldown/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/dependabot_cooldown/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+  {
+    "queryName": "Dependabot cooldown",
+    "severity": "MEDIUM",
+    "line": 9
+  },
+  {
+    "queryName": "Dependabot cooldown",
+    "severity": "MEDIUM",
+    "line": 12
+  },
+  {
+    "queryName": "Dependabot cooldown",
+    "severity": "MEDIUM",
+    "line": 22
+  },
+  {
+    "queryName": "Dependabot cooldown",
+    "severity": "MEDIUM",
+    "line": 30
+  }
+]

--- a/assets/queries/cicd/github/misfeature/metadata.json
+++ b/assets/queries/cicd/github/misfeature/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "a4b5c6d7-e8f9-40a1-b2c3-d4e5f6a7b8c9",
+  "queryName": "Misfeature",
+  "severity": "LOW",
+  "category": "Best Practices",
+  "descriptionText": "Certain GitHub Actions features create brittle or hard-to-audit workflows that increase the risk of inconsistent builds, unexpected runtime behavior, and missed detection of unsafe commands.\n\nThe `pip-install` input to `actions/setup-python` installs packages into a global (user or system) Python environment rather than an isolated virtual environment. This can lead to inconsistent dependency resolution and unexpected side effects across different runners and Python versions. This rule flags workflow steps that use `uses: actions/setup-python` with a `with` mapping that contains `pip-install`. Avoid that input and instead create and use a virtual environment, such as `python -m venv` and activating it, before installing packages.\n\nUsing `shell: cmd` or `cmd.exe` for `run` steps hampers static analysis because Windows `CMD` has no formal grammar and multiple line-continuation behaviors, which can hide unsafe commands or make auditing unreliable. This rule flags steps with `shell: cmd`/`cmd.exe` and will also flag other non‑well‑known shells as auditor findings. Prefer well-known shells like `pwsh` or `bash` when possible.\n\nSecure configuration examples:\n\n```yaml\n- name: Setup Python and use a virtual environment\n  uses: actions/setup-python@v4\n  with:\n    python-version: '3.11'\n\n- name: Create and activate venv, then install\n  run: |\n    python -m venv .venv\n    source .venv/bin/activate\n    pip install -r requirements.txt\n```\n\n```yaml\n- name: Run script with PowerShell on Windows\n  shell: pwsh\n  run: |\n    Write-Host \"Performing build steps...\"\n    ./build.ps1\n```",
+  "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/cicd/github/misfeature",
+  "platform": "CICD",
+  "descriptionID": "a4b5c6d7",
+  "cloudProvider": "common",
+  "cwe": "710",
+  "providerUrl": "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions"
+}

--- a/assets/queries/cicd/github/misfeature/query.rego
+++ b/assets/queries/cicd/github/misfeature/query.rego
@@ -1,0 +1,60 @@
+package Cx
+
+import data.generic.common as common_lib
+
+# Check for actions/setup-python with pip-install input
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	step := job.steps[s]
+
+	# Check if step uses actions/setup-python
+	step_uses := step.uses
+	startswith(step_uses, "actions/setup-python")
+
+	# Check if pip-install input is present
+	value := step.with[key]
+	key == "pip-install"
+
+	# Get step name if available
+	step_name := object.get(step, "name", sprintf("step-%d", [s]))
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].with.pip-install", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Python packages should be installed in a virtual environment, not using pip-install input",
+		"keyActualValue": sprintf("Step '%s' uses pip-install input which installs packages in a brittle manner", [step_name]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", s, "with", "pip-install"], []),
+		"resourceType": "github_action",
+		"resourceName": step_name,
+	}
+}
+
+# Check for shell: cmd usage
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	step := job.steps[s]
+
+	# Check if step has a run block
+	step.run
+
+	# Check if shell is cmd or cmd.exe
+	shell := object.get(step, "shell", "")
+	["cmd", "cmd.exe"][_] == shell
+
+	# Get step name if available
+	step_name := object.get(step, "name", sprintf("step-%d", [s]))
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].shell={{%s}}", [j, s, shell]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Use 'shell: pwsh' or 'shell: bash' for improved analysis and reliability",
+		"keyActualValue": sprintf("Step '%s' uses Windows CMD shell which limits security analysis", [step_name]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", s, "shell"], []),
+		"resourceType": "github_action",
+		"resourceName": step_name,
+	}
+}

--- a/assets/queries/cicd/github/misfeature/test/negative.yaml
+++ b/assets/queries/cicd/github/misfeature/test/negative.yaml
@@ -1,0 +1,24 @@
+name: Proper Features Usage
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python properly
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install with venv
+        shell: bash
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+
+      - name: PowerShell on Windows
+        shell: pwsh
+        run: Write-Host "Using PowerShell"

--- a/assets/queries/cicd/github/misfeature/test/positive.yaml
+++ b/assets/queries/cicd/github/misfeature/test/positive.yaml
@@ -1,0 +1,18 @@
+name: Misfeature Usage
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python with pip-install
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          pip-install: 'pytest requests'
+
+      - name: CMD shell usage
+        shell: cmd
+        run: echo "Using deprecated CMD shell"

--- a/assets/queries/cicd/github/misfeature/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/misfeature/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "Misfeature",
+    "severity": "LOW",
+    "line": 14
+  },
+  {
+    "queryName": "Misfeature",
+    "severity": "LOW",
+    "line": 17
+  }
+]

--- a/assets/queries/cicd/github/obfuscation/metadata.json
+++ b/assets/queries/cicd/github/obfuscation/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "af2c88c9-e360-4dc6-88ad-0f57085d54b8",
+  "queryName": "Obfuscation",
+  "severity": "LOW",
+  "category": "Insecure Configurations",
+  "descriptionText": "Obfuscated GitHub Actions usage (for example, weird `uses:` paths or needlessly complex/fenced expressions) makes workflows harder to audit and can hide malicious or unintended behavior.\n\nFor repository action references, the step `uses` property must not contain empty path components, `.` or `..`. It should be normalized to the concrete form `owner/repo[/path]@ref` so pattern-matching and provenance analysis work reliably.\n\nFor expressions anywhere routable text is allowed (such as step inputs/outputs and workflow fields), constant-reducible expressions should be replaced by their evaluated constant, and computed index expressions should be avoided. When replacing an entire fenced expression written `${{ ... }}`, the fix must remove the fencing to preserve semantics. Fixes for reducible sub-expressions should target only the subfragment.\n\nThis rule flags step `uses` values with empty components or `.`/`..`, fenced expressions that can be constant-reduced, and computed index expressions. Automated fixes normalize `uses` paths and either replace full expressions with their evaluated value or rewrite only the reducible subexpression when possible.\n\nSecure examples:\n\n```yaml\n# normalized repository action reference\n- uses: actions/checkout@v4\n```\n\n```yaml\n# replace constant-fenced expression with its evaluated value\noutputs:\n  iac/terraform/attribution.tfm--release_created: steps.release.outputs.iac/terraform/attribution.tfm--release_created\n```",
+  "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/cicd/github/obfuscation",
+  "platform": "CICD",
+  "descriptionID": "a1b2c3d4",
+  "cloudProvider": "common",
+  "cwe": "710",
+  "providerUrl": "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses"
+}

--- a/assets/queries/cicd/github/obfuscation/query.rego
+++ b/assets/queries/cicd/github/obfuscation/query.rego
@@ -1,0 +1,127 @@
+package Cx
+
+import data.generic.common as common_lib
+import future.keywords.in
+
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	step := job.steps[s]
+
+	# Get the uses field
+	uses := step.uses
+	is_string(uses)
+
+	# Parse and check for obfuscation
+	obfuscation_issues := detect_obfuscation(uses)
+	count(obfuscation_issues) > 0
+
+	issue_description := concat(", ", obfuscation_issues)
+	doc_name := object.get(doc, "name", "document")
+	result := {
+		"documentId": doc.id,
+		"resourceType": "step",
+		"resourceName": sprintf("step %d in job '%s'", [s, j]),
+		"searchKey": sprintf("jobs.%s.steps", [j]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", s, "uses"], []),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'uses' should not contain obfuscated path components", []),
+		"keyActualValue": sprintf("'uses' contains obfuscated path components: %s", [issue_description]),
+	}
+}
+
+# Detect obfuscation patterns in a uses string
+detect_obfuscation(uses) := issues {
+	# Exclude Docker actions
+	not startswith(uses, "docker://")
+
+	# Exclude local actions (legitimate use of ./ prefix)
+	not is_local_action(uses)
+
+	# Check if it's a repository action (owner/repo format)
+	is_repository_action(uses)
+
+	# Extract the path component (between owner/repo/ and @ref)
+	path_component := get_path_component(uses)
+
+	# Find all obfuscation issues in the path
+	issues := [issue |
+		some segment in path_component
+		issue := check_segment_obfuscation(segment)
+		issue != "" 
+	]
+}
+
+# Check if it's a local action (starts with ./ or ../)
+is_local_action(uses) {
+	startswith(uses, "./")
+}
+
+is_local_action(uses) {
+	startswith(uses, "../")
+}
+
+# Check if it's a repository action (owner/repo format)
+is_repository_action(uses) {
+	# Must contain @ symbol for versioning
+	contains(uses, "@")
+
+	# Must contain at least two slashes (owner/repo/path or owner/repo@ref)
+	parts := split(uses, "/")
+	count(parts) >= 2
+
+	# First part should not be . or ..
+	parts[0] != "."
+	parts[0] != ".."
+}
+
+# Extract path component from uses string
+# For "owner/repo/path/to/action@ref", extract "path/to/action"
+# For "owner/repo@ref", return empty array
+get_path_component(uses) := path {
+	# Split by @ to separate ref
+	at_parts := split(uses, "@")
+	before_at := at_parts[0]
+
+	# Split by / to get parts
+	slash_parts := split(before_at, "/")
+
+	# If only owner/repo (2 parts), no path component
+	count(slash_parts) == 2
+	path := []
+}
+
+get_path_component(uses) := path_parts {
+	# Split by @ to separate ref
+	at_parts := split(uses, "@")
+	before_at := at_parts[0]
+
+	# Split by / to get parts
+	slash_parts := split(before_at, "/")
+
+	# If more than owner/repo, extract path (everything after owner/repo)
+	count(slash_parts) > 2
+
+	# Join all parts after owner/repo
+	path_parts := array.slice(slash_parts, 2, count(slash_parts))
+}
+
+# Check individual path segment for obfuscation
+check_segment_obfuscation(segment) := "actions reference contains empty component" {
+	segment == ""
+}
+
+check_segment_obfuscation(segment) := "actions reference contains '.'" {
+	segment == "."
+}
+
+check_segment_obfuscation(segment) := "actions reference contains '..'" {
+	segment == ".."
+}
+
+check_segment_obfuscation(segment) := "" {
+	# No obfuscation detected
+	segment != ""
+	segment != "."
+	segment != ".."
+}

--- a/assets/queries/cicd/github/obfuscation/test/negative.yaml
+++ b/assets/queries/cicd/github/obfuscation/test/negative.yaml
@@ -1,0 +1,27 @@
+name: Valid Uses Paths
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # Standard action reference
+      - uses: actions/checkout@v4
+
+      # With subpath
+      - uses: github/codeql-action/init@v2
+
+      # Local action (starts with ./)
+      - uses: ./path/to/action
+
+      # Local action with subpath
+      - uses: ./.github/actions/custom-action
+
+      # Docker action
+      - uses: docker://alpine:3.18
+
+      # Action with valid nested path
+      - uses: aws-actions/configure-aws-credentials/subaction@v4
+
+      # Action with commit SHA
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/assets/queries/cicd/github/obfuscation/test/positive.yaml
+++ b/assets/queries/cicd/github/obfuscation/test/positive.yaml
@@ -1,0 +1,21 @@
+name: Obfuscated Uses Paths
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # Empty components (multiple slashes)
+      - uses: actions/checkout////@v4
+
+      # Dot reference (current directory)
+      - uses: github/codeql-action/./init@v2
+
+      # Parent directory traversal
+      - uses: actions/cache/save/../save@v4
+
+      # Complex combination
+      - uses: owner/repo/./path/../other//subdir@v1
+
+      # Trailing slash with empty component
+      - uses: actions/setup-node/@v4

--- a/assets/queries/cicd/github/obfuscation/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/obfuscation/test/positive_expected_result.json
@@ -1,0 +1,27 @@
+[
+  {
+    "queryName": "Obfuscation",
+    "severity": "LOW",
+    "line": 9
+  },
+  {
+    "queryName": "Obfuscation",
+    "severity": "LOW",
+    "line": 12
+  },
+  {
+    "queryName": "Obfuscation",
+    "severity": "LOW",
+    "line": 15
+  },
+  {
+    "queryName": "Obfuscation",
+    "severity": "LOW",
+    "line": 18
+  },
+  {
+    "queryName": "Obfuscation",
+    "severity": "LOW",
+    "line": 21
+  }
+]

--- a/assets/queries/cicd/github/overprovisioned_secrets/metadata.json
+++ b/assets/queries/cicd/github/overprovisioned_secrets/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "b2c3d4e5-f6a7-48b9-c0d1-e2f3a4b5c6d7",
+  "queryName": "Overprovisioned secrets",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Referencing the entire GitHub Actions `secrets` context or using dynamic/non-literal secret indexing exposes all repository secrets to the workflow runner. If a workflow or runner is compromised, an attacker could read every secret instead of only the ones required by the job.\n\nThis rule flags expression patterns that serialize or expand the secrets object—specifically calls to `toJSON(secrets)` and context accesses like `secrets[<non-literal>]` where the index is not a literal string or number. Reference required secrets explicitly by literal property names, such as `secrets.MY_SECRET`. Expressions that call `toJSON(secrets)` or use non-literal secret indices will be flagged.\n\nSecure usage example:\n\n```yaml\nenv:\n  MY_TOKEN: ${{ secrets.MY_TOKEN }}\nsteps:\n  - name: Use token\n    run: echo \"${{ secrets.MY_TOKEN }}\"\n```",
+  "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/cicd/github/overprovisioned_secrets",
+  "platform": "CICD",
+  "descriptionID": "b2c3d4e5",
+  "cloudProvider": "common",
+  "cwe": "250",
+  "providerUrl": "https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-secrets"
+}

--- a/assets/queries/cicd/github/overprovisioned_secrets/query.rego
+++ b/assets/queries/cicd/github/overprovisioned_secrets/query.rego
@@ -1,0 +1,280 @@
+package Cx
+
+import data.generic.common as common_lib
+
+# Detect toJSON(secrets) in step run blocks
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	step := job.steps[s]
+
+	# Check if step has parsed expressions for the run field
+	parsed_exprs := step._parsed_expressions_run[_]
+
+	# Verify parsing succeeded and secrets expansion was detected
+	parsed_exprs.parse_ok == true
+	parsed_exprs.has_secrets_expansion == true
+
+	step_name := object.get(step, "name", sprintf("step", [s]))
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].run", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be referenced individually, not as a whole context",
+		"keyActualValue": sprintf("Expression '%s' injects the entire secrets context into the runner", [parsed_exprs.raw]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", format_int(s, 10), "run"], []),
+		"resourceType": "github_action",
+		"resourceName": step_name
+	}
+}
+
+# Detect dynamic secret indexing: secrets[variable] in step run blocks
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	step := job.steps[s]
+
+	# Check if step has parsed expressions for the run field
+	parsed_exprs := step._parsed_expressions_run[_]
+
+	# Verify parsing succeeded and dynamic secret key access was detected
+	parsed_exprs.parse_ok == true
+	parsed_exprs.has_dynamic_secret_key == true
+	step_name := object.get(step, "name", sprintf("step", [s]))
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].run", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be accessed with literal keys, not dynamic expressions",
+		"keyActualValue": sprintf("Expression '%s' uses dynamic indexing to access secrets", [parsed_exprs.raw]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", format_int(s, 10), "run"], []),
+		"resourceType": "github_action",
+		"resourceName": step_name
+	}
+}
+
+# Detect toJSON(secrets) in job-level if conditions
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Check if job has parsed expressions for the if condition
+	parsed_exprs := job._parsed_expressions_if[_]
+
+	# Verify parsing succeeded and secrets expansion was detected
+	parsed_exprs.parse_ok == true
+	parsed_exprs.has_secrets_expansion == true
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.if", [j]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be referenced individually, not as a whole context",
+		"keyActualValue": sprintf("Expression '%s' injects the entire secrets context", [parsed_exprs.raw]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "if"], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}
+
+# Detect dynamic secret indexing in job-level if conditions
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Check if job has parsed expressions for the if condition
+	parsed_exprs := job._parsed_expressions_if[_]
+
+	# Verify parsing succeeded and dynamic secret key access was detected
+	parsed_exprs.parse_ok == true
+	parsed_exprs.has_dynamic_secret_key == true
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.if", [j]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be accessed with literal keys, not dynamic expressions",
+		"keyActualValue": sprintf("Expression '%s' uses dynamic indexing to access secrets", [parsed_exprs.raw]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "if"], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}
+
+# Detect toJSON(secrets) in step-level if conditions
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	step := job.steps[s]
+
+	# Check if step has parsed expressions for the if condition
+	parsed_exprs := step._parsed_expressions_if[_]
+
+	# Verify parsing succeeded and secrets expansion was detected
+	parsed_exprs.parse_ok == true
+	parsed_exprs.has_secrets_expansion == true
+
+	step_name := object.get(step, "name", sprintf("step", [s]))
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].if", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be referenced individually, not as a whole context",
+		"keyActualValue": sprintf("Expression '%s' injects the entire secrets context", [parsed_exprs.raw]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", format_int(s, 10), "if"], []),
+		"resourceType": "github_action",
+		"resourceName": step_name
+	}
+}
+
+# Detect dynamic secret indexing in step-level if conditions
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	step := job.steps[s]
+
+	# Check if step has parsed expressions for the if condition
+	parsed_exprs := step._parsed_expressions_if[_]
+
+	# Verify parsing succeeded and dynamic secret key access was detected
+	parsed_exprs.parse_ok == true
+	parsed_exprs.has_dynamic_secret_key == true
+
+	step_name := object.get(step, "name", sprintf("step", [s]))
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].if", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be accessed with literal keys, not dynamic expressions",
+		"keyActualValue": sprintf("Expression '%s' uses dynamic indexing to access secrets", [parsed_exprs.raw]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", format_int(s, 10), "if"], []),
+		"resourceType": "github_action",
+		"resourceName": step_name
+	}
+}
+
+# Detect toJSON(secrets) or dynamic secret access in step with blocks (action inputs)
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	step := job.steps[s]
+
+	# Get the with block
+	with_block := step.with
+	with_block[w]
+
+	# Check for parsed expressions in any with parameter
+	parsed_key := concat("", ["_parsed_expressions_", w])
+	parsed_exprs := with_block[parsed_key][_]
+
+	# Verify parsing succeeded
+	parsed_exprs.parse_ok == true
+
+	# Check for either secrets expansion or dynamic secret key
+	any([parsed_exprs.has_secrets_expansion, parsed_exprs.has_dynamic_secret_key])
+
+	# Build appropriate message
+	message := sprintf("Expression '%s' %s", [
+		parsed_exprs.raw,
+		get_submessage(parsed_exprs.has_secrets_expansion)
+	])
+
+	step_name := object.get(step, "name", sprintf("step", [s]))
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].with.%s", [j, s, w]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be referenced individually with literal keys",
+		"keyActualValue": message,
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", format_int(s, 10), "with", w], []),
+		"resourceType": "github_action",
+		"resourceName": step_name
+	}
+}
+
+# Detect toJSON(secrets) or dynamic secret access in step env blocks
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	step := job.steps[s]
+
+	# Get the env block
+	env_value := step.env[e]
+
+	# Check if it's a string with parsed expressions
+	is_string(env_value)
+
+	# Build the parsed expressions key
+	parsed_key := concat("", ["_parsed_expressions_", e])
+	parsed_exprs := step.env[parsed_key][_]
+
+	# Verify parsing succeeded
+	parsed_exprs.parse_ok == true
+
+	# Check for either secrets expansion or dynamic secret key
+	any([parsed_exprs.has_secrets_expansion, parsed_exprs.has_dynamic_secret_key])
+
+	# Build appropriate message
+	message := sprintf("Expression '%s' %s", [
+		parsed_exprs.raw,
+		get_submessage(parsed_exprs.has_secrets_expansion)
+	])
+
+	step_name := object.get(step, "name", sprintf("step", [s]))
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].env.%s", [j, s, e]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be referenced individually with literal keys",
+		"keyActualValue": message,
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", format_int(s, 10), "env", e], []),
+		"resourceType": "github_action",
+		"resourceName": step_name
+	}
+}
+
+# Detect toJSON(secrets) or dynamic secret access in job-level env blocks
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Get the env block
+	env_value := job.env[e]
+
+	# Check if it's a string with parsed expressions
+	is_string(env_value)
+
+	# Build the parsed expressions key
+	parsed_key := concat("", ["_parsed_expressions_", e])
+	parsed_exprs := job.env[parsed_key][_]
+
+	# Verify parsing succeeded
+	parsed_exprs.parse_ok == true
+
+	# Check for either secrets expansion or dynamic secret key
+	any([parsed_exprs.has_secrets_expansion, parsed_exprs.has_dynamic_secret_key])
+
+	# Build appropriate message
+	message := sprintf("Expression '%s' %s", [
+		parsed_exprs.raw,
+		get_submessage(parsed_exprs.has_secrets_expansion)
+	])
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.env.%s", [j, e]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be referenced individually with literal keys",
+		"keyActualValue": message,
+		"searchLine": common_lib.build_search_line(["jobs", j, "env", e], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}
+
+get_submessage(has_secrets_expansion) = "injects the entire secrets context" {
+	has_secrets_expansion
+} else = "uses dynamic indexing to access secrets" {
+	true
+}

--- a/assets/queries/cicd/github/overprovisioned_secrets/test/negative.yaml
+++ b/assets/queries/cicd/github/overprovisioned_secrets/test/negative.yaml
@@ -1,0 +1,50 @@
+name: Proper Secret Usage
+on: push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Proper: individual secret in job-level env
+    env:
+      DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+      API_KEY: ${{ secrets.API_KEY }}
+    # Proper: individual secret check in job-level if
+    if: ${{ secrets.DEPLOY_TOKEN != '' }}
+    steps:
+      # Proper: individual secrets in step run block
+      - name: Deploy with specific secret
+        run: |
+          curl -H "Authorization: Bearer ${{ secrets.DEPLOY_TOKEN }}" \
+               -H "API-Key: ${{ secrets.API_KEY }}" \
+               https://api.example.com/deploy
+
+      # Proper: individual secret in step-level if
+      - name: Conditional deployment
+        if: ${{ secrets.PRODUCTION_KEY != '' }}
+        run: echo "Deploying to production"
+
+      # Proper: individual secrets in step env block
+      - name: Step with environment variables
+        env:
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+        run: echo "Configured environment"
+
+      # Proper: individual secret in step with block
+      - name: Use action with secret
+        uses: some/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          api_key: ${{ secrets.API_KEY }}
+
+      # Proper: matrix with literal values (not dynamic secret indexing)
+      - name: Deploy to environment
+        run: echo "Deploying with ${{ secrets.DEPLOY_TOKEN }}"
+
+      # Proper: toJSON on non-secret contexts
+      - name: Use toJSON on env
+        run: echo '${{ toJSON(env) }}'
+
+      # Proper: toJSON on github context
+      - name: Use toJSON on github context
+        run: echo '${{ toJSON(github.event) }}'

--- a/assets/queries/cicd/github/overprovisioned_secrets/test/positive.yaml
+++ b/assets/queries/cicd/github/overprovisioned_secrets/test/positive.yaml
@@ -1,0 +1,65 @@
+name: Overprovisioned Secrets
+on: push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # toJSON(secrets) in job-level env block
+    env:
+      ALL_SECRETS: ${{ toJSON(secrets) }}
+    # toJSON(secrets) in job-level if condition
+    if: ${{ toJSON(secrets) != '{}' }}
+    steps:
+      # toJSON(secrets) in step run block
+      - name: Export all secrets
+        run: echo '${{ toJSON(secrets) }}'
+
+      # Dynamic secret indexing in step run block
+      - name: Dynamic secret access
+        run: |
+          SECRET_NAME="DEPLOY_TOKEN_${{ matrix.env }}"
+          echo ${{ secrets[format('DEPLOY_TOKEN_{0}', matrix.env)] }}
+
+      # toJSON(secrets) in step-level if condition
+      - name: Check secrets with toJSON
+        if: ${{ toJSON(secrets) != '{}' }}
+        run: echo "Has secrets"
+
+      # Dynamic secret indexing in step-level if condition
+      - name: Check dynamic secret
+        if: ${{ secrets[format('KEY_{0}', github.event.inputs.env)] != '' }}
+        run: echo "Secret exists"
+
+      # toJSON(secrets) in step env block
+      - name: Step with env secrets
+        env:
+          SECRETS_JSON: ${{ toJSON(secrets) }}
+        run: echo "Processing secrets"
+
+      # Dynamic indexing in step env block
+      - name: Step with dynamic env
+        env:
+          DYNAMIC_SECRET: ${{ secrets[github.event.inputs.secret_name] }}
+        run: echo "Using dynamic secret"
+
+      # toJSON(secrets) in step with block
+      - name: Action with toJSON secrets
+        uses: some/action@v1
+        with:
+          config: ${{ toJSON(secrets) }}
+
+      # Dynamic indexing in step with block
+      - name: Action with dynamic secret
+        uses: another/action@v1
+        with:
+          token: ${{ secrets[matrix.secret_key] }}
+
+  another-job:
+    runs-on: ubuntu-latest
+    # Dynamic indexing in job-level env block
+    env:
+      TOKEN: ${{ secrets[format('TOKEN_{0}', github.ref_name)] }}
+    # Dynamic indexing in job-level if condition
+    if: ${{ secrets[github.event.inputs.key] != '' }}
+    steps:
+      - run: echo "Running"

--- a/assets/queries/cicd/github/overprovisioned_secrets/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/overprovisioned_secrets/test/positive_expected_result.json
@@ -1,0 +1,62 @@
+[
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 9
+  },
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 11
+  },
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 15
+  },
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 19
+  },
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 25
+  },
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 30
+  },
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 36
+  },
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 42
+  },
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 49
+  },
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 55
+  },
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 61
+  },
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 63
+  }
+]

--- a/assets/queries/cicd/github/secrets_inherit/metadata.json
+++ b/assets/queries/cicd/github/secrets_inherit/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "e1f2a3b4-c5d6-47e8-f9a0-b1c2d3e4f5a6",
+  "queryName": "Secrets inherit",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Using `secrets: inherit` in reusable workflow calls passes all secrets from the calling workflow to the called workflow. This violates the principle of least privilege and can lead to broad secret exposure if the reusable workflow is compromised or contains vulnerabilities.\n\nThe `secrets` property on a job that invokes a reusable workflow (a job with `uses: <owner>/<repo>/.github/workflows/<file>@<ref>`) must not be set to `inherit`. Jobs with `secrets: inherit` will be flagged. Instead, explicitly map only the specific secrets the reusable workflow requires using the secrets mapping syntax, or omit the `secrets` property if none are needed.\n\nSecure example with explicit secret mapping:\n\n```yaml\njobs:\n  call-reusable:\n    uses: org/repo/.github/workflows/reusable.yml@v1\n    secrets:\n      API_TOKEN: ${{ secrets.API_TOKEN }}\n      DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}\n```",
+  "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/cicd/github/secrets_inherit",
+  "platform": "CICD",
+  "descriptionID": "e1f2a3b4",
+  "cloudProvider": "common",
+  "cwe": "269",
+  "providerUrl": "https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-secrets-to-nested-workflows"
+}

--- a/assets/queries/cicd/github/secrets_inherit/query.rego
+++ b/assets/queries/cicd/github/secrets_inherit/query.rego
@@ -1,0 +1,26 @@
+package Cx
+
+import data.generic.common as common_lib
+
+# Check for secrets: inherit in reusable workflow calls
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Check if this is a reusable workflow call (has 'uses' at job level)
+	job.uses
+
+	# Check if secrets is set to 'inherit'
+	job.secrets == "inherit"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.secrets={{%s}}", [j, job.secrets]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Reusable workflow should explicitly declare required secrets",
+		"keyActualValue": "Reusable workflow unconditionally inherits all parent secrets",
+		"searchLine": common_lib.build_search_line(["jobs", j, "secrets"], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}

--- a/assets/queries/cicd/github/secrets_inherit/test/negative.yaml
+++ b/assets/queries/cicd/github/secrets_inherit/test/negative.yaml
@@ -1,0 +1,10 @@
+name: Secure Reusable Workflow Call
+on: push
+
+jobs:
+  call-workflow:
+    uses: ./.github/workflows/reusable.yml
+    secrets:
+      token: ${{ secrets.DEPLOY_TOKEN }}
+      api_key: ${{ secrets.API_KEY }}
+    steps: "none"

--- a/assets/queries/cicd/github/secrets_inherit/test/positive.yaml
+++ b/assets/queries/cicd/github/secrets_inherit/test/positive.yaml
@@ -1,0 +1,8 @@
+name: Insecure Reusable Workflow Call
+on: push
+
+jobs:
+  call-workflow:
+    uses: ./.github/workflows/reusable.yml
+    secrets: inherit
+    steps: "none"

--- a/assets/queries/cicd/github/secrets_inherit/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/secrets_inherit/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Secrets inherit",
+    "severity": "MEDIUM",
+    "line": 7
+  }
+]

--- a/assets/queries/cicd/github/secrets_outside_env/metadata.json
+++ b/assets/queries/cicd/github/secrets_outside_env/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "176395cd-3c17-4e6b-b521-8eb73705c1d1",
+  "queryName": "Secrets outside environment",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Secrets referenced in GitHub Actions jobs should be scoped to a dedicated environment to limit their availability and reduce the blast radius if credentials are exposed. This rule inspects workflow job definitions and flags jobs that reference the `secrets` context in fenced expressions but do not define the `environment` property. It looks for `secrets.<NAME>` usages in expressions and excludes `secrets.GITHUB_TOKEN`, which is always available. Any job without an `environment` that accesses `secrets.*` will be reported.\n\nRemediate by adding an `environment` to the job and moving sensitive values to environment-scoped secrets with appropriate approvals, or confirm that repository/org-level secrets are intentionally used.",
+  "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/cicd/github/secrets_outside_env",
+  "platform": "CICD",
+  "descriptionID": "a1b2c3d4",
+  "cloudProvider": "common",
+  "cwe": "250",
+  "providerUrl": "https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment"
+}

--- a/assets/queries/cicd/github/secrets_outside_env/query.rego
+++ b/assets/queries/cicd/github/secrets_outside_env/query.rego
@@ -1,0 +1,221 @@
+package Cx
+
+import data.generic.common as common_lib
+import future.keywords.in
+
+# Check for secrets usage in step run blocks outside dedicated environments
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Skip if job has an environment defined (secrets are scoped to environment)
+	not job.environment
+
+	# Skip reusable workflow calls (they have 'uses' at job level)
+	not job.uses
+
+	# Check step run blocks for secret references
+	step := job.steps[s]
+	parsed_exprs := step._parsed_expressions_run[_]
+
+	# Verify parsing succeeded
+	parsed_exprs.parse_ok == true
+
+	# Check if the expression references secrets (excluding GITHUB_TOKEN)
+	references_secrets(parsed_exprs)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].run", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be referenced within a dedicated environment",
+		"keyActualValue": sprintf("Secret '%s' is accessed outside of a dedicated environment", [parsed_exprs.raw]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", format_int(s, 10), "run"], []),
+		"resourceType": "github_step",
+		"resourceName": sprintf("%s.steps[%d]", [j, s])
+	}
+}
+
+# Check for secrets usage in step if conditions outside dedicated environments
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Skip if job has an environment defined
+	not job.environment
+	not job.uses
+
+	# Check step if conditions for secret references
+	step := job.steps[s]
+	parsed_exprs := step._parsed_expressions_if[_]
+
+	# Verify parsing succeeded
+	parsed_exprs.parse_ok == true
+
+	# Check if the expression references secrets (excluding GITHUB_TOKEN)
+	references_secrets(parsed_exprs)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].if", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be referenced within a dedicated environment",
+		"keyActualValue": sprintf("Secret '%s' is accessed outside of a dedicated environment", [parsed_exprs.raw]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", format_int(s, 10), "if"], []),
+		"resourceType": "github_step",
+		"resourceName": sprintf("%s.steps[%d]", [j, s])
+	}
+}
+
+# Check for secrets usage in step env blocks outside dedicated environments
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Skip if job has an environment defined
+	not job.environment
+	not job.uses
+
+	# Check step env blocks for secret references
+	step := job.steps[s]
+	env_value := step.env[e]
+
+	# Check if it's a string with parsed expressions
+	is_string(env_value)
+
+	# Build the parsed expressions key
+	parsed_key := concat("", ["_parsed_expressions_", e])
+	parsed_exprs := step.env[parsed_key][_]
+
+	# Verify parsing succeeded
+	parsed_exprs.parse_ok == true
+
+	# Check if the expression references secrets (excluding GITHUB_TOKEN)
+	references_secrets(parsed_exprs)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].env.%s", [j, s, e]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be referenced within a dedicated environment",
+		"keyActualValue": sprintf("Secret '%s' is accessed outside of a dedicated environment", [parsed_exprs.raw]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", format_int(s, 10), "env", e], []),
+		"resourceType": "github_step",
+		"resourceName": sprintf("%s.steps[%d]", [j, s])
+	}
+}
+
+# Check for secrets usage in step with blocks outside dedicated environments
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Skip if job has an environment defined
+	not job.environment
+	not job.uses
+
+	# Check step with blocks for secret references
+	step := job.steps[s]
+	with_value := step.with[w]
+
+	# Check if it's a string with parsed expressions
+	is_string(with_value)
+
+	# Build the parsed expressions key
+	parsed_key := concat("", ["_parsed_expressions_", w])
+	parsed_exprs := step.with[parsed_key][_]
+
+	# Verify parsing succeeded
+	parsed_exprs.parse_ok == true
+
+	# Check if the expression references secrets (excluding GITHUB_TOKEN)
+	references_secrets(parsed_exprs)
+
+	step_name := object.get(step, "name", sprintf("step", [s]))
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].with.%s", [j, s, w]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be referenced within a dedicated environment",
+		"keyActualValue": sprintf("Secret '%s' is accessed outside of a dedicated environment", [parsed_exprs.raw]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", format_int(s, 10), "with", w], []),
+		"resourceType": "github_action",
+		"resourceName": step_name
+	}
+}
+
+# Check for secrets usage in job-level if conditions outside dedicated environments
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Skip if job has an environment defined
+	not job.environment
+	not job.uses
+
+	# Check job-level if conditions for secret references
+	parsed_exprs := job._parsed_expressions_if[_]
+
+	# Verify parsing succeeded
+	parsed_exprs.parse_ok == true
+
+	# Check if the expression references secrets (excluding GITHUB_TOKEN)
+	references_secrets(parsed_exprs)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.if", [j]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be referenced within a dedicated environment",
+		"keyActualValue": sprintf("Secret '%s' is accessed outside of a dedicated environment", [parsed_exprs.raw]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "if"], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}
+
+# Check for secrets usage in job-level env blocks outside dedicated environments
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Skip if job has an environment defined
+	not job.environment
+	not job.uses
+
+	# Check job-level env blocks for secret references
+	env_value := job.env[e]
+
+	# Check if it's a string with parsed expressions
+	is_string(env_value)
+
+	# Build the parsed expressions key
+	parsed_key := concat("", ["_parsed_expressions_", e])
+	parsed_exprs := job.env[parsed_key][_]
+
+	# Verify parsing succeeded
+	parsed_exprs.parse_ok == true
+
+	# Check if the expression references secrets (excluding GITHUB_TOKEN)
+	references_secrets(parsed_exprs)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.env.%s", [j, e]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be referenced within a dedicated environment",
+		"keyActualValue": sprintf("Secret '%s' is accessed outside of a dedicated environment", [parsed_exprs.raw]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "env", e], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}
+
+# Helper function to check if an expression references secrets (excluding GITHUB_TOKEN)
+references_secrets(parsed_expr) {
+	# Check if the raw expression contains "secrets."
+	contains(parsed_expr.raw, "secrets.")
+
+	# Exclude GITHUB_TOKEN references
+	not contains(parsed_expr.raw, "secrets.GITHUB_TOKEN")
+}

--- a/assets/queries/cicd/github/secrets_outside_env/test/negative.yaml
+++ b/assets/queries/cicd/github/secrets_outside_env/test/negative.yaml
@@ -1,0 +1,67 @@
+name: Secrets in Environment
+on: push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Proper: job has environment defined, so secrets are scoped
+    environment: production
+    env:
+      API_KEY: ${{ secrets.API_KEY }}
+    if: ${{ secrets.DEPLOY_TOKEN != '' }}
+    steps:
+      # Proper: secrets used within environment
+      - name: Deploy with secrets
+        run: |
+          echo "Deploying..."
+          curl -H "Authorization: Bearer ${{ secrets.DEPLOY_TOKEN }}" https://api.example.com/deploy
+
+      # Proper: step-level if with secret within environment
+      - name: Check production key
+        if: ${{ secrets.PRODUCTION_KEY != '' }}
+        run: echo "Has production key"
+
+      # Proper: step env with secret within environment
+      - name: Step with env secret
+        env:
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+        run: echo "Configured database"
+
+      # Proper: step with block with secret within environment
+      - name: Action with secret
+        uses: some/action@v1
+        with:
+          token: ${{ secrets.SERVICE_TOKEN }}
+          api_key: ${{ secrets.API_KEY }}
+
+  staging:
+    runs-on: ubuntu-latest
+    # Proper: another job with environment
+    environment: staging
+    env:
+      STAGING_KEY: ${{ secrets.STAGING_KEY }}
+    if: ${{ secrets.STAGING_TOKEN != '' }}
+    steps:
+      - run: echo "Deploying to staging"
+
+  # Proper: reusable workflow calls are skipped
+  call-workflow:
+    uses: ./.github/workflows/deploy.yml
+    secrets:
+      token: ${{ secrets.DEPLOY_TOKEN }}
+
+  # Proper: job without secrets doesn't trigger the rule
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm build
+
+  # Proper: using GITHUB_TOKEN is allowed (explicitly excluded in the rule)
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout with GITHUB_TOKEN
+        run: |
+          curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+               https://api.github.com/repos/${{ github.repository }}

--- a/assets/queries/cicd/github/secrets_outside_env/test/positive.yaml
+++ b/assets/queries/cicd/github/secrets_outside_env/test/positive.yaml
@@ -1,0 +1,45 @@
+name: Secrets Outside Environment
+on: push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Secret used in job-level env without environment
+    env:
+      API_KEY: ${{ secrets.API_KEY }}
+    # Secret used in job-level if without environment
+    if: ${{ secrets.DEPLOY_TOKEN != '' }}
+    steps:
+      # Secret used in step run block without environment
+      - name: Deploy with secrets
+        run: |
+          echo "Deploying..."
+          curl -H "Authorization: Bearer ${{ secrets.DEPLOY_TOKEN }}" https://api.example.com/deploy
+
+      # Secret used in step-level if without environment
+      - name: Check secret
+        if: ${{ secrets.PRODUCTION_KEY != '' }}
+        run: echo "Has production key"
+
+      # Secret used in step env block without environment
+      - name: Step with env secret
+        env:
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+        run: echo "Configured database"
+
+      # Secret used in step with block without environment
+      - name: Action with secret
+        uses: some/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          api_key: ${{ secrets.SERVICE_KEY }}
+
+  another-job:
+    runs-on: ubuntu-latest
+    # Another job-level env without environment
+    env:
+      TOKEN: ${{ secrets.SERVICE_TOKEN }}
+    # Another job-level if without environment
+    if: ${{ secrets.ADMIN_KEY != '' }}
+    steps:
+      - run: echo "Running"

--- a/assets/queries/cicd/github/secrets_outside_env/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/secrets_outside_env/test/positive_expected_result.json
@@ -1,0 +1,42 @@
+[
+  {
+    "queryName": "Secrets outside environment",
+    "severity": "MEDIUM",
+    "line": 9
+  },
+  {
+    "queryName": "Secrets outside environment",
+    "severity": "MEDIUM",
+    "line": 11
+  },
+  {
+    "queryName": "Secrets outside environment",
+    "severity": "MEDIUM",
+    "line": 15
+  },
+  {
+    "queryName": "Secrets outside environment",
+    "severity": "MEDIUM",
+    "line": 21
+  },
+  {
+    "queryName": "Secrets outside environment",
+    "severity": "MEDIUM",
+    "line": 27
+  },
+  {
+    "queryName": "Secrets outside environment",
+    "severity": "MEDIUM",
+    "line": 35
+  },
+  {
+    "queryName": "Secrets outside environment",
+    "severity": "MEDIUM",
+    "line": 41
+  },
+  {
+    "queryName": "Secrets outside environment",
+    "severity": "MEDIUM",
+    "line": 43
+  }
+]

--- a/assets/queries/cicd/github/self_hosted_runner/metadata.json
+++ b/assets/queries/cicd/github/self_hosted_runner/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "b8c9d0e1-f2a3-44b5-c6d7-e8f9a0b1c2d3",
+  "queryName": "Self-hosted runner",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "Self-hosted runners in public repositories are risky because they can retain state, files, or credentials between workflow runs. They also allow untrusted contributors (for example via pull requests) to access secrets or modify the runner environment.\n\nInspect the GitHub Actions workflow job `runs-on` setting. Any job whose `runs-on` value begins with the literal `self-hosted`, references a runner group, or uses expressions/matrix expansions that may evaluate to `self-hosted` should be reviewed or avoided in public repos.\n\nPrefer explicit GitHub-hosted runner labels such as `ubuntu-latest` for public workflows. Expression-based or group-based runner selections are flagged because they may expand to self-hosted runners at runtime.\n\nSecure example using a GitHub-hosted runner:\n\n```yaml\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n```",
+  "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/cicd/github/self_hosted_runner",
+  "platform": "CICD",
+  "descriptionID": "b8c9d0e1",
+  "cloudProvider": "common",
+  "cwe": "665",
+  "providerUrl": "https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security"
+}

--- a/assets/queries/cicd/github/self_hosted_runner/query.rego
+++ b/assets/queries/cicd/github/self_hosted_runner/query.rego
@@ -1,0 +1,124 @@
+package Cx
+
+import data.generic.common as common_lib
+
+# Check for self-hosted runner in runs-on (string format)
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Check if runs-on is a string and equals self-hosted
+	is_string(job["runs-on"])
+	job["runs-on"] == "self-hosted"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.runs-on={{%s}}", [j, job["runs-on"]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Job should not use self-hosted runners in public repositories",
+		"keyActualValue": "Job uses self-hosted runner which may be unsafe in public repositories",
+		"searchLine": common_lib.build_search_line(["jobs", j, "runs-on"], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}
+
+# Check for self-hosted runner in runs-on (array format)
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Check if runs-on is an array and first element is self-hosted
+	is_array(job["runs-on"])
+	count(job["runs-on"]) > 0
+	job["runs-on"][0] == "self-hosted"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.runs-on[0]={{%s}}", [j, job["runs-on"][0]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Job should not use self-hosted runners in public repositories",
+		"keyActualValue": "Job uses self-hosted runner which may be unsafe in public repositories",
+		"searchLine": common_lib.build_search_line(["jobs", j, "runs-on"], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}
+
+# Check for potential expression-based self-hosted runner
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	check_self_hosted(job)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.runs-on={{%s}}", [j, job["runs-on"]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Job should not use potentially self-hosted runners in public repositories",
+		"keyActualValue": "Job uses expression for runs-on which might expand to self-hosted runner",
+		"searchLine": common_lib.build_search_line(["jobs", j, "runs-on"], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}
+
+# Check for runner group (implies self-hosted runner)
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Check if runs-on is an object with 'group' key
+	is_object(job["runs-on"])
+	job["runs-on"].group
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.runs-on.group={{%s}}", [j, job["runs-on"].group]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Job should not use self-hosted runners in public repositories",
+		"keyActualValue": "Job uses runner group which implies self-hosted runner",
+		"searchLine": common_lib.build_search_line(["jobs", j, "runs-on"], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}
+
+# Helper function to check if job has self-hosted in matrix
+has_self_hosted_in_matrix(job) {
+	job.strategy
+	job.strategy.matrix
+	matrix_value := job.strategy.matrix[_]
+	is_string(matrix_value)
+	contains(matrix_value, "self-hosted")
+} else {
+	job.strategy
+	job.strategy.matrix
+	matrix_value := job.strategy.matrix[_]
+	is_array(matrix_value)
+	matrix_value[_] == "self-hosted"
+}
+
+# Case 1: Expression references matrix and matrix contains self-hosted
+check_self_hosted(job) {
+	# Get parsed expressions
+	parsed_exprs := job._parsed_expressions_runs_on[_]
+	parsed_exprs.parse_ok == true
+
+	# Check if expression references matrix
+	contains(parsed_exprs.raw, "matrix.")
+
+	# Look for self-hosted in strategy.matrix values
+	has_self_hosted_in_matrix(job)
+}
+
+# Case 2: Expression doesn't reference matrix
+check_self_hosted(job) {
+	# Get parsed expressions
+	parsed_exprs := job._parsed_expressions_runs_on[_]
+	parsed_exprs.parse_ok == true
+
+	# Expression exists but doesn't reference matrix
+	not contains(parsed_exprs.raw, "matrix.")
+}

--- a/assets/queries/cicd/github/self_hosted_runner/test/negative.yaml
+++ b/assets/queries/cicd/github/self_hosted_runner/test/negative.yaml
@@ -1,0 +1,34 @@
+name: GitHub Hosted Runner
+on: push
+
+jobs:
+  # Should NOT trigger: GitHub-hosted runner
+  test_github_hosted:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+
+  # Should NOT trigger: Array of GitHub-hosted runners
+  test_github_hosted_array:
+    runs-on: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+
+  # Should NOT trigger: Matrix without self-hosted
+  test_matrix_no_self_hosted:
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+
+  # Should NOT trigger: Expression that doesn't reference runner
+  test_expression_not_runner:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test with expression
+        run: echo "${{ github.sha }}"

--- a/assets/queries/cicd/github/self_hosted_runner/test/positive.yaml
+++ b/assets/queries/cicd/github/self_hosted_runner/test/positive.yaml
@@ -1,0 +1,42 @@
+name: Self Hosted Runner
+on: push
+
+jobs:
+  # Case 1: Literal self-hosted in array
+  test:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+
+  # Case 2a: Expression-based runner (string) - matrix with self-hosted
+  test_matrix_expression:
+    strategy:
+      matrix:
+        runner: [self-hosted, ubuntu-latest]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+
+  # Case 2b: Expression-based runner (array) - variable reference
+  test_expression_array:
+    runs-on: ["${{ inputs.runner }}"]
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+
+  # Case 2c: Expression-based runner (string) - simple expression
+  test_expression_string:
+    runs-on: ${{ github.event.inputs.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+
+  # Case 3: Runner group (implies self-hosted)
+  test_runner_group:
+    runs-on:
+      group: my-runner-group
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test

--- a/assets/queries/cicd/github/self_hosted_runner/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/self_hosted_runner/test/positive_expected_result.json
@@ -1,0 +1,27 @@
+[
+  {
+    "queryName": "Self-hosted runner",
+    "severity": "MEDIUM",
+    "line": 7
+  },
+  {
+    "queryName": "Self-hosted runner",
+    "severity": "MEDIUM",
+    "line": 17
+  },
+  {
+    "queryName": "Self-hosted runner",
+    "severity": "MEDIUM",
+    "line": 24
+  },
+  {
+    "queryName": "Self-hosted runner",
+    "severity": "MEDIUM",
+    "line": 31
+  },
+  {
+    "queryName": "Self-hosted runner",
+    "severity": "MEDIUM",
+    "line": 38
+  }
+]

--- a/assets/queries/cicd/github/superfluous_actions/metadata.json
+++ b/assets/queries/cicd/github/superfluous_actions/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "b5c6d7e8-f9a0-41b2-c3d4-e5f6a7b8c9d0",
+  "queryName": "Superfluous actions",
+  "severity": "LOW",
+  "category": "Best Practices",
+  "descriptionText": "Using third-party GitHub Actions that duplicate functionality already provided by GitHub-hosted runners increases supply-chain and maintenance risk. These actions introduce unnecessary external code, permissions, and update surface to your workflows.\n\nThis rule flags workflow job steps and composite steps that declare a repository action via the `uses` property. The following actions are flagged: `ncipollo/release-action`, `softprops/action-gh-release`, `elgohr/Github-Release-Action`, `peter-evans/create-pull-request`, `peter-evans/create-or-update-comment`, `addnab/docker-run-action`, and `dtolnay/rust-toolchain`.\n\nReplace these with `run` script steps that call built-in tools available on runners. For example, use `gh release`, `gh pr create`, `gh pr comment` / `gh issue comment`, `docker run`, or `rustup`/`cargo`. You can also use native container steps where appropriate. Any step with a `uses` value matching the listed repositories will be flagged.\n\nSecure replacement examples:\n\n```yaml\n- name: Create release\n  run: gh release create v1.0.0 --title \"v1.0.0\"\n\n- name: Post PR comment\n  run: gh pr comment ${{ github.event.pull_request.number }} --body \"Thanks for your contribution\"\n\n- name: Run container tool\n  run: docker run --rm my-image:latest my-command\n\n- name: Install Rust toolchain\n  run: rustup toolchain install stable && cargo build --release\n```",
+  "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/cicd/github/superfluous_actions",
+  "platform": "CICD",
+  "descriptionID": "b5c6d7e8",
+  "cloudProvider": "common",
+  "cwe": "1395",
+  "providerUrl": "https://docs.github.com/en/actions/using-workflows/about-workflows"
+}

--- a/assets/queries/cicd/github/superfluous_actions/query.rego
+++ b/assets/queries/cicd/github/superfluous_actions/query.rego
@@ -1,0 +1,50 @@
+package Cx
+
+import data.generic.common as common_lib
+
+# List of superfluous actions that have better alternatives
+# These actions provide functionality already available in GitHub-hosted runners
+
+superfluous_actions := {
+	"ncipollo/release-action": "use 'gh release' command in a script step",
+	"softprops/action-gh-release": "use 'gh release' command in a script step",
+	"elgohr/Github-Release-Action": "use 'gh release' command in a script step",
+	"peter-evans/create-pull-request":  "use 'gh pr create' in a script step",
+	"peter-evans/create-or-update-comment": "use 'gh pr comment' or 'gh issue comment' in a script step",
+	"addnab/docker-run-action": "use 'docker run' in a script step, or use a container step",
+	"dtolnay/rust-toolchain": "use 'rustup' and/or 'cargo' in a script step"
+}
+
+# Check for usage of superfluous actions
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	step := job.steps[s]
+
+	# Get the uses value
+	step_uses := step.uses
+
+	# Check if it matches any superfluous action (allow any version/ref)
+	recommendation := superfluous_actions[action_pattern]
+
+	# Extract owner/repo from uses (before @ symbol)
+	uses_parts := split(step_uses, "@")
+	owner_repo := uses_parts[0]
+
+	# Check if this matches a superfluous action
+	owner_repo == action_pattern
+
+	# Get step name if available
+	step_name := object.get(step, "name", sprintf("step-%d", [s]))
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].uses={{%s}}", [j, s, owner_repo]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Use built-in runner functionality instead of this action: %s", [recommendation]),
+		"keyActualValue": sprintf("Step '%s' uses superfluous action that duplicates runner functionality", [step_name]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", s, "uses"], []),
+		"resourceType": "github_step",
+		"resourceName": step_name
+	}
+}

--- a/assets/queries/cicd/github/superfluous_actions/test/negative.yaml
+++ b/assets/queries/cicd/github/superfluous_actions/test/negative.yaml
@@ -1,0 +1,49 @@
+name: Using Built-in Tools
+on: push
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Proper way to create releases
+      - name: Create release using gh CLI
+        run: gh release create v1.0.0 --notes "Release notes"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Proper way to add comments
+      - name: Add comment using gh CLI
+        run: gh pr comment ${{ github.event.pull_request.number }} --body "LGTM"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Proper way to run Docker containers
+      - name: Run Docker container natively
+        run: docker run --rm alpine:latest echo "Hello"
+
+      # Proper way to upload release assets
+      - name: Upload release assets using gh CLI
+        run: gh release upload v1.0.0 dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Proper way to setup Rust
+      - name: Setup Rust using rustup
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          rustup default stable
+          cargo --version
+
+      # Using non-superfluous actions is OK
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}

--- a/assets/queries/cicd/github/superfluous_actions/test/positive.yaml
+++ b/assets/queries/cicd/github/superfluous_actions/test/positive.yaml
@@ -1,0 +1,44 @@
+name: Using Superfluous Actions
+on: push
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Use 'gh release' command instead
+      - name: Create release with action
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v1.0.0
+
+      # Use 'gh pr comment' or 'gh issue comment' instead
+      - name: Comment with action
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: 1
+          body: LGTM
+
+      # Use 'docker run' command or container step instead
+      - name: Run Docker with action
+        uses: addnab/docker-run-action@v3
+        with:
+          image: alpine:latest
+          run: echo "Hello"
+
+      # Use 'gh release' command instead
+      - name: Alternative release action
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*
+
+      # Use 'gh release' command instead
+      - name: Another release action
+        uses: elgohr/Github-Release-Action@v5
+        with:
+          title: Release v1.0.0
+
+      # Use 'rustup' and/or 'cargo' commands instead
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable

--- a/assets/queries/cicd/github/superfluous_actions/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/superfluous_actions/test/positive_expected_result.json
@@ -1,0 +1,32 @@
+[
+  {
+    "queryName": "Superfluous actions",
+    "severity": "LOW",
+    "line": 12
+  },
+  {
+    "queryName": "Superfluous actions",
+    "severity": "LOW",
+    "line": 18
+  },
+  {
+    "queryName": "Superfluous actions",
+    "severity": "LOW",
+    "line": 25
+  },
+  {
+    "queryName": "Superfluous actions",
+    "severity": "LOW",
+    "line": 32
+  },
+  {
+    "queryName": "Superfluous actions",
+    "severity": "LOW",
+    "line": 38
+  },
+  {
+    "queryName": "Superfluous actions",
+    "severity": "LOW",
+    "line": 44
+  }
+]

--- a/assets/queries/cicd/github/unredacted_secrets/metadata.json
+++ b/assets/queries/cicd/github/unredacted_secrets/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "c3d4e5f6-a7b8-49c0-d1e2-f3a4b5c6d7e8",
+  "queryName": "Unredacted secrets",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "Passing GitHub Actions secrets through transformation functions such as `fromJSON()` is unsafe. The transformation produces a different string that GitHub's automatic redaction can't recognize, which can allow secret values to appear in plaintext in workflow logs.\n\nThis rule flags workflow expressions that call `fromJSON` with the `secrets` context or any child of it as an argument, for example `fromJSON(secrets)`, `fromJSON(secrets.MY_SECRET)`, or nested uses like `fromJSON(secrets.MY_SECRET).field`. Avoid storing multiple values as a single JSON secret. Instead, store individual secrets and reference them directly, or ensure any transformed value is never written to logs or exposed to third-party actions.\n\nSecure example — reference a single secret value instead of parsing a JSON blob:\n\n```yaml\n- name: Use secret directly\n  run: ./deploy --db-password \"${{ secrets.DB_PASSWORD }}\"\n```",
+  "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/cicd/github/unredacted_secrets",
+  "platform": "CICD",
+  "descriptionID": "c3d4e5f6",
+  "cloudProvider": "common",
+  "cwe": "532",
+  "providerUrl": "https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-secrets"
+}

--- a/assets/queries/cicd/github/unredacted_secrets/query.rego
+++ b/assets/queries/cicd/github/unredacted_secrets/query.rego
@@ -1,0 +1,170 @@
+package Cx
+
+import data.generic.common as common_lib
+
+# Check for fromJSON(secrets.*) patterns in all parsed expressions within a step
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	step := job.steps[s]
+
+	# Get all parsed expressions in the step
+	# The parser adds _parsed_expressions_* for each field containing expressions
+	parsed_exprs := get_all_parsed_expressions(step)
+	parsed_expr := parsed_exprs[_]
+
+	# Only process successfully parsed expressions
+	parsed_expr.parse_ok == true
+
+	# Check if this expression contains fromJSON(secrets.*)
+	has_vulnerable_pattern(parsed_expr.ast)
+
+	# Get step name if available, otherwise use index
+	step_name := object.get(step, "name", sprintf("step-%d", [s]))
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d]", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should not be passed through fromJSON() or similar transformation functions",
+		"keyActualValue": sprintf("Step '%s' bypasses secret redaction by transforming secret value", [step_name]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", s], []),
+		"resourceType": "github_action",
+		"resourceName": step_name
+	}
+}
+
+# Check for fromJSON(secrets.*) patterns in job-level fields
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Get all parsed expressions in the job
+	parsed_exprs := get_all_parsed_expressions(job)
+	parsed_expr := parsed_exprs[_]
+
+	# Only process successfully parsed expressions
+	parsed_expr.parse_ok == true
+
+	# Check if this expression contains fromJSON(secrets.*)
+	has_vulnerable_pattern(parsed_expr.ast)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s", [j]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should not be passed through fromJSON() or similar transformation functions",
+		"keyActualValue": "Expression bypasses secret redaction by transforming secret value",
+		"searchLine": common_lib.build_search_line(["jobs", j], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}
+
+# Get all parsed expressions from a map (step or job), including nested maps
+get_all_parsed_expressions(obj) = exprs {
+	# Collect expressions from top level
+	top_level_exprs := [expr |
+		key := object.keys(obj)[_]
+		startswith(key, "_parsed_expressions_")
+		expr := obj[key][_]
+	]
+
+	# Collect expressions from nested maps (env, with, etc.)
+	nested_exprs := [expr |
+		key := object.keys(obj)[_]
+		not startswith(key, "_parsed_expressions_")
+		is_object(obj[key])
+		nested_key := object.keys(obj[key])[_]
+		startswith(nested_key, "_parsed_expressions_")
+		expr := obj[key][nested_key][_]
+	]
+
+	# Combine both
+	exprs := array.concat(top_level_exprs, nested_exprs)
+}
+
+# Check if the AST contains fromJSON(secrets.*) pattern
+has_vulnerable_pattern(ast) {
+	# Get all nodes from the AST
+	all_nodes := get_all_nodes(ast)
+	node := all_nodes[_]
+
+	# Check if this is a fromJSON function call
+	node.type == "function_call"
+
+	# Get the function name (case insensitive check)
+	func_name := get_function_name(node)
+	lower(func_name) == "fromjson"
+
+	# Check if any argument contains a reference to secrets
+	arg_list := node.children[_]
+	arg_list.type == "argument_list"
+
+	# Check if any argument references secrets
+	contains_secrets_reference(arg_list)
+}
+
+# Get the function name from a function_call node
+get_function_name(node) = name {
+	# The first child should be the identifier
+	child := node.children[_]
+	child.type == "identifier"
+	name := child.value
+}
+
+# Check if an argument list contains a reference to secrets
+contains_secrets_reference(arg_list) {
+	# Get all nodes in the argument list
+	arg_nodes := get_all_nodes(arg_list)
+	node := arg_nodes[_]
+
+	# Check if this node is a dereference_expression that starts with "secrets"
+	node.type == "dereference_expression"
+	contains(lower(node.value), "secrets")
+}
+
+# Alternative: check for identifier "secrets"
+contains_secrets_reference(arg_list) {
+	arg_nodes := get_all_nodes(arg_list)
+	node := arg_nodes[_]
+	node.type == "identifier"
+	lower(node.value) == "secrets"
+}
+
+# Collect all nodes from the AST using iteration
+# Rego cannot use recursive function calls, thus the pseudo-iteration
+get_all_nodes(node) = nodes {
+	# Start with the node itself
+	nodes := {node} | get_children_nodes(node)
+}
+
+# Get all descendant nodes iteratively
+# Rego does not support recursion, thus this pseudo-iteration
+get_children_nodes(node) = nodes {
+	# Collect immediate children
+	children := {child | child := node.children[_]}
+
+	# Collect grandchildren and deeper
+	grandchildren := {grandchild |
+		child := node.children[_]
+		grandchild := child.children[_]
+	}
+
+	# Collect great-grandchildren
+	great_grandchildren := {ggchild |
+		child := node.children[_]
+		grandchild := child.children[_]
+		ggchild := grandchild.children[_]
+	}
+
+	# Collect great-great-grandchildren (should be deep enough for most expressions)
+	gggrandchildren := {gggchild |
+		child := node.children[_]
+		grandchild := child.children[_]
+		ggchild := grandchild.children[_]
+		gggchild := ggchild.children[_]
+	}
+
+	nodes := children | grandchildren | great_grandchildren | gggrandchildren
+}

--- a/assets/queries/cicd/github/unredacted_secrets/test/negative.yaml
+++ b/assets/queries/cicd/github/unredacted_secrets/test/negative.yaml
@@ -1,0 +1,85 @@
+name: Safe Secret Usage
+on: push
+
+jobs:
+  # Case 1: Direct secret usage (safe - GitHub can redact this)
+  test_direct_secret:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use secret directly
+        run: |
+          echo "Using secret safely"
+          curl -H "Authorization: Bearer ${{ secrets.API_TOKEN }}" https://api.example.com
+
+  # Case 2: fromJSON with non-secret context (safe - not a secret)
+  test_fromjson_env:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse environment variable
+        env:
+          CONFIG: ${{ fromJSON(env.CONFIG_JSON) }}
+        run: echo "Config parsed"
+
+  # Case 3: fromJSON with literal string (safe - no secret)
+  test_fromjson_literal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse literal JSON
+        run: echo '${{ fromJSON('{"key": "value"}') }}'
+
+  # Case 4: fromJSON with inputs (safe - workflow inputs)
+  test_fromjson_inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse workflow input
+        run: echo '${{ fromJSON(inputs.config) }}'
+
+  # Case 5: toJSON with secrets (different issue - not covered by this rule)
+  test_tojson_secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Convert to JSON
+        run: echo '${{ toJSON(secrets) }}'
+
+  # Case 6: Secret in env block directly (safe)
+  test_env_direct:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Environment variable
+        env:
+          API_KEY: ${{ secrets.API_KEY }}
+        run: echo "Key is set"
+
+  # Case 7: Multiple secrets used directly (safe)
+  test_multiple_direct:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Multiple direct secrets
+        env:
+          KEY1: ${{ secrets.KEY1 }}
+          KEY2: ${{ secrets.KEY2 }}
+        run: echo "Keys configured"
+
+  # Case 8: fromJSON with github context (safe - not secrets)
+  test_fromjson_github:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse GitHub context
+        run: echo '${{ fromJSON(github.event.client_payload.data) }}'
+
+  # Case 9: Secret used in conditional (safe)
+  test_conditional_direct:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Conditional on secret existence
+        if: ${{ secrets.DEPLOY_KEY != '' }}
+        run: echo "Deploy key exists"
+
+  # Case 10: Other transformation functions (not fromJSON)
+  test_other_functions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use other functions
+        run: |
+          echo '${{ format('Bearer {0}', secrets.TOKEN) }}'
+          echo '${{ contains(secrets.ALLOWED_USERS, github.actor) }}'

--- a/assets/queries/cicd/github/unredacted_secrets/test/positive.yaml
+++ b/assets/queries/cicd/github/unredacted_secrets/test/positive.yaml
@@ -1,0 +1,68 @@
+name: Unredacted Secret
+on: push
+
+jobs:
+  # Case 1: fromJSON in run command
+  test_run_command:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse secret as JSON in run
+        run: |
+          CONFIG='${{ fromJSON(secrets.CONFIG_JSON) }}'
+          echo "Config: $CONFIG"
+
+  # Case 2: fromJSON with lowercase (case insensitive)
+  test_lowercase:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lowercase fromjson
+        run: echo '${{ fromjson(secrets.DATA) }}'
+
+  # Case 3: fromJSON with property access
+  test_property_access:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Access property of JSON secret
+        run: echo '${{ fromJSON(secrets.CONFIG).apiKey }}'
+
+  # Case 4: fromJSON with nested property access
+  test_nested_property:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Access nested property
+        run: echo '${{ fromJSON(secrets.SETTINGS).database.host }}'
+
+  # Case 5: fromJSON in env block
+  test_env_block:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use in environment variable
+        env:
+          CONFIG: ${{ fromJSON(secrets.ENV_CONFIG) }}
+        run: echo "Using config"
+
+  # Case 6: fromJSON in with block
+  test_with_block:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use in action parameter
+        uses: some/action@v1
+        with:
+          config: ${{ fromJSON(secrets.ACTION_CONFIG) }}
+
+  # Case 7: fromJSON in if condition
+  test_if_condition:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Conditional step
+        if: ${{ fromJSON(secrets.FEATURE_FLAGS).enabled }}
+        run: echo "Feature enabled"
+
+  # Case 8: Multiple fromJSON calls
+  test_multiple:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Multiple secret transformations
+        run: |
+          echo '${{ fromJSON(secrets.CONFIG1) }}'
+          echo '${{ fromJSON(secrets.CONFIG2) }}'

--- a/assets/queries/cicd/github/unredacted_secrets/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/unredacted_secrets/test/positive_expected_result.json
@@ -1,0 +1,42 @@
+[
+  {
+    "queryName": "Unredacted secrets",
+    "severity": "MEDIUM",
+    "line": 9
+  },
+  {
+    "queryName": "Unredacted secrets",
+    "severity": "MEDIUM",
+    "line": 18
+  },
+  {
+    "queryName": "Unredacted secrets",
+    "severity": "MEDIUM",
+    "line": 25
+  },
+  {
+    "queryName": "Unredacted secrets",
+    "severity": "MEDIUM",
+    "line": 32
+  },
+  {
+    "queryName": "Unredacted secrets",
+    "severity": "MEDIUM",
+    "line": 39
+  },
+  {
+    "queryName": "Unredacted secrets",
+    "severity": "MEDIUM",
+    "line": 48
+  },
+  {
+    "queryName": "Unredacted secrets",
+    "severity": "MEDIUM",
+    "line": 57
+  },
+  {
+    "queryName": "Unredacted secrets",
+    "severity": "MEDIUM",
+    "line": 65
+  }
+]

--- a/assets/queries/cicd/github/unsound_contains_no_controllable_input/metadata.json
+++ b/assets/queries/cicd/github/unsound_contains_no_controllable_input/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "e5f6a7b8-c9d0-41e2-f3a4-b5c6d7e8f6a0",
+  "queryName": "Unsound contains without controllable input",
+  "severity": "LOW",
+  "category": "Insecure Defaults",
+  "descriptionText": "Using `contains()` with a string literal to validate a non-controllable value is unsafe because `contains()` performs substring matching. Crafted values such as `refs/heads/mai` or `ain` can satisfy the check and bypass intended restrictions.\n\nThe rule inspects job `if` expressions and flags calls of the form `contains(<string literal>, <Context>)`. Replace substring checks with explicit equality comparisons such as `github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'`, or use a JSON array with `fromJSON` and `contains`.\n\n```yaml\n# Explicit equality checks\nif: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'\n\n# Or use a JSON array for exact membership testing\nif: contains(fromJSON('[\"refs/heads/main\",\"refs/heads/develop\"]'), github.ref)\n```",
+  "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/cicd/github/unsound_contains_no_controllable_input",
+  "platform": "CICD",
+  "descriptionID": "e5f6a7b8",
+  "cloudProvider": "common",
+  "cwe": "185",
+  "providerUrl": "https://docs.github.com/en/actions/learn-github-actions/expressions#contains"
+}

--- a/assets/queries/cicd/github/unsound_contains_no_controllable_input/query.rego
+++ b/assets/queries/cicd/github/unsound_contains_no_controllable_input/query.rego
@@ -1,0 +1,159 @@
+package Cx
+
+import data.generic.common as common_lib
+
+# User-controllable contexts that make this HIGH severity
+user_controllable_contexts := {
+	"github.actor",
+	"github.triggering_actor",
+	"github.base_ref",
+	"github.head_ref",
+	"github.ref",
+	"github.ref_name",
+	"github.sha",
+	"env.",
+	"inputs."
+}
+
+# Check for unsafe contains() patterns in job conditions
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+
+	# Get parsed expressions from the if condition
+	parsed_exprs := job["_parsed_expressions_if"]
+	parsed_expr := parsed_exprs[_]
+
+	# Only process successfully parsed expressions
+	parsed_expr.parse_ok == true
+
+	# Find vulnerable contains() calls in the AST
+	vulnerable_call := find_vulnerable_contains(parsed_expr.ast)
+
+	# Determine severity based on context
+	is_user_controllable := check_user_controllable_in_ast(vulnerable_call.second_arg)
+
+	severity := get_severity(is_user_controllable)
+
+	severity == "LOW"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.if", [j]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Use explicit equality checks or JSON array with contains() instead of space-separated string",
+		"keyActualValue": sprintf("contains() condition can be bypassed if attacker controls the context value", []),
+		"searchLine": common_lib.build_search_line(["jobs", j, "if"], []),
+		"resourceType": "github_action",
+		"resourceName": j
+	}
+}
+
+# Check for unsafe contains() patterns in step conditions
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	step := job.steps[s]
+
+	# Get parsed expressions from the if condition
+	parsed_exprs := step["_parsed_expressions_if"]
+	parsed_expr := parsed_exprs[_]
+
+	# Only process successfully parsed expressions
+	parsed_expr.parse_ok == true
+
+	# Find vulnerable contains() calls in the AST
+	vulnerable_call := find_vulnerable_contains(parsed_expr.ast)
+
+	# Determine severity based on context
+	is_user_controllable := check_user_controllable_in_ast(vulnerable_call.second_arg)
+	severity := get_severity(is_user_controllable)
+
+	severity == "LOW"
+
+	# Get step name if available
+	step_name := object.get(step, "name", sprintf("step-%d", [s]))
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("jobs.%s.steps[%d].if", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Use explicit equality checks or JSON array with contains() instead of space-separated string",
+		"keyActualValue": sprintf("Step '%s' contains() condition can be bypassed", [step_name]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", s, "if"], []),
+		"resourceType": "github_action",
+		"resourceName": step_name
+	}
+}
+
+# Find vulnerable contains() calls in the AST
+# Returns an object with first_arg and second_arg if vulnerable pattern found
+find_vulnerable_contains(ast) = result {
+	# Get all nodes from the AST (root and all descendants)
+	walk(ast, [_, node])
+
+	# Check if this is a function_call node with function "contains"
+	node.type == "function_call"
+
+	# Get the function name
+	func_child := node.children[_]
+	func_child.type == "identifier"
+	func_child.value == "contains"
+
+	# Get the argument_list
+	arg_list := node.children[_]
+	arg_list.type == "argument_list"
+
+	# Extract the two arguments
+	args := [arg | arg := arg_list.children[_]; arg.type != ","]
+	count(args) == 2
+
+	first_arg := args[0]
+	second_arg := args[1]
+
+	# First argument must be a string literal
+	is_string_literal(first_arg)
+
+	result := {
+		"first_arg": first_arg,
+		"second_arg": second_arg
+	}
+}
+
+# Check if a node is a string literal
+is_string_literal(node) {
+	node.type == "string"
+}
+
+# Check if an AST node references a user-controllable context
+check_user_controllable_in_ast(node) = true {
+	# Get the full text of the node
+	node_text := get_node_text(node)
+
+	# Check against user-controllable contexts
+	context := user_controllable_contexts[_]
+	startswith(node_text, context)
+} else = false {
+	true
+}
+
+# Get the text representation of a node
+get_node_text(node) = node.value {
+	node.value != ""
+}
+
+get_node_text(node) = text {
+	# If node doesn't have a value, construct from children
+	node.value == ""
+	child_texts := [child.value | child := node.children[_]; child.value != ""]
+	text := concat(".", child_texts)
+}
+
+# Helper: Determine severity based on whether context is user-controllable
+get_severity(is_user_controllable) = "HIGH" {
+	is_user_controllable
+}
+
+get_severity(is_user_controllable) = "LOW" {
+	not is_user_controllable
+}

--- a/assets/queries/cicd/github/unsound_contains_no_controllable_input/test/negative.yaml
+++ b/assets/queries/cicd/github/unsound_contains_no_controllable_input/test/negative.yaml
@@ -1,0 +1,49 @@
+name: Sound Contains Usage
+on: pull_request
+
+jobs:
+  # Case 1: Explicit equality checks (best practice)
+  test_explicit_equality:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+
+  # Case 2: JSON array with contains() (safe approach)
+  test_json_array:
+    runs-on: ubuntu-latest
+    if: ${{ contains(fromJSON('["refs/heads/main", "refs/heads/develop"]'), github.ref) }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+
+  # Case 3: Step-level with explicit checks
+  test_step_explicit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check actor
+        if: ${{ github.actor == 'dependabot' || github.actor == 'renovate' }}
+        run: echo "Bot detected"
+
+  # Case 4: Using contains() for single substring (no spaces)
+  test_single_substring:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if contains feature
+        if: ${{ contains(github.ref, 'feature') }}
+        run: echo "Feature branch"
+
+  # Case 5: Using startsWith() for prefix matching
+  test_starts_with:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/heads/feature/') }}
+    steps:
+      - run: echo "Feature branch"
+
+  # Case 6: Using endsWith() for suffix matching
+  test_ends_with:
+    runs-on: ubuntu-latest
+    if: ${{ endsWith(github.ref, '/main') }}
+    steps:
+      - run: echo "Main branch"

--- a/assets/queries/cicd/github/unsound_contains_no_controllable_input/test/positive.yaml
+++ b/assets/queries/cicd/github/unsound_contains_no_controllable_input/test/positive.yaml
@@ -1,0 +1,10 @@
+name: Unsound Contains Usage
+on: pull_request
+
+jobs:
+  # Case 1: Contains with non-user-controllable context
+  test_safe_context:
+    runs-on: ubuntu-latest
+    if: ${{ contains('push pull_request', github.event_name) }}
+    steps:
+      - run: echo "This is informational, not high severity"

--- a/assets/queries/cicd/github/unsound_contains_no_controllable_input/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/unsound_contains_no_controllable_input/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Unsound contains without controllable input",
+    "severity": "LOW",
+    "line": 8
+  }
+]

--- a/assets/queries/cicd/github/unspecified_workflows_permissions/metadata.json
+++ b/assets/queries/cicd/github/unspecified_workflows_permissions/metadata.json
@@ -8,6 +8,6 @@
   "platform": "CICD",
   "descriptionID": "d946b13a",
   "cloudProvider": "common",
-  "cwe": "CWE-732",
+  "cwe": "732",
   "providerUrl": "https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions"
 }

--- a/assets/queries/cicd/github/use_trusted_publishing/metadata.json
+++ b/assets/queries/cicd/github/use_trusted_publishing/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "f9a0b1c2-d3e4-45f6-a7b8-c9d0e1f2a3b4",
+  "queryName": "Use trusted publishing for authentication",
+  "severity": "MEDIUM",
+  "category": "Best Practices",
+  "descriptionText": "Workflows that publish packages should use Trusted Publishing (GitHub OIDC) instead of embedding long-lived tokens or other manually configured credentials. Manual credentials increase the risk of leakage, reuse across projects, and supply-chain compromise. This rule flags publishing steps that supply explicit credentials or indicate manual token use, and `run` steps that invoke publish commands without OIDC `id-token` permissions.\n\nFor `uses` steps, known publishing actions are flagged — such as `pypa/gh-action-pypi-publish`, `rubygems/release-gem`, `rubygems/configure-rubygems-credentials`, and `actions/setup-node` — when `with` contains keys like `password`, `api-token`, or `always-auth` set to `true`, or when `with.setup-trusted-publisher` is not set to `true`. The rule also checks `with.repository-url` / `with.repository_url` and `with.registry-url` against known trusted indices to determine intent.\n\nFor `run` steps, commands that match publishing operations are flagged — such as `cargo publish`, `twine upload`, `npm publish`, `gem push`, and `dotnet nuget push` — when the parent job does not grant the OIDC `id-token` permission (e.g., `permissions.id-token: write`). Resources missing the appropriate OIDC permissions or containing the listed insecure `with` values will be flagged. Remediate by removing hardcoded tokens/credentials and configuring the job/actions to rely on `id-token` or the action's Trusted Publishing option. \n\nSecure example:\n\n```yaml\njobs:\n  publish:\n    permissions:\n      id-token: write\n    steps:\n      - name: Publish to PyPI\n        uses: pypa/gh-action-pypi-publish@v1\n        with:\n          repository-url: https://upload.pypi.org/legacy/\n```",
+  "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/cicd/github/use_trusted_publishing",
+  "platform": "CICD",
+  "descriptionID": "f9a0b1c2",
+  "cloudProvider": "common",
+  "cwe": "798",
+  "providerUrl": "https://docs.pypi.org/trusted-publishers/"
+}

--- a/assets/queries/cicd/github/use_trusted_publishing/query.rego
+++ b/assets/queries/cicd/github/use_trusted_publishing/query.rego
@@ -1,0 +1,537 @@
+package Cx
+
+import future.keywords.in
+import data.generic.common as common_lib
+
+# Check for known actions using manual credentials
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	is_object(job)
+
+	steps := job.steps
+	is_array(steps)
+	step := steps[s]
+
+	uses := step.uses
+	is_string(uses)
+
+	# Check known actions that should use trusted publishing
+	check_pypi_action(step, uses)
+
+	result := {
+		"documentId": doc.id,
+		"resourceType": "github_action",
+		"resourceName": j,
+		"searchKey": sprintf("jobs.%s.steps[%d].with.password", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Step should use Trusted Publishing instead of manual credentials",
+		"keyActualValue": "Step uses manually-configured password for PyPI publishing",
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", s, "with"], ["password"]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	is_object(job)
+
+	steps := job.steps
+	is_array(steps)
+	step := steps[s]
+
+	uses := step.uses
+	is_string(uses)
+
+	check_rubygems_release_action(step, uses)
+
+	result := {
+		"documentId": doc.id,
+		"resourceType": "github_action",
+		"resourceName": j,
+		"searchKey": sprintf("jobs.%s.steps[%d].uses", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Step should set setup-trusted-publisher: true",
+		"keyActualValue": "Step does not use Trusted Publishing for RubyGems",
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", s], ["uses"]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	is_object(job)
+
+	steps := job.steps
+	is_array(steps)
+	step := steps[s]
+
+	uses := step.uses
+	is_string(uses)
+
+	check_rubygems_credentials_action(step, uses)
+
+	result := {
+		"documentId": doc.id,
+		"resourceType": "github_action",
+		"resourceName": j,
+		"searchKey": sprintf("jobs.%s.steps[%d].with.api-token", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Step should use Trusted Publishing instead of manual api-token",
+		"keyActualValue": "Step uses manually-configured api-token for RubyGems",
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", s, "with"], ["api-token"]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	is_object(job)
+
+	steps := job.steps
+	is_array(steps)
+	step := steps[s]
+
+	uses := step.uses
+	is_string(uses)
+
+	check_npm_setup_action(step, uses)
+
+	result := {
+		"documentId": doc.id,
+		"resourceType": "github_action",
+		"resourceName": j,
+		"searchKey": sprintf("jobs.%s.steps[%d].with.always-auth", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Step should use Trusted Publishing instead of always-auth with manual tokens",
+		"keyActualValue": "Step uses always-auth with manual authentication for npm",
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", s, "with"], ["always-auth"]),
+	}
+}
+
+# Check for publishing commands in run blocks without id-token permission
+CxPolicy[result] {
+	doc := input.document[i]
+	job := doc.jobs[j]
+	is_object(job)
+
+	steps := job.steps
+	is_array(steps)
+	step := steps[s]
+
+	run_block := step.run
+	is_string(run_block)
+
+	# Detect publishing command
+	has_publishing_command(step, run_block)
+
+	# Check that job doesn't have id-token: write permission
+	not has_id_token_permission(doc, job)
+
+	result := {
+		"documentId": doc.id,
+		"resourceType": "github_action",
+		"resourceName": j,
+		"searchKey": sprintf("jobs.%s.steps[%d].run", [j, s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Publishing command should use Trusted Publishing (requires id-token: write permission)",
+		"keyActualValue": "Publishing command runs without id-token permission, likely using manual credentials",
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", s], ["run"]),
+	}
+}
+
+# PyPI action: pypa/gh-action-pypi-publish with password
+check_pypi_action(step, uses) {
+	regex.match(`pypa/gh-action-pypi-publish`, uses)
+	step["with"].password
+}
+
+# RubyGems release action: without setup-trusted-publisher
+check_rubygems_release_action(step, uses) {
+	regex.match(`rubygems/release-gem`, uses)
+	with_block := step["with"]
+	not with_block["setup-trusted-publisher"]
+}
+
+check_rubygems_release_action(step, uses) {
+	regex.match(`rubygems/release-gem`, uses)
+	with_block := step["with"]
+	with_block["setup-trusted-publisher"] == false
+}
+
+check_rubygems_release_action(step, uses) {
+	regex.match(`rubygems/release-gem`, uses)
+	not step["with"]
+}
+
+# RubyGems credentials action: with api-token for rubygems.org
+check_rubygems_credentials_action(step, uses) {
+	regex.match(`rubygems/configure-rubygems-credentials`, uses)
+	step["with"]["api-token"]
+
+	# Check if gem-server is rubygems.org (or not specified, which defaults to it)
+	gem_server := object.get(step["with"], "gem-server", "https://rubygems.org")
+	gem_server == "https://rubygems.org"
+}
+
+# npm setup-node action: with always-auth for npmjs registry
+check_npm_setup_action(step, uses) {
+	regex.match(`actions/setup-node`, uses)
+	with_block := step["with"]
+
+	# Check for always-auth: true
+	always_auth := object.get(with_block, "always-auth", false)
+	always_auth == true
+
+	# Check if registry is npmjs
+	registry_url := object.get(with_block, "registry-url", "")
+	regex.match(`(?i)registry\.npmjs\.org`, registry_url)
+}
+
+# Detect publishing commands using tree-sitter parsed data (bash/sh/zsh)
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for Rust/Cargo: cargo publish (without --dry-run)
+	command.command == "cargo"
+	has_arg_matching(command, "publish")
+	not has_dry_run_flag(command)
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for Python/uv: uv publish (without --dry-run)
+	command.command == "uv"
+	has_arg_matching(command, "publish")
+	not has_dry_run_flag(command)
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for Python/uv: uv run twine upload
+	command.command == "uv"
+	has_arg_matching(command, "run")
+	has_arg_matching(command, "twine")
+	has_arg_matching(command, "upload")
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for Python/uvx: uvx twine upload
+	command.command == "uvx"
+	has_arg_matching(command, "twine")
+	has_arg_matching(command, "upload")
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for Python/hatch: hatch publish
+	command.command == "hatch"
+	has_arg_matching(command, "publish")
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for Python/pdm: pdm publish
+	command.command == "pdm"
+	has_arg_matching(command, "publish")
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for Python/poetry: poetry publish (without --dry-run)
+	command.command == "poetry"
+	has_arg_matching(command, "publish")
+	not has_dry_run_flag(command)
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for Python/twine: twine upload
+	command.command == "twine"
+	has_arg_matching(command, "upload")
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for Python/pipx: pipx run twine upload
+	command.command == "pipx"
+	has_arg_matching(command, "run")
+	has_arg_matching(command, "twine")
+	has_arg_matching(command, "upload")
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for Python module: python -m twine upload
+	regex.match(`^python[0-9.]*$`, command.command)
+	has_arg_matching(command, "-m")
+	has_arg_matching(command, "twine")
+	has_arg_matching(command, "upload")
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for Ruby/gem: gem push
+	command.command == "gem"
+	has_arg_matching(command, "push")
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for Ruby/bundle: bundle exec gem push
+	command.command == "bundle"
+	has_arg_matching(command, "exec")
+	has_arg_matching(command, "gem")
+	has_arg_matching(command, "push")
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for npm: npm publish (without --dry-run)
+	command.command == "npm"
+	has_arg_matching(command, "publish")
+	not has_dry_run_flag(command)
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for yarn: yarn publish or yarn npm publish (without --dry-run)
+	command.command == "yarn"
+	has_arg_matching(command, "publish")
+	not has_dry_run_flag(command)
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for pnpm: pnpm publish (without --dry-run)
+	command.command == "pnpm"
+	has_arg_matching(command, "publish")
+	not has_dry_run_flag(command)
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for .NET/NuGet: nuget push or dotnet nuget push
+	command.command in ["nuget", "nuget.exe"]
+	has_arg_matching(command, "push")
+}
+
+has_publishing_command(step, _) {
+	parsed := step._parsed_run
+	parsed.parse_ok == true
+
+	command := parsed.commands[_]
+
+	# Check for .NET/NuGet: dotnet nuget push
+	command.command == "dotnet"
+	has_arg_matching(command, "nuget")
+	has_arg_matching(command, "push")
+}
+
+# Fallback: Detect publishing commands using regex patterns for PowerShell/cmd or unparsed shells
+has_publishing_command(step, run_block) {
+	# Only use regex fallback if tree-sitter parsing failed or not available
+	not step._parsed_run.parse_ok
+
+	# Rust/Cargo: cargo publish (without --dry-run)
+	regex.match(`(?i)\bcargo\s+.*publish`, run_block)
+	not regex.match(`(?i)--dry-run|-n`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# Python/uv: uv publish (without --dry-run)
+	regex.match(`(?i)\buv\s+.*publish`, run_block)
+	not regex.match(`(?i)--dry-run`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# Python/uv: uv run twine upload
+	regex.match(`(?i)\buv\s+run\s+.*twine.*upload`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# Python/uvx: uvx twine upload
+	regex.match(`(?i)\buvx\s+twine.*upload`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# Python/hatch: hatch publish
+	regex.match(`(?i)\bhatch\s+.*publish`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# Python/pdm: pdm publish
+	regex.match(`(?i)\bpdm\s+.*publish`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# Python/poetry: poetry publish (without --dry-run)
+	regex.match(`(?i)\bpoetry\s+.*publish`, run_block)
+	not regex.match(`(?i)--dry-run`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# Python/twine: twine upload
+	regex.match(`(?i)\btwine\s+.*upload`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# Python/pipx: pipx run twine upload
+	regex.match(`(?i)\bpipx\s+run\s+.*twine.*upload`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# Python module: python -m twine upload
+	regex.match(`(?i)\bpython[0-9.]*\s+-m\s+twine\s+.*upload`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# Ruby/gem: gem push
+	regex.match(`(?i)\bgem\s+push`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# Ruby/bundle: bundle exec gem push
+	regex.match(`(?i)\bbundle\s+exec\s+gem\s+push`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# npm: npm publish (without --dry-run)
+	regex.match(`(?i)\bnpm\s+.*publish`, run_block)
+	not regex.match(`(?i)--dry-run`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# yarn: yarn publish or yarn npm publish (without --dry-run)
+	regex.match(`(?i)\byarn\s+(npm\s+)?publish`, run_block)
+	not regex.match(`(?i)--dry-run|-n`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# pnpm: pnpm publish (without --dry-run)
+	regex.match(`(?i)\bpnpm\s+.*publish`, run_block)
+	not regex.match(`(?i)--dry-run`, run_block)
+}
+
+has_publishing_command(step, run_block) {
+	not step._parsed_run.parse_ok
+
+	# .NET/NuGet: nuget push or dotnet nuget push
+	regex.match(`(?i)\b(nuget|dotnet\s+nuget)(\.exe)?\s+push`, run_block)
+}
+
+# Helper: Check if command has an argument matching a value
+has_arg_matching(command, value) {
+	arg := command.args[_]
+	lower(arg.value) == lower(value)
+}
+
+# Helper: Check if command has dry-run flag
+has_dry_run_flag(command) {
+	arg := command.args[_]
+	arg.value in ["--dry-run", "-n"]
+}
+
+# Check if job has id-token: write permission
+has_id_token_permission(doc, job) {
+	permissions := job.permissions
+	permissions["id-token"] == "write"
+}
+
+has_id_token_permission(doc, job) {
+	# Check workflow-level permissions
+	permissions := doc.permissions
+	permissions["id-token"] == "write"
+}

--- a/assets/queries/cicd/github/use_trusted_publishing/test/negative.yaml
+++ b/assets/queries/cicd/github/use_trusted_publishing/test/negative.yaml
@@ -1,0 +1,114 @@
+name: Trusted Publishing Test - Negative Cases
+on:
+  push:
+    branches: [main]
+
+jobs:
+  pypi-trusted-publishing:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish to PyPI with Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No password - uses OIDC token
+
+  rubygems-trusted-publishing:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Release gem with trusted publishing
+        uses: rubygems/release-gem@v1
+        with:
+          setup-trusted-publisher: true
+
+  npm-trusted-publishing:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          # No always-auth, will use provenance
+
+  cargo-with-token:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish to crates.io with token permission
+        run: cargo publish
+
+  dry-run-commands:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Dry run cargo publish
+        run: cargo publish --dry-run
+
+      - name: Dry run npm publish
+        run: npm publish --dry-run
+
+      - name: Dry run poetry publish
+        run: poetry publish --dry-run
+
+  non-publishing-commands:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build with cargo
+        run: cargo build --release
+
+      - name: Run tests
+        run: npm test
+
+      - name: Install with gem
+        run: gem install bundler
+
+  different-registries:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Private registry, not npmjs.org
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com
+          always-auth: true
+
+  rubygems-private-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Private gem server, not rubygems.org
+      - name: Configure private gem server
+        uses: rubygems/configure-rubygems-credentials@main
+        with:
+          api-token: ${{ secrets.PRIVATE_GEM_TOKEN }}
+          gem-server: https://private-gems.example.com
+
+  workflow-level-permissions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish with workflow-level token
+        run: twine upload dist/*
+
+permissions:
+  id-token: write

--- a/assets/queries/cicd/github/use_trusted_publishing/test/positive.yaml
+++ b/assets/queries/cicd/github/use_trusted_publishing/test/positive.yaml
@@ -1,0 +1,143 @@
+name: Trusted Publishing Test - Positive Cases
+on:
+  push:
+    branches: [main]
+
+jobs:
+  pypi-manual-password:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish to PyPI with password
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  rubygems-no-trusted:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Release gem without trusted publishing
+        uses: rubygems/release-gem@v1
+
+  rubygems-disabled-trusted:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Release gem with trusted publishing disabled
+        uses: rubygems/release-gem@v1
+        with:
+          setup-trusted-publisher: false
+
+  rubygems-manual-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure RubyGems with manual token
+        uses: rubygems/configure-rubygems-credentials@main
+        with:
+          api-token: ${{ secrets.RUBYGEMS_API_KEY }}
+          gem-server: https://rubygems.org
+
+  npm-manual-auth:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          always-auth: true
+
+  cargo-publish-no-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish to crates.io
+        run: cargo publish
+
+  twine-upload-no-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish to PyPI with twine
+        run: twine upload dist/*
+
+  npm-publish-no-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish to npm
+        run: npm publish
+
+  gem-push-no-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Push gem
+        run: gem push mygem-1.0.0.gem
+
+  poetry-publish-no-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish with poetry
+        run: poetry publish
+
+  yarn-publish-no-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish with yarn
+        run: yarn publish
+
+  pnpm-publish-no-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish with pnpm
+        run: pnpm publish
+
+  nuget-push-no-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Push to NuGet
+        run: nuget push MyPackage.nupkg
+
+  dotnet-nuget-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Push with dotnet
+        run: dotnet nuget push MyPackage.nupkg
+
+  uv-publish-no-token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish with uv
+        run: uv publish
+
+  python-m-twine:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish with python -m twine
+        run: python -m twine upload dist/*

--- a/assets/queries/cicd/github/use_trusted_publishing/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/use_trusted_publishing/test/positive_expected_result.json
@@ -1,0 +1,82 @@
+[
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 15
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 23
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 31
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 43
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 55
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 63
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 71
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 79
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 87
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 95
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 103
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 111
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 119
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 127
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 135
+  },
+  {
+    "queryName": "Use trusted publishing for authentication",
+    "severity": "MEDIUM",
+    "line": 143
+  }
+]

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -114,12 +114,14 @@ func Test_E2EExclusions(t *testing.T) {
 			name:     "cicd no exclusions",
 			testFile: filepath.Join("fixtures", "cicd-no-exclusions.yaml"),
 			expectedOutput: scan.ScanStats{
-				Violations: 2,
+				Violations: 4,
 				Files:      1,
-				Rules:      13,
+				Rules:      26,
 				ViolationBreakdowns: map[string]map[string]int{
 					"LOW": {
 						"555ab8f9-2001-455e-a077-f2d0f41e2fb9": 1,
+						"a1b2c3d4-e5f6-47a8-b9c0-d1e2f3a4b5c6": 1,
+						"f6a7b8c9-d0e1-42f3-a4b5-c6d7e8f9a0b1": 1,
 					},
 					"MEDIUM": {
 						"d946b13a-0b2b-49c5-b560-45b9666373e1": 1,
@@ -131,10 +133,14 @@ func Test_E2EExclusions(t *testing.T) {
 			name:     "cicd disabled rule inline",
 			testFile: filepath.Join("fixtures", "cicd-inline-disabled-rule.yaml"),
 			expectedOutput: scan.ScanStats{
-				Violations: 1,
+				Violations: 3,
 				Files:      1,
-				Rules:      13,
+				Rules:      26,
 				ViolationBreakdowns: map[string]map[string]int{
+					"LOW": {
+						"a1b2c3d4-e5f6-47a8-b9c0-d1e2f3a4b5c6": 1,
+						"f6a7b8c9-d0e1-42f3-a4b5-c6d7e8f9a0b1": 1,
+					},
 					"MEDIUM": {
 						"d946b13a-0b2b-49c5-b560-45b9666373e1": 1,
 					},


### PR DESCRIPTION
> [!TIP]
> To review the rules, use the positive and negative cases to grasp the general idea of the rule

## Motivation

There are only few rules to scan github-actions, which are not enough to cover the flaws hackers may use to attack a codebase. This series of PRs aims to extend the CICD scan coverage.

The previous PR aimed at implementing all the HIGH Severity rules. This PR implements the other ones.

## Changes

- Added the rules that are not HIGH Severity
  - anonymous definition
  - concurrency limits
  - dependabot cooldown
  - misfeature
  - obfuscation
  - overprovisioned secrets
  - secrets inherit
  - secrets outside env
  - self hosted runner
  - superfluous actions
  - unredacted secrets
  - use trusted publishing
- Changed CWE for unspecified workflow permissions to only keep the number and be coherent with the rest of the rules

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- Review rule after rule, check the examples to understand what it checks
- Review the attributes returned in the results of the rules: ensure that the values are all there, that they explain stuff related to the issue.
- Take a look at the logic to make sure their is no flaw.

## Blast Radius

IaC findings for CICD platform

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
