### PR TITLE
fix: mutex deadlock in filesystem.go

### DIFF
--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -61,7 +61,7 @@ func NewFileSystemSourceProvider(ctx context.Context, paths, excludes []string) 
 		if err != nil {
 			return nil, err
 		}
-		if err := fs.AddExcluded(ctx, excludePaths); err != nil {
+		if err := fs.addExcluded(ctx, excludePaths); err != nil {
 			return nil, err
 		}
 	}
@@ -71,7 +71,7 @@ func NewFileSystemSourceProvider(ctx context.Context, paths, excludes []string) 
 
 // AddExcluded add new excluded files to the File System Source Provider
 // Hold a mutex before calling this function
-func (s *FileSystemSourceProvider) AddExcluded(ctx context.Context, excludePaths []string) error {
+func (s *FileSystemSourceProvider) addExcluded(ctx context.Context, excludePaths []string) error {
 	contextLogger := logger.FromContext(ctx)
 	for _, excludePath := range excludePaths {
 		info, err := os.Stat(excludePath)
@@ -226,7 +226,7 @@ func (s *FileSystemSourceProvider) collectFiles(ctx context.Context, scanPath st
 				return nil
 			}
 			s.mu.Lock()
-			if errAdd := s.AddExcluded(ctx, excluded); errAdd != nil {
+			if errAdd := s.addExcluded(ctx, excluded); errAdd != nil {
 				contextLogger.Err(errAdd).Msgf("Filesystem files provider couldn't exclude rendered Chart files, Chart=%s", info.Name())
 			}
 			s.mu.Unlock()
@@ -366,7 +366,7 @@ func (s *FileSystemSourceProvider) walkDir(ctx context.Context, scanPath string,
 				return nil
 			}
 			s.mu.Lock()
-			if errAdd := s.AddExcluded(ctx, excluded); errAdd != nil {
+			if errAdd := s.addExcluded(ctx, excluded); errAdd != nil {
 				contextLogger.Err(errAdd).Msgf("Filesystem files provider couldn't exclude rendered Chart files, Chart=%s", info.Name())
 			}
 			s.mu.Unlock()
@@ -415,7 +415,7 @@ func (s *FileSystemSourceProvider) checkConditions(ctx context.Context, info os.
 		if queryRegexExcludeTerraCache.MatchString(path) {
 			contextLogger.Info().Msgf("Directory ignored: %s", path)
 
-			err := s.AddExcluded(ctx, []string{info.Name()})
+			err := s.addExcluded(ctx, []string{info.Name()})
 			if err != nil {
 				return true, err
 			}

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -55,6 +55,7 @@ func NewFileSystemSourceProvider(ctx context.Context, paths, excludes []string) 
 		paths:    osPaths,
 		excludes: ex,
 	}
+
 	for _, exclude := range excludes {
 		excludePaths, err := GetExcludePaths(ctx, exclude)
 		if err != nil {
@@ -69,6 +70,7 @@ func NewFileSystemSourceProvider(ctx context.Context, paths, excludes []string) 
 }
 
 // AddExcluded add new excluded files to the File System Source Provider
+// Hold a mutex before calling this function
 func (s *FileSystemSourceProvider) AddExcluded(ctx context.Context, excludePaths []string) error {
 	contextLogger := logger.FromContext(ctx)
 	for _, excludePath := range excludePaths {
@@ -84,12 +86,10 @@ func (s *FileSystemSourceProvider) AddExcluded(ctx context.Context, excludePaths
 			}
 			return errors.Wrap(err, "failed to open excluded file")
 		}
-		s.mu.Lock()
 		if _, ok := s.excludes[info.Name()]; !ok {
 			s.excludes[info.Name()] = make([]os.FileInfo, 0)
 		}
 		s.excludes[info.Name()] = append(s.excludes[info.Name()], info)
-		s.mu.Unlock()
 	}
 	return nil
 }
@@ -225,9 +225,11 @@ func (s *FileSystemSourceProvider) collectFiles(ctx context.Context, scanPath st
 			if errRes != nil {
 				return nil
 			}
+			s.mu.Lock()
 			if errAdd := s.AddExcluded(ctx, excluded); errAdd != nil {
 				contextLogger.Err(errAdd).Msgf("Filesystem files provider couldn't exclude rendered Chart files, Chart=%s", info.Name())
 			}
+			s.mu.Unlock()
 			resolved = true
 			return nil
 		}
@@ -363,9 +365,11 @@ func (s *FileSystemSourceProvider) walkDir(ctx context.Context, scanPath string,
 			if errRes != nil {
 				return nil
 			}
+			s.mu.Lock()
 			if errAdd := s.AddExcluded(ctx, excluded); errAdd != nil {
 				contextLogger.Err(errAdd).Msgf("Filesystem files provider couldn't exclude rendered Chart files, Chart=%s", info.Name())
 			}
+			s.mu.Unlock()
 			resolved = true
 			return nil
 		}
@@ -403,8 +407,8 @@ func openScanFile(ctx context.Context, scanPath string, extensions model.Extensi
 func (s *FileSystemSourceProvider) checkConditions(ctx context.Context, info os.FileInfo, extensions model.Extensions,
 	path string, resolved bool) (bool, error) {
 	contextLogger := logger.FromContext(ctx)
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if info.IsDir() {
 		// exclude terraform cache folders

--- a/pkg/engine/provider/filesystem_test.go
+++ b/pkg/engine/provider/filesystem_test.go
@@ -535,7 +535,7 @@ func TestFileSystemSourceProvider_AddExcluded(t *testing.T) {
 	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.fields.fs.AddExcluded(ctx, tt.args.excludePaths)
+			err := tt.fields.fs.addExcluded(ctx, tt.args.excludePaths)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AddExcluded() = %v, wantErr = %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
## Motivation

Scans were failing, often because of a `context deadline exceeded`. This is due to a deadlock in mutex usage:

If a repo with a folder that matched the terracache regex (`XXX.terraXXX`), the mutex already held by the `checkCondition` function would then be tried to be locked by `AddExcluded` inside the same goroutine, resulting in a deadlock.

The SourceProvider is not stateless. Making it so ended up making the code messy and so the resulting PR is compromising:
- The `excludes` is populated once when creating the source provider
- When sourcing starts, the source provider copies the state and passes it to each function to prevent concurrency.

## Changes

- The exclusion attribute of the filesystem is only used to store the exclusion parameters from the launch of the scan
- This attribute is copied once when the sourcing starts and then the copy is passed as argument through the rest of the sourcing.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- No more deadlocks in mutex
- The tests should pass 

## Blast Radius

`iac-scanning`

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
