### PR TITLE
Use dd-sts to get access tokens instead of using repo's secrets

### DIFF
--- a/.github/workflows/fp-benchmark.yml
+++ b/.github/workflows/fp-benchmark.yml
@@ -13,8 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     
     steps:
+    - name: Get Datadog credentials
+      id: dd-sts
+      uses: DataDog/dd-sts-action@8c5343b895b3291bda3e081cd2be96b420ea35a2 # 09 Mar. 2026
+      with:
+        policy: iac-fp-benchmark
+
     - name: Checkout kics repo
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
@@ -53,8 +60,8 @@ jobs:
 
     - name: Run FP evaluation
       env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-        DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+        DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+        DD_APP_KEY: ${{ steps.dd-sts.outputs.app_key }}
       run: |
         cd iac-benchmarking
         python benchmark-tools/fp_eval.py \
@@ -65,8 +72,8 @@ jobs:
     - name: Submit metrics to Datadog
       if: always()
       env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
-        DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+        DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+        DD_APP_KEY: ${{ steps.dd-sts.outputs.app_key }}
       run: |
         cd iac-benchmarking
         if [ -f results/fp_eval_results.json ]; then


### PR DESCRIPTION
## Motivation

The FP Benchmark needs credentials to call the DD API. The way to do it is to use the dd-sts action to ask for credentials.

## Changes

- Add use dd-sts step in fp-bencmark action
- Replace secrets usage by retrieved tokens

## Author Checklist

- [x] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

-  _Can we trigger the action from this branch and expect it to work?_
  - No, the policy only accepts the main branch as caller, however, you may see that the action may be [called](https://github.com/DataDog/datadog-iac-scanner/actions/runs/23302739625/job/67773016354) and show the attributes related to this call.
- Is there any documentation to help me review this PR?
  - Yes! Please refer to the guide in the message that lead you to this PR to help you review

## Blast Radius

Only the action itself will be affected

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
