### PR TITLE
Ansible regos tests up to date

### DIFF
--- a/assets/queries/ansible/aws/alb_listening_on_http/test/negative.yaml
+++ b/assets/queries/ansible/aws/alb_listening_on_http/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: my_elb_application
-  community.aws.elb_application_lb:
+  amazon.aws.elb_application_lb:
     name: myelb
     security_groups:
     - sg-12345678

--- a/assets/queries/ansible/aws/alb_listening_on_http/test/positive.yaml
+++ b/assets/queries/ansible/aws/alb_listening_on_http/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: my_elb_application
-  community.aws.elb_application_lb:
+  amazon.aws.elb_application_lb:
     name: myelb
     security_groups:
       - sg-12345678
@@ -18,7 +18,7 @@
             TargetGroupName: targetname
     state: present
 - name: my_elb_application2
-  community.aws.elb_application_lb:
+  amazon.aws.elb_application_lb:
     name: myelb2
     security_groups:
       - sg-12345678

--- a/assets/queries/ansible/aws/api_gateway_endpoint_config_is_not_private/test/negative.yaml
+++ b/assets/queries/ansible/aws/api_gateway_endpoint_config_is_not_private/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Setup AWS API Gateway setup on AWS and deploy API definition
-  community.aws.aws_api_gateway:
+  community.aws.api_gateway:
     name: my-private-api
     swagger_file: my_api.yml
     stage: production

--- a/assets/queries/ansible/aws/api_gateway_endpoint_config_is_not_private/test/positive.yaml
+++ b/assets/queries/ansible/aws/api_gateway_endpoint_config_is_not_private/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Setup AWS API Gateway setup on AWS and deploy API definition
-  community.aws.aws_api_gateway:
+  community.aws.api_gateway:
     name: my-edge-api
     swagger_file: my_api.yml
     stage: production

--- a/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Setup AWS API Gateway setup on AWS cloudwatchlogs
-  community.aws.cloudwatchlogs_log_group:
+  amazon.aws.cloudwatchlogs_log_group:
     state: present
     log_group_name: test-log-group
     tags: {Name: test-log-group, Env: QA}

--- a/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/test/positive.yaml
@@ -1,5 +1,5 @@
 ---
 - name: Setup AWS API Gateway setup on AWS cloudwatchlogs
-  community.aws.cloudwatchlogs_log_group:
+  amazon.aws.cloudwatchlogs_log_group:
     state: present
     kms_key_id: arn:aws:kms:region:account-id:key/key-id

--- a/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/negative1.yaml
+++ b/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/negative1.yaml
@@ -1,5 +1,5 @@
 - name: Setup AWS API Gateway setup on AWS and deploy API definition3
-  community.aws.aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api
     swagger_file: swaggerFile.yaml
     stage: production

--- a/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/negative2.yaml
+++ b/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/negative2.yaml
@@ -1,5 +1,5 @@
 - name: Setup AWS API Gateway setup on AWS and deploy API definition22222
-  community.aws.aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api
     swagger_dict:
       {

--- a/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/negative3.yaml
+++ b/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/negative3.yaml
@@ -1,5 +1,5 @@
 - name: Setup AWS API Gateway setup on AWS and deploy API 222
-  aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api
     swagger_text: |
       openapi: 3.0.0

--- a/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/positive1.yaml
+++ b/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/positive1.yaml
@@ -1,5 +1,5 @@
 - name: Setup AWS API Gateway setup on AWS and deploy API definition
-  community.aws.aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api
     swagger_dict:
       {

--- a/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/positive2.yaml
+++ b/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/positive2.yaml
@@ -1,5 +1,5 @@
 - name: Setup AWS API Gateway setup on AWS and deploy API definition2
-  aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api
     stage: production
     cache_enabled: true

--- a/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/positive3.yaml
+++ b/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/positive3.yaml
@@ -1,5 +1,5 @@
 - name: Setup AWS API Gateway setup on AWS and deploy API 222
-  aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api
     swagger_file: swaggerFileWithoutAuthorizer.yaml
     stage: production

--- a/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/positive4.yaml
+++ b/assets/queries/ansible/aws/api_gateway_without_configured_authorizer/test/positive4.yaml
@@ -1,5 +1,5 @@
 - name: Setup AWS API Gateway setup on AWS and deploy API 222
-  aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api
     swagger_text: |
       openapi: 3.0.0

--- a/assets/queries/ansible/aws/api_gateway_without_ssl_certificate/test/negative.yaml
+++ b/assets/queries/ansible/aws/api_gateway_without_ssl_certificate/test/negative.yaml
@@ -1,12 +1,12 @@
 - name: update API v2
-  aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api
     api_id: abc123321cba
     state: present
     swagger_file: my_api.yml
     validate_certs: yes
 - name: Setup AWS API Gateway setup on AWS and deploy API definition v2
-  community.aws.aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api-v2
     swagger_file: my_api.yml
     stage: production

--- a/assets/queries/ansible/aws/api_gateway_without_ssl_certificate/test/positive.yaml
+++ b/assets/queries/ansible/aws/api_gateway_without_ssl_certificate/test/positive.yaml
@@ -1,18 +1,18 @@
 - name: update API
-  aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api
     api_id: 'abc123321cba'
     state: present
     swagger_file: my_api.yml
     validate_certs: no
 - name: update API v1
-  aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api-v1
     api_id: 'abc123321cba'
     state: present
     swagger_file: my_api.yml
 - name: Setup AWS API Gateway setup on AWS and deploy API definition
-  community.aws.aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api-v2
     swagger_file: my_api.yml
     stage: production
@@ -23,7 +23,7 @@
     state: present
     validate_certs: no
 - name: Setup AWS API Gateway setup on AWS and deploy API definition v1
-  community.aws.aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api-v3
     swagger_file: my_api.yml
     stage: production

--- a/assets/queries/ansible/aws/api_gateway_without_waf/test/negative.yaml
+++ b/assets/queries/ansible/aws/api_gateway_without_waf/test/negative.yaml
@@ -5,7 +5,7 @@
     state: present
     arn: "arn:aws:apigateway:region::/restapis/api-id/stages/produ"
 - name: Setup AWS API Gateway setup on AWS and deploy API definition
-  community.aws.aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api
     swagger_file: my_api.yml
     stage: produ

--- a/assets/queries/ansible/aws/api_gateway_without_waf/test/positive.yaml
+++ b/assets/queries/ansible/aws/api_gateway_without_waf/test/positive.yaml
@@ -5,7 +5,7 @@
     state: present
     arn: "arn:aws:apigateway:region::/restapis/api-id/stages/prod"
 - name: Setup AWS API Gateway setup on AWS and deploy API definition2
-  community.aws.aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api
     swagger_file: my_api.yml
     stage: production

--- a/assets/queries/ansible/aws/api_gateway_xray_disabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/api_gateway_xray_disabled/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Setup AWS API Gateway setup on AWS and deploy API definition
-  community.aws.aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api
     swagger_file: my_api.yml
     stage: production

--- a/assets/queries/ansible/aws/api_gateway_xray_disabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/api_gateway_xray_disabled/test/positive.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Setup AWS API Gateway setup on AWS and deploy API definition
-  community.aws.aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api
     swagger_file: my_api.yml
     stage: production
@@ -10,7 +10,7 @@
     endpoint_type: EDGE
     state: present
 - name: Update API definition to deploy new version
-  community.aws.aws_api_gateway:
+  community.aws.api_gateway:
     name: my-api-v2
     api_id: 'abc123321cba'
     swagger_file: my_api.yml

--- a/assets/queries/ansible/aws/authentication_without_mfa/test/negative.yaml
+++ b/assets/queries/ansible/aws/authentication_without_mfa/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Assume an existing role
-  community.aws.sts_assume_role:
+  amazon.aws.sts_assume_role:
     mfa_serial_number: '{{ mfa_devices.mfa_devices[0].serial_number }}'
     mfa_token: weewew
     role_arn: arn:aws:iam::123456789012:role/someRole

--- a/assets/queries/ansible/aws/authentication_without_mfa/test/positive.yaml
+++ b/assets/queries/ansible/aws/authentication_without_mfa/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Assume an existing role
-  community.aws.sts_assume_role:
+  amazon.aws.sts_assume_role:
     mfa_serial_number: "{{ mfa_devices.mfa_devices[0].serial_number }}"
     role_arn: "arn:aws:iam::123456789012:role/someRole"
     role_session_name: "someRoleSession"

--- a/assets/queries/ansible/aws/auto_scaling_group_with_no_associated_elb/test/negative1.yaml
+++ b/assets/queries/ansible/aws/auto_scaling_group_with_no_associated_elb/test/negative1.yaml
@@ -1,5 +1,5 @@
 - name: elb12
-  community.aws.ec2_asg:
+  amazon.aws.autoscaling_group:
     name: special
     load_balancers: [ 'lb1', 'lb2' ]
     availability_zones: [ 'eu-west-1a', 'eu-west-1b' ]

--- a/assets/queries/ansible/aws/auto_scaling_group_with_no_associated_elb/test/negative2.yaml
+++ b/assets/queries/ansible/aws/auto_scaling_group_with_no_associated_elb/test/negative2.yaml
@@ -1,5 +1,5 @@
 - name: elb22
-  ec2_asg:
+  amazon.aws.autoscaling_group:
     name: special
     load_balancers: [ 'lb1', 'lb2' ]
     availability_zones: [ 'eu-west-1a', 'eu-west-1b' ]

--- a/assets/queries/ansible/aws/auto_scaling_group_with_no_associated_elb/test/positive1.yaml
+++ b/assets/queries/ansible/aws/auto_scaling_group_with_no_associated_elb/test/positive1.yaml
@@ -1,5 +1,5 @@
 - name: elb1
-  community.aws.ec2_asg:
+  amazon.aws.autoscaling_group:
     name: special
     load_balancers: []
     availability_zones: [ 'eu-west-1a', 'eu-west-1b' ]

--- a/assets/queries/ansible/aws/auto_scaling_group_with_no_associated_elb/test/positive2.yaml
+++ b/assets/queries/ansible/aws/auto_scaling_group_with_no_associated_elb/test/positive2.yaml
@@ -1,5 +1,5 @@
 - name: elb2
-  ec2_asg:
+  amazon.aws.autoscaling_group:
     name: special
     availability_zones: [ 'eu-west-1a', 'eu-west-1b' ]
     launch_config_name: 'lc-1'

--- a/assets/queries/ansible/aws/automatic_minor_upgrades_disabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/automatic_minor_upgrades_disabled/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: negative - create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small
@@ -8,7 +8,7 @@
     cluster_id: ansible-test-cluster
     auto_minor_version_upgrade: true
 - name: negative - Create a DB instance using the default AWS KMS encryption key
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: test-encrypted-db
     id: test-encrypted-db
     state: present
@@ -20,7 +20,7 @@
     allocated_storage: '{{ allocated_storage }}'
     auto_minor_version_upgrade: yes
 - name: negative - Create a DB instance using the default AWS KMS encryption key
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: test-encrypted-db
     id: test-encrypted-db
     state: present

--- a/assets/queries/ansible/aws/automatic_minor_upgrades_disabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/automatic_minor_upgrades_disabled/test/positive.yaml
@@ -1,6 +1,6 @@
 ---
 - name: community - create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small
@@ -9,7 +9,7 @@
     cluster_id: ansible-test-cluster
     auto_minor_version_upgrade: false
 - name: community - Create a DB instance using the default AWS KMS encryption key
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: test-encrypted-db
     id: test-encrypted-db
     state: present

--- a/assets/queries/ansible/aws/aws_password_policy_with_unchangeable_passwords/test/negative.yaml
+++ b/assets/queries/ansible/aws/aws_password_policy_with_unchangeable_passwords/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Password policy for AWS account
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false

--- a/assets/queries/ansible/aws/aws_password_policy_with_unchangeable_passwords/test/positive.yaml
+++ b/assets/queries/ansible/aws/aws_password_policy_with_unchangeable_passwords/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Password policy for AWS account
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false
@@ -11,7 +11,7 @@
     pw_reuse_prevent: 5
     pw_expire: false
 - name: Alias Password policy for AWS account
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false

--- a/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/test/negative.yaml
+++ b/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: My Batch Job Definition
-  community.aws.aws_batch_job_definition:
+  community.aws.batch_job_definition:
     job_definition_name: My Batch Job Definition without privilege
     state: present
     type: container
@@ -18,7 +18,7 @@
     attempts: 3
   register: job_definition_create_result
 - name: My Batch Job Definition without explicit privilege
-  community.aws.aws_batch_job_definition:
+  community.aws.batch_job_definition:
     job_definition_name: My Batch Job Definition
     state: present
     type: container

--- a/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/test/positive.yaml
+++ b/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: My Batch Job Definition
-  community.aws.aws_batch_job_definition:
+  community.aws.batch_job_definition:
     job_definition_name: My Batch Job Definition
     state: present
     type: container

--- a/assets/queries/ansible/aws/ca_certificate_identifier_is_outdated/test/negative.yaml
+++ b/assets/queries/ansible/aws/ca_certificate_identifier_is_outdated/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small
@@ -8,7 +8,7 @@
     cluster_id: ansible-test-cluster
     ca_certificate_identifier: rds-ca-2019
 - name: Create a DB instance using the default AWS KMS encryption key
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: test-encrypted-db
     id: test-encrypted-db
     state: present

--- a/assets/queries/ansible/aws/ca_certificate_identifier_is_outdated/test/positive.yaml
+++ b/assets/queries/ansible/aws/ca_certificate_identifier_is_outdated/test/positive.yaml
@@ -1,6 +1,6 @@
 ---
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small
@@ -9,7 +9,7 @@
     cluster_id: ansible-test-cluster
     ca_certificate_identifier: rds-ca-2015
 - name: create a DB instance using the default AWS KMS encryption key
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: test-encrypted-db
     id: test-encrypted-db
     state: present

--- a/assets/queries/ansible/aws/certificate_has_expired/test/negative.yaml
+++ b/assets/queries/ansible/aws/certificate_has_expired/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: upload a self-signed certificate2
-  community.aws.aws_acm:
+  community.aws.acm_certificate:
     certificate: "{{ lookup('file', 'validCertificate.pem' ) }}"
     privateKey: "{{ lookup('file', 'key.pem' ) }}"
     name_tag: my_cert

--- a/assets/queries/ansible/aws/certificate_has_expired/test/positive.yaml
+++ b/assets/queries/ansible/aws/certificate_has_expired/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: upload a self-signed certificate
-  community.aws.aws_acm:
+  community.aws.acm_certificate:
     certificate: "{{ lookup('file', 'expiredCertificate.pem' ) }}"
     privateKey: "{{ lookup('file', 'key.pem' ) }}"
     name_tag: my_cert

--- a/assets/queries/ansible/aws/certificate_rsa_key_bytes_lower_than_256/test/negative.yaml
+++ b/assets/queries/ansible/aws/certificate_rsa_key_bytes_lower_than_256/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: upload a self-signed certificate2
-  community.aws.aws_acm:
+  community.aws.acm_certificate:
     certificate: "{{ lookup('file', 'rsa4096.pem' ) }}"
     privateKey: "{{ lookup('file', 'key.pem' ) }}"
     name_tag: my_cert

--- a/assets/queries/ansible/aws/certificate_rsa_key_bytes_lower_than_256/test/positive.yaml
+++ b/assets/queries/ansible/aws/certificate_rsa_key_bytes_lower_than_256/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: upload a self-signed certificate
-  community.aws.aws_acm:
+  community.aws.acm_certificate:
     certificate: "{{ lookup('file', 'rsa1024.pem' ) }}"
     privateKey: "{{ lookup('file', 'key.pem' ) }}"
     name_tag: my_cert

--- a/assets/queries/ansible/aws/cloudtrail_log_file_validation_disabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_log_file_validation_disabled/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: create multi-region trail with validation and tags v2
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket
@@ -13,7 +13,7 @@
       environment: dev
       Name: default
 - name: create multi-region trail with validation and tags v3
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket

--- a/assets/queries/ansible/aws/cloudtrail_log_file_validation_disabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_log_file_validation_disabled/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: create multi-region trail with validation and tags
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket
@@ -12,7 +12,7 @@
       environment: dev
       Name: default
 - name: create multi-region trail with validation and tags v7
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket

--- a/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: create multi-region trail with validation and tags v2
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket

--- a/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: no sns topic name
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket

--- a/assets/queries/ansible/aws/cloudtrail_logging_disabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_logging_disabled/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: example
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     enable_logging: true

--- a/assets/queries/ansible/aws/cloudtrail_logging_disabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_logging_disabled/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: example
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     enable_logging: false

--- a/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: example1
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket

--- a/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: example1
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket

--- a/assets/queries/ansible/aws/cloudtrail_not_integrated_with_cloudwatch/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_not_integrated_with_cloudwatch/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: create multi-region trail with validation and tags negative
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket

--- a/assets/queries/ansible/aws/cloudtrail_not_integrated_with_cloudwatch/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_not_integrated_with_cloudwatch/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: positive1
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket
@@ -11,7 +11,7 @@
       environment: dev
       Name: default
 - name: positive2
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket
@@ -24,7 +24,7 @@
       environment: dev
       Name: default
 - name: positive3
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket

--- a/assets/queries/ansible/aws/cloudtrail_sns_topic_name_undefined/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_sns_topic_name_undefined/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: sns topic name defined
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket

--- a/assets/queries/ansible/aws/cloudtrail_sns_topic_name_undefined/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_sns_topic_name_undefined/test/positive.yaml
@@ -1,12 +1,12 @@
 - name: no sns topic name
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket
     s3_key_prefix: cloudtrail
     region: us-east-1
 - name: sns topic name defined
-  community.aws.cloudtrail:
+  amazon.aws.cloudtrail:
     state: present
     name: default
     s3_bucket_name: mylogbucket

--- a/assets/queries/ansible/aws/cloudwatch_without_retention_period_specified/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_period_specified/test/negative.yaml
@@ -1,4 +1,4 @@
 - name: example3 ec2 group
-  community.aws.cloudwatchlogs_log_group:
+  amazon.aws.cloudwatchlogs_log_group:
     log_group_name: test-log-group
     retention: 5

--- a/assets/queries/ansible/aws/cloudwatch_without_retention_period_specified/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_period_specified/test/positive.yaml
@@ -1,7 +1,7 @@
 - name: example ec2 group
-  community.aws.cloudwatchlogs_log_group:
+  amazon.aws.cloudwatchlogs_log_group:
     log_group_name: test-log-group
 - name: example2 ec2 group
-  community.aws.cloudwatchlogs_log_group:
+  amazon.aws.cloudwatchlogs_log_group:
     log_group_name: test-log-group
     retention: 111111

--- a/assets/queries/ansible/aws/cmk_is_unusable/test/negative1.yaml
+++ b/assets/queries/ansible/aws/cmk_is_unusable/test/negative1.yaml
@@ -1,5 +1,5 @@
 - name: Update IAM policy on an existing KMS key
-  community.aws.aws_kms:
+  amazon.aws.kms_key:
     alias: my-kms-key
     policy: '{"Version": "2012-10-17", "Id": "my-kms-key-permissions", "Statement": [ { <SOME STATEMENT> } ]}'
     state: present

--- a/assets/queries/ansible/aws/cmk_is_unusable/test/positive1.yaml
+++ b/assets/queries/ansible/aws/cmk_is_unusable/test/positive1.yaml
@@ -1,5 +1,5 @@
 - name: Update IAM policy on an existing KMS key1
-  community.aws.aws_kms:
+  amazon.aws.kms_key:
     alias: my-kms-key
     policy: '{"Version": "2012-10-17", "Id": "my-kms-key-permissions", "Statement": [ { <SOME STATEMENT> } ]}'
     state: present

--- a/assets/queries/ansible/aws/cmk_is_unusable/test/positive2.yaml
+++ b/assets/queries/ansible/aws/cmk_is_unusable/test/positive2.yaml
@@ -1,5 +1,5 @@
 - name: Update IAM policy on an existing KMS key2
-  community.aws.aws_kms:
+  amazon.aws.kms_key:
     alias: my-kms-key
     policy: '{"Version": "2012-10-17", "Id": "my-kms-key-permissions", "Statement": [ { <SOME STATEMENT> } ]}'
     state: present

--- a/assets/queries/ansible/aws/cmk_rotation_disabled/test/negative1.yaml
+++ b/assets/queries/ansible/aws/cmk_rotation_disabled/test/negative1.yaml
@@ -1,5 +1,5 @@
 - name: Update IAM policy on an existing KMS key3
-  community.aws.aws_kms:
+  amazon.aws.kms_key:
     alias: my-kms-key
     policy: '{"Version": "2012-10-17", "Id": "my-kms-key-permissions", "Statement": [ { <SOME STATEMENT> } ]}'
     state: present

--- a/assets/queries/ansible/aws/cmk_rotation_disabled/test/positive1.yaml
+++ b/assets/queries/ansible/aws/cmk_rotation_disabled/test/positive1.yaml
@@ -1,5 +1,5 @@
 - name: Update IAM policy on an existing KMS key
-  community.aws.aws_kms:
+  amazon.aws.kms_key:
     alias: my-kms-key
     policy: '{"Version": "2012-10-17", "Id": "my-kms-key-permissions", "Statement": [ { <SOME STATEMENT> } ]}'
     state: present

--- a/assets/queries/ansible/aws/cmk_rotation_disabled/test/positive2.yaml
+++ b/assets/queries/ansible/aws/cmk_rotation_disabled/test/positive2.yaml
@@ -1,5 +1,5 @@
 - name: Update IAM policy on an existing KMS key2
-  community.aws.aws_kms:
+  amazon.aws.kms_key:
     alias: my-kms-key
     policy: '{"Version": "2012-10-17", "Id": "my-kms-key-permissions", "Statement": [ { <SOME STATEMENT> } ]}'
     state: present

--- a/assets/queries/ansible/aws/codebuild_not_encrypted/test/negative.yaml
+++ b/assets/queries/ansible/aws/codebuild_not_encrypted/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: My project v2
-  community.aws.aws_codebuild:
+  community.aws.codebuild_project:
     name: my-codebuild-project
     description: My nice little project
     service_role: arn:aws:iam::123123:role/service-role/code-build-service-role

--- a/assets/queries/ansible/aws/codebuild_not_encrypted/test/positive.yaml
+++ b/assets/queries/ansible/aws/codebuild_not_encrypted/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: My project
-  community.aws.aws_codebuild:
+  community.aws.codebuild_project:
     name: my-codebuild-project
     description: My nice little project v2
     service_role: "arn:aws:iam::123123:role/service-role/code-build-service-role"

--- a/assets/queries/ansible/aws/config_configuration_aggregator_to_all_regions_disabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/config_configuration_aggregator_to_all_regions_disabled/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Create cross-account aggregator
-  community.aws.aws_config_aggregator:
+  community.aws.config_aggregator:
     name: test_config_rule
     state: present
     account_sources:

--- a/assets/queries/ansible/aws/config_configuration_aggregator_to_all_regions_disabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/config_configuration_aggregator_to_all_regions_disabled/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Create cross-account aggregator
-  community.aws.aws_config_aggregator:
+  community.aws.config_aggregator:
     name: test_config_rule
     state: present
     account_sources:
@@ -11,7 +11,7 @@
     organization_source:
       all_aws_regions: yes
 - name: Create cross-account aggregator2
-  community.aws.aws_config_aggregator:
+  community.aws.config_aggregator:
     name: test_config_rule
     state: present
     account_sources:

--- a/assets/queries/ansible/aws/config_rule_for_encrypted_volumes_is_disabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/config_rule_for_encrypted_volumes_is_disabled/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: foo
-  community.aws.aws_config_rule:
+  community.aws.config_rule:
     name: test_config_rule
     state: present
     description: This AWS Config rule checks for public write access on S3 buckets

--- a/assets/queries/ansible/aws/config_rule_for_encrypted_volumes_is_disabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/config_rule_for_encrypted_volumes_is_disabled/test/positive.yaml
@@ -1,6 +1,6 @@
 ---
 - name: foo
-  community.aws.aws_config_rule:
+  community.aws.config_rule:
     name: test_config_rule
     state: present
     description: 'This AWS Config rule checks for public write access on S3 buckets'

--- a/assets/queries/ansible/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/negative1.yaml
+++ b/assets/queries/ansible/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/negative1.yaml
@@ -1,5 +1,5 @@
 - name: Create a role with description and tags4
-  community.aws.iam_role:
+  amazon.aws.iam_role:
     name: mynewrole4
     assume_role_policy_document: >
       {

--- a/assets/queries/ansible/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/negative2.yaml
+++ b/assets/queries/ansible/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/negative2.yaml
@@ -1,5 +1,5 @@
 - name: Create a role with description and tags5
-  community.aws.iam_role:
+  amazon.aws.iam_role:
     name: mynewrole5
     assume_role_policy_document: >
       {

--- a/assets/queries/ansible/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/positive1.yaml
+++ b/assets/queries/ansible/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/positive1.yaml
@@ -1,5 +1,5 @@
 - name: Create a role with description and tags
-  community.aws.iam_role:
+  amazon.aws.iam_role:
     name: mynewrole
     assume_role_policy_document: >
       {

--- a/assets/queries/ansible/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/positive2.yaml
+++ b/assets/queries/ansible/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/positive2.yaml
@@ -1,5 +1,5 @@
 - name: Create a role with description and tags2
-  community.aws.iam_role:
+  amazon.aws.iam_role:
     name: mynewrole2
     assume_role_policy_document: >
       {

--- a/assets/queries/ansible/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/positive3.yaml
+++ b/assets/queries/ansible/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/positive3.yaml
@@ -1,5 +1,5 @@
 - name: Create a role with description and tags3
-  community.aws.iam_role:
+  amazon.aws.iam_role:
     name: mynewrole3
     assume_role_policy_document: >
       {

--- a/assets/queries/ansible/aws/db_instance_storage_not_encrypted/test/negative.yaml
+++ b/assets/queries/ansible/aws/db_instance_storage_not_encrypted/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: foo
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: my-db-1
     id: test-encrypted-db
     state: present
@@ -10,7 +10,7 @@
     password: '{{ password }}'
     allocated_storage: '{{ allocated_storage }}'
 - name: foo2
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: my-db-2
     id: test-encrypted-db
     state: present
@@ -21,7 +21,7 @@
     password: '{{ password }}'
     allocated_storage: '{{ allocated_storage }}'
 - name: foo3
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: my-db-3
     id: test-encrypted-db
     state: present

--- a/assets/queries/ansible/aws/db_instance_storage_not_encrypted/test/positive.yaml
+++ b/assets/queries/ansible/aws/db_instance_storage_not_encrypted/test/positive.yaml
@@ -1,6 +1,6 @@
 ---
 - name: foo
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: my-db-1
     id: test-encrypted-db
     state: present
@@ -11,7 +11,7 @@
     password: "{{ password }}"
     allocated_storage: "{{ allocated_storage }}"
 - name: foo2
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: my-db-2
     id: test-encrypted-db
     state: present
@@ -22,7 +22,7 @@
     password: "{{ password }}"
     allocated_storage: "{{ allocated_storage }}"
 - name: foo3
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: my-db-3
     id: test-encrypted-db
     state: present

--- a/assets/queries/ansible/aws/db_security_group_open_to_large_scope/test/positive.yaml
+++ b/assets/queries/ansible/aws/db_security_group_open_to_large_scope/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/db_security_group_with_public_scope/test/positive.yaml
+++ b/assets/queries/ansible/aws/db_security_group_with_public_scope/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/ec2_group_has_public_interface/test/positive.yaml
+++ b/assets/queries/ansible/aws/ec2_group_has_public_interface/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/negative.yaml
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/negative.yaml
@@ -5,13 +5,13 @@
     vpc_subnet_id: subnet-29e63245
     assign_public_ip: false
 - name: Create an ec2 launch template
-  community.aws.ec2_launch_template:
+  amazon.aws.ec2_launch_template:
     name: my_template
     image_id: ami-04b762b4289fba92b
     key_name: my_ssh_key
     instance_type: t2.micro
 - name: Create an ec2 launch template
-  community.aws.ec2_launch_template:
+  amazon.aws.ec2_launch_template:
     name: "my_template"
     image_id: "ami-04b762b4289fba92b"
     key_name: my_ssh_key

--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/positive.yaml
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Create an ec2 launch template
-  community.aws.ec2_launch_template:
+  amazon.aws.ec2_launch_template:
     name: "my_template"
     image_id: "ami-04b762b4289fba92b"
     key_name: my_ssh_key
@@ -7,7 +7,7 @@
     network_interfaces:
       associate_public_ip_address: true
 - name: start an instance with a public IP address
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: "public-compute-instance"
     key_name: "prod-ssh-key"
     vpc_subnet_id: subnet-5ca1ab1e

--- a/assets/queries/ansible/aws/ec2_instance_using_default_security_group/test/negative.yaml
+++ b/assets/queries/ansible/aws/ec2_instance_using_default_security_group/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Launch instance with custom SG
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: web-server
     key_name: mykey
     instance_type: t2.micro

--- a/assets/queries/ansible/aws/ec2_instance_using_default_security_group/test/positive1.yaml
+++ b/assets/queries/ansible/aws/ec2_instance_using_default_security_group/test/positive1.yaml
@@ -1,5 +1,5 @@
 - name: Launch instance with default SG
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: web-server
     key_name: mykey
     instance_type: t2.micro

--- a/assets/queries/ansible/aws/ec2_instance_using_default_security_group/test/positive2.yaml
+++ b/assets/queries/ansible/aws/ec2_instance_using_default_security_group/test/positive2.yaml
@@ -1,5 +1,5 @@
 - name: Launch instance with default SG in list
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: web-server-2
     key_name: mykey
     instance_type: t2.micro

--- a/assets/queries/ansible/aws/ec2_instance_using_default_vpc/test/negative.yaml
+++ b/assets/queries/ansible/aws/ec2_instance_using_default_vpc/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Launch instance in subnet from custom VPC
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: db-instance
     key_name: mykey
     instance_type: t2.micro

--- a/assets/queries/ansible/aws/ec2_instance_using_default_vpc/test/positive.yaml
+++ b/assets/queries/ansible/aws/ec2_instance_using_default_vpc/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Launch instance in subnet from default VPC
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: db-instance
     key_name: mykey
     instance_type: t2.micro

--- a/assets/queries/ansible/aws/ec2_not_ebs_optimized/test/negative1.yaml
+++ b/assets/queries/ansible/aws/ec2_not_ebs_optimized/test/negative1.yaml
@@ -1,5 +1,5 @@
 - name: Launch with ebs_optimized true
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: app-server
     key_name: mykey
     instance_type: t2.micro

--- a/assets/queries/ansible/aws/ec2_not_ebs_optimized/test/negative2.yaml
+++ b/assets/queries/ansible/aws/ec2_not_ebs_optimized/test/negative2.yaml
@@ -1,5 +1,5 @@
 - name: Launch instance type EBS-optimized by default
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: app-server
     key_name: mykey
     instance_type: m5.large

--- a/assets/queries/ansible/aws/ec2_not_ebs_optimized/test/negative3.yaml
+++ b/assets/queries/ansible/aws/ec2_not_ebs_optimized/test/negative3.yaml
@@ -1,5 +1,5 @@
 - name: Launch EBS-optimized type with false
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: app-server
     key_name: mykey
     instance_type: m5.large

--- a/assets/queries/ansible/aws/ec2_not_ebs_optimized/test/positive1.yaml
+++ b/assets/queries/ansible/aws/ec2_not_ebs_optimized/test/positive1.yaml
@@ -1,5 +1,5 @@
 - name: Launch t2.micro without ebs_optimized
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: app-server
     key_name: mykey
     instance_type: t2.micro

--- a/assets/queries/ansible/aws/ec2_not_ebs_optimized/test/positive2.yaml
+++ b/assets/queries/ansible/aws/ec2_not_ebs_optimized/test/positive2.yaml
@@ -1,5 +1,5 @@
 - name: Launch t2.micro with ebs_optimized false
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: app-server-2
     key_name: mykey
     instance_type: t2.micro

--- a/assets/queries/ansible/aws/ec2_not_ebs_optimized/test/positive3.yaml
+++ b/assets/queries/ansible/aws/ec2_not_ebs_optimized/test/positive3.yaml
@@ -1,5 +1,5 @@
 - name: Launch instance default type without ebs_optimized
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: app-server-3
     key_name: mykey
     image_id: ami-123456

--- a/assets/queries/ansible/aws/elb_using_insecure_protocols/test/negative.yaml
+++ b/assets/queries/ansible/aws/elb_using_insecure_protocols/test/negative.yaml
@@ -1,6 +1,6 @@
 #this code is a correct code for which the query should not find any result
 - name: elb1
-  community.aws.elb_application_lb:
+  amazon.aws.elb_application_lb:
     name: myelb1
     security_groups:
     - sg-12345678

--- a/assets/queries/ansible/aws/elb_using_insecure_protocols/test/positive.yaml
+++ b/assets/queries/ansible/aws/elb_using_insecure_protocols/test/positive.yaml
@@ -1,6 +1,6 @@
 #this is a problematic code where the query should report a result(s)
 - name: elb1
-  community.aws.elb_application_lb:
+  amazon.aws.elb_application_lb:
     name: myelb1
     security_groups:
       - sg-12345678
@@ -10,7 +10,7 @@
       - subnet-abcdef000
     state: present
 - name: elb2
-  community.aws.elb_application_lb:
+  amazon.aws.elb_application_lb:
     name: myelb2
     security_groups:
       - sg-12345678
@@ -29,7 +29,7 @@
             TargetGroupName: # Required. The name of the target group
     state: present
 - name: elb3
-  community.aws.elb_application_lb:
+  amazon.aws.elb_application_lb:
     name: myelb3
     security_groups:
       - sg-12345678

--- a/assets/queries/ansible/aws/elb_using_weak_ciphers/test/negative.yaml
+++ b/assets/queries/ansible/aws/elb_using_weak_ciphers/test/negative.yaml
@@ -1,6 +1,6 @@
 #this code is a correct code for which the query should not find any result
 - name: elb1
-  community.aws.elb_application_lb:
+  amazon.aws.elb_application_lb:
     name: myelb1
     security_groups:
     - sg-12345678

--- a/assets/queries/ansible/aws/elb_using_weak_ciphers/test/positive.yaml
+++ b/assets/queries/ansible/aws/elb_using_weak_ciphers/test/positive.yaml
@@ -1,6 +1,6 @@
 #this is a problematic code where the query should report a result(s)
 - name: elb1
-  community.aws.elb_application_lb:
+  amazon.aws.elb_application_lb:
     name: myelb1
     security_groups:
       - sg-12345678
@@ -10,7 +10,7 @@
       - subnet-abcdef000
     state: present
 - name: elb2
-  community.aws.elb_application_lb:
+  amazon.aws.elb_application_lb:
     name: myelb2
     security_groups:
       - sg-12345678
@@ -29,7 +29,7 @@
             TargetGroupName: # Required. The name of the target group
     state: present
 - name: elb3
-  community.aws.elb_application_lb:
+  amazon.aws.elb_application_lb:
     name: myelb3
     security_groups:
       - sg-12345678

--- a/assets/queries/ansible/aws/hardcoded_aws_access_key/test/negative.yaml
+++ b/assets/queries/ansible/aws/hardcoded_aws_access_key/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: start an instance with a cpu_options
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: public-cpuoption-instance
     vpc_subnet_id: subnet-5ca1ab1e
     tags:

--- a/assets/queries/ansible/aws/hardcoded_aws_access_key/test/positive.yaml
+++ b/assets/queries/ansible/aws/hardcoded_aws_access_key/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: start an instance with a cpu_options
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: "public-cpuoption-instance"
     vpc_subnet_id: subnet-5ca1ab1e
     tags:

--- a/assets/queries/ansible/aws/hardcoded_aws_access_key_in_lambda/test/negative.yaml
+++ b/assets/queries/ansible/aws/hardcoded_aws_access_key_in_lambda/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: looped creation
-  community.aws.lambda:
+  amazon.aws.lambda:
     name: '{{ item.name }}'
     state: present
     zip_file: '{{ item.zip_file }}'
@@ -27,7 +27,7 @@
           key1: '1'
           key2: '2'
 - name: remove tags
-  community.aws.lambda:
+  amazon.aws.lambda:
     name: Lambda function
     state: present
     zip_file: code.zip
@@ -36,7 +36,7 @@
     handler: hello_python.my_handler
     tags: {}
 - name: Delete Lambda functions HelloWorld and ByeBye
-  community.aws.lambda:
+  amazon.aws.lambda:
     name: '{{ item }}'
     state: absent
     loop:

--- a/assets/queries/ansible/aws/hardcoded_aws_access_key_in_lambda/test/positive.yaml
+++ b/assets/queries/ansible/aws/hardcoded_aws_access_key_in_lambda/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: looped creation
-  community.aws.lambda:
+  amazon.aws.lambda:
     aws_access_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
     name: '{{ item.name }}'
     state: present
@@ -28,7 +28,7 @@
           key1: "1"
           key2: "2"
 - name: remove tags
-  community.aws.lambda:
+  amazon.aws.lambda:
     aws_access_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
     name: 'Lambda function'
     state: present
@@ -38,7 +38,7 @@
     handler: 'hello_python.my_handler'
     tags: {}
 - name: Delete Lambda functions HelloWorld and ByeBye
-  community.aws.lambda:
+  amazon.aws.lambda:
     name: '{{ item }}'
     state: absent
     loop:

--- a/assets/queries/ansible/aws/iam_access_key_is_exposed/test/negative.yaml
+++ b/assets/queries/ansible/aws/iam_access_key_is_exposed/test/negative.yaml
@@ -1,17 +1,17 @@
 # Root user with active key (covered by root_account_has_active_access_keys)
 - name: Create root access key
-  community.aws.iam_access_key:
+  amazon.aws.iam_access_key:
     user_name: root
     state: present
 
 # Non-root user with inactive key
 - name: Create inactive access key
-  community.aws.iam_access_key:
+  amazon.aws.iam_access_key:
     user_name: jcleese
     active: false
 
 # Non-root user with absent state
 - name: Remove access key
-  community.aws.iam_access_key:
+  amazon.aws.iam_access_key:
     user_name: jdavila
     state: absent

--- a/assets/queries/ansible/aws/iam_access_key_is_exposed/test/positive.yaml
+++ b/assets/queries/ansible/aws/iam_access_key_is_exposed/test/positive.yaml
@@ -1,8 +1,8 @@
 - name: Create non-root user with active access key
-  community.aws.iam_access_key:
+  amazon.aws.iam_access_key:
     user_name: jcleese
     state: present
 - name: Create another non-root user with active access key
-  community.aws.iam_access_key:
+  amazon.aws.iam_access_key:
     user_name: mpython
     state: present

--- a/assets/queries/ansible/aws/iam_database_auth_not_enabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/iam_database_auth_not_enabled/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small
@@ -10,7 +10,7 @@
 
 
 - name: Create a DB instance using the default AWS KMS encryption key
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: test-encrypted-db
     id: test-encrypted-db
     state: present
@@ -23,7 +23,7 @@
     enable_iam_database_authentication: true
 
 - name: remove the DB instance without a final snapshot
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: test-db-remove-1
     id: '{{ instance_id }}'
     state: absent
@@ -31,7 +31,7 @@
     enable_iam_database_authentication: true
 
 - name: remove the DB instance with a final snapshot
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: test-db-remove-2
     id: '{{ instance_id }}'
     state: absent
@@ -39,7 +39,7 @@
     enable_iam_database_authentication: true
 
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small
@@ -49,7 +49,7 @@
     enable_iam_database_authentication: "No"
 
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: mariadb
     engine_version: 10.2.43
     db_instance_identifier: ansible-test-aurora-db-instance

--- a/assets/queries/ansible/aws/iam_database_auth_not_enabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/iam_database_auth_not_enabled/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: mysql
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small
@@ -10,7 +10,7 @@
 
 
 - name: Create a DB instance using the default AWS KMS encryption key
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: test-encrypted-db
     id: test-encrypted-db
     state: present

--- a/assets/queries/ansible/aws/iam_password_without_minimum_length/test/negative.yaml
+++ b/assets/queries/ansible/aws/iam_password_without_minimum_length/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Password policy for AWS account
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false
@@ -12,7 +12,7 @@
     pw_expire: false
 
 - name: aws_iam_account_password_policy
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     minimum_password_length: 8
     require_symbols: false

--- a/assets/queries/ansible/aws/iam_password_without_minimum_length/test/positive.yaml
+++ b/assets/queries/ansible/aws/iam_password_without_minimum_length/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Password policy for AWS account
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     require_symbols: false
     require_numbers: true
@@ -11,7 +11,7 @@
     pw_expire: false
 
 - name: aws_iam_account_password_policy
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 3
     require_symbols: false
@@ -24,7 +24,7 @@
     pw_expire: false
 
 - name: aws_iam_account_password_policy_2
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     minimum_password_length: 3
     require_symbols: false

--- a/assets/queries/ansible/aws/iam_policies_attached_to_user/test/negative.yaml
+++ b/assets/queries/ansible/aws/iam_policies_attached_to_user/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Assign a policy called Admin to the administrators group
-  community.aws.iam_policy:
+  amazon.aws.iam_policy:
     iam_type: group
     iam_name: administrators
     policy_name: Admin

--- a/assets/queries/ansible/aws/iam_policies_attached_to_user/test/positive.yaml
+++ b/assets/queries/ansible/aws/iam_policies_attached_to_user/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Assign a policy called Admin to user
-  community.aws.iam_policy:
+  amazon.aws.iam_policy:
     iam_type: user
     iam_name: administrators
     policy_name: Admin

--- a/assets/queries/ansible/aws/iam_policies_with_full_privileges/test/negative.yaml
+++ b/assets/queries/ansible/aws/iam_policies_with_full_privileges/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Create IAM Managed Policy
-  community.aws.iam_managed_policy:
+  amazon.aws.iam_managed_policy:
     name: my-iam-policy
     policy_name: ManagedPolicy
     policy:

--- a/assets/queries/ansible/aws/iam_policies_with_full_privileges/test/positive.yaml
+++ b/assets/queries/ansible/aws/iam_policies_with_full_privileges/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Create IAM Managed Policy
-  community.aws.iam_managed_policy:
+  amazon.aws.iam_managed_policy:
     name: my-iam-policy
     policy_name: "ManagedPolicy"
     policy:

--- a/assets/queries/ansible/aws/iam_policy_grants_assumerole_permission_across_all_services/test/negative.yaml
+++ b/assets/queries/ansible/aws/iam_policy_grants_assumerole_permission_across_all_services/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Create IAM Managed Policy
-  community.aws.iam_managed_policy:
+  amazon.aws.iam_managed_policy:
     name: my-iam-policy
     policy_name: ManagedPolicy
     policy:

--- a/assets/queries/ansible/aws/iam_policy_grants_assumerole_permission_across_all_services/test/positive.yaml
+++ b/assets/queries/ansible/aws/iam_policy_grants_assumerole_permission_across_all_services/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Create IAM Managed Policy
-  community.aws.iam_managed_policy:
+  amazon.aws.iam_managed_policy:
     name: my-iam-policy
     policy_name: "ManagedPolicy"
     policy:

--- a/assets/queries/ansible/aws/iam_policy_grants_full_permissions/test/negative.yaml
+++ b/assets/queries/ansible/aws/iam_policy_grants_full_permissions/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Create IAM Managed Policy
-  community.aws.iam_managed_policy:
+  amazon.aws.iam_managed_policy:
     name: my-iam-policy
     policy_name: ManagedPolicy
     policy:

--- a/assets/queries/ansible/aws/iam_policy_grants_full_permissions/test/negative2.yaml
+++ b/assets/queries/ansible/aws/iam_policy_grants_full_permissions/test/negative2.yaml
@@ -1,5 +1,5 @@
 - name: Create IAM Managed Policy
-  community.aws.iam_managed_policy:
+  amazon.aws.iam_managed_policy:
     name: my-iam-policy
     policy_name: ManagedPolicy
     policy:

--- a/assets/queries/ansible/aws/iam_policy_grants_full_permissions/test/positive.yaml
+++ b/assets/queries/ansible/aws/iam_policy_grants_full_permissions/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Create IAM Managed Policy
-  community.aws.iam_managed_policy:
+  amazon.aws.iam_managed_policy:
     name: my-iam-policy
     policy_name: "ManagedPolicy"
     policy:

--- a/assets/queries/ansible/aws/iam_role_allows_all_principals_to_assume/test/negative.yaml
+++ b/assets/queries/ansible/aws/iam_role_allows_all_principals_to_assume/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Create IAM Managed Policy
-  community.aws.iam_managed_policy:
+  amazon.aws.iam_managed_policy:
     name: my-iam-policy
     policy_name: ManagedPolicy
     policy:

--- a/assets/queries/ansible/aws/iam_role_allows_all_principals_to_assume/test/positive.yaml
+++ b/assets/queries/ansible/aws/iam_role_allows_all_principals_to_assume/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Create IAM Managed Policy
-  community.aws.iam_managed_policy:
+  amazon.aws.iam_managed_policy:
     name: my-iam-policy
     policy_name: "ManagedPolicy"
     policy:
@@ -13,7 +13,7 @@
     make_default: false
     state: present
 - name: Create2 IAM Managed Policy
-  community.aws.iam_managed_policy:
+  amazon.aws.iam_managed_policy:
     name: my-iam-policy2
     policy_name: "ManagedPolicy2"
     policy: >

--- a/assets/queries/ansible/aws/instance_uses_metadata_service_IMDSv1/test/negative.yaml
+++ b/assets/queries/ansible/aws/instance_uses_metadata_service_IMDSv1/test/negative.yaml
@@ -11,7 +11,7 @@
       http_tokens: required
 
 - name: start an instance with legacy naming and metadata options
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: "public-metadataoptions-instance"
     vpc_subnet_id: subnet-5calable
     instance_type: t3.small

--- a/assets/queries/ansible/aws/instance_uses_metadata_service_IMDSv1/test/positive.yaml
+++ b/assets/queries/ansible/aws/instance_uses_metadata_service_IMDSv1/test/positive.yaml
@@ -10,7 +10,7 @@
       http_tokens: optional
 
 - name: start an instance with legacy naming and metadata options
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: "public-metadataoptions-instance-legacy"
     vpc_subnet_id: subnet-5calable
     instance_type: t3.small

--- a/assets/queries/ansible/aws/instance_with_no_vpc/test/negative.yaml
+++ b/assets/queries/ansible/aws/instance_with_no_vpc/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Start an instance and have it begin a Tower callback on boot v3
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: tower-callback-test
     key_name: prod-ssh-key
     vpc_subnet_id: subnet-5ca1ab1e

--- a/assets/queries/ansible/aws/instance_with_no_vpc/test/positive.yaml
+++ b/assets/queries/ansible/aws/instance_with_no_vpc/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Start an instance and have it begin a Tower callback on boot
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: "tower-callback-test"
     key_name: "prod-ssh-key"
     security_group: default

--- a/assets/queries/ansible/aws/kms_key_with_full_permissions/test/negative.yaml
+++ b/assets/queries/ansible/aws/kms_key_with_full_permissions/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Update IAM policy on an existing KMS key
-  community.aws.aws_kms:
+  amazon.aws.kms_key:
     alias: my-kms-key
     policy: |
       { Id: auto-ebs-2, Statement: [{Action: [kms:Encrypt, kms:Decrypt, kms:ReEncrypt*,

--- a/assets/queries/ansible/aws/kms_key_with_full_permissions/test/positive.yaml
+++ b/assets/queries/ansible/aws/kms_key_with_full_permissions/test/positive.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Update IAM policy on an existing KMS key
-  community.aws.aws_kms:
+  amazon.aws.kms_key:
     alias: my-kms-key
     policy: {'Id': 'auto-ebs-2', 'Statement': [{'Action': ['kms:*'], 'Effect': 'Allow', 'Principal': {'AWS': '*'}, 'Resource': '*', 'Sid': 'Allow access through EBS for all principals in the account that are authorized to use EBS'}, {'Action': ['kms:Describe*', 'kms:Get*', 'kms:List*', 'kms:RevokeGrant'], 'Effect': 'Allow', 'Principal': {'AWS': 'arn:aws:iam::111111111111:root'}, 'Resource': '*', 'Sid': 'Allow direct access to key metadata to the account'}], 'Version': '2012-10-17'}
     state: present

--- a/assets/queries/ansible/aws/kms_key_with_full_permissions/test/positive2.yaml
+++ b/assets/queries/ansible/aws/kms_key_with_full_permissions/test/positive2.yaml
@@ -1,5 +1,5 @@
 ---
 - name: Update IAM policy on an existing KMS key2
-  community.aws.aws_kms:
+  amazon.aws.kms_key:
     alias: my-kms-key
     state: present

--- a/assets/queries/ansible/aws/lambda_function_without_tags/test/negative.yaml
+++ b/assets/queries/ansible/aws/lambda_function_without_tags/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: add tags
-  community.aws.lambda:
+  amazon.aws.lambda:
     name: 'Lambda function'
     state: present
     zip_file: 'code.zip'

--- a/assets/queries/ansible/aws/lambda_function_without_tags/test/positive.yaml
+++ b/assets/queries/ansible/aws/lambda_function_without_tags/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: add tags
-  community.aws.lambda:
+  amazon.aws.lambda:
     name: 'Lambda function'
     state: present
     zip_file: 'code.zip'

--- a/assets/queries/ansible/aws/lambda_functions_without_x-ray_tracing/test/negative.yaml
+++ b/assets/queries/ansible/aws/lambda_functions_without_x-ray_tracing/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: looped creation V3
-  community.aws.lambda:
+  amazon.aws.lambda:
     name: '{{ item.name }}'
     state: present
     zip_file: '{{ item.zip_file }}'

--- a/assets/queries/ansible/aws/lambda_functions_without_x-ray_tracing/test/positive.yaml
+++ b/assets/queries/ansible/aws/lambda_functions_without_x-ray_tracing/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: looped creation
-  community.aws.lambda:
+  amazon.aws.lambda:
     name: '{{ item.name }}'
     state: present
     zip_file: '{{ item.zip_file }}'
@@ -27,7 +27,7 @@
       key1: "1"
       key2: "2"
 - name: looped creation V2
-  community.aws.lambda:
+  amazon.aws.lambda:
     name: '{{ item.name }}'
     state: present
     zip_file: '{{ item.zip_file }}'

--- a/assets/queries/ansible/aws/lambda_permission_misconfigured/test/negative.yaml
+++ b/assets/queries/ansible/aws/lambda_permission_misconfigured/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Lambda S3 notification negative
-  community.aws.lambda_policy:
+  amazon.aws.lambda_policy:
     state: present
     function_name: functionName
     alias: Dev

--- a/assets/queries/ansible/aws/lambda_permission_misconfigured/test/positive.yaml
+++ b/assets/queries/ansible/aws/lambda_permission_misconfigured/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Lambda S3 notification positive
-  community.aws.lambda_policy:
+  amazon.aws.lambda_policy:
     state: present
     function_name: functionName
     alias: Dev

--- a/assets/queries/ansible/aws/lambda_permission_principal_is_wildcard/test/negative.yaml
+++ b/assets/queries/ansible/aws/lambda_permission_principal_is_wildcard/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Lambda S3 event notification negative
-  community.aws.lambda_policy:
+  amazon.aws.lambda_policy:
     state: present
     function_name: functionName
     alias: Dev

--- a/assets/queries/ansible/aws/lambda_permission_principal_is_wildcard/test/positive.yaml
+++ b/assets/queries/ansible/aws/lambda_permission_principal_is_wildcard/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Lambda S3 event notification
-  community.aws.lambda_policy:
+  amazon.aws.lambda_policy:
     state: present
     function_name: functionName
     alias: Dev

--- a/assets/queries/ansible/aws/launch_configuration_is_not_encrypted/test/negative.yaml
+++ b/assets/queries/ansible/aws/launch_configuration_is_not_encrypted/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: note that encrypted volumes are only supported in >= Ansible 2.4 v4
-  ec2_lc:
+  community.aws.autoscaling_launch_config:
     name: special
     image_id: ami-XXX
     key_name: default
@@ -13,7 +13,7 @@
       delete_on_termination: true
       encrypted: yes
 - name: note that encrypted volumes are only supported in >= Ansible 2.4 v5
-  community.aws.ec2_lc:
+  community.aws.autoscaling_launch_config:
     name: special
     image_id: ami-XXX
     key_name: default

--- a/assets/queries/ansible/aws/launch_configuration_is_not_encrypted/test/positive.yaml
+++ b/assets/queries/ansible/aws/launch_configuration_is_not_encrypted/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: note that encrypted volumes are only supported in >= Ansible 2.4
-  community.aws.ec2_lc:
+  community.aws.autoscaling_launch_config:
     name: special
     image_id: ami-XXX
     key_name: default
@@ -13,7 +13,7 @@
       delete_on_termination: true
       encrypted: no
 - name: note that encrypted volumes are only supported in >= Ansible 2.4 v2
-  ec2_lc:
+  community.aws.autoscaling_launch_config:
     name: special
     image_id: ami-XXX
     key_name: default
@@ -26,7 +26,7 @@
       iops: 3000
       delete_on_termination: true
 - name: note that encrypted volumes are only supported in >= Ansible 2.4 v3
-  ec2_lc:
+  community.aws.autoscaling_launch_config:
     name: special
     image_id: ami-XXX
     key_name: default

--- a/assets/queries/ansible/aws/misconfigured_password_policy_expiration/test/negative.yaml
+++ b/assets/queries/ansible/aws/misconfigured_password_policy_expiration/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Missing Password policy for AWS account
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false

--- a/assets/queries/ansible/aws/misconfigured_password_policy_expiration/test/positive.yaml
+++ b/assets/queries/ansible/aws/misconfigured_password_policy_expiration/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: Missing Password policy for AWS account
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false
@@ -10,7 +10,7 @@
     pw_reuse_prevent: 5
     pw_expire: false
 - name: Extreme Password policy for AWS account
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false
@@ -22,7 +22,7 @@
     pw_reuse_prevent: 5
     pw_expire: false
 - name: Alias extreme Password policy for AWS account
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false

--- a/assets/queries/ansible/aws/password_without_reuse_prevention/test/negative.yaml
+++ b/assets/queries/ansible/aws/password_without_reuse_prevention/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Password policy for AWS account
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false
@@ -11,7 +11,7 @@
     pw_reuse_prevent: 5
     pw_expire: false
 - name: Password policy for AWS account2
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false
@@ -23,7 +23,7 @@
     password_reuse_prevent: 5
     pw_expire: false
 - name: Password policy for AWS account3
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false

--- a/assets/queries/ansible/aws/password_without_reuse_prevention/test/positive.yaml
+++ b/assets/queries/ansible/aws/password_without_reuse_prevention/test/positive.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Password policy for AWS account
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false
@@ -11,7 +11,7 @@
     pw_max_age: 60
     pw_expire: false
 - name: Password policy for AWS account2
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false
@@ -23,7 +23,7 @@
     password_reuse_prevent: 0
     pw_expire: false
 - name: Password policy for AWS account3
-  community.aws.iam_password_policy:
+  amazon.aws.iam_password_policy:
     state: present
     min_pw_length: 8
     require_symbols: false

--- a/assets/queries/ansible/aws/rds_associated_with_public_subnet/test/negative.yaml
+++ b/assets/queries/ansible/aws/rds_associated_with_public_subnet/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group2
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small
@@ -8,7 +8,7 @@
     cluster_id: ansible-test-cluster
     db_subnet_group_name: my_subnet_group2
 - name: Add or change a subnet group2
-  community.aws.rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
     name: my_subnet_group2
     description: My Fancy Ex Parrot Subnet Group

--- a/assets/queries/ansible/aws/rds_associated_with_public_subnet/test/positive.yaml
+++ b/assets/queries/ansible/aws/rds_associated_with_public_subnet/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small
@@ -8,7 +8,7 @@
     cluster_id: ansible-test-cluster
     db_subnet_group_name: my_subnet_group
 - name: Add or change a subnet group
-  community.aws.rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
     name: my_subnet_group
     description: My Fancy Ex Parrot Subnet Group

--- a/assets/queries/ansible/aws/rds_db_instance_publicly_accessible/test/negative.yaml
+++ b/assets/queries/ansible/aws/rds_db_instance_publicly_accessible/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: create RDS instance in default VPC and default subnet group02
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/rds_db_instance_publicly_accessible/test/positive.yaml
+++ b/assets/queries/ansible/aws/rds_db_instance_publicly_accessible/test/positive.yaml
@@ -1,6 +1,6 @@
 ---
 - name: community - Create a DB instance using the default AWS KMS encryption key
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: my-db-1
     id: test-encrypted-db
     state: present
@@ -12,7 +12,7 @@
     allocated_storage: "{{ allocated_storage }}"
     publicly_accessible: Yes
 - name: community - Basic mysql provisioning example
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     db_instance_identifier: my-db-2
     command: create
     instance_name: new-database

--- a/assets/queries/ansible/aws/rds_using_default_port/test/negative1.yaml
+++ b/assets/queries/ansible/aws/rds_using_default_port/test/negative1.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/rds_using_default_port/test/negative2.yaml
+++ b/assets/queries/ansible/aws/rds_using_default_port/test/negative2.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group2
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: postgres
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/rds_using_default_port/test/negative3.yaml
+++ b/assets/queries/ansible/aws/rds_using_default_port/test/negative3.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group2
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: oracle-ee
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/rds_using_default_port/test/negative4.yaml
+++ b/assets/queries/ansible/aws/rds_using_default_port/test/negative4.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group2
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: sqlserver-ee
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/rds_using_default_port/test/positive1.yaml
+++ b/assets/queries/ansible/aws/rds_using_default_port/test/positive1.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/rds_using_default_port/test/positive2.yaml
+++ b/assets/queries/ansible/aws/rds_using_default_port/test/positive2.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group2
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: postgres
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/rds_using_default_port/test/positive3.yaml
+++ b/assets/queries/ansible/aws/rds_using_default_port/test/positive3.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group2
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: oracle-ee
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/rds_using_default_port/test/positive4.yaml
+++ b/assets/queries/ansible/aws/rds_using_default_port/test/positive4.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group2
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: sqlserver-ee
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/rds_with_backup_disabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/rds_with_backup_disabled/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small
@@ -8,7 +8,7 @@
     cluster_id: ansible-test-cluster  # This cluster must exist - see rds_cluster to manage it
     backup_retention_period: 5
 - name: create minimal aurora instance in default VPC and default subnet group2
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/rds_with_backup_disabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/rds_with_backup_disabled/test/positive.yaml
@@ -1,6 +1,6 @@
 ---
 - name: create minimal aurora instance in default VPC and default subnet group
-  community.aws.rds_instance:
+  amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
     instance_type: db.t2.small

--- a/assets/queries/ansible/aws/root_account_has_active_access_keys/test/negative.yaml
+++ b/assets/queries/ansible/aws/root_account_has_active_access_keys/test/negative.yaml
@@ -1,5 +1,5 @@
 #this code is a correct code for which the query should not find any result
 - name: Create root access key but inactive
-  community.aws.iam_access_key:
+  amazon.aws.iam_access_key:
     user_name: root
     active: false

--- a/assets/queries/ansible/aws/root_account_has_active_access_keys/test/positive.yaml
+++ b/assets/queries/ansible/aws/root_account_has_active_access_keys/test/positive.yaml
@@ -1,5 +1,5 @@
 #this is a problematic code where the query should report a result(s)
 - name: Create root access key
-  community.aws.iam_access_key:
+  amazon.aws.iam_access_key:
     user_name: root
     state: present

--- a/assets/queries/ansible/aws/route53_record_undefined/test/negative.yaml
+++ b/assets/queries/ansible/aws/route53_record_undefined/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: Use a routing policy to distribute traffic
-  community.aws.route53:
+  amazon.aws.route53:
     state: present
     zone: foo.com
     record: www.foo.com

--- a/assets/queries/ansible/aws/route53_record_undefined/test/positive.yaml
+++ b/assets/queries/ansible/aws/route53_record_undefined/test/positive.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Use a routing policy to distribute traffic02
-  community.aws.route53:
+  amazon.aws.route53:
     state: present
     zone: foo.com
     record: www.foo.com
@@ -11,7 +11,7 @@
     weight: 100
     health_check: "d994b780-3150-49fd-9205-356abdd42e75"
 - name: Use a routing policy to distribute traffic03
-  community.aws.route53:
+  amazon.aws.route53:
     state: present
     zone: foo.com
     record: www.foo.com

--- a/assets/queries/ansible/aws/s3_bucket_acl_allows_read_to_all_users/test/negative.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_acl_allows_read_to_all_users/test/negative.yaml
@@ -1,11 +1,11 @@
 - name: Create an empty bucket
-  amazon.aws.aws_s3:
+  amazon.aws.s3_object:
     bucket: mybucket
     object: my-object
     mode: create
     permission: private
 - name: Create an empty bucket2
-  amazon.aws.aws_s3:
+  amazon.aws.s3_object:
     bucket: mybucket
     object: my-object-2
     mode: create

--- a/assets/queries/ansible/aws/s3_bucket_acl_allows_read_to_all_users/test/positive.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_acl_allows_read_to_all_users/test/positive.yaml
@@ -1,12 +1,12 @@
 ---
 - name: Create an empty bucket
-  amazon.aws.aws_s3:
+  amazon.aws.s3_object:
     bucket: mybucket
     object: my-object
     mode: create
     permission: public-read
 - name: Create an empty bucket2
-  amazon.aws.aws_s3:
+  amazon.aws.s3_object:
     bucket: mybucket
     object: my-object-2
     mode: create

--- a/assets/queries/ansible/aws/s3_bucket_acl_allows_read_to_any_authenticated_user/test/negative.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_acl_allows_read_to_any_authenticated_user/test/negative.yaml
@@ -1,10 +1,10 @@
 - name: Create an empty bucket
-  amazon.aws.aws_s3:
+  amazon.aws.s3_object:
     bucket: mybucket
     object: my-object
     mode: create
 - name: Create an empty bucket2
-  amazon.aws.aws_s3:
+  amazon.aws.s3_object:
     bucket: mybucket
     object: my-object-2
     mode: create

--- a/assets/queries/ansible/aws/s3_bucket_acl_allows_read_to_any_authenticated_user/test/positive.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_acl_allows_read_to_any_authenticated_user/test/positive.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Create an empty bucket2
-  amazon.aws.aws_s3:
+  amazon.aws.s3_object:
     bucket: mybucket
     object: my-object
     mode: create

--- a/assets/queries/ansible/aws/s3_bucket_with_public_access/test/negative.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_public_access/test/negative.yaml
@@ -1,11 +1,11 @@
 - name: Create an empty bucket
-  amazon.aws.aws_s3:
+  amazon.aws.s3_object:
     bucket: mybucket
     object: my-object
     mode: create
     permission: private
 - name: Create an empty bucket 02
-  amazon.aws.aws_s3:
+  amazon.aws.s3_object:
     bucket: mybucket
     object: my-object-2
     mode: create

--- a/assets/queries/ansible/aws/s3_bucket_with_public_access/test/positive.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_public_access/test/positive.yaml
@@ -1,12 +1,12 @@
 ---
 - name: Create an empty bucket
-  amazon.aws.aws_s3:
+  amazon.aws.s3_object:
     bucket: mybucket
     object: my-object
     mode: create
     permission: public-read
 - name: Create an empty bucket 01
-  amazon.aws.aws_s3:
+  amazon.aws.s3_object:
     bucket: mybucket 01
     object: my-object-2
     mode: create

--- a/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/negative1.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/negative1.yaml
@@ -1,5 +1,5 @@
 - name: Create s3 bucket
-  community.aws.aws_s3_cors:
+  community.aws.s3_cors:
     name: mys3bucket3
     state: present
     rules:

--- a/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/negative2.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/negative2.yaml
@@ -1,5 +1,5 @@
 - name: Create s3 bucket1
-  aws_s3_cors:
+  community.aws.s3_cors:
     name: mys3bucket4
     state: present
     rules:

--- a/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/positive1.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/positive1.yaml
@@ -1,5 +1,5 @@
 - name: Create s3 bucket2
-  community.aws.aws_s3_cors:
+  community.aws.s3_cors:
     name: mys3bucket
     state: present
     rules:

--- a/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/positive2.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/positive2.yaml
@@ -1,5 +1,5 @@
 - name: Create s3 bucket4
-  aws_s3_cors:
+  community.aws.s3_cors:
     name: mys3bucket2
     state: present
     rules:

--- a/assets/queries/ansible/aws/ses_policy_with_allowed_iam_actions/test/negative.yaml
+++ b/assets/queries/ansible/aws/ses_policy_with_allowed_iam_actions/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: add sending authorization policy to email identity2
-  community.aws.aws_ses_identity_policy:
+  community.aws.ses_identity_policy:
     identity: example@example.com
     policy_name: ExamplePolicy
     policy: >

--- a/assets/queries/ansible/aws/ses_policy_with_allowed_iam_actions/test/positive.yaml
+++ b/assets/queries/ansible/aws/ses_policy_with_allowed_iam_actions/test/positive.yaml
@@ -1,5 +1,5 @@
 - name: add sending authorization policy to email identityyy
-  community.aws.aws_ses_identity_policy:
+  community.aws.ses_identity_policy:
     identity: example@example.com
     policy_name: ExamplePolicy
     policy: >

--- a/assets/queries/ansible/aws/user_data_contains_encoded_private_key/test/negative.yaml
+++ b/assets/queries/ansible/aws/user_data_contains_encoded_private_key/test/negative.yaml
@@ -1,5 +1,5 @@
 - name: note that encrypted volumes are only supported in >= Ansible 2.4
-  community.aws.ec2_lc:
+  community.aws.autoscaling_launch_config:
     name: special
     image_id: ami-XXX
     key_name: default
@@ -16,7 +16,7 @@
     - device_name: /dev/sdb
       ephemeral: ephemeral0
 - name: note that encrypted volumes are only supported in >= Ansible 2.4.2
-  community.aws.ec2_lc:
+  community.aws.autoscaling_launch_config:
     name: special2
     image_id: ami-XXX
     key_name: default

--- a/assets/queries/ansible/aws/user_data_contains_encoded_private_key/test/positive.yaml
+++ b/assets/queries/ansible/aws/user_data_contains_encoded_private_key/test/positive.yaml
@@ -1,6 +1,6 @@
 ---
 - name: note that encrypted volumes are only supported in >= Ansible 2.4
-  community.aws.ec2_lc:
+  community.aws.autoscaling_launch_config:
     name: special
     image_id: ami-XXX
     key_name: default


### PR DESCRIPTION
## Motivation

Ansible modules have undergone significant deprecations and collection migrations over the past few releases (e.g., `community.aws.*` → `amazon.aws.*`, old `aws_*` short names removed). Our Ansible rules were still referencing these outdated FQCNs in query logic, test fixtures, and documentation, causing inaccurate `resourceType` values in findings and misleading code examples for users, which we corrected in the previous PRs.

This PR brings the full Ansible rule set up to date with the current Ansible collection landscape for the tests.

## Changes

Update the regos' tests to use the most up to date modules according the Ansible documentation

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

CI should pass

## Additional Notes

I submit this contribution under the Apache-2.0 license.
