### PR TITLE
Add release for Intel Mac

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,7 @@ builds:
     binary: datadog-iac-scanner
     targets:
       - darwin_arm64
+      - darwin_amd64
       - linux_arm64
       - linux_amd64
       - windows_amd64


### PR DESCRIPTION
## Motivation

Apparently, some GH runners want to use it.

## Changes

Added the appropriate target to .goreleaser.yaml

## Author Checklist

- [X] I have reviewed my own PR.
- [X] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [X] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Ran goreleaser and checked that it produced the archive for the new target.

```
% goreleaser release --snapshot --clean
[...]
  • archives
    • archiving                                      name=dist/datadog-iac-scanner_windows_amd64.zip
    • archiving                                      name=dist/datadog-iac-scanner_linux_amd64.tar.gz
    • archiving                                      name=dist/datadog-iac-scanner_linux_arm64.tar.gz
    • archiving                                      name=dist/datadog-iac-scanner_darwin_amd64.tar.gz
    • archiving                                      name=dist/datadog-iac-scanner_darwin_arm64.tar.gz
```
