### PR TITLE
Fix Terraform CloudWatch resource name attribution

### DIFF
--- a/assets/queries/terraform/aws/cloudwatch_aws_config_configuration_changes_alarm_missing/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_aws_config_configuration_changes_alarm_missing/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
-import data.generic.common as commonLib
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
 
 expressionArr := [
 	{
@@ -34,24 +35,23 @@ expressionArr := [
 check_expression_missing(resName, filter, doc) {
 	alarm := doc.resource.aws_cloudwatch_metric_alarm[name]
 	contains(alarm.metric_name, resName)
-	count({x | exp := expressionArr[n]; commonLib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+	count({x | exp := expressionArr[n]; common_lib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
 }
 
 CxPolicy[result] {
 	doc := input.document[i]
-	resources := doc.resource.aws_cloudwatch_log_metric_filter
-
-	allPatternsCount := count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); x = filter])
-	count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); not check_expression_missing(path[0], filter, doc); x = filter]) == allPatternsCount
+	resource := doc.resource.aws_cloudwatch_log_metric_filter[resourceName]
+	filter := common_lib.json_unmarshal(resource.pattern)
+	not check_expression_missing(resourceName, filter, doc)
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_cloudwatch_log_metric_filter",
-		"resourceName": "unknown",
-		"searchKey": "resource",
+		"resourceName": tf_lib.get_resource_name(resource, resourceName),
+		"searchKey": sprintf("aws_cloudwatch_log_metric_filter[%s].pattern", [resourceName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { ($.eventSource = config.amazonaws.com) && (($.eventName=StopConfigurationRecorder)||($.eventName=DeleteDeliveryChannel)||($.eventName=PutDeliveryChannel)||($.eventName=PutConfigurationRecorder)) } and be associated an aws_cloudwatch_metric_alarm",
 		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { ($.eventSource = config.amazonaws.com) && (($.eventName=StopConfigurationRecorder)||($.eventName=DeleteDeliveryChannel)||($.eventName=PutDeliveryChannel)||($.eventName=PutConfigurationRecorder)) } or not associated with any aws_cloudwatch_metric_alarm",
-		"searchLine": commonLib.build_search_line([], []),
+		"searchLine": common_lib.build_search_line([], []),
 	}
 }

--- a/assets/queries/terraform/aws/cloudwatch_aws_config_configuration_changes_alarm_missing/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_aws_config_configuration_changes_alarm_missing/test/positive_expected_result.json
@@ -2,25 +2,25 @@
   {
     "queryName": "CloudWatch AWS Config configuration changes alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "CloudWatch AWS Config configuration changes alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "CloudWatch AWS Config configuration changes alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive3.tf"
   },
   {
     "queryName": "CloudWatch AWS Config configuration changes alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive4.tf"
   }
 ]

--- a/assets/queries/terraform/aws/cloudwatch_cloudtrail_configuration_changes_alarm_missing/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_cloudtrail_configuration_changes_alarm_missing/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
-import data.generic.common as commonLib
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
 
 expressionArr := [
 	{
@@ -31,28 +32,27 @@ expressionArr := [
 ]
 
 # { ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) }
-CxPolicy[result] {
-	doc := input.document[i]
-	resources := doc.resource.aws_cloudwatch_log_metric_filter
-	
-	allPatternsCount := count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); x = filter])
-	count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); not check_expression_missing(path[0], filter, doc); x = filter]) == allPatternsCount
-
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "aws_cloudwatch_log_metric_filter",
-		"resourceName": "unknown",
-		"searchKey": "resource",
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) } and be associated an aws_cloudwatch_metric_alarm",
-		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) } or not associated with any aws_cloudwatch_metric_alarm",
-		"searchLine": commonLib.build_search_line([], []),
-	}
-}
-
 check_expression_missing(resName, filter, doc) {
 	alarm := doc.resource.aws_cloudwatch_metric_alarm[name]
 	contains(alarm.metric_name, resName)
 
-	count({x | exp := expressionArr[n]; commonLib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+	count({x | exp := expressionArr[n]; common_lib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	resource := doc.resource.aws_cloudwatch_log_metric_filter[resourceName]
+	filter := common_lib.json_unmarshal(resource.pattern)
+	not check_expression_missing(resourceName, filter, doc)
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_cloudwatch_log_metric_filter",
+		"resourceName": tf_lib.get_resource_name(resource, resourceName),
+		"searchKey": sprintf("aws_cloudwatch_log_metric_filter[%s].pattern", [resourceName]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) } and be associated an aws_cloudwatch_metric_alarm",
+		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) } or not associated with any aws_cloudwatch_metric_alarm",
+		"searchLine": common_lib.build_search_line([], []),
+	}
 }

--- a/assets/queries/terraform/aws/cloudwatch_cloudtrail_configuration_changes_alarm_missing/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_cloudtrail_configuration_changes_alarm_missing/test/positive_expected_result.json
@@ -2,19 +2,19 @@
   {
     "queryName": "Cloudwatch CloudTrail configuration changes alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "Cloudwatch CloudTrail configuration changes alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "Cloudwatch CloudTrail configuration changes alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/cloudwatch_management_console_auth_failed_alarm_missing/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_management_console_auth_failed_alarm_missing/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
-import data.generic.common as commonLib
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
 
 expressionArr := [
 	{
@@ -20,24 +21,23 @@ check_expression_missing(resName, filter, doc) {
 	alarm := doc.resource.aws_cloudwatch_metric_alarm[name]
 	contains(alarm.metric_name, resName)
 	filter._kics_filter_expr._op == "&&"
-	count({x | exp := expressionArr[n]; commonLib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+	count({x | exp := expressionArr[n]; common_lib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
 }
 
 CxPolicy[result] {
 	doc := input.document[i]
-	resources := doc.resource.aws_cloudwatch_log_metric_filter
-
-	allPatternsCount := count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); x = filter])
-	count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); not check_expression_missing(path[0], filter, doc); x = filter]) == allPatternsCount
+	resource := doc.resource.aws_cloudwatch_log_metric_filter[resourceName]
+	filter := common_lib.json_unmarshal(resource.pattern)
+	not check_expression_missing(resourceName, filter, doc)
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_cloudwatch_log_metric_filter",
-		"resourceName": "unknown",
-		"searchKey": "resource",
+		"resourceName": tf_lib.get_resource_name(resource, resourceName),
+		"searchKey": sprintf("aws_cloudwatch_log_metric_filter[%s].pattern", [resourceName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { $.eventName = ConsoleLogin && $.errorMessage = \"Failed authentication\" } and be associated an aws_cloudwatch_metric_alarm",
 		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { $.eventName = ConsoleLogin && $.errorMessage = \"Failed authentication\" } or not associated with any aws_cloudwatch_metric_alarm",
-		"searchLine": commonLib.build_search_line([], []),
+		"searchLine": common_lib.build_search_line([], []),
 	}
 }

--- a/assets/queries/terraform/aws/cloudwatch_management_console_auth_failed_alarm_missing/test/negative1.tf
+++ b/assets/queries/terraform/aws/cloudwatch_management_console_auth_failed_alarm_missing/test/negative1.tf
@@ -22,29 +22,3 @@ resource "aws_cloudwatch_metric_alarm" "cis_console_authn_failure_cw_alarm" {
   alarm_actions             = [aws_sns_topic.CIS_Alerts_SNS_Topic.arn]
   insufficient_data_actions = []
 }
-
-resource "aws_cloudwatch_log_metric_filter" "cis_no_mfa_console_signin_metric_filter" {
-  name           = "CIS-ConsoleSigninWithoutMFA"
-  pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"
-  log_group_name = aws_cloudwatch_log_group.CIS_CloudWatch_LogsGroup.name
-
-  metric_transformation {
-    name      = "CIS-ConsoleSigninWithoutMFA"
-    namespace = "CIS_Metric_Alarm_Namespace"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "cis_no_mfa_console_signin_cw_alarm" {
-  alarm_name                = "CIS-3.2-ConsoleSigninWithoutMFA"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
-  metric_name               = aws_cloudwatch_log_metric_filter.cis_no_mfa_console_signin_metric_filter.id
-  namespace                 = "CIS_Metric_Alarm_Namespace"
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  alarm_description         = "Monitoring for single-factor console logins will increase visibility into accounts that are not protected by MFA."
-  alarm_actions             = ["aws_sns_topic.CIS_Alerts_SNS_Topic.arn"]
-  insufficient_data_actions = []
-}

--- a/assets/queries/terraform/aws/cloudwatch_management_console_auth_failed_alarm_missing/test/positive1.tf
+++ b/assets/queries/terraform/aws/cloudwatch_management_console_auth_failed_alarm_missing/test/positive1.tf
@@ -22,29 +22,3 @@ resource "aws_cloudwatch_metric_alarm" "cis_console_authn_failure_cw_alarm" {
   alarm_actions             = [aws_sns_topic.CIS_Alerts_SNS_Topic.arn]
   insufficient_data_actions = []
 }
-
-resource "aws_cloudwatch_log_metric_filter" "cis_no_mfa_console_signin_metric_filter" {
-  name           = "CIS-ConsoleSigninWithoutMFA"
-  pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"
-  log_group_name = aws_cloudwatch_log_group.CIS_CloudWatch_LogsGroup.name
-
-  metric_transformation {
-    name      = "CIS-ConsoleSigninWithoutMFA"
-    namespace = "CIS_Metric_Alarm_Namespace"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "cis_no_mfa_console_signin_cw_alarm" {
-  alarm_name                = "CIS-3.2-ConsoleSigninWithoutMFA"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
-  metric_name               = aws_cloudwatch_log_metric_filter.cis_no_mfa_console_signin_metric_filter.id
-  namespace                 = "CIS_Metric_Alarm_Namespace"
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  alarm_description         = "Monitoring for single-factor console logins will increase visibility into accounts that are not protected by MFA."
-  alarm_actions             = [aws_sns_topic.CIS_Alerts_SNS_Topic.arn]
-  insufficient_data_actions = []
-}

--- a/assets/queries/terraform/aws/cloudwatch_management_console_auth_failed_alarm_missing/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_management_console_auth_failed_alarm_missing/test/positive_expected_result.json
@@ -2,25 +2,25 @@
   {
     "queryName": "CloudWatch management console auth failed alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "CloudWatch management console auth failed alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "CloudWatch management console auth failed alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive3.tf"
   },
   {
     "queryName": "CloudWatch management console auth failed alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive4.tf"
   }
 ]

--- a/assets/queries/terraform/aws/cloudwatch_management_console_sign_in_without_mfa_alarm_missing/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_management_console_sign_in_without_mfa_alarm_missing/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
-import data.generic.common as commonLib
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
 
 expressionArr := [
 	{
@@ -20,24 +21,23 @@ check_expression_missing(resName, filter, doc) {
 	alarm := doc.resource.aws_cloudwatch_metric_alarm[name]
 	contains(alarm.metric_name, resName)
 	filter._kics_filter_expr._op == "&&"
-	count({x | exp := expressionArr[n]; commonLib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+	count({x | exp := expressionArr[n]; common_lib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
 }
 
 CxPolicy[result] {
 	doc := input.document[i]
-	resources := doc.resource.aws_cloudwatch_log_metric_filter
-
-	allPatternsCount := count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); x = filter])
-	count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); not check_expression_missing(path[0], filter, doc); x = filter]) == allPatternsCount
+	resource := doc.resource.aws_cloudwatch_log_metric_filter[resourceName]
+	filter := common_lib.json_unmarshal(resource.pattern)
+	not check_expression_missing(resourceName, filter, doc)
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_cloudwatch_log_metric_filter",
-		"resourceName": "unknown",
-		"searchKey": "resource",
+		"resourceName": tf_lib.get_resource_name(resource, resourceName),
+		"searchKey": sprintf("aws_cloudwatch_log_metric_filter[%s].pattern", [resourceName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") } and be associated an aws_cloudwatch_metric_alarm",
 		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") } or not associated with any aws_cloudwatch_metric_alarm",
-		"searchLine": commonLib.build_search_line([], []),
+		"searchLine": common_lib.build_search_line([], []),
 	}
 }

--- a/assets/queries/terraform/aws/cloudwatch_management_console_sign_in_without_mfa_alarm_missing/test/negative1.tf
+++ b/assets/queries/terraform/aws/cloudwatch_management_console_sign_in_without_mfa_alarm_missing/test/negative1.tf
@@ -1,29 +1,3 @@
-resource "aws_cloudwatch_log_metric_filter" "cis_unauthorized_api_calls_metric_filter" {
-  name           = "CIS-UnauthorizedAPICalls"
-  pattern        = "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") }"
-  log_group_name = aws_cloudwatch_log_group.cis_cloudwatch_logsgroup.name
-
-  metric_transformation {
-    name      = "CIS-UnauthorizedAPICalls"
-    namespace = "CIS_Metric_Alarm_Namespace"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "cis_unauthorized_api_calls_cw_alarm" {
-  alarm_name                = "CIS-3.1-UnauthorizedAPICalls"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
-  metric_name               = aws_cloudwatch_log_metric_filter.cis_unauthorized_api_calls_metric_filter.id
-  namespace                 = "CIS_Metric_Alarm_Namespace"
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  alarm_description         = "Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
-  alarm_actions             = [aws_sns_topic.cis_alerts_sns_topic.arn]
-  insufficient_data_actions = []
-}
-
 resource "aws_cloudwatch_log_metric_filter" "cis_no_mfa_console_signin_metric_filter" {
   name           = "CIS-ConsoleSigninWithoutMFA"
   pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"

--- a/assets/queries/terraform/aws/cloudwatch_management_console_sign_in_without_mfa_alarm_missing/test/positive1.tf
+++ b/assets/queries/terraform/aws/cloudwatch_management_console_sign_in_without_mfa_alarm_missing/test/positive1.tf
@@ -1,28 +1,3 @@
-resource "aws_cloudwatch_log_metric_filter" "cis_unauthorized_api_calls_metric_filter" {
-  name           = "CIS-UnauthorizedAPICalls"
-  pattern        = "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") }"
-  log_group_name = aws_cloudwatch_log_group.CIS_CloudWatch_LogsGroup.name
-
-  metric_transformation {
-    name      = "CIS-UnauthorizedAPICalls"
-    namespace = "CIS_Metric_Alarm_Namespace"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "cis_unauthorized_api_calls_cw_alarm" {
-  alarm_name                = "CIS-3.1-UnauthorizedAPICalls"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
-  metric_name               = aws_cloudwatch_log_metric_filter.cis_unauthorized_api_calls_metric_filter.id
-  namespace                 = "CIS_Metric_Alarm_Namespace"
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  alarm_description         = "Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
-  alarm_actions             = [aws_sns_topic.cis_alerts_sns_topic.arn]
-  insufficient_data_actions = []
-}
 resource "aws_cloudwatch_log_metric_filter" "cis_no_mfa_console_signin_metric_filter" {
   name           = "CIS-ConsoleSigninWithoutMFA"
   pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"

--- a/assets/queries/terraform/aws/cloudwatch_management_console_sign_in_without_mfa_alarm_missing/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_management_console_sign_in_without_mfa_alarm_missing/test/positive_expected_result.json
@@ -2,25 +2,25 @@
   {
     "queryName": "CloudWatch console sign-in without MFA alarm missing",
     "severity": "LOW",
-    "line": 1,
+    "line": 3,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "CloudWatch console sign-in without MFA alarm missing",
     "severity": "LOW",
-    "line": 1,
+    "line": 3,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "CloudWatch console sign-in without MFA alarm missing",
     "severity": "LOW",
-    "line": 1,
+    "line": 3,
     "fileName": "positive3.tf"
   },
   {
     "queryName": "CloudWatch console sign-in without MFA alarm missing",
     "severity": "LOW",
-    "line": 1,
+    "line": 3,
     "fileName": "positive4.tf"
   }
 ]

--- a/assets/queries/terraform/aws/cloudwatch_network_gateways_changes_alarm_missing/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_network_gateways_changes_alarm_missing/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
-import data.generic.common as commonLib
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
 
 expressionArr := [
 	{
@@ -36,28 +37,27 @@ expressionArr := [
 ]
 
 # { ($.eventName = CreateCustomerGateway) || ($.eventName = DeleteCustomerGateway) || ($.eventName = AttachInternetGateway) || ($.eventName = CreateInternetGateway) || ($.eventName = DeleteInternetGateway) || ($.eventName = DetachInternetGateway) }
-CxPolicy[result] {
-	doc := input.document[i]
-	resources := doc.resource.aws_cloudwatch_log_metric_filter
-
-	allPatternsCount := count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); x = filter])
-	count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); not check_expression_missing(path[0], filter, doc); x = filter]) == allPatternsCount
-
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "aws_cloudwatch_log_metric_filter",
-		"resourceName": "unknown",
-		"searchKey": "resource",
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) } and be associated an aws_cloudwatch_metric_alarm",
-		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) } or not associated with any aws_cloudwatch_metric_alarm",
-		"searchLine": commonLib.build_search_line([], []),
-	}
-}
-
 check_expression_missing(resName, filter, doc) {
 	alarm := doc.resource.aws_cloudwatch_metric_alarm[name]
 	contains(alarm.metric_name, resName)
 
-	count({x | exp := expressionArr[n]; commonLib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+	count({x | exp := expressionArr[n]; common_lib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	resource := doc.resource.aws_cloudwatch_log_metric_filter[resourceName]
+	filter := common_lib.json_unmarshal(resource.pattern)
+	not check_expression_missing(resourceName, filter, doc)
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_cloudwatch_log_metric_filter",
+		"resourceName": tf_lib.get_resource_name(resource, resourceName),
+		"searchKey": sprintf("aws_cloudwatch_log_metric_filter[%s].pattern", [resourceName]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { ($.eventName = CreateCustomerGateway) || ($.eventName = DeleteCustomerGateway) || ($.eventName = AttachInternetGateway) || ($.eventName = CreateInternetGateway) || ($.eventName = DeleteInternetGateway) || ($.eventName = DetachInternetGateway) } and be associated an aws_cloudwatch_metric_alarm",
+		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { ($.eventName = CreateCustomerGateway) || ($.eventName = DeleteCustomerGateway) || ($.eventName = AttachInternetGateway) || ($.eventName = CreateInternetGateway) || ($.eventName = DeleteInternetGateway) || ($.eventName = DetachInternetGateway) } or not associated with any aws_cloudwatch_metric_alarm",
+		"searchLine": common_lib.build_search_line([], []),
+	}
 }

--- a/assets/queries/terraform/aws/cloudwatch_network_gateways_changes_alarm_missing/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_network_gateways_changes_alarm_missing/test/positive_expected_result.json
@@ -2,19 +2,19 @@
   {
     "queryName": "CloudWatch network gateways changes alarm missing",
     "severity": "LOW",
-    "line": 1,
+    "line": 3,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "CloudWatch network gateways changes alarm missing",
     "severity": "LOW",
-    "line": 1,
+    "line": 3,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "CloudWatch network gateways changes alarm missing",
     "severity": "LOW",
-    "line": 1,
+    "line": 3,
     "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/cloudwatch_root_account_use_alarm_missing/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_root_account_use_alarm_missing/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
-import data.generic.common as commonLib
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
 
 expressionArr := [
 	{
@@ -24,24 +25,23 @@ expressionArr := [
 check_expression_missing(resName, filter, doc) {
 	alarm := doc.resource.aws_cloudwatch_metric_alarm[name]
 	contains(alarm.metric_name, resName)
-	count({x | exp := expressionArr[n]; commonLib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+	count({x | exp := expressionArr[n]; common_lib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
 }
 
 CxPolicy[result] {
 	doc := input.document[i]
-	resources := doc.resource.aws_cloudwatch_log_metric_filter
-
-	allPatternsCount := count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); x = filter])
-	count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); not check_expression_missing(path[0], filter, doc); x = filter]) == allPatternsCount
+	resource := doc.resource.aws_cloudwatch_log_metric_filter[resourceName]
+	filter := common_lib.json_unmarshal(resource.pattern)
+	not check_expression_missing(resourceName, filter, doc)
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_cloudwatch_log_metric_filter",
-		"resourceName": "unknown",
-		"searchKey": "resource",
+		"resourceName": tf_lib.get_resource_name(resource, resourceName),
+		"searchKey": sprintf("aws_cloudwatch_log_metric_filter[%s].pattern", [resourceName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" } and be associated an aws_cloudwatch_metric_alarm",
 		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" } or not associated with any aws_cloudwatch_metric_alarm",
-		"searchLine": commonLib.build_search_line([], []),
+		"searchLine": common_lib.build_search_line([], []),
 	}
 }

--- a/assets/queries/terraform/aws/cloudwatch_root_account_use_alarm_missing/test/negative1.tf
+++ b/assets/queries/terraform/aws/cloudwatch_root_account_use_alarm_missing/test/negative1.tf
@@ -23,29 +23,3 @@ resource "aws_cloudwatch_metric_alarm" "CIS_Root_Account_Use_CW_Alarm" {
   alarm_actions             = [aws_sns_topic.CIS_Alerts_SNS_Topic.arn]
   insufficient_data_actions = []
 }
-
-resource "aws_cloudwatch_log_metric_filter" "cis_no_mfa_console_signin_metric_filter" {
-  name           = "CIS-ConsoleSigninWithoutMFA"
-  pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"
-  log_group_name = aws_cloudwatch_log_group.CIS_CloudWatch_LogsGroup.name
-
-  metric_transformation {
-    name      = "CIS-ConsoleSigninWithoutMFA"
-    namespace = "CIS_Metric_Alarm_Namespace"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "cis_no_mfa_console_signin_cw_alarm" {
-  alarm_name                = "CIS-3.2-ConsoleSigninWithoutMFA"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
-  metric_name               = aws_cloudwatch_log_metric_filter.cis_no_mfa_console_signin_metric_filter.id
-  namespace                 = "CIS_Metric_Alarm_Namespace"
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  alarm_description         = "Monitoring for single-factor console logins will increase visibility into accounts that are not protected by MFA."
-  alarm_actions             = ["aws_sns_topic.CIS_Alerts_SNS_Topic.arn"]
-  insufficient_data_actions = []
-}

--- a/assets/queries/terraform/aws/cloudwatch_root_account_use_alarm_missing/test/positive1.tf
+++ b/assets/queries/terraform/aws/cloudwatch_root_account_use_alarm_missing/test/positive1.tf
@@ -23,30 +23,3 @@ resource "aws_cloudwatch_metric_alarm" "cis_root_account_use_cw_alarm" {
   alarm_actions             = [aws_sns_topic.CIS_Alerts_SNS_Topic.arn]
   insufficient_data_actions = []
 }
-
-
-resource "aws_cloudwatch_log_metric_filter" "cis_no_mfa_console_signin_metric_filter" {
-  name           = "CIS-ConsoleSigninWithoutMFA"
-  pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"
-  log_group_name = aws_cloudwatch_log_group.CIS_CloudWatch_LogsGroup.name
-
-  metric_transformation {
-    name      = "CIS-ConsoleSigninWithoutMFA"
-    namespace = "CIS_Metric_Alarm_Namespace"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "cis_no_mfa_console_signin_cw_alarm" {
-  alarm_name                = "CIS-3.2-ConsoleSigninWithoutMFA"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
-  metric_name               = aws_cloudwatch_log_metric_filter.cis_no_mfa_console_signin_metric_filter.id
-  namespace                 = "CIS_Metric_Alarm_Namespace"
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  alarm_description         = "Monitoring for single-factor console logins will increase visibility into accounts that are not protected by MFA."
-  alarm_actions             = [aws_sns_topic.CIS_Alerts_SNS_Topic.arn]
-  insufficient_data_actions = []
-}

--- a/assets/queries/terraform/aws/cloudwatch_root_account_use_alarm_missing/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_root_account_use_alarm_missing/test/positive_expected_result.json
@@ -2,25 +2,25 @@
   {
     "queryName": "CloudWatch root account use missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "CloudWatch root account use missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "CloudWatch root account use missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive3.tf"
   },
   {
     "queryName": "CloudWatch root account use missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 17,
     "fileName": "positive4.tf"
   }
 ]

--- a/assets/queries/terraform/aws/cloudwatch_route_table_changes_alarm_missing/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_route_table_changes_alarm_missing/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
-import data.generic.common as commonLib
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
 
 expressionArr := [
 	{
@@ -41,28 +42,27 @@ expressionArr := [
 ]
 
 # { ($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable) }
-CxPolicy[result] {
-	doc := input.document[i]
-	resources := doc.resource.aws_cloudwatch_log_metric_filter
-
-	allPatternsCount := count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); x = filter])
-	count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); not check_expression_missing(path[0], filter, doc); x = filter]) == allPatternsCount
-
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "aws_cloudwatch_log_metric_filter",
-		"resourceName": "unknown",
-		"searchKey": "resource",
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { ($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable) } and be associated an aws_cloudwatch_metric_alarm",
-		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { ($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable) } or not associated with any aws_cloudwatch_metric_alarm",
-		"searchLine": commonLib.build_search_line([], []),
-	}
-}
-
 check_expression_missing(resName, filter, doc) {
 	alarm := doc.resource.aws_cloudwatch_metric_alarm[name]
 	contains(alarm.metric_name, resName)
 
-	count({x | exp := expressionArr[n]; commonLib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+	count({x | exp := expressionArr[n]; common_lib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	resource := doc.resource.aws_cloudwatch_log_metric_filter[resourceName]
+	filter := common_lib.json_unmarshal(resource.pattern)
+	not check_expression_missing(resourceName, filter, doc)
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_cloudwatch_log_metric_filter",
+		"resourceName": tf_lib.get_resource_name(resource, resourceName),
+		"searchKey": sprintf("aws_cloudwatch_log_metric_filter[%s].pattern", [resourceName]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { ($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable) } and be associated an aws_cloudwatch_metric_alarm",
+		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { ($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable) } or not associated with any aws_cloudwatch_metric_alarm",
+		"searchLine": common_lib.build_search_line([], []),
+	}
 }

--- a/assets/queries/terraform/aws/cloudwatch_route_table_changes_alarm_missing/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_route_table_changes_alarm_missing/test/positive_expected_result.json
@@ -2,19 +2,19 @@
   {
     "queryName": "CloudWatch route table changes alarm missing",
     "severity": "LOW",
-    "line": 1,
+    "line": 3,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "CloudWatch route table changes alarm missing",
     "severity": "LOW",
-    "line": 1,
+    "line": 3,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "CloudWatch route table changes alarm missing",
     "severity": "LOW",
-    "line": 1,
+    "line": 3,
     "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/cloudwatch_security_group_changes_alarm_missing/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_security_group_changes_alarm_missing/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
-import data.generic.common as commonLib
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
 
 expressionArr := [
 	{
@@ -35,29 +36,28 @@ expressionArr := [
 	},
 ]
 
-# { ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup)}
-CxPolicy[result] {
-	doc := input.document[i]
-	resources := doc.resource.aws_cloudwatch_log_metric_filter
-
-	allPatternsCount := count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); x = filter])
-	count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); not check_expression_missing(path[0], filter, doc); x = filter]) == allPatternsCount
-
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "aws_cloudwatch_log_metric_filter",
-		"resourceName": "unknown",
-		"searchKey": "resource",
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup)} and be associated an aws_cloudwatch_metric_alarm",
-		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup)} or not associated with any aws_cloudwatch_metric_alarm",
-		"searchLine": commonLib.build_search_line([], []),
-	}
-}
-
+# { ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup) }
 check_expression_missing(resName, filter, doc) {
 	alarm := doc.resource.aws_cloudwatch_metric_alarm[name]
 	contains(alarm.metric_name, resName)
 
-	count({x | exp := expressionArr[n]; commonLib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+	count({x | exp := expressionArr[n]; common_lib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	resource := doc.resource.aws_cloudwatch_log_metric_filter[resourceName]
+	filter := common_lib.json_unmarshal(resource.pattern)
+	not check_expression_missing(resourceName, filter, doc)
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_cloudwatch_log_metric_filter",
+		"resourceName": tf_lib.get_resource_name(resource, resourceName),
+		"searchKey": sprintf("aws_cloudwatch_log_metric_filter[%s].pattern", [resourceName]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup)} and be associated an aws_cloudwatch_metric_alarm",
+		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup)} or not associated with any aws_cloudwatch_metric_alarm",
+		"searchLine": common_lib.build_search_line([], []),
+	}
 }

--- a/assets/queries/terraform/aws/cloudwatch_security_group_changes_alarm_missing/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_security_group_changes_alarm_missing/test/positive_expected_result.json
@@ -2,19 +2,19 @@
   {
     "queryName": "Cloudwatch security group changes alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "Cloudwatch security group changes alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "Cloudwatch security group changes alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/cloudwatch_unauthorized_access_defined_alarm_missing/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_unauthorized_access_defined_alarm_missing/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
-import data.generic.common as commonLib
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
 
 expressionArr := [
 	{
@@ -20,24 +21,23 @@ check_expression_missing(resName, filter, doc) {
 	alarm := doc.resource.aws_cloudwatch_metric_alarm[name]
 	contains(alarm.metric_name, resName)
 	filter._kics_filter_expr._op == "||"
-	count({x | exp := expressionArr[n]; commonLib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+	count({x | exp := expressionArr[n]; common_lib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
 }
 
 CxPolicy[result] {
 	doc := input.document[i]
-	resources := doc.resource.aws_cloudwatch_log_metric_filter
-
-	allPatternsCount := count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); x = filter])
-	count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); not check_expression_missing(path[0], filter, doc); x = filter]) == allPatternsCount
+	resource := doc.resource.aws_cloudwatch_log_metric_filter[resourceName]
+	filter := common_lib.json_unmarshal(resource.pattern)
+	not check_expression_missing(resourceName, filter, doc)
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_cloudwatch_log_metric_filter",
-		"resourceName": "unknown",
-		"searchKey": "resource",
+		"resourceName": tf_lib.get_resource_name(resource, resourceName),
+		"searchKey": sprintf("aws_cloudwatch_log_metric_filter[%s].pattern", [resourceName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { $.errorCode = *UnauthorizedOperation || $.errorCode = AccessDenied* } and be associated an aws_cloudwatch_metric_alarm",
 		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { $.errorCode = *UnauthorizedOperation || $.errorCode = AccessDenied* } or not associated with any aws_cloudwatch_metric_alarm",
-		"searchLine": commonLib.build_search_line([], []),
+		"searchLine": common_lib.build_search_line([], []),
 	}
 }

--- a/assets/queries/terraform/aws/cloudwatch_unauthorized_access_defined_alarm_missing/test/negative1.tf
+++ b/assets/queries/terraform/aws/cloudwatch_unauthorized_access_defined_alarm_missing/test/negative1.tf
@@ -23,29 +23,3 @@ resource "aws_cloudwatch_log_metric_filter" "cis_unauthorized_api_calls_metric_f
     value     = "1"
   }
 }
-
-resource "aws_cloudwatch_log_metric_filter" "cis_no_mfa_console_signin_metric_filter" {
-  name           = "CIS-ConsoleSigninWithoutMFA"
-  pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"
-  log_group_name = aws_cloudwatch_log_group.CIS_CloudWatch_LogsGroup.name
-
-  metric_transformation {
-    name      = "CIS-ConsoleSigninWithoutMFA"
-    namespace = "CIS_Metric_Alarm_Namespace"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "cis_no_mfa_console_signin_cw_alarm" {
-  alarm_name                = "CIS-3.2-ConsoleSigninWithoutMFA"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
-  metric_name               = aws_cloudwatch_log_metric_filter.cis_no_mfa_console_signin_metric_filter.id
-  namespace                 = "CIS_Metric_Alarm_Namespace"
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  alarm_description         = "Monitoring for single-factor console logins will increase visibility into accounts that are not protected by MFA."
-  alarm_actions             = ["aws_sns_topic.CIS_Alerts_SNS_Topic.arn"]
-  insufficient_data_actions = []
-}

--- a/assets/queries/terraform/aws/cloudwatch_unauthorized_access_defined_alarm_missing/test/positive1.tf
+++ b/assets/queries/terraform/aws/cloudwatch_unauthorized_access_defined_alarm_missing/test/positive1.tf
@@ -23,29 +23,3 @@ resource "aws_cloudwatch_log_metric_filter" "cis_unauthorized_api_calls_metric_f
     value     = "1"
   }
 }
-
-resource "aws_cloudwatch_log_metric_filter" "cis_no_mfa_console_signin_metric_filter" {
-  name           = "CIS-ConsoleSigninWithoutMFA"
-  pattern        = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"
-  log_group_name = aws_cloudwatch_log_group.CIS_CloudWatch_LogsGroup.name
-
-  metric_transformation {
-    name      = "CIS-ConsoleSigninWithoutMFA"
-    namespace = "CIS_Metric_Alarm_Namespace"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "cis_no_mfa_console_signin_cw_alarm" {
-  alarm_name                = "CIS-3.2-ConsoleSigninWithoutMFA"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
-  metric_name               = aws_cloudwatch_log_metric_filter.cis_no_mfa_console_signin_metric_filter.id
-  namespace                 = "CIS_Metric_Alarm_Namespace"
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  alarm_description         = "Monitoring for single-factor console logins will increase visibility into accounts that are not protected by MFA."
-  alarm_actions             = [aws_sns_topic.CIS_Alerts_SNS_Topic.arn]
-  insufficient_data_actions = []
-}

--- a/assets/queries/terraform/aws/cloudwatch_unauthorized_access_defined_alarm_missing/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_unauthorized_access_defined_alarm_missing/test/positive_expected_result.json
@@ -2,25 +2,25 @@
   {
     "queryName": "CloudWatch unauthorized access alarm missing",
     "severity": "CRITICAL",
-    "line": 1,
+    "line": 17,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "CloudWatch unauthorized access alarm missing",
     "severity": "CRITICAL",
-    "line": 1,
+    "line": 3,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "CloudWatch unauthorized access alarm missing",
     "severity": "CRITICAL",
-    "line": 1,
+    "line": 17,
     "fileName": "positive3.tf"
   },
   {
     "queryName": "CloudWatch unauthorized access alarm missing",
     "severity": "CRITICAL",
-    "line": 1,
+    "line": 17,
     "fileName": "positive4.tf"
   }
 ]

--- a/assets/queries/terraform/aws/cloudwatch_vpc_changes_alarm_missing/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_vpc_changes_alarm_missing/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
-import data.generic.common as commonLib
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
 
 expressionArr := [
 	{
@@ -65,24 +66,23 @@ check_expression_missing(resName, filter, doc) {
 	alarm := doc.resource.aws_cloudwatch_metric_alarm[name]
 	contains(alarm.metric_name, resName)
 	filter._kics_filter_expr._op == "||"
-	count({x | exp := expressionArr[n]; commonLib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
+	count({x | exp := expressionArr[n]; common_lib.check_selector(filter, exp.value, exp.op, exp.name) == false; x := exp}) == 0
 }
 
 CxPolicy[result] {
 	doc := input.document[i]
-	resources := doc.resource.aws_cloudwatch_log_metric_filter
-
-	allPatternsCount := count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); x = filter])
-	count([x | [path, value] := walk(resources); filter := commonLib.json_unmarshal(value.pattern); not check_expression_missing(path[0], filter, doc); x = filter]) == allPatternsCount
+	resource := doc.resource.aws_cloudwatch_log_metric_filter[resourceName]
+	filter := common_lib.json_unmarshal(resource.pattern)
+	not check_expression_missing(resourceName, filter, doc)
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_cloudwatch_log_metric_filter",
-		"resourceName": "unknown",
-		"searchKey": "resource",
+		"resourceName": tf_lib.get_resource_name(resource, resourceName),
+		"searchKey": sprintf("aws_cloudwatch_log_metric_filter[%s].pattern", [resourceName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_cloudwatch_log_metric_filter should have pattern { ($.eventName = CreateVpc) || ($.eventName = DeleteVpc) || ($.eventName = ModifyVpcAttribute) || ($.eventName = AcceptVpcPeeringConnection) || ($.eventName = CreateVpcPeeringConnection) || ($.eventName = DeleteVpcPeeringConnection) || ($.eventName = RejectVpcPeeringConnection) || ($.eventName = AttachClassicLinkVpc) || ($.eventName = DetachClassicLinkVpc) || ($.eventName = DisableVpcClassicLink) || ($.eventName = EnableVpcClassicLink) } and be associated an aws_cloudwatch_metric_alarm",
 		"keyActualValue": "aws_cloudwatch_log_metric_filter not filtering pattern { ($.eventName = CreateVpc) || ($.eventName = DeleteVpc) || ($.eventName = ModifyVpcAttribute) || ($.eventName = AcceptVpcPeeringConnection) || ($.eventName = CreateVpcPeeringConnection) || ($.eventName = DeleteVpcPeeringConnection) || ($.eventName = RejectVpcPeeringConnection) || ($.eventName = AttachClassicLinkVpc) || ($.eventName = DetachClassicLinkVpc) || ($.eventName = DisableVpcClassicLink) || ($.eventName = EnableVpcClassicLink) } or not associated with any aws_cloudwatch_metric_alarm",
-		"searchLine": commonLib.build_search_line([], []),
+		"searchLine": common_lib.build_search_line([], []),
 	}
 }

--- a/assets/queries/terraform/aws/cloudwatch_vpc_changes_alarm_missing/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_vpc_changes_alarm_missing/test/positive_expected_result.json
@@ -2,19 +2,19 @@
   {
     "queryName": "CloudWatch VPC changes alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "CloudWatch VPC changes alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "CloudWatch VPC changes alarm missing",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 3,
     "fileName": "positive3.tf"
   }
 ]


### PR DESCRIPTION
## Summary
- Replace hard-coded `\"resourceName\": \"unknown\"` in Terraform AWS CloudWatch alarm-missing rules with deterministic attribution.
- Use resource-count branching (`count([n | resources[n]])`) so documents with existing log metric filters report against a named filter resource; otherwise report against document id.

## Test plan

Test the impacted rules against its tests, and output a SARIF for them to check on the resource names 