### PR TITLE
SARIF: use rule name as title

### DIFF
--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -537,7 +537,7 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 				ResultRuleIndex: ruleIndex,
 				ResultLevel:     severityLevelEquivalence[issue.Severity],
 				ResultMessage: sarifMessage{
-					Text: issue.Files[idx].KeyActualValue,
+					Text: issue.QueryName,
 				},
 				ResultLocations: []SarifLocation{
 					{

--- a/pkg/report/model/sarif_test.go
+++ b/pkg/report/model/sarif_test.go
@@ -462,7 +462,7 @@ var sarifTests = []sarifTest{
 							ResultRuleIndex: 1,
 							ResultKind:      "informational",
 							ResultMessage: sarifMessage{
-								Text:              "test",
+								Text:              "test info",
 								MessageProperties: sarifProperties{"platform": ""},
 							},
 							ResultLocations: []SarifLocation{
@@ -741,7 +741,7 @@ var sarifTests = []sarifTest{
 							ResultRuleID:    "test dockerfile",
 							ResultRuleIndex: 0,
 							ResultKind:      "",
-							ResultMessage:   sarifMessage{Text: "test dockerfile issue", MessageProperties: nil},
+							ResultMessage:   sarifMessage{Text: "test dockerfile", MessageProperties: nil},
 							ResultLocations: []SarifLocation{
 								{
 									PhysicalLocation: sarifPhysicalLocation{


### PR DESCRIPTION
## Motivation

SARIF consumers (e.g. Datadog Code Security) were using `results[].message.text` as the finding title; it was populated with `KeyActualValue` (long Rego detail). Using the rule name (`QueryName`) matches the rule title and reads clearly in the UI.


## Changes

- Set SARIF `results[].message.text` to `issue.QueryName` in `BuildSarifIssue` (`pkg/report/model/sarif.go`).
- Adjusted `sarif_test` expectations where `QueryName` differed from `KeyActualValue`.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run `go test ./pkg/report/model/...`. Optionally run a scan with SARIF output and confirm `message.text` equals the rule name (e.g. metadata `queryName`) per finding.

## Blast Radius

Affects SARIF output from Datadog IaC Scanner only. Other report formats (HTML, CSV, JSON summary) still use `KeyActualValue` where they did before.

## Additional Notes

I submit this contribution under the Apache-2.0 license.


[K9VULN-10653]: https://datadoghq.atlassian.net/browse/K9VULN-10653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ