### PR TITLE
style: changed Error log for Warn on maximum file size exceeded

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -805,7 +805,7 @@ func (a *Analyzer) checkIgnore(ctx context.Context, fileSize int64, hasGitIgnore
 		a.Exc = append(a.Exc, fullPath)
 
 		if exceededFileSize {
-			contextLogger.Error().Msgf("file %s exceeds maximum file size of %d Mb", fullPath, a.MaxFileSize)
+			contextLogger.Warn().Msgf("file %s exceeds maximum file size of %d Mb", fullPath, a.MaxFileSize)
 		}
 	}
 	return ignoreFiles


### PR DESCRIPTION
## Motivation

This Error should be a warning as the file exceeding size is a parameter of the scan: the skip is expected.

Other possibility: considering changing to `INFO`

## Changes

- log `file %s exceeds maximum file size of %d Mb` is now warning

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## Blast Radius

IaC scanning logs

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
