### PR TITLE
Remove rule Id from description in sarif report

### DIFF
--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -378,7 +378,7 @@ func (sr *sarifReport) buildSarifRule(queryMetadata *ruleMetadata, cisMetadata r
 			RuleID:               queryMetadata.queryName,
 			RuleName:             queryMetadata.queryName,
 			RuleShortDescription: sarifMessage{Text: queryMetadata.queryName},
-			RuleFullDescription:  sarifMessage{Text: fmt.Sprintf("%s\nRule ID: [%s]", queryMetadata.queryDescription, queryMetadata.queryID)},
+			RuleFullDescription:  sarifMessage{Text: queryMetadata.queryDescription},
 			DefaultConfiguration: sarifConfiguration{Level: severityLevelEquivalence[queryMetadata.severity]},
 			// Relationships:        relationships,
 			HelpURI: helpURI,

--- a/pkg/report/model/sarif_test.go
+++ b/pkg/report/model/sarif_test.go
@@ -102,7 +102,7 @@ var sarifTests = []sarifTest{
 									RuleID:               "test",
 									RuleName:             "test",
 									RuleShortDescription: sarifMessage{Text: "test"},
-									RuleFullDescription:  sarifMessage{Text: "test description\nRule ID: [1]"},
+									RuleFullDescription:  sarifMessage{Text: "test description"},
 									DefaultConfiguration: sarifConfiguration{
 										Level: "note",
 									},
@@ -205,7 +205,7 @@ var sarifTests = []sarifTest{
 									RuleID:               "test",
 									RuleName:             "test",
 									RuleShortDescription: sarifMessage{Text: "test"},
-									RuleFullDescription:  sarifMessage{Text: "test description\nRule ID: [1]"},
+									RuleFullDescription:  sarifMessage{Text: "test description"},
 									DefaultConfiguration: sarifConfiguration{
 										Level: "error",
 									},
@@ -360,7 +360,7 @@ var sarifTests = []sarifTest{
 									RuleID:               "test",
 									RuleName:             "test",
 									RuleShortDescription: sarifMessage{Text: "test"},
-									RuleFullDescription:  sarifMessage{Text: "test description\nRule ID: [test]"},
+									RuleFullDescription:  sarifMessage{Text: "test description"},
 									DefaultConfiguration: sarifConfiguration{
 										Level: "error",
 									},
@@ -383,7 +383,7 @@ var sarifTests = []sarifTest{
 									RuleID:               "test info",
 									RuleName:             "test info",
 									RuleShortDescription: sarifMessage{Text: "test"},
-									RuleFullDescription:  sarifMessage{Text: "test description/nRule ID: [test info]"},
+									RuleFullDescription:  sarifMessage{Text: "test description"},
 									DefaultConfiguration: sarifConfiguration{
 										Level: "none",
 									},
@@ -578,7 +578,7 @@ var sarifTests = []sarifTest{
 									RuleID:               "test",
 									RuleName:             "test",
 									RuleShortDescription: sarifMessage{Text: "test"},
-									RuleFullDescription:  sarifMessage{Text: "test description\nRule ID: [1]"},
+									RuleFullDescription:  sarifMessage{Text: "test description"},
 									DefaultConfiguration: sarifConfiguration{
 										Level: "error",
 									},
@@ -714,7 +714,7 @@ var sarifTests = []sarifTest{
 									RuleID:               "test dockerfile",
 									RuleName:             "test dockerfile",
 									RuleShortDescription: sarifMessage{Text: "test dockerfile"},
-									RuleFullDescription:  sarifMessage{Text: "test dockerfile description\nRule ID: [dockerfile-test-1]"},
+									RuleFullDescription:  sarifMessage{Text: "test dockerfile description"},
 									DefaultConfiguration: sarifConfiguration{
 										Level: "error",
 									},


### PR DESCRIPTION
## Motivation

The Rule ID appearing at the end of a finding is not useful to customers, removing it to keep the description clean.
<img width="1746" height="542" alt="Screenshot 2026-03-23 at 15 13 31" src="https://github.com/user-attachments/assets/599f741a-3977-4323-91e0-9ca6c96be051" />

## Changes

- Remove the Rule Id

## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## Blast Radius

IaC scanning findings

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
