### PR TITLE
Helm Multi Chart resolution

### DIFF
--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -155,7 +155,7 @@ func (s *FileSystemSourceProvider) GetSources(ctx context.Context,
 			continue
 		}
 
-		err = s.walkDir(ctx, scanPath, false, sink, resolverSink, extensions)
+		err = s.walkDir(ctx, scanPath, sink, resolverSink, extensions)
 		if err != nil {
 			return errors.Wrap(err, "failed to walk directory")
 		}
@@ -192,7 +192,7 @@ func (s *FileSystemSourceProvider) GetParallelSources(ctx context.Context,
 		}
 
 		// Directory - collect all files first
-		files, err := s.collectFiles(ctx, scanPath, false, resolverSink, extensions)
+		files, err := s.collectFiles(ctx, scanPath, resolverSink, extensions)
 		if err != nil {
 			return errors.Wrap(err, "failed to collect files")
 		}
@@ -206,16 +206,17 @@ func (s *FileSystemSourceProvider) GetParallelSources(ctx context.Context,
 }
 
 // collectFiles walks the directory tree and collects file paths without processing them, except Helm files
-func (s *FileSystemSourceProvider) collectFiles(ctx context.Context, scanPath string, resolved bool,
+func (s *FileSystemSourceProvider) collectFiles(ctx context.Context, scanPath string,
 	resolverSink ResolverSink, extensions model.Extensions) (files []string, err error) {
 	contextLogger := logger.FromContext(ctx)
+	var resolvedChartPaths []string
 
 	err = filepath.Walk(scanPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if shouldSkip, skipFolder := s.checkConditions(ctx, info, extensions, path, resolved); shouldSkip {
+		if shouldSkip, skipFolder := s.checkConditions(ctx, info, extensions, path, resolvedChartPaths); shouldSkip {
 			return skipFolder
 		}
 
@@ -230,7 +231,7 @@ func (s *FileSystemSourceProvider) collectFiles(ctx context.Context, scanPath st
 				contextLogger.Err(errAdd).Msgf("Filesystem files provider couldn't exclude rendered Chart files, Chart=%s", info.Name())
 			}
 			s.mu.Unlock()
-			resolved = true
+			resolvedChartPaths = append(resolvedChartPaths, path)
 			return nil
 		}
 		// -----------------------------------------------------------------
@@ -347,15 +348,16 @@ func (s *FileSystemSourceProvider) feedFilesToWorkers(ctx context.Context, files
 	}
 }
 
-func (s *FileSystemSourceProvider) walkDir(ctx context.Context, scanPath string, resolved bool,
+func (s *FileSystemSourceProvider) walkDir(ctx context.Context, scanPath string,
 	sink Sink, resolverSink ResolverSink, extensions model.Extensions) error {
 	contextLogger := logger.FromContext(ctx)
+	var resolvedChartPaths []string
 	return filepath.Walk(scanPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if shouldSkip, skipFolder := s.checkConditions(ctx, info, extensions, path, resolved); shouldSkip {
+		if shouldSkip, skipFolder := s.checkConditions(ctx, info, extensions, path, resolvedChartPaths); shouldSkip {
 			return skipFolder
 		}
 
@@ -370,7 +372,7 @@ func (s *FileSystemSourceProvider) walkDir(ctx context.Context, scanPath string,
 				contextLogger.Err(errAdd).Msgf("Filesystem files provider couldn't exclude rendered Chart files, Chart=%s", info.Name())
 			}
 			s.mu.Unlock()
-			resolved = true
+			resolvedChartPaths = append(resolvedChartPaths, path)
 			return nil
 		}
 		// -----------------------------------------------------------------
@@ -405,7 +407,7 @@ func openScanFile(ctx context.Context, scanPath string, extensions model.Extensi
 }
 
 func (s *FileSystemSourceProvider) checkConditions(ctx context.Context, info os.FileInfo, extensions model.Extensions,
-	path string, resolved bool) (bool, error) {
+	path string, resolvedChartPaths []string) (bool, error) {
 	contextLogger := logger.FromContext(ctx)
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -426,7 +428,7 @@ func (s *FileSystemSourceProvider) checkConditions(ctx context.Context, info os.
 			return true, filepath.SkipDir
 		}
 		_, err := os.Stat(filepath.Join(path, "Chart.yaml"))
-		if err != nil || resolved {
+		if err != nil || isUnderResolvedChart(path, resolvedChartPaths) {
 			return true, nil
 		}
 		return false, nil
@@ -440,6 +442,15 @@ func (s *FileSystemSourceProvider) checkConditions(ctx context.Context, info os.
 		return true, nil
 	}
 	return false, nil
+}
+
+func isUnderResolvedChart(path string, resolvedChartPaths []string) bool {
+	for _, chartRoot := range resolvedChartPaths {
+		if strings.HasPrefix(path, chartRoot+string(os.PathSeparator)) {
+			return true
+		}
+	}
+	return false
 }
 
 func containsFile(fileList []os.FileInfo, target os.FileInfo) bool {

--- a/pkg/engine/provider/filesystem_test.go
+++ b/pkg/engine/provider/filesystem_test.go
@@ -473,7 +473,7 @@ func TestFileSystemSourceProvider_checkConditions(t *testing.T) {
 				paths:    tt.fields.paths,
 				excludes: tt.fields.excludes,
 			}
-			if got, err := s.checkConditions(ctx, tt.args.info, tt.args.extensions, tt.args.path, false); got != tt.want.got || err != tt.want.err {
+			if got, err := s.checkConditions(ctx, tt.args.info, tt.args.extensions, tt.args.path, nil); got != tt.want.got || err != tt.want.err {
 				t.Errorf("FileSystemSourceProvider.checkConditions() = %v, want %v", err, tt.want)
 			}
 		})
@@ -626,4 +626,89 @@ func TestProvider_getExcludePaths(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestIsUnderResolvedChart(t *testing.T) {
+	tests := []struct {
+		name               string
+		path               string
+		resolvedChartPaths []string
+		want               bool
+	}{
+		{
+			name:               "empty resolved list",
+			path:               filepath.FromSlash("k8s/chart-a/templates"),
+			resolvedChartPaths: nil,
+			want:               false,
+		},
+		{
+			name:               "subdirectory of resolved chart is skipped",
+			path:               filepath.FromSlash("k8s/chart-a/templates"),
+			resolvedChartPaths: []string{filepath.FromSlash("k8s/chart-a")},
+			want:               true,
+		},
+		{
+			name:               "sibling chart is not skipped",
+			path:               filepath.FromSlash("k8s/chart-b"),
+			resolvedChartPaths: []string{filepath.FromSlash("k8s/chart-a")},
+			want:               false,
+		},
+		{
+			name:               "chart root itself is not considered under itself",
+			path:               filepath.FromSlash("k8s/chart-a"),
+			resolvedChartPaths: []string{filepath.FromSlash("k8s/chart-a")},
+			want:               false,
+		},
+		{
+			name:               "path sharing a prefix but different directory is not skipped",
+			path:               filepath.FromSlash("k8s/chart"),
+			resolvedChartPaths: []string{filepath.FromSlash("k8s/chart-a")},
+			want:               false,
+		},
+		{
+			name: "subdirectory matched against multiple resolved charts",
+			path: filepath.FromSlash("k8s/chart-b/templates"),
+			resolvedChartPaths: []string{
+				filepath.FromSlash("k8s/chart-a"),
+				filepath.FromSlash("k8s/chart-b"),
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isUnderResolvedChart(tt.path, tt.resolvedChartPaths)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetSources_multipleHelmCharts(t *testing.T) {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
+		t.Fatalf("failed to change dir: %s", err)
+	}
+
+	ctx := context.Background()
+	fs, err := NewFileSystemSourceProvider(ctx,
+		[]string{filepath.FromSlash("test/fixtures/multi_helm")}, []string{})
+	require.NoError(t, err)
+
+	resolvedDirs := make([]string, 0)
+	countingResolverSink := func(_ context.Context, filename string) ([]string, error) {
+		info, statErr := os.Stat(filename)
+		if statErr == nil && info.IsDir() {
+			if _, chartErr := os.Stat(filepath.Join(filename, "Chart.yaml")); chartErr == nil {
+				resolvedDirs = append(resolvedDirs, filepath.Base(filename))
+			}
+		}
+		return []string{}, nil
+	}
+
+	err = fs.GetSources(ctx, model.Extensions{".yaml": {}},
+		mockSink, countingResolverSink)
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, []string{"chart-a", "chart-b"}, resolvedDirs,
+		"both sibling Helm charts must be sent to the resolver, not just the first one")
 }

--- a/test/fixtures/multi_helm/chart-a/Chart.yaml
+++ b/test/fixtures/multi_helm/chart-a/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: chart-a
+version: 0.1.0

--- a/test/fixtures/multi_helm/chart-b/Chart.yaml
+++ b/test/fixtures/multi_helm/chart-b/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: chart-b
+version: 0.1.0


### PR DESCRIPTION
## Motivation

When a scan root contains **multiple sibling Helm chart directories**, a single global “resolved” flag caused only the first chart to be sent through the Helm resolver. Later charts were skipped for rendering, so their template files could be parsed as plain YAML instead, leading to noisy failures and inconsistent behavior depending on walk order.

## Changes

- Track resolved chart roots as a path list instead of one boolean.
- Skip only paths under an already-rendered chart; sibling charts are still resolved independently.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [x] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- `go test ./pkg/engine/provider/...`
- Optional: run the scanner against a directory that contains **two or more** chart roots (each with `Chart.yaml`) under the same parent and confirm both are handled without YAML parse errors on raw templates when Helm render succeeds, I have some real repository examples I can provide

## Blast Radius

This PR only affects how Helm charts are discovered and excluded during directory walks.

## Additional Notes

I submit this contribution under the Apache-2.0 license.
