### PR TITLE
Put the scanner version in the SARIF file

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -133,7 +133,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		MaxResolverDepth:           c.Int("max-resolver-depth"),
 		ExcludePlatform:            []string{""},
 		PayloadPath:                payloadPath,
-		SCIInfo:                    model.SCIInfo{RunType: "ci", RepositoryCommitInfo: *repoInfo},
+		SCIInfo:                    model.SCIInfo{RepositoryCommitInfo: *repoInfo},
 		FlagEvaluator:              getFeatureFlagEvaluator(c),
 		ExcludeCategories:          config.ExcludeCategories,
 		ExcludeQueries:             append(c.StringSlice("exclude-queries"), config.ExcludeQueries...),

--- a/pkg/model/source_code.go
+++ b/pkg/model/source_code.go
@@ -7,7 +7,6 @@ package model
 
 type SCIInfo struct {
 	DiffAware            DiffAware
-	RunType              string               `json:"run_type"`
 	RepositoryCommitInfo RepositoryCommitInfo `json:"repository_commit_info"`
 	OrgId                int64                `json:"org_id"`
 }

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -189,7 +189,6 @@ type SarifReport interface {
 	GetGUIDFromRelationships(idx int, cweID string) string
 	AddTags(ctx context.Context, summary *model.Summary, diffAware *model.DiffAware) error
 	ResolveFilepaths(basePath string) error
-	SetToolVersionType(ctx context.Context, runType string)
 }
 
 type sarifReport struct {
@@ -587,16 +586,6 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 		return issue.CWE
 	}
 	return ""
-}
-
-func (sr *sarifReport) SetToolVersionType(ctx context.Context, runType string) {
-	contextLogger := logger.FromContext(ctx)
-	if runType != "" {
-		for idx := range sr.Runs {
-			sr.Runs[idx].Tool.Driver.ToolVersion = runType
-		}
-		contextLogger.Info().Msgf("Tool version set to %s", runType)
-	}
 }
 
 func (sr *sarifReport) AddTags(ctx context.Context, summary *model.Summary, diffAware *model.DiffAware) error {

--- a/pkg/report/model/sarif_test.go
+++ b/pkg/report/model/sarif_test.go
@@ -149,7 +149,6 @@ var sarifTests = []sarifTest{
 							PartialFingerprints: SarifPartialFingerprints{
 								DatadogFingerprint: GetDatadogFingerprintHash(
 									model.SCIInfo{
-										RunType: "",
 										RepositoryCommitInfo: model.RepositoryCommitInfo{
 											RepositoryUrl: "",
 											Branch:        "",
@@ -248,7 +247,6 @@ var sarifTests = []sarifTest{
 							PartialFingerprints: SarifPartialFingerprints{
 								DatadogFingerprint: GetDatadogFingerprintHash(
 									model.SCIInfo{
-										RunType: "",
 										RepositoryCommitInfo: model.RepositoryCommitInfo{
 											RepositoryUrl: "",
 											Branch:        "",
@@ -441,7 +439,6 @@ var sarifTests = []sarifTest{
 							PartialFingerprints: SarifPartialFingerprints{
 								DatadogFingerprint: GetDatadogFingerprintHash(
 									model.SCIInfo{
-										RunType: "",
 										RepositoryCommitInfo: model.RepositoryCommitInfo{
 											RepositoryUrl: "",
 											Branch:        "",
@@ -479,7 +476,6 @@ var sarifTests = []sarifTest{
 							PartialFingerprints: SarifPartialFingerprints{
 								DatadogFingerprint: GetDatadogFingerprintHash(
 									model.SCIInfo{
-										RunType: "",
 										RepositoryCommitInfo: model.RepositoryCommitInfo{
 											RepositoryUrl: "",
 											Branch:        "",
@@ -621,7 +617,6 @@ var sarifTests = []sarifTest{
 							PartialFingerprints: SarifPartialFingerprints{
 								DatadogFingerprint: GetDatadogFingerprintHash(
 									model.SCIInfo{
-										RunType: "",
 										RepositoryCommitInfo: model.RepositoryCommitInfo{
 											RepositoryUrl: "",
 											Branch:        "",

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -41,7 +41,6 @@ func PrintSarifReport(ctx context.Context, path, filename string, body interface
 		if err != nil {
 			return err
 		}
-		sarifReport.SetToolVersionType(ctx, sciInfo.RunType)
 
 		body = sarifReport
 	}

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -20,7 +20,6 @@ type reportTestCase struct {
 }
 
 type sarifReport struct {
-	basePath     string                 `json:"-"`
 	Schema       string                 `json:"$schema"`
 	SarifVersion string                 `json:"version"`
 	Runs         []reportModel.SarifRun `json:"runs"`
@@ -60,52 +59,9 @@ func TestPrintSarifReport(t *testing.T) {
 			var resultSarif sarifReport
 			err = json.Unmarshal(jsonResult, &resultSarif)
 			require.NoError(t, err)
-			require.Equal(t, "", resultSarif.basePath)
 			require.Equal(t, "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json", resultSarif.Schema)
 			require.Equal(t, "2.1.0", resultSarif.SarifVersion)
 			require.Len(t, resultSarif.Runs, len(sarifTest.expectedResult.Queries))
-			require.NoError(t, os.RemoveAll(sarifTest.caseTest.path))
-		})
-	}
-}
-
-func TestPrintSarifReportWithToolVersionFullScan(t *testing.T) {
-	ctx := context.Background()
-	for idx, sarifTest := range sarifTests {
-		t.Run(fmt.Sprintf("Sarif File test case %d", idx), func(t *testing.T) {
-			if err := os.MkdirAll(sarifTest.caseTest.path, os.ModePerm); err != nil {
-				t.Fatal(err)
-			}
-			err := PrintSarifReport(ctx, sarifTest.caseTest.path, sarifTest.caseTest.filename, sarifTest.caseTest.summary, &model.SCIInfo{RunType: "full_scan"})
-			checkFileExists(t, err, &sarifTest, "sarif")
-			jsonResult, err := os.ReadFile(filepath.Join(sarifTest.caseTest.path, sarifTest.caseTest.filename+".sarif"))
-			require.NoError(t, err)
-			var resultSarif sarifReport
-			err = json.Unmarshal(jsonResult, &resultSarif)
-			require.NoError(t, err)
-			require.Len(t, resultSarif.Runs, len(sarifTest.expectedResult.Queries))
-			require.Equal(t, resultSarif.Runs[0].Tool.Driver.ToolVersion, "full_scan")
-			require.NoError(t, os.RemoveAll(sarifTest.caseTest.path))
-		})
-	}
-}
-
-func TestPrintSarifReportWithToolVersionCodeUpdate(t *testing.T) {
-	ctx := context.Background()
-	for idx, sarifTest := range sarifTests {
-		t.Run(fmt.Sprintf("Sarif File test case %d", idx), func(t *testing.T) {
-			if err := os.MkdirAll(sarifTest.caseTest.path, os.ModePerm); err != nil {
-				t.Fatal(err)
-			}
-			err := PrintSarifReport(ctx, sarifTest.caseTest.path, sarifTest.caseTest.filename, sarifTest.caseTest.summary, &model.SCIInfo{RunType: "code_update"})
-			checkFileExists(t, err, &sarifTest, "sarif")
-			jsonResult, err := os.ReadFile(filepath.Join(sarifTest.caseTest.path, sarifTest.caseTest.filename+".sarif"))
-			require.NoError(t, err)
-			var resultSarif sarifReport
-			err = json.Unmarshal(jsonResult, &resultSarif)
-			require.NoError(t, err)
-			require.Len(t, resultSarif.Runs, len(sarifTest.expectedResult.Queries))
-			require.Equal(t, resultSarif.Runs[0].Tool.Driver.ToolVersion, "code_update")
 			require.NoError(t, os.RemoveAll(sarifTest.caseTest.path))
 		})
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -148,7 +148,7 @@ func Test_E2EExclusions(t *testing.T) {
 			params, ctx := scan.GetDefaultParameters(context.Background(), "")
 			params.Path = []string{tt.testFile}
 			params.OutputPath = t.TempDir()
-			params.SCIInfo = model.SCIInfo{DiffAware: model.DiffAware{Enabled: false}, RunType: "code_update", RepositoryCommitInfo: model.RepositoryCommitInfo{RepositoryUrl: "test/url", CommitSHA: "test/hash", Branch: "test/branch"}}
+			params.SCIInfo = model.SCIInfo{DiffAware: model.DiffAware{Enabled: false}, RepositoryCommitInfo: model.RepositoryCommitInfo{RepositoryUrl: "test/url", CommitSHA: "test/hash", Branch: "test/branch"}}
 			params.FlagEvaluator = featureflags.NewLocalEvaluator()
 			metadata, err := console.ExecuteScan(ctx, params)
 			require.NoError(t, err)


### PR DESCRIPTION
... by not overwriting it with some "run type" that's always the same.

## Motivation

We don't have the scanner version in the IaC event. This will make sure that `tool.version` has it.

## Changes

Removed RunType from SCIInfo and the functions that use it. Removed tests that checked for the old functionality.

## Author Checklist

- [X] I have reviewed my own PR.
- [X] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [X] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

```
% make build
...
% bin/datadog-iac-scanner scan -p . -o /tmp
...
% cat /tmp/datadog-iac-scanner-result.sarif| jq '.runs[0].tool.driver.version'
"snapshot-8e2ac5a4"
```

(instead of `"ci"`).


I submit this contribution under the Apache-2.0 license.
