### PR TITLE
Normalize file paths in SARIF file to repo dir

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -133,7 +133,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		MaxResolverDepth:           c.Int("max-resolver-depth"),
 		ExcludePlatform:            []string{""},
 		PayloadPath:                payloadPath,
-		SCIInfo:                    model.SCIInfo{RepositoryCommitInfo: *repoInfo},
+		SCIInfo:                    model.SCIInfo{RepositoryDir: repoDir, RepositoryCommitInfo: *repoInfo},
 		FlagEvaluator:              getFeatureFlagEvaluator(c),
 		ExcludeCategories:          config.ExcludeCategories,
 		ExcludeQueries:             append(c.StringSlice("exclude-queries"), config.ExcludeQueries...),

--- a/e2e/utils/helper.go
+++ b/e2e/utils/helper.go
@@ -46,15 +46,16 @@ func DevPathAdapter(path string) string {
 	case "/path/e2e/fixtures/samples/configs/config.yaml":
 		path = strings.ReplaceAll(path, "config.yaml", "config-dev.yaml")
 	}
+	wd, _ := filepath.Abs(".")
 	regex := regexp.MustCompile(`/path/\w+/`)
 	matches := regex.FindString(path)
 	switch matches {
 	case "":
 		return path
 	case "/path/e2e/":
-		return strings.ReplaceAll(path, matches, "")
+		return strings.ReplaceAll(path, matches, wd+"/")
 	default:
-		return strings.ReplaceAll(path, "/path/", "../")
+		return strings.ReplaceAll(path, "/path/", wd+"/../")
 	}
 }
 

--- a/pkg/model/source_code.go
+++ b/pkg/model/source_code.go
@@ -7,6 +7,7 @@ package model
 
 type SCIInfo struct {
 	DiffAware            DiffAware
+	RepositoryDir        string
 	RepositoryCommitInfo RepositoryCommitInfo `json:"repository_commit_info"`
 	OrgId                int64                `json:"org_id"`
 }

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
@@ -184,11 +183,10 @@ type SarifRun struct {
 
 // SarifReport represents a usable sarif report reference
 type SarifReport interface {
-	BuildSarifIssue(ctx context.Context, issue *model.QueryResult, sciInfo model.SCIInfo) string
+	BuildSarifIssue(ctx context.Context, issue *model.QueryResult, sciInfo model.SCIInfo) (string, error)
 	RebuildTaxonomies(cwes []string, guids map[string]string)
 	GetGUIDFromRelationships(idx int, cweID string) string
 	AddTags(ctx context.Context, summary *model.Summary, diffAware *model.DiffAware) error
-	ResolveFilepaths(basePath string) error
 }
 
 type sarifReport struct {
@@ -431,9 +429,13 @@ func (sr *sarifReport) RebuildTaxonomies(cwes []string, guids map[string]string)
 }
 
 // BuildSarifIssue creates a new entries in Results (one for each file) and new entry in Rules and Taxonomy if necessary
-// nolint:gocritic
-func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryResult, sciInfo model.SCIInfo) string {
+// nolint:gocritic,gocyclo
+func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryResult, sciInfo model.SCIInfo) (string, error) {
 	contextLogger := logger.FromContext(ctx)
+	repoPath, err := getRepoPath(&sciInfo)
+	if err != nil {
+		return "", err
+	}
 	if len(issue.Files) > 0 {
 		metadata := ruleMetadata{
 			queryID:          issue.QueryID,
@@ -530,7 +532,10 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 				vulnerability.Line,
 			)
 
-			absoluteFilePath := strings.ReplaceAll(issue.Files[idx].FileName, "../", "")
+			artifactPath, err := resolvePath(repoPath, issue.Files[idx].FileName)
+			if err != nil {
+				return "", err
+			}
 			result := sarifResult{
 				ResultRuleID:    issue.QueryName,
 				ResultRuleIndex: ruleIndex,
@@ -541,7 +546,7 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 				ResultLocations: []SarifLocation{
 					{
 						PhysicalLocation: sarifPhysicalLocation{
-							ArtifactLocation: sarifArtifactLocation{ArtifactURI: absoluteFilePath},
+							ArtifactLocation: sarifArtifactLocation{ArtifactURI: artifactPath},
 							Region: model.SarifRegion{
 								StartLine:   resourceStartLocation.Line,
 								EndLine:     resourceEndLocation.Line,
@@ -557,7 +562,7 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 				PartialFingerprints: SarifPartialFingerprints{
 					DatadogFingerprint: GetDatadogFingerprintHash(
 						sciInfo,
-						absoluteFilePath,
+						artifactPath,
 						issue.Platform,
 						resourceType,
 						resourceName,
@@ -583,9 +588,9 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 			}
 			sr.Runs[0].Results = append(sr.Runs[0].Results, result)
 		}
-		return issue.CWE
+		return issue.CWE, nil
 	}
-	return ""
+	return "", nil
 }
 
 func (sr *sarifReport) AddTags(ctx context.Context, summary *model.Summary, diffAware *model.DiffAware) error {
@@ -627,13 +632,24 @@ func (sr *sarifReport) AddTags(ctx context.Context, summary *model.Summary, diff
 	return nil
 }
 
-func (sr *sarifReport) ResolveFilepaths(basePath string) error {
-	for idx := range sr.Runs[0].Results {
-		artifactLocation := &sr.Runs[0].Results[idx].ResultLocations[0].PhysicalLocation.ArtifactLocation.ArtifactURI
-		resolvedLocation := strings.TrimPrefix(*artifactLocation, basePath+"/")
-		sr.Runs[0].Results[idx].ResultLocations[0].PhysicalLocation.ArtifactLocation.ArtifactURI = resolvedLocation
+func getRepoPath(sciInfo *model.SCIInfo) (string, error) {
+	repoDir := sciInfo.RepositoryDir
+	if sciInfo.RepositoryDir == "" {
+		repoDir = "."
 	}
-	return nil
+	return filepath.Abs(repoDir)
+}
+
+func resolvePath(root, path string) (string, error) {
+	if abs, err := filepath.Abs(path); err != nil {
+		return "", err
+	} else if rel, err := filepath.Rel(root, abs); err != nil {
+		return "", err
+	} else if rel == "." {
+		return "", nil
+	} else {
+		return rel, nil
+	}
 }
 
 // nolint:gocritic

--- a/pkg/report/model/sarif_test.go
+++ b/pkg/report/model/sarif_test.go
@@ -877,7 +877,8 @@ func TestBuildSarifIssueWithFrameworks(t *testing.T) {
 	}
 
 	report := NewSarifReport().(*sarifReport)
-	cwe := report.BuildSarifIssue(ctx, &queryResult, model.SCIInfo{})
+	cwe, err := report.BuildSarifIssue(ctx, &queryResult, model.SCIInfo{})
+	require.NoError(t, err)
 
 	// Verify CWE was returned
 	require.Equal(t, "284", cwe)

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -27,18 +27,14 @@ func PrintSarifReport(ctx context.Context, path, filename string, body interface
 		sarifReport := reportModel.NewSarifReport()
 		auxGUID := map[string]string{}
 		for idx := range summary.Queries {
-			x := sarifReport.BuildSarifIssue(ctx, &summary.Queries[idx], *sciInfo)
-			if x != "" {
-				guid := sarifReport.GetGUIDFromRelationships(idx, x)
-				auxGUID[x] = guid
+			if cwe, err := sarifReport.BuildSarifIssue(ctx, &summary.Queries[idx], *sciInfo); err != nil {
+				return err
+			} else if cwe != "" {
+				guid := sarifReport.GetGUIDFromRelationships(idx, cwe)
+				auxGUID[cwe] = guid
 			}
 		}
-		err = sarifReport.AddTags(ctx, &summary, &sciInfo.DiffAware)
-		if err != nil {
-			return err
-		}
-		err = sarifReport.ResolveFilepaths(path)
-		if err != nil {
+		if err := sarifReport.AddTags(ctx, &summary, &sciInfo.DiffAware); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
## Motivation

The original code writes to the SARIF file whatever file paths were provided in the command line. This means that if someone writes `datadog-iac-scanner -p foo/bar`, the file names will start with `foo/bar`, but if they go one level up in the directory hierarchy and write `datadog-iac-scanner -p repo/foo/bar`, the file names will start with `repo/foo/bar`.

This code uses the `repoDir` that was computed in `cmd/scanner/scan.go` to compute each file's relative path from that `repoDir`.

## Changes

When generating the SARIF, resolve each file relative to the repository dir. Remove naive post-processing.

## Author Checklist

- [X] I have reviewed my own PR.
- [X] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [X] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

### Before the change

```
% make build
...
% cd ..
...
% datadog-iac-scanner/bin/datadog-iac-scanner scan -p datadog-iac-scanner -o /tmp
...
% cat /tmp/datadog-iac-scanner-result.sarif | jq '.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri'
"datadog-iac-scanner/assets/queries/cloudFormation/aws/amazon_dms_replication_instance_is_publicly_accessible/test/positive1.yaml"
```

### After the change

```
% make build
...
% cd ..
...
% datadog-iac-scanner/bin/datadog-iac-scanner scan -p datadog-iac-scanner -o /tmp
...
% cat /tmp/datadog-iac-scanner-result.sarif | jq '.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri'
"assets/queries/cloudFormation/aws/amazon_dms_replication_instance_is_publicly_accessible/test/positive1.yaml"
```

I submit this contribution under the Apache-2.0 license.
