### PR TITLE
Use sync.Pool to decrease memory usage on the parsing

### DIFF
--- a/pkg/kics/service.go
+++ b/pkg/kics/service.go
@@ -67,6 +67,13 @@ type Service struct {
 	MaxFileSize    int
 }
 
+var bufferPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, mbConst)
+		return &b
+	},
+}
+
 // PrepareSources will prepare the sources to be scanned
 func (s *Service) PrepareSources(ctx context.Context,
 	scanID string,
@@ -79,31 +86,30 @@ func (s *Service) PrepareSources(ctx context.Context,
 	// CxSAST query under review
 	contextLogger.Info().Msgf("Getting sources")
 	var err error
+
+	var sink = func(ctx context.Context, filename string, rc io.ReadCloser) error {
+		data := bufferPool.Get().(*[]byte)
+		defer bufferPool.Put(data)
+		return s.sink(ctx, filename, scanID, rc, *data, openAPIResolveReferences, maxResolverDepth)
+	}
+	var resolverSink = func(ctx context.Context, filename string) ([]string, error) { // Sink used for resolver files and templates
+		return s.resolverSink(ctx, filename, scanID, openAPIResolveReferences, maxResolverDepth)
+	}
+
 	// TODO: Remove this if / else upon finishing dogfooding phase
 	if ok := flagEvaluator.EvaluateWithOrgAndEnv(featureflags.IaCEnableKicsParallelFileParsing); ok {
 		err = s.SourceProvider.GetParallelSources(
 			ctx,
 			s.Parser.SupportedExtensions(),
-			func(ctx context.Context, filename string, rc io.ReadCloser) error {
-				// data will be used as buffer as the sink is used multiple times concurrently
-				data := make([]byte, mbConst)
-				return s.sink(ctx, filename, scanID, rc, data, openAPIResolveReferences, maxResolverDepth)
-			},
-			func(ctx context.Context, filename string) ([]string, error) { // Sink used for resolver files and templates
-				return s.resolverSink(ctx, filename, scanID, openAPIResolveReferences, maxResolverDepth)
-			},
+			sink,
+			resolverSink,
 		)
 	} else {
 		err = s.SourceProvider.GetSources(
 			ctx,
 			s.Parser.SupportedExtensions(),
-			func(ctx context.Context, filename string, rc io.ReadCloser) error {
-				data := make([]byte, mbConst)
-				return s.sink(ctx, filename, scanID, rc, data, openAPIResolveReferences, maxResolverDepth)
-			},
-			func(ctx context.Context, filename string) ([]string, error) { // Sink used for resolver files and templates
-				return s.resolverSink(ctx, filename, scanID, openAPIResolveReferences, maxResolverDepth)
-			},
+			sink,
+			resolverSink,
 		)
 	}
 	if err != nil {


### PR DESCRIPTION
## Motivation

IaC scanning tends to use lots of memory scanning big repositories. This PR aims to decrease the memory load by using a sync.Pool

## Changes

- Added a sync.Pool to reuse objects instead of creating new objects each time

## Author Checklist

- [x] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
  - Only added a sync pool that does not change the logic. The tests should pass
- [x] All new and existing tests pass.
- [x] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).
  - Logic does not change

## QA Instruction

Tell the reviewer how they can make sure the PR is indeed working as intended. Tell them what they should be looking for.

## Blast Radius

IaC scanning

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
