### PR TITLE
Ansible: benign fixes

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -590,6 +590,12 @@ func checkYamlPlatform(ctx context.Context, content []byte, path string) string 
 		contentNode = node.Content[0]
 	}
 
+	// A scalar root means the document is empty/null (e.g. a comment-only vars file).
+	// No platform can be detected; skip silently.
+	if contentNode.Kind == yamlParser.ScalarNode {
+		return ""
+	}
+
 	var yamlContent model.Document
 	if err := yamlContent.UnmarshalYAML(ctx, contentNode, nil); err != nil {
 		contextLogger.Warn().Msgf("failed to unmarshal yaml file (%s): %s", path, err)

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -564,8 +564,18 @@ func checkHelm(ctx context.Context, path string) bool {
 }
 
 func checkYamlPlatform(ctx context.Context, content []byte, path string) string {
+	// Ansible 'templates/' directories contain Jinja2 files; {{ }} syntax is invalid YAML.
+	if isInsideAnsibleTemplatesDir(path) {
+		return ""
+	}
+
 	contextLogger := logger.FromContext(ctx)
-	content = utils.DecryptAnsibleVault(ctx, content, os.Getenv("ANSIBLE_VAULT_PASSWORD_FILE"))
+
+	content = utils.DecryptAnsibleVault(ctx, content, utils.GetVaultPassword())
+
+	if utils.IsAnsibleVaultEncrypted(content) {
+		return ""
+	}
 
 	// Parse as Node to manually call Datadog's version of UnmarshalYAML with context
 	var node yamlParser.Node
@@ -610,6 +620,23 @@ func checkYamlPlatform(ctx context.Context, content []byte, path string) string 
 
 func checkForAnsibleByPaths(path string) bool {
 	return queryRegexPathsAnsible.MatchString(path)
+}
+
+// isInsideAnsibleTemplatesDir reports whether path is inside an Ansible templates directory.
+// It requires a preceding "roles" or "ansible" path component to avoid false positives on
+// non-Ansible repos that happen to have their own templates/ directories.
+func isInsideAnsibleTemplatesDir(path string) bool {
+	parts := strings.Split(filepath.ToSlash(path), "/")
+	seenSignal := false
+	for _, part := range parts {
+		if part == "ansible" || part == "roles" {
+			seenSignal = true
+		}
+		if part == "templates" && seenSignal {
+			return true
+		}
+	}
+	return false
 }
 
 func checkForAnsible(yamlContent model.Document) bool {

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
@@ -632,7 +633,12 @@ func checkForAnsibleByPaths(path string) bool {
 // It requires a preceding "roles" or "ansible" path component to avoid false positives on
 // non-Ansible repos that happen to have their own templates/ directories.
 func isInsideAnsibleTemplatesDir(path string) bool {
-	parts := strings.Split(filepath.ToSlash(path), "/")
+	parts := strings.FieldsFunc(filepath.Clean(path), func(r rune) bool {
+		if r > unicode.MaxLatin1 {
+			return false
+		}
+		return os.IsPathSeparator(uint8(r))
+	})
 	seenSignal := false
 	for _, part := range parts {
 		if part == "ansible" || part == "roles" {

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -439,3 +439,22 @@ func TestAnalyzer_Analyze(t *testing.T) {
 		})
 	}
 }
+
+func Test_isInsideAnsibleTemplatesDir(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"templates", false},
+		{"my-templates/foo.yaml", false},
+		{"frontend/templates/config.yaml", false},
+		{"roles/web/templates/nginx.conf.j2", true},
+		{"ansible/roles/kube-scheduler/templates/config.yaml", true},
+		{"ansible/templates/main.yaml", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			require.Equal(t, tt.want, isInsideAnsibleTemplatesDir(tt.path))
+		})
+	}
+}

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -440,6 +440,24 @@ func TestAnalyzer_Analyze(t *testing.T) {
 	}
 }
 
+func Test_checkYamlPlatform_emptyFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+	}{
+		{"comment-only vars file", []byte("---\n# vars file for sshconf\n\n")},
+		{"blank document", []byte("---\n")},
+		{"completely empty", []byte("")},
+	}
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkYamlPlatform(ctx, tt.content, "ansible/roles/sshd/vars/main.yml")
+			require.Equal(t, "", got)
+		})
+	}
+}
+
 func Test_isInsideAnsibleTemplatesDir(t *testing.T) {
 	tests := []struct {
 		path string

--- a/pkg/parser/ansible/ini/config/parser.go
+++ b/pkg/parser/ansible/ini/config/parser.go
@@ -7,6 +7,7 @@ package ansibleconfig
 
 import (
 	"context"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -26,6 +27,11 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	ignoreLines []int,
 	resolvedFiles map[string]model.ResolvedFile,
 	err error) {
+	// Files in Ansible 'files/' directories are raw host artifacts, not IaC config.
+	if isInsideFilesDir(filePath) {
+		return fileContent, []model.Document{}, []int{}, nil, nil
+	}
+
 	reader := strings.NewReader(string(fileContent))
 	configparser.Delimiters("=")
 	inline := configparser.InlineCommentPrefixes([]string{";"})
@@ -106,4 +112,17 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 
 func emptyDocument() *model.Document {
 	return &model.Document{}
+}
+
+// isInsideFilesDir reports whether filePath has a "files" path component.
+// A broad match on "files" is safe here because SupportedTypes() returns only "ansible",
+// so only Ansible-typed repos reach this parser.
+func isInsideFilesDir(filePath string) bool {
+	normalized := filepath.ToSlash(filePath)
+	for _, part := range strings.Split(normalized, "/") {
+		if part == "files" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/parser/ansible/ini/config/parser.go
+++ b/pkg/parser/ansible/ini/config/parser.go
@@ -7,9 +7,11 @@ package ansibleconfig
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/ansible/ini/comments"
@@ -118,8 +120,12 @@ func emptyDocument() *model.Document {
 // A broad match on "files" is safe here because SupportedTypes() returns only "ansible",
 // so only Ansible-typed repos reach this parser.
 func isInsideFilesDir(filePath string) bool {
-	normalized := filepath.ToSlash(filePath)
-	for _, part := range strings.Split(normalized, "/") {
+	for _, part := range strings.FieldsFunc(filepath.Clean(filePath), func(r rune) bool {
+		if r > unicode.MaxLatin1 {
+			return false
+		}
+		return os.IsPathSeparator(uint8(r))
+	}) {
 		if part == "files" {
 			return true
 		}

--- a/pkg/parser/ansible/ini/config/parser_test.go
+++ b/pkg/parser/ansible/ini/config/parser_test.go
@@ -37,19 +37,21 @@ func TestParser_SupportedTypes(t *testing.T) {
 // TestParser_Parse tests the functions [Parse()] and all the methods called by them
 func TestParser_Parse(t *testing.T) {
 	type args struct {
-		content []byte
+		content  []byte
+		filePath string
 	}
 	tests := []struct {
-		name    string
-		p       *Parser
-		args    args
-		want    string
-		wantErr bool
+		name          string
+		p             *Parser
+		args          args
+		wantDocuments int
+		wantErr       bool
 	}{
 		{
 			name: "CFG to model.Document",
 			p:    &Parser{},
 			args: args{
+				filePath: "ansible.cfg",
 				content: []byte(`
 [defaults]
 inventory = /etc/ansible/hosts
@@ -73,27 +75,50 @@ ssh_args = -o ControlMaster=auto -o ControlPersist=30m -o ControlPath=/tmp/ansib
 profile_tasks = yes
 `),
 			},
-			want:    "",
-			wantErr: false,
+			wantDocuments: 1,
+			wantErr:       false,
+		},
+		{
+			name: "skip non-INI file inside ansible files/ dir",
+			p:    &Parser{},
+			args: args{
+				filePath: "packer/common/ansible/files/etc/sysctl.conf",
+				content: []byte(`
+net.core.rmem_max = 26214400
+net.ipv4.tcp_rmem = 4096 87380 26214400
+`),
+			},
+			wantDocuments: 0,
+			wantErr:       false,
+		},
+		{
+			name: "skip non-INI file inside role files/ dir",
+			p:    &Parser{},
+			args: args{
+				filePath: "ansible/roles/base/files/nsswitch.conf",
+				content: []byte(`
+passwd:         compat cache systemd
+group:          compat cache systemd
+`),
+			},
+			wantDocuments: 0,
+			wantErr:       false,
 		},
 	}
 
 	ctx := context.Background()
-	for i, tt := range tests {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Parser{}
-			switch i {
-			case 0:
-				_, got, _, _, err := p.Parse(ctx, tt.args.content, "", true, 15)
-				if (err != nil) != tt.wantErr {
-					t.Errorf("Parser() error = %v, wantErr %v", err, tt.wantErr)
-					return
-				}
-				_, err = json.Marshal(got)
-				if err != nil {
-					t.Errorf("json.Marshal() error = %v, wantErr %v", err, tt.wantErr)
-					return
-				}
+			_, got, _, _, err := p.Parse(ctx, tt.args.content, tt.args.filePath, true, 15)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parser() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			require.Equal(t, tt.wantDocuments, len(got))
+			_, err = json.Marshal(got)
+			if err != nil {
+				t.Errorf("json.Marshal() error = %v", err)
 			}
 		})
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"os"
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
@@ -138,7 +137,7 @@ func (c *Parser) Parse(
 	openAPIResolveReferences, isMinified bool,
 	maxResolverDepth int) (ParsedDocument, error) {
 	contextLogger := logger.FromContext(ctx)
-	fileContent = utils.DecryptAnsibleVault(ctx, fileContent, os.Getenv("ANSIBLE_VAULT_PASSWORD_FILE"))
+	fileContent = utils.DecryptAnsibleVault(ctx, fileContent, utils.GetVaultPassword())
 
 	if c.isValidExtension(ctx, filePath) {
 		resolved, obj, igLines, resolvedFiles, err := c.parsers.Parse(ctx, fileContent, filePath, openAPIResolveReferences, maxResolverDepth)

--- a/pkg/utils/ansible_vault.go
+++ b/pkg/utils/ansible_vault.go
@@ -8,6 +8,7 @@ package utils
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -57,7 +58,7 @@ func ReadVaultPassword(filePath string) string {
 	if filePath == "" {
 		return ""
 	}
-	data, err := os.ReadFile(filePath)
+	data, err := os.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		return ""
 	}

--- a/pkg/utils/ansible_vault.go
+++ b/pkg/utils/ansible_vault.go
@@ -7,26 +7,59 @@ package utils
 
 import (
 	"context"
+	"os"
 	"regexp"
+	"strings"
+	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	vault "github.com/sosedoff/ansible-vault-go"
 )
 
+var ansibleVaultHeaderPattern = regexp.MustCompile(`^\s*\$ANSIBLE_VAULT`)
+
 // DecryptAnsibleVault verifies if the fileContent is encrypted by ansible-vault. If yes, the function decrypts it
 func DecryptAnsibleVault(ctx context.Context, fileContent []byte, secret string) []byte {
 	contextLogger := logger.FromContext(ctx)
-	match, err := regexp.MatchString(`^\s*\$ANSIBLE_VAULT.*`, string(fileContent))
-	if err != nil {
-		return fileContent
-	}
+	match := ansibleVaultHeaderPattern.Match(fileContent)
 	if secret != "" && match {
 		content, err := vault.Decrypt(string(fileContent), secret)
-
 		if err == nil {
 			contextLogger.Info().Msg("Decrypting Ansible Vault file")
 			fileContent = []byte(content)
+		} else {
+			contextLogger.Debug().Msgf("failed to decrypt Ansible Vault content: %s", err)
 		}
 	}
 	return fileContent
+}
+
+var (
+	vaultPasswordOnce   sync.Once
+	cachedVaultPassword string
+)
+
+// GetVaultPassword returns the vault password read from ANSIBLE_VAULT_PASSWORD_FILE, cached after the first call.
+func GetVaultPassword() string {
+	vaultPasswordOnce.Do(func() {
+		cachedVaultPassword = ReadVaultPassword(os.Getenv("ANSIBLE_VAULT_PASSWORD_FILE"))
+	})
+	return cachedVaultPassword
+}
+
+// IsAnsibleVaultEncrypted reports whether content is Ansible Vault encrypted.
+func IsAnsibleVaultEncrypted(content []byte) bool {
+	return ansibleVaultHeaderPattern.Match(content)
+}
+
+// ReadVaultPassword reads the vault password from the file at filePath.
+func ReadVaultPassword(filePath string) string {
+	if filePath == "" {
+		return ""
+	}
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }

--- a/pkg/utils/ansible_vault.go
+++ b/pkg/utils/ansible_vault.go
@@ -22,8 +22,7 @@ var ansibleVaultHeaderPattern = regexp.MustCompile(`^\s*\$ANSIBLE_VAULT`)
 // DecryptAnsibleVault verifies if the fileContent is encrypted by ansible-vault. If yes, the function decrypts it
 func DecryptAnsibleVault(ctx context.Context, fileContent []byte, secret string) []byte {
 	contextLogger := logger.FromContext(ctx)
-	match := ansibleVaultHeaderPattern.Match(fileContent)
-	if secret != "" && match {
+	if secret != "" && IsAnsibleVaultEncrypted(fileContent) {
 		content, err := vault.Decrypt(string(fileContent), secret)
 		if err == nil {
 			contextLogger.Info().Msg("Decrypting Ansible Vault file")

--- a/pkg/utils/ansible_vault_test.go
+++ b/pkg/utils/ansible_vault_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -62,4 +63,24 @@ func Test_DecryptAnsibleVault(t *testing.T) {
 			require.Equal(t, test.ansibleVaultDecrypted, got)
 		})
 	}
+}
+
+func Test_ReadVaultPassword(t *testing.T) {
+	t.Run("returns empty string for empty path", func(t *testing.T) {
+		require.Equal(t, "", ReadVaultPassword(""))
+	})
+
+	t.Run("returns empty string for non-existent file", func(t *testing.T) {
+		require.Equal(t, "", ReadVaultPassword("/nonexistent/path/to/vault_password"))
+	})
+
+	t.Run("reads and trims password from file", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "vault_password")
+		require.NoError(t, err)
+		_, err = f.WriteString("cosmic\n")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		require.Equal(t, "cosmic", ReadVaultPassword(f.Name()))
+	})
 }


### PR DESCRIPTION
## Motivation

Reduce noisy `iac-scanning` errors and warnings for Ansible repos: vault password was read incorrectly from `ANSIBLE_VAULT_PASSWORD_FILE`, raw files under `files/` were parsed as INI, Jinja2 under `templates/` and empty YAML vars files caused false warnings and logs that are not correct for files we aren't supposed to parse.

## Changes

- Read vault password from the path in `ANSIBLE_VAULT_PASSWORD_FILE` instead of directly `ANSIBLE_VAULT_PASSWORD_FILE`
- Skip Ansible INI parsing for paths under `files/`; narrow template skip to paths with `ansible` or `roles` before `templates`.
- After vault decrypt, skip still-encrypted YAML in platform detection; skip scalar-root YAML (e.g. comment-only vars files). This is something that will fix also other yaml-platform based parsing.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run `go test ./pkg/analyzer/... ./pkg/parser/... ./pkg/utils/...`. After deploy, spot-check Datadog logs: fewer `missing section header` on `files/*.conf`, fewer `failed to unmarshal yaml` for vault/empty vars.

## Blast Radius

This PR impacts the analyzer for YAML platform detection, Ansible CFG/CONF parser, shared vault helper, main parser vault hook.

## Additional Notes

I submit this contribution under the Apache-2.0 license.
