### PR TITLE
Decreased max num workers and make it configurable

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -73,6 +73,11 @@ var scanAction = &cli.Command{
 			Usage:   "a list of platform types to scan",
 			Value:   GetSupportedPlatforms(),
 		},
+		&cli.IntFlag{
+			Name:  "max-num-workers",
+			Usage: "Max workers running parallel jobs for parallel parsing",
+			Value: 32,
+		},
 		&cli.BoolFlag{
 			Name:   "x-parallelparsing",
 			Hidden: true,
@@ -142,6 +147,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		ExcludePaths:               config.ExcludePaths,
 		IncludeQueries:             config.IncludeQueries,
 		DownloadQueriesFromDatadog: c.Bool("x-downloadqueriesfromdatadog"),
+		MaxNumWorkers:              c.Int("max-num-workers"),
 	}
 
 	metadata, err := console.ExecuteScan(ctx, params)

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -26,14 +26,14 @@ import (
 // FileSystemSourceProvider provides a path to be scanned
 // and a list of files which will not be scanned
 type FileSystemSourceProvider struct {
-	paths    []string
-	excludes map[string][]os.FileInfo
-	mu       sync.RWMutex
+	paths         []string
+	excludes      map[string][]os.FileInfo
+	mu            sync.RWMutex
+	maxNumWorkers int
 }
 
 const (
 	minNumWorkers = 4
-	maxNumWorkers = 64
 )
 
 var (
@@ -43,7 +43,7 @@ var (
 )
 
 // NewFileSystemSourceProvider initializes a FileSystemSourceProvider with path and files that will be ignored
-func NewFileSystemSourceProvider(ctx context.Context, paths, excludes []string) (*FileSystemSourceProvider, error) {
+func NewFileSystemSourceProvider(ctx context.Context, paths, excludes []string, maxNumWorkers int) (*FileSystemSourceProvider, error) {
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msgf("provider.NewFileSystemSourceProvider()")
 	ex := make(map[string][]os.FileInfo, len(excludes))
@@ -52,8 +52,9 @@ func NewFileSystemSourceProvider(ctx context.Context, paths, excludes []string) 
 		osPaths[idx] = filepath.FromSlash(path)
 	}
 	fs := &FileSystemSourceProvider{
-		paths:    osPaths,
-		excludes: ex,
+		paths:         osPaths,
+		excludes:      ex,
+		maxNumWorkers: maxNumWorkers,
 	}
 
 	for _, exclude := range excludes {
@@ -293,8 +294,8 @@ func (s *FileSystemSourceProvider) calculateWorkerCount() int {
 	if numWorkers < 1 {
 		numWorkers = minNumWorkers
 	}
-	if numWorkers > maxNumWorkers {
-		numWorkers = maxNumWorkers
+	if numWorkers > s.maxNumWorkers {
+		numWorkers = s.maxNumWorkers
 	}
 	return numWorkers
 }

--- a/pkg/engine/provider/filesystem_test.go
+++ b/pkg/engine/provider/filesystem_test.go
@@ -22,8 +22,9 @@ import (
 // TestNewFileSystemSourceProvider tests the functions [NewFileSystemSourceProvider()] and all the methods called by them
 func TestNewFileSystemSourceProvider(t *testing.T) {
 	type args struct {
-		paths    []string
-		excludes []string
+		paths         []string
+		excludes      []string
+		maxNumWorkers int
 	}
 	tests := []struct {
 		name    string
@@ -38,10 +39,12 @@ func TestNewFileSystemSourceProvider(t *testing.T) {
 				excludes: []string{
 					".tf",
 				},
+				maxNumWorkers: 32,
 			},
 			want: &FileSystemSourceProvider{
-				paths:    []string{filepath.FromSlash("./test")},
-				excludes: make(map[string][]os.FileInfo, 1),
+				paths:         []string{filepath.FromSlash("./test")},
+				excludes:      make(map[string][]os.FileInfo, 1),
+				maxNumWorkers: 32,
 			},
 			wantErr: false,
 		},
@@ -52,10 +55,12 @@ func TestNewFileSystemSourceProvider(t *testing.T) {
 				excludes: []string{
 					".tf",
 				},
+				maxNumWorkers: 17,
 			},
 			want: &FileSystemSourceProvider{
-				paths:    []string{filepath.FromSlash("./test"), filepath.FromSlash("./test2")},
-				excludes: make(map[string][]os.FileInfo, 1),
+				paths:         []string{filepath.FromSlash("./test"), filepath.FromSlash("./test2")},
+				excludes:      make(map[string][]os.FileInfo, 1),
+				maxNumWorkers: 17,
 			},
 			wantErr: false,
 		},
@@ -64,7 +69,7 @@ func TestNewFileSystemSourceProvider(t *testing.T) {
 	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewFileSystemSourceProvider(ctx, tt.args.paths, tt.args.excludes)
+			got, err := NewFileSystemSourceProvider(ctx, tt.args.paths, tt.args.excludes, tt.args.maxNumWorkers)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewFileSystemSourceProvider() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -572,7 +577,7 @@ func checkStatErr(t *testing.T, err error) {
 // initFs creates a new instance of File System Source Provider
 func initFs(paths, excluded []string) (*FileSystemSourceProvider, error) {
 	ctx := context.Background()
-	return NewFileSystemSourceProvider(ctx, paths, excluded)
+	return NewFileSystemSourceProvider(ctx, paths, excluded, 32)
 }
 
 func getFSExcludes(fsystem *FileSystemSourceProvider) []string {
@@ -691,7 +696,7 @@ func TestGetSources_multipleHelmCharts(t *testing.T) {
 
 	ctx := context.Background()
 	fs, err := NewFileSystemSourceProvider(ctx,
-		[]string{filepath.FromSlash("test/fixtures/multi_helm")}, []string{})
+		[]string{filepath.FromSlash("test/fixtures/multi_helm")}, []string{}, 32)
 	require.NoError(t, err)
 
 	resolvedDirs := make([]string, 0)

--- a/pkg/kics/service_test.go
+++ b/pkg/kics/service_test.go
@@ -133,7 +133,7 @@ func createParserSourceProvider(path string) ([]*parser.Parser,
 		Add(terraformParser.NewDefault()).
 		Build([]string{""}, []string{""})
 
-	mockFilesSource, _ := provider.NewFileSystemSourceProvider(ctx, []string{path}, []string{})
+	mockFilesSource, _ := provider.NewFileSystemSourceProvider(ctx, []string{path}, []string{}, 32)
 
 	mockResolver, _ := resolver.NewBuilder().Build(ctx)
 

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -59,6 +59,7 @@ type Parameters struct {
 	SCIInfo                     model.SCIInfo
 	FlagEvaluator               featureflags.FlagEvaluator
 	DownloadQueriesFromDatadog  bool
+	MaxNumWorkers               int
 }
 
 // Client represents a scan client
@@ -114,6 +115,7 @@ func GetDefaultParameters(ctx context.Context, rootPath string) (*Parameters, co
 		UseOldSeverities:            false,
 		MaxResolverDepth:            15,
 		ExcludePlatform:             []string{""},
+		MaxNumWorkers:               32,
 	}, logCtx
 }
 

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -297,7 +297,7 @@ func (c *Client) getFileSystemSourceProvider(ctx context.Context, paths []string
 		excludePaths = append(excludePaths, c.ScanParams.ExcludePaths...)
 	}
 
-	filesSource, err := provider.NewFileSystemSourceProvider(ctx, paths, excludePaths)
+	filesSource, err := provider.NewFileSystemSourceProvider(ctx, paths, excludePaths, c.ScanParams.MaxNumWorkers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scan/scan_test.go
+++ b/pkg/scan/scan_test.go
@@ -37,6 +37,7 @@ func Test_ExecuteScan(t *testing.T) {
 				ScanID:                  "console",
 				MaxResolverDepth:        15,
 				FlagEvaluator:           featureflags.NewLocalEvaluator(),
+				MaxNumWorkers:           32,
 			},
 			ctx:                  context.Background(),
 			expectedResultsCount: 5,

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -93,7 +93,7 @@ func TestScanner_StartScan(t *testing.T) {
 
 func createServices(types, cloudProviders []string) (serviceSlice, *storage.MemoryStorage, error) {
 	ctx := context.Background()
-	filesSource, err := provider.NewFileSystemSourceProvider(ctx, []string{filepath.FromSlash("../../test")}, []string{})
+	filesSource, err := provider.NewFileSystemSourceProvider(ctx, []string{filepath.FromSlash("../../test")}, []string{}, 32)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Motivation

IaC Scanning is using a lot of memory, and the parallel parsing is only going to increase the load: the goal of this PR is to make this impact configurable by allowing to set the number of workers

## Changes

- Added a `MaxNumWorkers` scan parameter
- Added a `max-num-workers` flag

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- Check the default flag value
- Check that the value is indeed being used within the source provider

## Blast Radius

`iac-scanning`

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
