### PR TITLE
Made unsupported extension log debug

### DIFF
--- a/pkg/utils/get_extension.go
+++ b/pkg/utils/get_extension.go
@@ -49,7 +49,7 @@ func GetExtension(ctx context.Context, path string) (string, error) {
 
 			if isText {
 				err := fmt.Errorf("file %s does not have a supported extension", path)
-				contextLogger.Info().Msg(err.Error())
+				contextLogger.Debug().Msg(err.Error())
 				return "", err
 			}
 		}


### PR DESCRIPTION
## Motivation

This log: `file %s does not have a supported extension` is very noisy and cannot be filtered out as part of the `Info` logs.

This PR aims to make this log `Debug` to be able to filter it out.

## Changes

Turned log status from `Info` to `Debug`

## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Check that `Info` is now `Debug` on the log

## Blast Radius

iac scanning logs

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
