### PR TITLE
Remove error from logged content when parsing files fails

### DIFF
--- a/pkg/kics/resolver_sink.go
+++ b/pkg/kics/resolver_sink.go
@@ -44,7 +44,7 @@ func (s *Service) resolverSink(
 			if documents.Kind == "break" {
 				return []string{}, nil
 			}
-			contextLogger.Err(err).Msgf("failed to parse file content '%s' with fileType '%s'", rfile.FileName, kind)
+			contextLogger.Error().Msgf("failed to parse file content '%s' with fileType '%s'", rfile.FileName, kind)
 			return []string{}, nil
 		}
 

--- a/pkg/kics/sink.go
+++ b/pkg/kics/sink.go
@@ -49,7 +49,7 @@ func (s *Service) sink(ctx context.Context, filename, scanID string,
 	}
 	documents, err := s.Parser.Parse(ctx, filename, *content, openAPIResolveReferences, c.IsMinified, maxResolverDepth)
 	if err != nil {
-		contextLogger.Err(err).Msgf("failed to parse file content: %s", filename)
+		contextLogger.Error().Msgf("failed to parse file content: %s", filename)
 		return nil
 	}
 


### PR DESCRIPTION
## Motivation

The error displays the content of the file. This is to be avoided.

## Changes

Removed the errors showing the content of the files

## Author Checklist

- [x] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
  - No new logic, only a change in the logs
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Ensure that the logs are the ones meant to be targetted

## Blast Radius

iac-scanning logs

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
