### PR TITLE
fix: extend SNS public access rule to cover aws_sns_topic_policy

### DIFF
--- a/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/query.rego
+++ b/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/query.rego
@@ -3,8 +3,11 @@ package Cx
 import data.generic.common as common_lib
 import data.generic.terraform as tf_lib
 
+resource_type := {"aws_sns_topic", "aws_sns_topic_policy"}
+
 CxPolicy[result] {
-	resource := input.document[i].resource.aws_sns_topic[name]
+	res_type := resource_type[_]
+	resource := input.document[i].resource[res_type][name]
 
 	policy := common_lib.json_unmarshal(resource.policy)
 	st := common_lib.get_statement(policy)
@@ -15,13 +18,13 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "aws_sns_topic",
+		"resourceType": res_type,
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_sns_topic[%s].policy", [name]),
+		"searchKey": sprintf("%s[%s].policy", [res_type, name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'Statement.Principal.AWS' shouldn't contain '*'",
 		"keyActualValue": "'Statement.Principal.AWS' contains '*'",
-		"searchLine": common_lib.build_search_line(["resource", "aws_sns_topic", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", res_type, name, "policy"], []),
 	}
 }
 

--- a/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/negative2.tf
+++ b/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/negative2.tf
@@ -1,0 +1,20 @@
+resource "aws_sns_topic_policy" "negative2" {
+  arn = aws_sns_topic.example.arn
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSpecificAccount",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/positive2.tf
+++ b/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/positive2.tf
@@ -1,0 +1,18 @@
+resource "aws_sns_topic_policy" "positive2" {
+  arn = aws_sns_topic.example.arn
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowPublicAccess",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/positive_expected_result.json
@@ -10,5 +10,11 @@
     "severity": "CRITICAL",
     "line": 12,
     "fileName": "positive_module.tf"
+  },
+  {
+    "queryName": "SNS topic is publicly accessible",
+    "severity": "CRITICAL",
+    "line": 4,
+    "filename": "positive2.tf"
   }
 ]


### PR DESCRIPTION
## Summary
- Extends `sns_topic_is_publicly_accessible` Rego rule to also detect public access on `aws_sns_topic_policy` resources using the dynamic resource set pattern
- Adds positive and negative test cases for the new resource type