### PR TITLE
Fix Terraform policy line reporting for jsonencode and SARIF regions

### DIFF
--- a/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/query.rego
+++ b/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/query.rego
@@ -7,7 +7,7 @@ CxPolicy[result] {
 	resource := input.document[i].resource.aws_ecr_repository_policy[name]
 	policy := common_lib.json_unmarshal(resource.policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	tf_lib.anyPrincipal(statement)
@@ -16,10 +16,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_ecr_repository_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_ecr_repository_policy[%s].policy", [name]),
+		"searchKey": sprintf("aws_ecr_repository_policy[%s].policy.Statement[%d].Principal", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'Statement.Principal' shouldn't contain '*'",
 		"keyActualValue": "'Statement.Principal' contains '*'",
-		"searchLine": common_lib.build_search_line(["resource", "aws_ecr_repository_policy", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_ecr_repository_policy", name, "policy", "Statement", idx, "Principal"], []),
 	}
 }

--- a/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/test/positive2.tf
+++ b/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/test/positive2.tf
@@ -1,0 +1,35 @@
+resource "aws_ecr_repository" "multi" {
+  name = "multi-statement-repo"
+}
+
+resource "aws_ecr_repository_policy" "multi" {
+  repository = aws_ecr_repository.multi.name
+
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSpecific",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Action": [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+      ]
+    },
+    {
+      "Sid": "AllowAnyone",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/test/positive_expected_result.json
@@ -2,6 +2,6 @@
   {
     "queryName": "ECR repository is publicly accessible",
     "severity": "CRITICAL",
-    "line": 8
+    "line": 15
   }
 ]

--- a/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/test/positive_expected_result.json
@@ -3,5 +3,11 @@
     "queryName": "ECR repository is publicly accessible",
     "severity": "CRITICAL",
     "line": 15
+  },
+  {
+    "queryName": "ECR repository is publicly accessible",
+    "severity": "CRITICAL",
+    "line": 26,
+    "fileName": "positive2.tf"
   }
 ]

--- a/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/query.rego
+++ b/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/query.rego
@@ -9,7 +9,7 @@ CxPolicy[result] {
 	re_match("Service", resource.assume_role_policy)
 	policy := common_lib.json_unmarshal(resource.assume_role_policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	tf_lib.anyPrincipal(statement)
@@ -18,10 +18,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_iam_role",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_iam_role[%s].assume_role_policy", [name]),
+		"searchKey": sprintf("aws_iam_role[%s].assume_role_policy.Statement[%d].Principal", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'assume_role_policy.Statement.Principal' shouldn't contain '*'",
 		"keyActualValue": "'assume_role_policy.Statement.Principal' contains '*'",
-		"searchLine": common_lib.build_search_line(["resource", "aws_iam_role", name, "assume_role_policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_iam_role", name, "assume_role_policy", "Statement", idx, "Principal"], []),
 	}
 }

--- a/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/test/positive2.tf
+++ b/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/test/positive2.tf
@@ -1,0 +1,28 @@
+resource "aws_iam_role" "multi" {
+  name = "multi-statement-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": "AllowSpecific"
+    },
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com",
+        "AWS": "*"
+      },
+      "Effect": "Allow",
+      "Sid": "AllowAll"
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/test/positive_expected_result.json
@@ -2,11 +2,11 @@
   {
     "queryName": "IAM policy grants 'AssumeRole' permission across all services",
     "severity": "MEDIUM",
-    "line": 7
+    "line": 13
   },
   {
     "queryName": "IAM policy grants 'AssumeRole' permission across all services",
     "severity": "MEDIUM",
-    "line": 70
+    "line": 76
   }
 ]

--- a/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/test/positive_expected_result.json
@@ -8,5 +8,11 @@
     "queryName": "IAM policy grants 'AssumeRole' permission across all services",
     "severity": "MEDIUM",
     "line": 76
+  },
+  {
+    "queryName": "IAM policy grants 'AssumeRole' permission across all services",
+    "severity": "MEDIUM",
+    "line": 18,
+    "fileName": "positive2.tf"
   }
 ]

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
@@ -9,12 +9,7 @@ CxPolicy[result] {
 	resourceType := pl[r]
 	resource := input.document[i].resource[resourceType][name]
 
-	policy := common_lib.json_unmarshal(resource.policy)
-	st := common_lib.get_statement(policy)
-	statement := st[idx]
-
-	common_lib.is_allow_effect(statement)
-	tf_lib.anyPrincipal(statement)
+	idx := access_to_any_principal(resource.policy)[_]
 
 	result := {
 		"documentId": input.document[i].id,
@@ -33,12 +28,7 @@ CxPolicy[result] {
 	resourceType := pl[r]
 	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, resourceType, "policy")
 
-	policy := common_lib.json_unmarshal(module[keyToCheck])
-	st := common_lib.get_statement(policy)
-	statement := st[idx]
-
-	common_lib.is_allow_effect(statement)
-	tf_lib.anyPrincipal(statement)
+	idx := access_to_any_principal(module[keyToCheck])[_]
 
 	result := {
 		"documentId": input.document[i].id,
@@ -50,4 +40,15 @@ CxPolicy[result] {
 		"keyActualValue": "'policy.Principal' is equal to or contains '*'",
 		"searchLine": common_lib.build_search_line(["module", name, "policy", "Statement", idx, "Principal"], []),
 	}
+}
+
+access_to_any_principal(policyValue) = indices {
+	policy := common_lib.json_unmarshal(policyValue)
+	st := common_lib.get_statement(policy)
+	indices := [idx |
+		statement := st[idx]
+		common_lib.is_allow_effect(statement)
+		tf_lib.anyPrincipal(statement)
+	]
+	count(indices) > 0
 }

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
@@ -9,17 +9,22 @@ CxPolicy[result] {
 	resourceType := pl[r]
 	resource := input.document[i].resource[resourceType][name]
 
-	access_to_any_principal(resource.policy)
+	policy := common_lib.json_unmarshal(resource.policy)
+	st := common_lib.get_statement(policy)
+	statement := st[idx]
+
+	common_lib.is_allow_effect(statement)
+	tf_lib.anyPrincipal(statement)
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
 		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
-		"searchKey": sprintf("%s[%s].policy", [resourceType, name]),
+		"searchKey": sprintf("%s[%s].policy.Statement[%d].Principal", [resourceType, name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy.Principal should not equal to, nor contain '*'", [resourceType, name]),
 		"keyActualValue": sprintf("%s[%s].policy.Principal is equal to or contains '*'", [resourceType, name]),
-		"searchLine": common_lib.build_search_line(["resource", resourceType, name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", resourceType, name, "policy", "Statement", idx, "Principal"], []),
 	}
 }
 
@@ -28,28 +33,21 @@ CxPolicy[result] {
 	resourceType := pl[r]
 	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, resourceType, "policy")
 
-	access_to_any_principal(module[keyToCheck])
+	policy := common_lib.json_unmarshal(module[keyToCheck])
+	st := common_lib.get_statement(policy)
+	statement := st[idx]
+
+	common_lib.is_allow_effect(statement)
+	tf_lib.anyPrincipal(statement)
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].policy", [name]),
+		"searchKey": sprintf("module[%s].policy.Statement[%d].Principal", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Principal' should not equal to, nor contain '*'",
 		"keyActualValue": "'policy.Principal' is equal to or contains '*'",
-		"searchLine": common_lib.build_search_line(["module", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["module", name, "policy", "Statement", idx, "Principal"], []),
 	}
-}
-
-access_to_any_principal(policyValue) {
-  policy := common_lib.json_unmarshal(policyValue)
-
-  st := common_lib.get_statement(policy)
-  statement := st[_]
-
-  common_lib.is_allow_effect(statement)
-  tf_lib.anyPrincipal(statement)
-
-  keys := [k | k := key; _ := policy[k]]
 }

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive_expected_result.json
@@ -2,19 +2,19 @@
   {
     "queryName": "S3 bucket access to any principal",
     "severity": "CRITICAL",
-    "line": 4,
+    "line": 12,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "S3 bucket access to any principal",
     "severity": "CRITICAL",
-    "line": 12,
+    "line": 20,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "S3 bucket access to any principal",
     "severity": "CRITICAL",
-    "line": 10,
+    "line": 45,
     "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/query.rego
+++ b/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(resource.policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	tf_lib.anyPrincipal(statement)
@@ -20,11 +20,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": res_type,
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("%s[%s].policy", [res_type, name]),
+		"searchKey": sprintf("%s[%s].policy.Statement[%d].Principal", [res_type, name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'Statement.Principal.AWS' shouldn't contain '*'",
 		"keyActualValue": "'Statement.Principal.AWS' contains '*'",
-		"searchLine": common_lib.build_search_line(["resource", res_type, name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", res_type, name, "policy", "Statement", idx, "Principal"], []),
 	}
 }
 
@@ -36,7 +36,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(module[keyToCheck])
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	tf_lib.anyPrincipal(statement)
@@ -45,10 +45,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
+		"searchKey": sprintf("module[%s].%s.Statement[%d].Principal", [name, keyToCheck, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'Statement.Principal.AWS' shouldn't contain '*'",
 		"keyActualValue": "'Statement.Principal.AWS' contains '*'",
-		"searchLine": common_lib.build_search_line(["module", name, keyToCheck], []),
+		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx, "Principal"], []),
 	}
 }

--- a/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/positive3.tf
+++ b/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/positive3.tf
@@ -1,0 +1,27 @@
+resource "aws_sns_topic" "multi" {
+  name = "multi-statement-topic"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSpecific",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:multi-statement-topic"
+    },
+    {
+      "Sid": "AllowAnyone",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:multi-statement-topic"
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/positive_expected_result.json
@@ -2,19 +2,19 @@
   {
     "queryName": "SNS topic is publicly accessible",
     "severity": "CRITICAL",
-    "line": 2,
-    "filename": "positive.tf"
+    "line": 8,
+    "fileName": "positive.tf"
   },
   {
     "queryName": "SNS topic is publicly accessible",
     "severity": "CRITICAL",
-    "line": 12,
+    "line": 29,
     "fileName": "positive_module.tf"
   },
   {
     "queryName": "SNS topic is publicly accessible",
     "severity": "CRITICAL",
-    "line": 4,
-    "filename": "positive2.tf"
+    "line": 11,
+    "fileName": "positive2.tf"
   }
 ]

--- a/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/positive_expected_result.json
@@ -16,5 +16,11 @@
     "severity": "CRITICAL",
     "line": 11,
     "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "SNS topic is publicly accessible",
+    "severity": "CRITICAL",
+    "line": 20,
+    "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/sqs_policy_with_public_access/query.rego
+++ b/assets/queries/terraform/aws/sqs_policy_with_public_access/query.rego
@@ -8,7 +8,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(resource.policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	check_principal(statement.Principal, "*")
@@ -18,11 +18,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_sqs_queue_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_sqs_queue_policy[%s].policy", [name]),
+		"searchKey": sprintf("aws_sqs_queue_policy[%s].policy.Statement[%d].Principal", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement.Principal.AWS' should not equal '*'",
 		"keyActualValue": "'policy.Statement.Principal.AWS' is equal '*'",
-		"searchLine": common_lib.build_search_line(["resource", "aws_sqs_queue_policy", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_sqs_queue_policy", name, "policy", "Statement", idx, "Principal"], []),
 	}
 }
 
@@ -34,7 +34,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(module[keyToCheck])
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	check_principal(statement.Principal, "*")
@@ -44,11 +44,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
+		"searchKey": sprintf("module[%s].%s.Statement[%d].Principal", [name, keyToCheck, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'module[%s].%s.Statement.Principal.AWS' should not equal '*'", [name, keyToCheck]),
 		"keyActualValue": sprintf("'module[%s].%s.Statement.Principal.AWS' is equal '*'", [name, keyToCheck]),
-		"searchLine": common_lib.build_search_line(["module", name, keyToCheck], []),
+		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx, "Principal"], []),
 	}
 }
 

--- a/assets/queries/terraform/aws/sqs_policy_with_public_access/test/positive2.tf
+++ b/assets/queries/terraform/aws/sqs_policy_with_public_access/test/positive2.tf
@@ -1,0 +1,32 @@
+resource "aws_sqs_queue" "multi" {
+  name = "multi-statement-queue"
+}
+
+resource "aws_sqs_queue_policy" "multi" {
+  queue_url = aws_sqs_queue.multi.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Id": "MultiStatementPolicy",
+  "Statement": [
+    {
+      "Sid": "AllowSpecific",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:aws:sqs:us-east-1:123456789012:multi-statement-queue"
+    },
+    {
+      "Sid": "AllowAnyone",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:aws:sqs:us-east-1:123456789012:multi-statement-queue"
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/sqs_policy_with_public_access/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sqs_policy_with_public_access/test/positive_expected_result.json
@@ -2,22 +2,22 @@
   {
     "queryName": "SQS policy with public access",
     "severity": "MEDIUM",
-    "line": 8
+    "line": 15
   },
   {
     "queryName": "SQS policy with public access",
     "severity": "MEDIUM",
-    "line": 39
+    "line": 46
   },
   {
     "queryName": "SQS policy with public access",
     "severity": "MEDIUM",
-    "line": 64
+    "line": 71
   },
   {
     "queryName": "SQS policy with public access",
     "severity": "MEDIUM",
-    "line": 6,
+    "line": 14,
     "fileName": "positive_module.tf"
   }
 ]

--- a/assets/queries/terraform/aws/sqs_policy_with_public_access/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sqs_policy_with_public_access/test/positive_expected_result.json
@@ -19,5 +19,11 @@
     "severity": "MEDIUM",
     "line": 14,
     "fileName": "positive_module.tf"
+  },
+  {
+    "queryName": "SQS policy with public access",
+    "severity": "MEDIUM",
+    "line": 25,
+    "fileName": "positive2.tf"
   }
 ]

--- a/assets/queries/terraform/aws/sqs_queue_exposed/query.rego
+++ b/assets/queries/terraform/aws/sqs_queue_exposed/query.rego
@@ -6,12 +6,7 @@ import data.generic.terraform as tf_lib
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_sqs_queue[name]
 
-	policy := common_lib.json_unmarshal(resource.policy)
-	st := common_lib.get_statement(policy)
-	statement := st[idx]
-
-	common_lib.is_allow_effect(statement)
-	tf_lib.anyPrincipal(statement)
+	idx := exposed_statement_indices(resource.policy)[_]
 
 	result := {
 		"documentId": input.document[i].id,
@@ -29,12 +24,7 @@ CxPolicy[result] {
 	module := input.document[i].module[name]
 	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, "aws_sqs_queue", "policy")
 
-	policy := common_lib.json_unmarshal(module[keyToCheck])
-	st := common_lib.get_statement(policy)
-	statement := st[idx]
-
-	common_lib.is_allow_effect(statement)
-	tf_lib.anyPrincipal(statement)
+	idx := exposed_statement_indices(module[keyToCheck])[_]
 
 	result := {
 		"documentId": input.document[i].id,
@@ -46,4 +36,15 @@ CxPolicy[result] {
 		"keyActualValue": "'policy.Principal' does get the queue publicly accessible",
 		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx, "Principal"], []),
 	}
+}
+
+exposed_statement_indices(policyValue) = indices {
+	policy := common_lib.json_unmarshal(policyValue)
+	st := common_lib.get_statement(policy)
+	indices := [idx |
+		statement := st[idx]
+		common_lib.is_allow_effect(statement)
+		tf_lib.anyPrincipal(statement)
+	]
+	count(indices) > 0
 }

--- a/assets/queries/terraform/aws/sqs_queue_exposed/query.rego
+++ b/assets/queries/terraform/aws/sqs_queue_exposed/query.rego
@@ -6,17 +6,22 @@ import data.generic.terraform as tf_lib
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_sqs_queue[name]
 
-	exposed(resource.policy)
+	policy := common_lib.json_unmarshal(resource.policy)
+	st := common_lib.get_statement(policy)
+	statement := st[idx]
+
+	common_lib.is_allow_effect(statement)
+	tf_lib.anyPrincipal(statement)
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_sqs_queue",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_sqs_queue[%s].policy", [name]),
+		"searchKey": sprintf("aws_sqs_queue[%s].policy.Statement[%d].Principal", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("resource.aws_sqs_queue[%s].policy.Principal shouldn't get the queue publicly accessible", [name]),
 		"keyActualValue": sprintf("resource.aws_sqs_queue[%s].policy.Principal does get the queue publicly accessible", [name]),
-		"searchLine": common_lib.build_search_line(["resource", "aws_sqs_queue", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_sqs_queue", name, "policy", "Statement", idx, "Principal"], []),
 	}
 }
 
@@ -24,25 +29,21 @@ CxPolicy[result] {
 	module := input.document[i].module[name]
 	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, "aws_sqs_queue", "policy")
 
-	exposed(module[keyToCheck])
+	policy := common_lib.json_unmarshal(module[keyToCheck])
+	st := common_lib.get_statement(policy)
+	statement := st[idx]
+
+	common_lib.is_allow_effect(statement)
+	tf_lib.anyPrincipal(statement)
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
+		"searchKey": sprintf("module[%s].%s.Statement[%d].Principal", [name, keyToCheck, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Principal' shouldn't get the queue publicly accessible",
 		"keyActualValue": "'policy.Principal' does get the queue publicly accessible",
-		"searchLine": common_lib.build_search_line(["module", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx, "Principal"], []),
 	}
-}
-
-exposed(policyValue) {
-	policy := common_lib.json_unmarshal(policyValue)
-	st := common_lib.get_statement(policy)
-	statement := st[_]
-
-	common_lib.is_allow_effect(statement)
-	tf_lib.anyPrincipal(statement)
 }

--- a/assets/queries/terraform/aws/sqs_queue_exposed/test/positive3.tf
+++ b/assets/queries/terraform/aws/sqs_queue_exposed/test/positive3.tf
@@ -1,0 +1,28 @@
+resource "aws_sqs_queue" "positive3" {
+  name = "multi-statement-queue"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "sqspolicy",
+  "Statement": [
+    {
+      "Sid": "AllowSpecific",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:aws:sqs:us-east-1:123456789012:my-queue"
+    },
+    {
+      "Sid": "AllowAnyone",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:aws:sqs:us-east-1:123456789012:my-queue"
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/sqs_queue_exposed/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sqs_queue_exposed/test/positive_expected_result.json
@@ -2,13 +2,13 @@
   {
     "queryName": "SQS queue exposed",
     "severity": "HIGH",
-    "line": 4,
+    "line": 12,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "SQS queue exposed",
     "severity": "HIGH",
-    "line": 12,
+    "line": 20,
     "fileName": "positive2.tf"
   }
 ]

--- a/assets/queries/terraform/aws/sqs_queue_exposed/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sqs_queue_exposed/test/positive_expected_result.json
@@ -10,5 +10,11 @@
     "severity": "HIGH",
     "line": 20,
     "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "SQS queue exposed",
+    "severity": "HIGH",
+    "line": 21,
+    "fileName": "positive3.tf"
   }
 ]

--- a/pkg/detector/terraform/terraform_detect_test.go
+++ b/pkg/detector/terraform/terraform_detect_test.go
@@ -943,3 +943,61 @@ const OriginalDataMissingVersioning = `resource "aws_s3_bucket" "no_versioning" 
 	}
   }
   `
+
+const policyStatementPrincipalJSONEncode = `resource "aws_s3_bucket_policy" "x" {
+  bucket = "b"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = "s3:GetObject"
+      Resource  = "*"
+    }]
+  })
+}
+`
+
+const policyStatementPrincipalHeredocJSON = `resource "aws_ecr_repository_policy" "x" {
+  repository = "r"
+
+  policy = <<EOF
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "*"
+    }
+  ]
+}
+EOF
+}
+`
+
+func TestDetectLinePolicyStatementPrincipalJsonencode(t *testing.T) {
+	ctx := context.Background()
+	file := &model.FileMetadata{
+		ScanID:            "t",
+		ID:                "t",
+		Kind:              model.KindTerraform,
+		OriginalData:      policyStatementPrincipalJSONEncode,
+		LinesOriginalData: utils.SplitLines(policyStatementPrincipalJSONEncode),
+	}
+	got := DetectKindLine{}.DetectLine(ctx, file, `aws_s3_bucket_policy[x].policy.Statement[0].Principal`, 3)
+	require.Equal(t, 8, got.Line)
+}
+
+func TestDetectLinePolicyStatementPrincipalHeredocJSON(t *testing.T) {
+	ctx := context.Background()
+	file := &model.FileMetadata{
+		ScanID:            "t",
+		ID:                "t",
+		Kind:              model.KindTerraform,
+		OriginalData:      policyStatementPrincipalHeredocJSON,
+		LinesOriginalData: utils.SplitLines(policyStatementPrincipalHeredocJSON),
+	}
+	got := DetectKindLine{}.DetectLine(ctx, file, `aws_ecr_repository_policy[x].policy.Statement[0].Principal`, 3)
+	require.Equal(t, 9, got.Line)
+}

--- a/pkg/detector/terraform/terraform_helper.go
+++ b/pkg/detector/terraform/terraform_helper.go
@@ -420,15 +420,10 @@ func extractArrayContent(attrName string, lines []string, startLine int) string 
 		currentIndent := len(currentIndentMatch)
 		trimmed := strings.TrimSpace(line)
 
-		// Check if array is closed
-		if strings.Contains(line, "]") {
+		// Check if array is closed at our indentation level
+		if strings.Contains(line, "]") && currentIndent <= baseIndent {
 			result.WriteString(line)
-			// Verify this is the closing bracket at our level
-			if currentIndent <= baseIndent || trimmed == "]" {
-				return result.String()
-			}
-			result.WriteString("\n")
-			continue
+			return result.String()
 		}
 
 		// Continue collecting if:

--- a/pkg/detector/terraform/terraform_helper.go
+++ b/pkg/detector/terraform/terraform_helper.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -96,7 +97,71 @@ func resolveListIndex(
 
 	// Search for the attribute in the parsed tree
 	result, lineNum := findInHCLBody(body, attrName, index, currentLine)
+	if result == "" && lineNum == 0 {
+		if line, ok := findTupleElementLineInJsonencodeArgs(body, attrName, index, currentLine); ok {
+			return "", line
+		}
+		return resolveListIndexStringBased(attrName, index, currentLine, lines)
+	}
 	return result, lineNum
+}
+
+// findTupleElementLineInJsonencodeArgs finds attrName = [ ... ] tuple element index inside jsonencode({...})
+// (or nested merge/...) when it is not a top-level block attribute.
+func findTupleElementLineInJsonencodeArgs(body *hclsyntax.Body, attrName string, index, contextLine int) (int, bool) {
+	contextLineHCL := contextLine + 1
+	for _, block := range body.Blocks {
+		start := block.TypeRange.Start.Line
+		end := block.Body.SrcRange.End.Line
+		if contextLineHCL < start || contextLineHCL > end {
+			continue
+		}
+		for _, attr := range block.Body.Attributes {
+			if line := findTupleElementLineInExpr(attr.Expr, attrName, index); line >= 0 {
+				return line, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func findTupleElementLineInExpr(expr hclsyntax.Expression, attrName string, index int) int {
+	switch e := expr.(type) {
+	case *hclsyntax.FunctionCallExpr:
+		if e.Name == "jsonencode" && len(e.Args) > 0 {
+			if line := findTupleElementLineInObject(e.Args[0], attrName, index); line >= 0 {
+				return line
+			}
+		}
+		for _, arg := range e.Args {
+			if line := findTupleElementLineInExpr(arg, attrName, index); line >= 0 {
+				return line
+			}
+		}
+	case *hclsyntax.ObjectConsExpr:
+		if line := findTupleElementLineInObject(e, attrName, index); line >= 0 {
+			return line
+		}
+	}
+	return -1
+}
+
+func findTupleElementLineInObject(expr hclsyntax.Expression, attrName string, index int) int {
+	obj, ok := expr.(*hclsyntax.ObjectConsExpr)
+	if !ok {
+		return -1
+	}
+	for _, item := range obj.Items {
+		if hcl.ExprAsKeyword(item.KeyExpr) != attrName {
+			continue
+		}
+		tup, ok := item.ValueExpr.(*hclsyntax.TupleConsExpr)
+		if !ok || index < 0 || index >= len(tup.Exprs) {
+			return -1
+		}
+		return tup.Exprs[index].Range().Start.Line - 1
+	}
+	return -1
 }
 
 func findInHCLBody(body *hclsyntax.Body, attrName string, index, contextLine int) (substr string, lineNum int) {
@@ -170,6 +235,12 @@ func findInHCLBodyScoped(body *hclsyntax.Body, attrName string, index int) (subs
 	return "", 0
 }
 
+func lineDeclaresJSONArray(trimmed, attrName string) bool {
+	norm := whitespaceRegex.ReplaceAllString(trimmed, "")
+	return strings.HasPrefix(norm, attrName+"=[") ||
+		strings.HasPrefix(norm, `"`+attrName+`":[`)
+}
+
 func resolveListIndexStringBased(attrName string, index, currentLine int, lines []string) (substr string, lineNum int) {
 	if index < 0 {
 		return "", 0
@@ -178,8 +249,8 @@ func resolveListIndexStringBased(attrName string, index, currentLine int, lines 
 	countAttr := 0
 	for i := currentLine; i < len(lines); i++ {
 		trimmed := strings.TrimSpace(lines[i])
-		// Case 1: This is an actual array
-		if strings.HasPrefix(trimmed, attrName+" = [") || strings.HasPrefix(trimmed, attrName+"=[") {
+		// Case 1: This is an actual array (HCL or JSON key inside heredoc / string)
+		if lineDeclaresJSONArray(trimmed, attrName) {
 			// Check if it's a single-line array
 			start := strings.Index(trimmed, "[")
 			end := strings.Index(trimmed, "]")
@@ -255,23 +326,57 @@ func getArrayElementLine(attrName string, index int, lines []string, startLine i
 
 	// Parse the array expression, telling HCL that the content starts at line startLine+1 (1-indexed)
 	expr, diags := hclsyntax.ParseExpression([]byte(arrayContent), "", hcl.Pos{Line: startLine + 1, Column: 1})
+	if !diags.HasErrors() {
+		if tuple, ok := expr.(*hclsyntax.TupleConsExpr); ok {
+			if index < 0 || index >= len(tuple.Exprs) {
+				return 0, fmt.Errorf("index %d out of bounds (array has %d elements)", index, len(tuple.Exprs))
+			}
+			// Get the line number of the element (1-indexed from HCL)
+			// Convert to 0-indexed for consistency with the detector's expectations
+			return tuple.Exprs[index].Range().Start.Line - 1, nil
+		}
+	}
+
+	jsonLine, errJSON := getArrayElementLineJSON(arrayContent, index, startLine)
+	if errJSON == nil {
+		return jsonLine, nil
+	}
+
 	if diags.HasErrors() {
-		return 0, fmt.Errorf("parse error: %s", diags.Error())
+		return 0, fmt.Errorf("parse error: %s; json fallback: %v", diags.Error(), errJSON)
 	}
+	return 0, fmt.Errorf("not an array expression; json fallback: %v", errJSON)
+}
 
-	// Check if it's a tuple (array)
-	tuple, ok := expr.(*hclsyntax.TupleConsExpr)
-	if !ok {
-		return 0, fmt.Errorf("not an array expression")
+// getArrayElementLineJSON resolves array element line for JSON array syntax (e.g. inside heredocs).
+func getArrayElementLineJSON(arrayContent string, index, arrayStartLine0 int) (int, error) {
+	dec := json.NewDecoder(strings.NewReader(arrayContent))
+	tok, err := dec.Token()
+	if err != nil {
+		return 0, err
 	}
-
-	if index < 0 || index >= len(tuple.Exprs) {
-		return 0, fmt.Errorf("index %d out of bounds (array has %d elements)", index, len(tuple.Exprs))
+	d, ok := tok.(json.Delim)
+	if !ok || d != '[' {
+		return 0, fmt.Errorf("expected JSON array")
 	}
-
-	// Get the line number of the element (1-indexed from HCL)
-	// Convert to 0-indexed for consistency with the detector's expectations
-	return tuple.Exprs[index].Range().Start.Line - 1, nil
+	for i := 0; dec.More(); i++ {
+		offsetBefore := int(dec.InputOffset())
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			return 0, err
+		}
+		if i == index {
+			suffix := arrayContent[offsetBefore:]
+			trimmed := strings.TrimLeft(suffix, " \t\n\r,")
+			pos := offsetBefore + (len(suffix) - len(trimmed))
+			if pos < len(arrayContent) {
+				newlines := strings.Count(arrayContent[:pos], "\n")
+				return arrayStartLine0 + newlines, nil
+			}
+			return 0, fmt.Errorf("empty element position")
+		}
+	}
+	return 0, fmt.Errorf("index %d out of bounds", index)
 }
 
 // extractArrayContent extracts the array content from the attribute definition
@@ -287,7 +392,7 @@ func extractArrayContent(attrName string, lines []string, startLine int) string 
 		// Find the attribute definition
 		if !arrayStarted {
 			trimmed := strings.TrimSpace(line)
-			if strings.HasPrefix(whitespaceRegex.ReplaceAllString(trimmed, ""), attrName+"=[") {
+			if lineDeclaresJSONArray(trimmed, attrName) {
 				// Found the array start - determine base indentation
 				indentMatch := indentRegex.FindString(line)
 				baseIndent = len(indentMatch)

--- a/pkg/detector/terraform/terraform_helper_test.go
+++ b/pkg/detector/terraform/terraform_helper_test.go
@@ -2,9 +2,12 @@ package terraform
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -248,6 +251,27 @@ func TestExtractArrayContent(t *testing.T) {
     "sg-2"
   ]`,
 		},
+		{
+			name:     "JSON Statement array inside heredoc body",
+			attrName: "Statement",
+			lines: []string{
+				`  policy = <<EOF`,
+				`{`,
+				`  "Statement": [`,
+				`    {`,
+				`      "Effect": "Allow"`,
+				`    }`,
+				`  ]`,
+				`}`,
+				`EOF`,
+			},
+			startLine: 1,
+			wantContent: `[
+    {
+      "Effect": "Allow"
+    }
+  ]`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -353,4 +377,17 @@ func TestGetArrayElementLine(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveListIndexStatementInJsonencodeThirdElement(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "assets", "queries", "terraform", "aws", "s3_bucket_access_to_any_principal", "test", "positive3.tf"))
+	require.NoError(t, err)
+	linesPtr := utils.SplitLines(string(data))
+	lines := *linesPtr
+	ctx := context.Background()
+	// currentLine 9 = line after `policy =` (0-indexed), same as DetectLine when resolving Statement[2]
+	sub, lineNum := resolveListIndex(ctx, "Statement", 2, 9, lines, data)
+	require.Empty(t, sub)
+	// Third tuple element starts at `{` on file line 41 (1-based) -> index 40
+	require.Equal(t, 40, lineNum)
 }

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -514,7 +514,9 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 				resourceStartLocation.Col = 1
 			}
 
-			if remediationStartLocation.Line >= resourceStartLocation.Line && remediationEndLocation.Line <= resourceEndLocation.Line {
+			if vulnerability.Remediation != "" &&
+				remediationStartLocation.Line >= resourceStartLocation.Line &&
+				remediationEndLocation.Line <= resourceEndLocation.Line {
 				resourceStartLocation = remediationStartLocation
 				resourceEndLocation = remediationEndLocation
 			}

--- a/pkg/report/model/sarif_test.go
+++ b/pkg/report/model/sarif_test.go
@@ -536,7 +536,7 @@ var sarifTests = []sarifTest{
 		},
 	},
 	{
-		name: "Should create one occurrence with remediation startLine",
+		name: "Should keep resource location when remediation is empty",
 		vq: []model.QueryResult{
 			{
 				QueryName:   "test",
@@ -559,6 +559,143 @@ var sarifTests = []sarifTest{
 							Start: model.ResourceLine{Line: 2, Col: 1},
 							End:   model.ResourceLine{Line: 3, Col: 2},
 						},
+					},
+				},
+				CWE: "",
+			},
+		},
+		want: sarifReport{
+			Runs: []SarifRun{
+				{
+					Tool: sarifTool{
+						Driver: sarifDriver{
+							Rules: []sarifRule{
+								{
+									RuleID:               "test",
+									RuleName:             "test",
+									RuleShortDescription: sarifMessage{Text: "test"},
+									RuleFullDescription:  sarifMessage{Text: "test description"},
+									DefaultConfiguration: sarifConfiguration{
+										Level: "error",
+									},
+									HelpURI: "https://www.test.com",
+									Relationships: []sarifRelationship{
+										{
+											Relationship: sarifDescriptorReference{
+												ReferenceID:    "CAT000",
+												ReferenceIndex: 0,
+												ToolComponent: sarifComponentReference{
+													ComponentReferenceGUID:  "58cdcc6f-fe41-4724-bfb3-131a93df4c3f",
+													ComponentReferenceName:  "Categories",
+													ComponentReferenceIndex: targetTemplate.ToolComponent.ComponentReferenceIndex,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Results: []sarifResult{
+						{
+							ResultRuleID:    "test",
+							ResultRuleIndex: 0,
+							ResultKind:      "",
+							ResultMessage:   sarifMessage{Text: "test", MessageProperties: nil},
+							ResultLocations: []SarifLocation{
+								{
+									PhysicalLocation: sarifPhysicalLocation{
+										ArtifactLocation: sarifArtifactLocation{ArtifactURI: "test.json"},
+										Region:           model.SarifRegion{StartLine: 1, EndLine: 5, StartColumn: 1, EndColumn: 2},
+									},
+								},
+							},
+							ResultLevel: "warning",
+							ResultProperties: sarifProperties{
+								"tags": []string{"DATADOG_CATEGORY:", "IAC_RESOURCE_TYPE:test_resource_type", "IAC_RESOURCE_NAME:test_resource_name"},
+							},
+							PartialFingerprints: SarifPartialFingerprints{
+								DatadogFingerprint: GetDatadogFingerprintHash(
+									model.SCIInfo{
+										RepositoryCommitInfo: model.RepositoryCommitInfo{
+											RepositoryUrl: "",
+											Branch:        "",
+											CommitSHA:     "",
+										},
+									},
+									"test.json",
+									"Terraform",
+									"test_resource_type",
+									"test_resource_name",
+									"1",
+									"",
+								),
+							},
+						},
+					},
+					Taxonomies: []sarifTaxonomy{
+						{
+							TaxonomyGUID:             "58cdcc6f-fe41-4724-bfb3-131a93df4c3f",
+							TaxonomyName:             "Categories",
+							TaxonomyFullDescription:  sarifMessage{Text: "Category is not defined"},
+							TaxonomyShortDescription: sarifMessage{Text: "Category is not defined"},
+							TaxonomyDefinitions: []taxonomyDefinitions{
+								{
+									DefinitionGUID:             "",
+									DefinitionName:             "Undefined Category",
+									DefinitionID:               "CAT000",
+									DefinitionShortDescription: cweMessage{Text: "Category is not defined"},
+									DefinitionFullDescription:  cweMessage{Text: "Category is not defined"},
+									HelpURI:                    "",
+								},
+							},
+						},
+						{
+							TaxonomyGUID:                              "1489b0c4-d7ce-4d31-af66-6382a01202e3",
+							TaxonomyName:                              "CWE",
+							TaxonomyFullDescription:                   sarifMessage{Text: "The MITRE Common Weakness Enumeration"},
+							TaxonomyShortDescription:                  sarifMessage{Text: "The MITRE Common Weakness Enumeration"},
+							TaxonomyDownloadURI:                       "https://cwe.mitre.org/data/published/cwe_v4.13.pdf",
+							TaxonomyIsComprehensive:                   true,
+							TaxonomyLanguage:                          "en",
+							TaxonomyMinRequiredLocDataSemanticVersion: "4.13",
+							TaxonomyOrganization:                      "MITRE",
+							TaxonomyRealeaseDateUtc:                   "2023-10-26",
+							TaxonomyDefinitions: []taxonomyDefinitions{
+								{},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "Should use remediation location when remediation is non-empty",
+		vq: []model.QueryResult{
+			{
+				QueryName:   "test",
+				QueryID:     "1",
+				Description: "test description",
+				QueryURI:    "https://www.test.com",
+				Severity:    model.SeverityHigh,
+				Files: []model.VulnerableFile{
+					{
+						KeyActualValue: "test",
+						FileName:       "test.json",
+						Line:           1,
+						ResourceType:   "test_resource_type",
+						ResourceName:   "test_resource_name",
+						ResourceLocation: model.ResourceLocation{
+							Start: model.ResourceLine{Line: 1, Col: 1},
+							End:   model.ResourceLine{Line: 5, Col: 2},
+						},
+						RemediationLocation: model.ResourceLocation{
+							Start: model.ResourceLine{Line: 2, Col: 1},
+							End:   model.ResourceLine{Line: 3, Col: 2},
+						},
+						Remediation:       "not-json",
+						RemediationType: "replacement",
 					},
 				},
 				CWE: "",


### PR DESCRIPTION
> [!TIP]
> This PR is best reviewed commit by commit.

## Motivation

Findings on Terraform policies that use `jsonencode()` (or JSON-shaped policy strings) could report the wrong source line: the detector did not always resolve `Statement[i].Principal` inside nested expressions, and SARIF could prefer an empty remediation snippet over the resource span. This change aligns reported lines with the actual policy fields and keeps SARIF regions consistent when no remediation text exists.

## Changes

- SARIF: use remediation insertion locations only when remediation content is non-empty; otherwise keep the resource span.
- Terraform: improve list/array resolution for `Statement` entries inside `jsonencode` and JSON array syntax; small refactors in array-start detection.
- Rego: extend `searchKey` paths for several AWS policy rules so line resolution targets `Statement[idx].Principal` (and related keys) where applicable; update expected test fixtures.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run unit tests for affected packages, for example:

`go test ./pkg/report/model/... ./pkg/detector/terraform/...`

Run the scanner on a small Terraform file that uses `jsonencode` for `aws_s3_bucket_policy` (or similar) with `Principal = "*"` and confirm the reported line matches that attribute line and SARIF regions behave as expected.

## Blast Radius

Affects the open-source IaC scanner: SARIF output shape for some findings, Terraform line detection for policy-related rules, and bundled Rego query metadata used for fingerprints and locations

## Additional Notes

I submit this contribution under the Apache-2.0 license.
