### PR TITLE
docs(terraform): refresh AWS rule examples after multi-statement fixtures

### DIFF
--- a/documentation/rules/terraform/aws/ecr_repository_is_publicly_accessible.md
+++ b/documentation/rules/terraform/aws/ecr_repository_is_publicly_accessible.md
@@ -74,6 +74,45 @@ EOF
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_ecr_repository" "multi" {
+  name = "multi-statement-repo"
+}
+
+resource "aws_ecr_repository_policy" "multi" {
+  repository = aws_ecr_repository.multi.name
+
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSpecific",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Action": [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+      ]
+    },
+    {
+      "Sid": "AllowAnyone",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+```
+
+```terraform
 resource "aws_ecr_repository" "positive1" {
   name = "bar"
 }

--- a/documentation/rules/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services.md
+++ b/documentation/rules/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services.md
@@ -100,6 +100,38 @@ resource "aws_iam_instance_profile" "negative4" {
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_iam_role" "multi" {
+  name = "multi-statement-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": "AllowSpecific"
+    },
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com",
+        "AWS": "*"
+      },
+      "Effect": "Allow",
+      "Sid": "AllowAll"
+    }
+  ]
+}
+EOF
+}
+
+```
+
+```terraform
 //  Create a role which OpenShift instances will assume.
 //  This role has a policy saying it can be assumed by ec2
 //  instances.

--- a/documentation/rules/terraform/aws/sns_topic_is_publicly_accessible.md
+++ b/documentation/rules/terraform/aws/sns_topic_is_publicly_accessible.md
@@ -34,6 +34,30 @@ Secure configuration requires specifying explicit IAM principals rather than usi
 
 ## Compliant Code Examples
 ```terraform
+resource "aws_sns_topic_policy" "negative2" {
+  arn = aws_sns_topic.example.arn
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSpecificAccount",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
+    }
+  ]
+}
+EOF
+}
+
+```
+
+```terraform
 resource "aws_sns_topic" "negative1" {
 policy = <<EOF
 {
@@ -55,6 +79,59 @@ EOF
 
 ```
 ## Non-Compliant Code Examples
+```terraform
+resource "aws_sns_topic_policy" "positive2" {
+  arn = aws_sns_topic.example.arn
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowPublicAccess",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
+    }
+  ]
+}
+EOF
+}
+
+```
+
+```terraform
+resource "aws_sns_topic" "multi" {
+  name = "multi-statement-topic"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSpecific",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:multi-statement-topic"
+    },
+    {
+      "Sid": "AllowAnyone",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:multi-statement-topic"
+    }
+  ]
+}
+EOF
+}
+
+```
+
 ```terraform
 resource "aws_sns_topic" "positive1" {
 policy = <<EOF

--- a/documentation/rules/terraform/aws/sqs_policy_with_public_access.md
+++ b/documentation/rules/terraform/aws/sqs_policy_with_public_access.md
@@ -97,6 +97,42 @@ POLICY
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_sqs_queue" "multi" {
+  name = "multi-statement-queue"
+}
+
+resource "aws_sqs_queue_policy" "multi" {
+  queue_url = aws_sqs_queue.multi.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Id": "MultiStatementPolicy",
+  "Statement": [
+    {
+      "Sid": "AllowSpecific",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:aws:sqs:us-east-1:123456789012:multi-statement-queue"
+    },
+    {
+      "Sid": "AllowAnyone",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:aws:sqs:us-east-1:123456789012:multi-statement-queue"
+    }
+  ]
+}
+EOF
+}
+
+```
+
+```terraform
 resource "aws_sqs_queue" "q" {
   name = "examplequeue"
 }

--- a/documentation/rules/terraform/aws/sqs_queue_exposed.md
+++ b/documentation/rules/terraform/aws/sqs_queue_exposed.md
@@ -152,6 +152,38 @@ POLICY
 ```
 
 ```terraform
+resource "aws_sqs_queue" "positive3" {
+  name = "multi-statement-queue"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "sqspolicy",
+  "Statement": [
+    {
+      "Sid": "AllowSpecific",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:aws:sqs:us-east-1:123456789012:my-queue"
+    },
+    {
+      "Sid": "AllowAnyone",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:aws:sqs:us-east-1:123456789012:my-queue"
+    }
+  ]
+}
+POLICY
+}
+
+```
+
+```terraform
 resource "aws_sqs_queue" "positive1" {
   name = "examplequeue"
 


### PR DESCRIPTION
## Motivation

New multi-statement positive Terraform fixtures were added for several AWS policy rules [here](https://github.com/DataDog/datadog-iac-scanner/pull/80). The published rule pages under `documentation/rules/terraform/aws/` still showed older non-compliant examples. This PR refreshes those markdown files so the embedded examples match the current test fixtures (via `documentation/local_gen.py`).

## Changes

- Regenerated **Non-Compliant Code Examples** for five Terraform AWS rules: `sqs_queue_exposed`, `sqs_policy_with_public_access`, `sns_topic_is_publicly_accessible`, `ecr_repository_is_publicly_accessible`, `iam_policy_grants_assumerole_permission_across_all_services`.

## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Spot-check the updated `.md` files: each should include up to three non-compliant Terraform snippets consistent with `assets/queries/terraform/aws/<rule>/test/positive*.tf`. Optionally re-run `python3 documentation/local_gen.py` with the same arguments used locally and confirm no further diff for these five paths.

## Blast Radius

Documentation-only: affects the in-repo Terraform AWS rule markdown under `documentation/rules/terraform/aws/`. No scanner or query behavior changes.

## Additional Notes

I submit this contribution under the Apache-2.0 license.
