### PR TITLE
Added new workflow to check if the documentation is up to date

### DIFF
--- a/.github/workflows/check-documentation-up-to-date.yaml
+++ b/.github/workflows/check-documentation-up-to-date.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-documentation-up-to-date:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     permissions:
       contents: read
     steps:

--- a/.github/workflows/check-documentation-up-to-date.yaml
+++ b/.github/workflows/check-documentation-up-to-date.yaml
@@ -3,6 +3,10 @@ name: check-documentation-up-to-date
 on:
   workflow_dispatch:
   pull_request:
+    paths:
+      - "assets/queries/**"
+      - "documentation/**"
+      - ".github/workflows/check-documentation-up-to-date.yaml"
 
 jobs:
   check-documentation-up-to-date:

--- a/.github/workflows/check-documentation-up-to-date.yaml
+++ b/.github/workflows/check-documentation-up-to-date.yaml
@@ -1,0 +1,58 @@
+name: check-documentation-up-to-date
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  check-documentation-up-to-date:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Generate documentation and validate no change
+        run: |
+          cd documentation
+
+          python local_gen.py ../assets/queries/ \
+          --resources-json "resources.json" \
+          --output-dir "rules" \
+          --list-json "list.json" \
+          --frontmatter-yaml "frontmatter.yaml"
+          
+          cd ..
+          if ! git diff --quiet; then
+            echo "ERROR: Documentation is out of date!"
+            echo "Please run the following command to update the documentation:"
+            echo ""
+            echo "  cd documentation"
+            echo "  python local_gen.py ../assets/queries/ \\"
+            echo "    --resources-json \"resources.json\" \\"
+            echo "    --output-dir \"rules\" \\"
+            echo "    --list-json \"list.json\" \\"
+            echo "    --frontmatter-yaml \"frontmatter.yaml\""
+            echo ""
+            echo "Then commit the changes."
+            echo ""
+            echo "Changed files:"
+            git diff --name-only
+            echo ""
+            echo "Diff of first changed file:"
+            FIRST_FILE=$(git diff --name-only | head -n 1)
+            git diff "$FIRST_FILE"
+            exit 1
+          fi
+          echo "Documentation is up to date!"

--- a/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/metadata.json
+++ b/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "72a931c2-12f5-40d1-93cc-47bff2f7aa2a",
-  "queryName": "API Gateway with CloudWatch Logs disabled",
+  "queryName": "API gateway with CloudWatch Logs disabled",
   "severity": "MEDIUM",
   "category": "Observability",
   "descriptionText": "APIs must send request logs and execution traces to CloudWatch Logs so activity, errors, and suspicious behavior can be detected and investigated. Without a configured log group, you lose critical visibility for incident response and troubleshooting.\n\nIn Ansible, tasks using the `amazon.aws.cloudwatchlogs_log_group` or `cloudwatchlogs_log_group` modules must include the `log_group_name` property to create or reference a specific CloudWatch Logs group. Tasks missing `log_group_name` (or with it unset) are flagged. Set `log_group_name` to a stable, descriptive string and ensure API Gateway access logging or tracing is pointed to that group.\n\nSecure configuration example:\n\n```yaml\n- name: Create CloudWatch log group for API Gateway\n  amazon.aws.cloudwatchlogs_log_group:\n    log_group_name: \"/aws/apigateway/my-api\"\n    state: present\n    retention_in_days: 30\n```",

--- a/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/metadata.json
+++ b/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "72a931c2-12f5-40d1-93cc-47bff2f7aa2a",
-  "queryName": "API gateway with CloudWatch Logs disabled",
+  "queryName": "API Gateway with CloudWatch Logs disabled",
   "severity": "MEDIUM",
   "category": "Observability",
   "descriptionText": "APIs must send request logs and execution traces to CloudWatch Logs so activity, errors, and suspicious behavior can be detected and investigated. Without a configured log group, you lose critical visibility for incident response and troubleshooting.\n\nIn Ansible, tasks using the `amazon.aws.cloudwatchlogs_log_group` or `cloudwatchlogs_log_group` modules must include the `log_group_name` property to create or reference a specific CloudWatch Logs group. Tasks missing `log_group_name` (or with it unset) are flagged. Set `log_group_name` to a stable, descriptive string and ensure API Gateway access logging or tracing is pointed to that group.\n\nSecure configuration example:\n\n```yaml\n- name: Create CloudWatch log group for API Gateway\n  amazon.aws.cloudwatchlogs_log_group:\n    log_group_name: \"/aws/apigateway/my-api\"\n    state: present\n    retention_in_days: 30\n```",

--- a/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
   {
-    "queryName": "API gateway with CloudWatch Logs disabled",
+    "queryName": "API Gateway with CloudWatch Logs disabled",
     "severity": "MEDIUM",
     "line": 3
   }

--- a/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/api_gateway_with_cloudwatch_logging_disabled/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
   {
-    "queryName": "API Gateway with CloudWatch Logs disabled",
+    "queryName": "API gateway with CloudWatch Logs disabled",
     "severity": "MEDIUM",
     "line": 3
   }

--- a/assets/queries/terraform/alicloud/api_gateway_api_protocol_not_https/metadata.json
+++ b/assets/queries/terraform/alicloud/api_gateway_api_protocol_not_https/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "1bcdf9f0-b1aa-40a4-b8c6-cd7785836843",
-  "queryName": "API gateway API protocol not HTTPS",
+  "queryName": "API Gateway API protocol not HTTPS",
   "severity": "MEDIUM",
   "category": "Networking and Firewall",
   "descriptionText": "API Gateway APIs must use `HTTPS`.\nThis rule flags `alicloud_api_gateway_api` resources where `request_config.protocol` is not set to `HTTPS`.\nIt supports both single and indexed forms of `request_config`, and reports the resource name and attribute location.",

--- a/assets/queries/terraform/alicloud/api_gateway_api_protocol_not_https/test/positive_expected_result.json
+++ b/assets/queries/terraform/alicloud/api_gateway_api_protocol_not_https/test/positive_expected_result.json
@@ -1,20 +1,20 @@
 [
-	{
-		"queryName": "API gateway API protocol not HTTPS",
-		"severity": "MEDIUM",
-		"line": 14,
-		"fileName": "positive1.tf"
-	},
-	{
-		"queryName": "API gateway API protocol not HTTPS",
-		"severity": "MEDIUM",
-		"line": 14,
-		"fileName": "positive2.tf"
-	},
-	{
-		"queryName": "API gateway API protocol not HTTPS",
-		"severity": "MEDIUM",
-		"line": 21,
-		"fileName": "positive2.tf"
-	}
+  {
+    "queryName": "API Gateway API protocol not HTTPS",
+    "severity": "MEDIUM",
+    "line": 14,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "API Gateway API protocol not HTTPS",
+    "severity": "MEDIUM",
+    "line": 14,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "API Gateway API protocol not HTTPS",
+    "severity": "MEDIUM",
+    "line": 21,
+    "fileName": "positive2.tf"
+  }
 ]

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/metadata.json
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "b3a59b8e-94a3-403e-b6e2-527abaf12034",
-  "queryName": "API gateway deployment without API gateway usage plan associated",
+  "queryName": "API Gateway deployment without API Gateway usage plan associated",
   "severity": "LOW",
   "category": "Observability",
   "descriptionText": "An API Gateway Deployment should have an associated UsagePlan defined using the `aws_api_gateway_usage_plan` resource, with the `api_stages` attribute referencing the relevant API and stage. Without a UsagePlan, API Gateway endpoints are left unprotected, allowing unlimited, unauthenticated access and risking abuse, denial of service, or unexpected cost overruns. To prevent this, always associate deployments with a UsagePlan, as shown below:\n\n```\nresource \"aws_api_gateway_usage_plan\" \"example\" {\n  name = \"usage-plan\"\n  api_stages {\n    api_id = aws_api_gateway_deployment.example.rest_api_id\n    stage  = aws_api_gateway_deployment.example.stage_name\n  }\n}\n```",

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/test/positive_expected_result.json
@@ -1,24 +1,24 @@
 [
   {
-    "queryName": "API gateway deployment without API gateway usage plan associated",
+    "queryName": "API Gateway deployment without API Gateway usage plan associated",
     "severity": "LOW",
     "line": 1,
     "filename": "positive1.tf"
   },
   {
-    "queryName": "API gateway deployment without API gateway usage plan associated",
+    "queryName": "API Gateway deployment without API Gateway usage plan associated",
     "severity": "LOW",
     "line": 9,
     "filename": "positive1.tf"
   },
   {
-    "queryName": "API gateway deployment without API gateway usage plan associated",
+    "queryName": "API Gateway deployment without API Gateway usage plan associated",
     "severity": "LOW",
     "line": 14,
     "filename": "positive2.json"
   },
   {
-    "queryName": "API gateway deployment without API gateway usage plan associated",
+    "queryName": "API Gateway deployment without API Gateway usage plan associated",
     "severity": "LOW",
     "line": 31,
     "filename": "positive2.json"

--- a/documentation/frontmatter.yaml
+++ b/documentation/frontmatter.yaml
@@ -14,8 +14,8 @@ rules:
         description: API Gateway endpoint config is not private
         title: API Gateway endpoint config is not private
       api_gateway_with_cloudwatch_logging_disabled:
-        description: API Gateway with CloudWatch Logs disabled
-        title: API Gateway with CloudWatch Logs disabled
+        description: API gateway with CloudWatch Logs disabled
+        title: API gateway with CloudWatch Logs disabled
       api_gateway_without_configured_authorizer:
         description: API Gateway without configured authorizer
         title: API Gateway without configured authorizer

--- a/documentation/frontmatter.yaml
+++ b/documentation/frontmatter.yaml
@@ -14,8 +14,8 @@ rules:
         description: API Gateway endpoint config is not private
         title: API Gateway endpoint config is not private
       api_gateway_with_cloudwatch_logging_disabled:
-        description: API gateway with CloudWatch Logs disabled
-        title: API gateway with CloudWatch Logs disabled
+        description: API Gateway with CloudWatch Logs disabled
+        title: API Gateway with CloudWatch Logs disabled
       api_gateway_without_configured_authorizer:
         description: API Gateway without configured authorizer
         title: API Gateway without configured authorizer
@@ -2159,8 +2159,8 @@ rules:
         description: ALB listening on HTTP
         title: ALB listening on HTTP
       api_gateway_api_protocol_not_https:
-        description: API gateway API protocol not HTTPS
-        title: API gateway API protocol not HTTPS
+        description: API Gateway API protocol not HTTPS
+        title: API Gateway API protocol not HTTPS
       cmk_is_unusable:
         description: CMK is unusable
         title: CMK is unusable
@@ -2355,8 +2355,8 @@ rules:
         description: API Gateway deployment without access log setting
         title: API Gateway deployment without access log setting
       api_gateway_deployment_without_api_gateway_usage_plan_associated:
-        description: API gateway deployment without API gateway usage plan associated
-        title: API gateway deployment without API gateway usage plan associated
+        description: API Gateway deployment without API Gateway usage plan associated
+        title: API Gateway deployment without API Gateway usage plan associated
       api_gateway_endpoint_config_is_not_private:
         description: API Gateway endpoint config is not private
         title: API Gateway endpoint config is not private

--- a/documentation/list.json
+++ b/documentation/list.json
@@ -24,7 +24,7 @@
           },
           {
             "name": "api_gateway_with_cloudwatch_logging_disabled",
-            "short_description": "API gateway with CloudWatch Logs disabled"
+            "short_description": "API Gateway with CloudWatch Logs disabled"
           },
           {
             "name": "api_gateway_without_configured_authorizer",
@@ -2951,7 +2951,7 @@
           },
           {
             "name": "api_gateway_api_protocol_not_https",
-            "short_description": "API gateway API protocol not HTTPS"
+            "short_description": "API Gateway API protocol not HTTPS"
           },
           {
             "name": "cmk_is_unusable",
@@ -3213,7 +3213,7 @@
           },
           {
             "name": "api_gateway_deployment_without_api_gateway_usage_plan_associated",
-            "short_description": "API gateway deployment without API gateway usage plan associated"
+            "short_description": "API Gateway deployment without API Gateway usage plan associated"
           },
           {
             "name": "api_gateway_endpoint_config_is_not_private",

--- a/documentation/list.json
+++ b/documentation/list.json
@@ -24,7 +24,7 @@
           },
           {
             "name": "api_gateway_with_cloudwatch_logging_disabled",
-            "short_description": "API Gateway with CloudWatch Logs disabled"
+            "short_description": "API gateway with CloudWatch Logs disabled"
           },
           {
             "name": "api_gateway_without_configured_authorizer",

--- a/documentation/local_gen.py
+++ b/documentation/local_gen.py
@@ -120,9 +120,12 @@ def build_markdown(
     category = metadata.get("category", "unknown")
     description = metadata.get("descriptionText", "No description provided.")
     provider_url = metadata.get("providerUrl", metadata.get("descriptionUrl", ""))
-    compliant, non_compliant = get_code_snippets(
-        rule_path / "test", resource_type, max_examples
+    test_path = (
+        rule_path / "test"
+        if cloud_provider != "github" or platform != "CICD"
+        else rule_path / "test" / ".github"
     )
+    compliant, non_compliant = get_code_snippets(test_path, resource_type, max_examples)
     meta_name = f"{cloud_provider}/{rule_name}"
     clean_provider = CLOUD_PROVIDER[cloud_provider]
 

--- a/documentation/rules/ansible/aws/api_gateway_with_cloudwatch_logging_disabled.md
+++ b/documentation/rules/ansible/aws/api_gateway_with_cloudwatch_logging_disabled.md
@@ -1,5 +1,5 @@
 ---
-title: "API gateway with CloudWatch Logs disabled"
+title: "API Gateway with CloudWatch Logs disabled"
 group_id: "Ansible / AWS"
 meta:
   name: "aws/api_gateway_with_cloudwatch_logging_disabled"

--- a/documentation/rules/ansible/aws/api_gateway_with_cloudwatch_logging_disabled.md
+++ b/documentation/rules/ansible/aws/api_gateway_with_cloudwatch_logging_disabled.md
@@ -1,5 +1,5 @@
 ---
-title: "API Gateway with CloudWatch Logs disabled"
+title: "API gateway with CloudWatch Logs disabled"
 group_id: "Ansible / AWS"
 meta:
   name: "aws/api_gateway_with_cloudwatch_logging_disabled"

--- a/documentation/rules/cicd/github/github_env.md
+++ b/documentation/rules/cicd/github/github_env.md
@@ -106,8 +106,58 @@ jobs:
         with:
           node-version: 18
 
+---
+# Composite action: write to GITHUB_PATH with only local bash variables. Even
+# though `$HOME` is variable expansion, no attacker-influenced GitHub Actions
+# context flows in, so the composite branch must not flag this.
+name: Benign composite action
+description: Composite action whose write to GITHUB_PATH only uses local bash vars
+runs:
+  using: composite
+  steps:
+    - name: Add local bin to PATH
+      shell: bash
+      run: echo "$HOME/bin" >> $GITHUB_PATH
+
+---
+# Composite action: step.env carries an unused untrusted input but the actual
+# GITHUB_ENV write only appends a constant. The taint never flows into the
+# env-file write, so the composite branch must not flag this.
+name: Composite with unused taint
+description: Untrusted env entry is unused; the GITHUB_ENV write is constant
+inputs:
+  message:
+    description: Untrusted but unused
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Constant write with unused taint
+      shell: bash
+      env:
+        MSG: ${{ inputs.message }}
+      run: echo "$HOME/bin" >> $GITHUB_PATH
+
 ```
 ## Non-Compliant Code Examples
+```yaml
+name: Composite action writing to GITHUB_ENV
+description: Composite action that writes attacker-influenced content to GITHUB_ENV
+inputs:
+  message:
+    description: Untrusted input
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Unsafe redirect
+      shell: bash
+      env:
+        MSG: ${{ inputs.message }}
+      run: echo $MSG >> $GITHUB_ENV
+
+```
+
 ```yaml
 name: GitHub Env Test - Positive Cases
 on:
@@ -182,5 +232,23 @@ jobs:
       - name: CMD redirect pattern
         shell: cmd
         run: echo LIBRARY=%LIBRARY% >> %GITHUB_ENV%
+
+```
+
+```yaml
+name: Composite multi-arg redirect to GITHUB_ENV
+description: Composite step writes more than one arg to GITHUB_ENV in a single redirect
+inputs:
+  message:
+    description: Untrusted input
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Multi-arg unsafe redirect
+      shell: bash
+      env:
+        MSG: ${{ inputs.message }}
+      run: echo "FOO=$MSG" "BAR=baz" >> $GITHUB_ENV
 
 ```

--- a/documentation/rules/cicd/github/misfeature.md
+++ b/documentation/rules/cicd/github/misfeature.md
@@ -87,6 +87,23 @@ jobs:
 ```
 ## Non-Compliant Code Examples
 ```yaml
+name: Composite action with misfeatures
+description: Composite action that uses pip-install and CMD shell
+runs:
+  using: composite
+  steps:
+    - name: Setup Python with pip-install
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        pip-install: 'pytest requests'
+    - name: CMD shell usage
+      shell: cmd
+      run: echo "Using deprecated CMD shell"
+
+```
+
+```yaml
 name: Misfeature Usage
 on: push
 

--- a/documentation/rules/cicd/github/obfuscation.md
+++ b/documentation/rules/cicd/github/obfuscation.md
@@ -82,6 +82,17 @@ jobs:
 ```
 ## Non-Compliant Code Examples
 ```yaml
+name: Composite action with obfuscated uses
+description: Composite action that calls another action through an obfuscated path
+runs:
+  using: composite
+  steps:
+    - name: Use obfuscated action
+      uses: actions/checkout/./@v4
+
+```
+
+```yaml
 name: Obfuscated Uses Paths
 on: push
 

--- a/documentation/rules/cicd/github/run_block_injection.md
+++ b/documentation/rules/cicd/github/run_block_injection.md
@@ -43,6 +43,19 @@ jobs:
 
 ## Compliant Code Examples
 ```yaml
+name: Safe composite action without inputs
+description: A composite action whose run block does not interpolate untrusted data
+runs:
+  using: composite
+  steps:
+    - name: Show repository
+      shell: bash
+      run: |
+        echo "Build triggered for ${{ github.repository }}"
+
+```
+
+```yaml
 name: check-go-coverage
 
 on:
@@ -76,38 +89,21 @@ jobs:
 ```
 
 ```yaml
-name: Author Workflow
-
-on:
-  author:
-    types:
-      - created
-
-jobs:
-  process_author:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Greet the New Author
-        run: |
-          echo "Hello, a new author has been created!"
-
-```
-
-```yaml
-name: Workflow Run Workflow
-
-on:
-  workflow_run:
-    workflows:
-      - "Your Workflow Name" # Replace with the name of your specific workflow
-
-jobs:
-  process_workflow_run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Greet the New Workflow Run
-        run: |
-          echo "Hello, a new workflow run has started for 'Your Workflow Name'!"
+name: Safe composite action
+description: A composite action that uses inputs through environment variables to avoid shell injection
+inputs:
+  slack-message:
+    description: The message to send
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Send message safely
+      shell: bash
+      env:
+        SLACK_MESSAGE: ${{ inputs.slack-message }}
+      run: |
+        echo "$SLACK_MESSAGE"
 
 ```
 ## Non-Compliant Code Examples

--- a/documentation/rules/cicd/github/script_block_injection.md
+++ b/documentation/rules/cicd/github/script_block_injection.md
@@ -161,56 +161,40 @@ jobs:
 ```
 
 ```yaml
-name: test-script-run
-
-on:
-  issue_comment:
-    types: [opened]
-
-jobs:
-  script-run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run script
-        uses: actions/github-script@latest
-        with:
-          script: |
-            const fs = require('fs');
-            const body = fs.readFileSync('/tmp/${{ github.event.issue.title }}.txt', {encoding: 'utf8'});
-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Thanks for reporting!'
-            })
-
-            return true;
+name: Composite action with github-script using inputs
+description: Composite action that runs github-script with attacker-controlled composite inputs
+inputs:
+  message:
+    description: Message provided by the caller
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Run script
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const body = `${{ inputs.message }}`;
+          core.info(body);
 
 ```
 
 ```yaml
-name: test-script-run
-
-on:
-  pull_request:
-
-jobs:
-  script-run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run script
-        uses: actions/github-script@latest
-        with:
-          script: |
-            const head_ref = ${{ github.head_ref }};
-
-            return true;
+name: Composite action with github-script
+description: Composite action that runs github-script with untrusted issue body
+runs:
+  using: composite
+  steps:
+    - name: Run script
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const body = `${{ github.event.issue.body }}`;
+          await github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'Thanks for reporting!'
+          })
 
 ```

--- a/documentation/rules/cicd/github/superfluous_actions.md
+++ b/documentation/rules/cicd/github/superfluous_actions.md
@@ -105,6 +105,17 @@ jobs:
 ```
 ## Non-Compliant Code Examples
 ```yaml
+name: Composite action using superfluous third-party action
+description: Composite action that uses a superfluous third-party release action
+runs:
+  using: composite
+  steps:
+    - name: Create release
+      uses: ncipollo/release-action@v1
+
+```
+
+```yaml
 name: Using Superfluous Actions
 on: push
 

--- a/documentation/rules/cicd/github/unpinned_actions_full_length_commit_sha.md
+++ b/documentation/rules/cicd/github/unpinned_actions_full_length_commit_sha.md
@@ -58,7 +58,7 @@ jobs:
 ```
 
 ```yaml
-name: test-negative4
+name: test-negative6
 on:
   pull_request:
     types: [opened, synchronize, edited, reopened]
@@ -71,18 +71,27 @@ jobs:
 ```
 
 ```yaml
-name: test-negative4
-on:
-  pull_request:
-    types: [opened, synchronize, edited, reopened]
-    branches:
-      - master
-jobs:
-  test-negative4:
-    uses: ./.github/workflows/pr-comment-thollander.yml
+name: Composite action with pinned third-party action
+description: Composite action that pins a third-party action to a full SHA
+runs:
+  using: composite
+  steps:
+    - name: PR comment
+      uses: thollander/actions-comment-pull-request@b07c7f86be67002023e6cb13f57df3f21cdd3411
 
 ```
 ## Non-Compliant Code Examples
+```yaml
+name: Composite action with unpinned third-party action
+description: Composite action that calls a third-party action by tag instead of SHA
+runs:
+  using: composite
+  steps:
+    - name: PR comment
+      uses: thollander/actions-comment-pull-request@v2
+
+```
+
 ```yaml
 name: test-positive
 on:

--- a/documentation/rules/cicd/github/unsound_conditions.md
+++ b/documentation/rules/cicd/github/unsound_conditions.md
@@ -89,6 +89,20 @@ jobs:
 ```
 ## Non-Compliant Code Examples
 ```yaml
+name: Composite action with unsound conditions
+description: Composite action whose step conditions use YAML block scalars
+runs:
+  using: composite
+  steps:
+    - name: Unsound literal block
+      if: |
+        ${{ inputs.deploy == 'true' }}
+      shell: bash
+      run: echo "This will always run!"
+
+```
+
+```yaml
 name: Unsound Conditions
 on: push
 

--- a/documentation/rules/cicd/github/unsound_contains_no_controllable_input.md
+++ b/documentation/rules/cicd/github/unsound_contains_no_controllable_input.md
@@ -95,6 +95,19 @@ jobs:
 ```
 ## Non-Compliant Code Examples
 ```yaml
+name: Composite action with unsafe contains
+description: Composite step uses contains() against a non-user-controllable context
+runs:
+  using: composite
+  steps:
+    - name: Check trigger
+      if: ${{ contains('push pull_request', github.event_name) }}
+      shell: bash
+      run: echo "Trigger check"
+
+```
+
+```yaml
 name: Unsound Contains Usage
 on: pull_request
 

--- a/documentation/rules/cicd/github/unsound_contains_with_controllable_input.md
+++ b/documentation/rules/cicd/github/unsound_contains_with_controllable_input.md
@@ -97,6 +97,19 @@ jobs:
 ```
 ## Non-Compliant Code Examples
 ```yaml
+name: Composite action with unsafe contains
+description: Composite step if condition uses contains() against user-controllable input
+runs:
+  using: composite
+  steps:
+    - name: Check input
+      if: ${{ contains('dev test prod', inputs.environment) }}
+      shell: bash
+      run: echo "Valid environment"
+
+```
+
+```yaml
 name: Unsound Contains Usage
 on: pull_request
 

--- a/documentation/rules/terraform/alicloud/api_gateway_api_protocol_not_https.md
+++ b/documentation/rules/terraform/alicloud/api_gateway_api_protocol_not_https.md
@@ -1,10 +1,10 @@
 ---
-title: "API gateway API protocol not HTTPS"
+title: "API Gateway API protocol not HTTPS"
 group_id: "Terraform / Alicloud"
 meta:
   name: "alicloud/api_gateway_api_protocol_not_https"
   id: "1bcdf9f0-b1aa-40a4-b8c6-cd7785836843"
-  display_name: "API gateway API protocol not HTTPS"
+  display_name: "API Gateway API protocol not HTTPS"
   cloud_provider: "Alicloud"
   platform: "Terraform"
   severity: "MEDIUM"

--- a/documentation/rules/terraform/alicloud/oss_buckets_securetransport_disabled.md
+++ b/documentation/rules/terraform/alicloud/oss_buckets_securetransport_disabled.md
@@ -156,6 +156,41 @@ resource "alicloud_oss_bucket" "bucket-securetransport3" {
 ```
 
 ```terraform
+resource "alicloud_oss_bucket" "multi_statement" {
+  policy = <<POLICY
+{
+  "Version": "1",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      "Principal": ["*"],
+      "Action": ["oss:*"],
+      "Resource": ["acs:oss:*:*:bucket/*"],
+      "Condition": {
+        "Bool": {
+          "acs:SecureTransport": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": ["*"],
+      "Action": ["oss:GetObject"],
+      "Resource": ["acs:oss:*:*:bucket/*"],
+      "Condition": {
+        "Bool": {
+          "acs:SecureTransport": "false"
+        }
+      }
+    }
+  ]
+}
+POLICY
+}
+
+```
+
+```terraform
 resource "alicloud_oss_bucket" "bucket-securetransport1"{
         policy = <<POLICY
 {

--- a/documentation/rules/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated.md
+++ b/documentation/rules/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated.md
@@ -1,10 +1,10 @@
 ---
-title: "API gateway deployment without API gateway usage plan associated"
+title: "API Gateway deployment without API Gateway usage plan associated"
 group_id: "Terraform / AWS"
 meta:
   name: "aws/api_gateway_deployment_without_api_gateway_usage_plan_associated"
   id: "b3a59b8e-94a3-403e-b6e2-527abaf12034"
-  display_name: "API gateway deployment without API gateway usage plan associated"
+  display_name: "API Gateway deployment without API Gateway usage plan associated"
   cloud_provider: "AWS"
   platform: "Terraform"
   severity: "LOW"

--- a/documentation/rules/terraform/aws/authentication_without_mfa.md
+++ b/documentation/rules/terraform/aws/authentication_without_mfa.md
@@ -122,44 +122,63 @@ EOF
 
 ```terraform
 provider "aws" {
-  region  = "us-east-1"
+  region = "us-east-1"
 }
 
-resource "aws_iam_user" "positive1" {
-  name = "aws-foundations-benchmark-1-4-0-terraform-user"
-  path = "/"
-}
-
-resource "aws_iam_user_login_profile" "positive1" {
-  user = aws_iam_user.positive1.name
-  pgp_key = "gpgkeybase64gpgkeybase64gpgkeybase64gpgkeybase64"
-}
-
-resource "aws_iam_access_key" "positive1" {
-  user = aws_iam_user.positive1.name
-}
-
-resource "aws_iam_user_policy" "positive1" {
-  name = "aws-foundations-benchmark-1-4-0-terraform-user"
-  user = aws_iam_user.positive1.name
+resource "aws_iam_user_policy" "multi_statement" {
+  name = "multi-statement-policy"
+  user = aws_iam_user.positive3.name
 
   policy = <<EOF
 {
-   "Version": "2012-10-17",
-   "Statement": [
-     {
-       "Effect": "Allow",
-       "Resource": "${aws_iam_user.positive1.arn}",
-       "Action": "sts:AssumeRole",
-       "Condition": {
-         "BoolIfExists": {
-           "aws:MultiFactorAuthPresent" : "false"
-         }
-       }
-     }
-   ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "${aws_iam_user.positive3.arn}",
+      "Condition": {
+        "BoolIfExists": {
+          "aws:MultiFactorAuthPresent": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "${aws_iam_user.positive3.arn}"
+    }
+  ]
 }
 EOF
+}
+
+```
+
+```terraform
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_iam_user_policy" "jsonencoded" {
+  name = "jsonencoded-policy"
+  user = aws_iam_user.positive4.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
+        Resource = aws_iam_user.positive4.arn
+        Condition = {
+          BoolIfExists = {
+            "aws:MultiFactorAuthPresent" = "false"
+          }
+        }
+      }
+    ]
+  })
 }
 
 ```

--- a/documentation/rules/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy.md
+++ b/documentation/rules/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy.md
@@ -62,6 +62,52 @@ resource "aws_cloudwatch_log_destination_policy" "test_destination_policy2" {
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_cloudwatch_log_destination_policy" "multi_statement" {
+  destination_name = aws_cloudwatch_log_destination.example.name
+
+  access_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": ["logs:PutSubscriptionFilter"]
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["logs:*"]
+    }
+  ]
+}
+POLICY
+}
+
+```
+
+```terraform
+resource "aws_cloudwatch_log_destination_policy" "jsonencoded" {
+  destination_name = aws_cloudwatch_log_destination.example.name
+
+  access_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = ["logs:*"]
+      }
+    ]
+  })
+}
+
+```
+
+```terraform
 data "aws_iam_policy_document" "test_destination_policy" {
   statement {
     effect = "Allow"

--- a/documentation/rules/terraform/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa.md
+++ b/documentation/rules/terraform/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa.md
@@ -168,29 +168,47 @@ EOF
 ```
 
 ```terraform
-resource "aws_iam_role" "positive1" {
-  name = "test_role"
+resource "aws_iam_role" "multi_statement" {
+  name = "multi_statement"
 
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "AWS": "arn:aws:iam::987654321145:root"
-      },
+      "Sid": "SafeWithMFA",
       "Effect": "Allow",
-      "Resource": "*",
-      "Sid": ""
+      "Principal": {"AWS": "arn:aws:iam::111111111111:root"},
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "Bool": {"aws:MultiFactorAuthPresent": "true"}
+      }
+    },
+    {
+      "Sid": "VulnerableCrossAccountWithoutMFA",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::222222222222:root"},
+      "Action": "sts:AssumeRole"
     }
   ]
 }
 EOF
+}
 
-  tags = {
-    tag-key = "tag-value"
-  }
+resource "aws_iam_role" "jsonencoded" {
+  name = "jsonencoded"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::333333333333:root" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
 }
 
 ```

--- a/documentation/rules/terraform/aws/ecr_repository_is_publicly_accessible.md
+++ b/documentation/rules/terraform/aws/ecr_repository_is_publicly_accessible.md
@@ -113,6 +113,36 @@ EOF
 ```
 
 ```terraform
+resource "aws_ecr_repository" "aws_wildcard" {
+  name = "aws-wildcard-repo"
+}
+
+resource "aws_ecr_repository_policy" "aws_wildcard" {
+  repository = aws_ecr_repository.aws_wildcard.name
+
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowAnyAccount",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+```
+
+```terraform
 resource "aws_ecr_repository" "positive1" {
   name = "bar"
 }

--- a/documentation/rules/terraform/aws/efs_with_vulnerable_policy.md
+++ b/documentation/rules/terraform/aws/efs_with_vulnerable_policy.md
@@ -81,6 +81,54 @@ POLICY
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_efs_file_system_policy" "multi_statement" {
+  file_system_id = aws_efs_file_system.example.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SafeStatement",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Action": ["elasticfilesystem:ClientRead"]
+    },
+    {
+      "Sid": "VulnerableStatement",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["elasticfilesystem:*"]
+    }
+  ]
+}
+POLICY
+}
+
+```
+
+```terraform
+resource "aws_efs_file_system_policy" "jsonencoded" {
+  file_system_id = aws_efs_file_system.example.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = ["elasticfilesystem:*"]
+      }
+    ]
+  })
+}
+
+```
+
+```terraform
 provider "aws" {
   region = "us-east-1"
 }

--- a/documentation/rules/terraform/aws/elasticsearch_domain_with_vulnerable_policy.md
+++ b/documentation/rules/terraform/aws/elasticsearch_domain_with_vulnerable_policy.md
@@ -64,6 +64,52 @@ POLICIES
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_elasticsearch_domain_policy" "multi_statement" {
+  domain_name = aws_elasticsearch_domain.example.domain_name
+
+  access_policies = <<POLICIES
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": ["es:DescribeDomain"]
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["es:*"]
+    }
+  ]
+}
+POLICIES
+}
+
+```
+
+```terraform
+resource "aws_elasticsearch_domain_policy" "jsonencoded" {
+  domain_name = aws_elasticsearch_domain.example.domain_name
+
+  access_policies = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = ["es:*"]
+      }
+    ]
+  })
+}
+
+```
+
+```terraform
 provider "aws" {
   region = "us-east-1"
 }

--- a/documentation/rules/terraform/aws/glue_with_vulnerable_policy.md
+++ b/documentation/rules/terraform/aws/glue_with_vulnerable_policy.md
@@ -62,6 +62,48 @@ resource "aws_glue_resource_policy" "example2" {
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_glue_resource_policy" "multi_statement" {
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": ["glue:GetTable"]
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["glue:*"]
+    }
+  ]
+}
+POLICY
+}
+
+```
+
+```terraform
+resource "aws_glue_resource_policy" "jsonencoded" {
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = ["glue:*"]
+      }
+    ]
+  })
+}
+
+```
+
+```terraform
 data "aws_iam_policy_document" "glue-example-policy" {
   statement {
     actions = [

--- a/documentation/rules/terraform/aws/iam_policies_with_full_privileges.md
+++ b/documentation/rules/terraform/aws/iam_policies_with_full_privileges.md
@@ -77,6 +77,68 @@ data "aws_iam_policy_document" "example" {
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_iam_role_policy" "multi_statement" {
+  name = "multi-statement"
+  role = aws_iam_role.example.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::example-bucket/*"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+```
+
+```terraform
+resource "aws_iam_role_policy" "jsonencoded" {
+  name = "jsonencoded"
+  role = aws_iam_role.example.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "*"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+data "aws_iam_policy_document" "multi_statement" {
+  statement {
+    sid    = "Safe"
+    effect = "Allow"
+    actions = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::example-bucket/*"]
+  }
+  statement {
+    sid    = "Vulnerable"
+    effect = "Allow"
+    actions = ["*"]
+    resources = ["*"]
+  }
+}
+
+```
+
+```terraform
 resource "aws_iam_role_policy" "positive1" {
   name = "apigateway-cloudwatch-logging"
   role = aws_iam_role.apigateway_cloudwatch_logging.id

--- a/documentation/rules/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services.md
+++ b/documentation/rules/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services.md
@@ -132,6 +132,30 @@ EOF
 ```
 
 ```terraform
+//  Role whose assume-role policy grants trust to every AWS service.
+resource "aws_iam_role" "service_wildcard" {
+  name = "service-wildcard-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "*"
+      },
+      "Effect": "Allow",
+      "Sid": "AllowAnyService"
+    }
+  ]
+}
+EOF
+}
+
+```
+
+```terraform
 //  Create a role which OpenShift instances will assume.
 //  This role has a policy saying it can be assumed by ec2
 //  instances.

--- a/documentation/rules/terraform/aws/iam_policy_grants_full_permissions.md
+++ b/documentation/rules/terraform/aws/iam_policy_grants_full_permissions.md
@@ -167,34 +167,23 @@ EOF
 ```
 
 ```terraform
-resource "aws_iam_user" "positive1" {
-  name          = "${local.resource_prefix.value}-user"
-  force_destroy = true
-
-  tags = {
-    Name        = "${local.resource_prefix.value}-user"
-    Environment = local.resource_prefix.value
-  }
-
-}
-
-resource "aws_iam_access_key" "positive2" {
-  user = aws_iam_user.user.name
-}
-
-resource "aws_iam_user_policy" "positive3" {
-  name = "excess_policy"
-  user = aws_iam_user.user.name
+resource "aws_iam_policy" "multi_statement" {
+  name = "multi_statement"
 
   policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Action": [
-      "*"
-      ],
+      "Sid": "Safe",
       "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::example-bucket/*"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Action": "*",
       "Resource": "*"
     }
   ]
@@ -202,13 +191,23 @@ resource "aws_iam_user_policy" "positive3" {
 EOF
 }
 
-output "username" {
-  value = aws_iam_user.user.name
-}
+```
 
-output "secret" {
-  value = aws_iam_access_key.user.encrypted_secret
-}
+```terraform
+resource "aws_iam_policy" "jsonencoded" {
+  name = "jsonencoded"
 
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "JsonEncodedVulnerable"
+        Effect   = "Allow"
+        Action   = "*"
+        Resource = "*"
+      }
+    ]
+  })
+}
 
 ```

--- a/documentation/rules/terraform/aws/iam_role_allows_all_principals_to_assume.md
+++ b/documentation/rules/terraform/aws/iam_role_allows_all_principals_to_assume.md
@@ -103,6 +103,55 @@ resource "aws_iam_instance_profile" "negative4" {
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_iam_role" "multi_statement" {
+  name = "multi-statement-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow"
+    },
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+```
+
+```terraform
+resource "aws_iam_role" "jsonencoded" {
+  name = "jsonencoded-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Principal = {
+          AWS = "arn:aws:iam::123456789012:root"
+        }
+        Effect = "Allow"
+      }
+    ]
+  })
+}
+
+```
+
+```terraform
 //  Create a role which OpenShift instances will assume.
 //  This role has a policy saying it can be assumed by ec2
 //  instances.

--- a/documentation/rules/terraform/aws/iam_role_policy_passrole_allows_all.md
+++ b/documentation/rules/terraform/aws/iam_role_policy_passrole_allows_all.md
@@ -56,6 +56,51 @@ resource "aws_iam_role_policy" "test_policy" {
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_iam_role_policy" "multi_statement" {
+  name = "multi_statement"
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "Safe",
+        "Effect": "Allow",
+        "Action": "iam:passrole",
+        "Resource": "arn:aws:iam::123456789012:role/example-role"
+      },
+      {
+        "Sid": "Vulnerable",
+        "Effect": "Allow",
+        "Action": "iam:passrole",
+        "Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role_policy" "jsonencoded" {
+  name = "jsonencoded"
+  role = aws_iam_role.test_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "JsonEncodedVulnerable"
+        Effect   = "Allow"
+        Action   = "iam:passrole"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+```
+
+```terraform
 resource "aws_iam_role_policy" "test_policy" {
   name = "test_policy"
   role = aws_iam_role.test_role.id

--- a/documentation/rules/terraform/aws/iam_role_with_full_privileges.md
+++ b/documentation/rules/terraform/aws/iam_role_with_full_privileges.md
@@ -69,6 +69,52 @@ EOF
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_iam_role" "multi_statement" {
+  name = "test_multi"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"Service": "ec2.amazonaws.com"},
+      "Action": "sts:AssumeRole",
+      "Resource": "*"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": {"Service": "ec2.amazonaws.com"},
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "jsonencoded" {
+  name = "test_jsonencoded"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = { Service = "ec2.amazonaws.com" }
+        Action    = "*"
+        Resource  = "*"
+      }
+    ]
+  })
+}
+
+```
+
+```terraform
 resource "aws_iam_role" "positive1" {
   name = "test_role"
 

--- a/documentation/rules/terraform/aws/iam_user_policy_without_mfa.md
+++ b/documentation/rules/terraform/aws/iam_user_policy_without_mfa.md
@@ -100,6 +100,55 @@ EOF
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_iam_user_policy" "mfa_false" {
+  name = "test-mfa-false"
+  user = aws_iam_user.lb.name
+
+  policy = <<EOF
+{
+   "Version": "2012-10-17",
+   "Statement": [
+     {
+       "Effect": "Allow",
+       "Principal": {
+         "AWS": "arn:aws:iam::111122223333:root"
+       },
+       "Action": "sts:AssumeRole",
+       "Condition": {
+         "BoolIfExists": {
+           "aws:MultiFactorAuthPresent": "false"
+         }
+       }
+     }
+   ]
+}
+EOF
+}
+
+```
+
+```terraform
+resource "aws_iam_user_policy" "wildcard_principal" {
+  name = "test-wildcard"
+  user = aws_iam_user.lb.name
+
+  policy = <<EOF
+{
+   "Version": "2012-10-17",
+   "Statement": [
+     {
+       "Effect": "Allow",
+       "Principal": "*",
+       "Action": "sts:AssumeRole"
+     }
+   ]
+}
+EOF
+}
+
+```
+
+```terraform
 resource "aws_iam_user" "positive1" {
   name = "root"
   path = "/system/"

--- a/documentation/rules/terraform/aws/kms_key_with_full_permissions.md
+++ b/documentation/rules/terraform/aws/kms_key_with_full_permissions.md
@@ -115,23 +115,31 @@ resource "aws_kms_key" "positive3" {
 ```
 
 ```terraform
-resource "aws_kms_key" "positive1" {
-  description             = "KMS key 1"
-  deletion_window_in_days = 10
+resource "aws_kms_key" "multi_statement" {
+  description             = "KMS multi-statement"
+  deletion_window_in_days = 7
 
   policy = <<POLICY
-  {
-    "Version": "2012-10-17",
-    "Statement":[
-      {
-        "Sid":"AddCannedAcl",
-        "Effect":"Allow",
-        "Principal": {"AWS":"*"},
-        "Action":["kms:*"],
-        "Resource":"*"
-      }
-    ]
-  }
-  POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": ["kms:Encrypt"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["kms:*"],
+      "Resource": "*"
+    }
+  ]
 }
+POLICY
+}
+
 ```

--- a/documentation/rules/terraform/aws/policy_without_principal.md
+++ b/documentation/rules/terraform/aws/policy_without_principal.md
@@ -166,6 +166,50 @@ EOF
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_sns_topic_policy" "multi_statement" {
+  arn = aws_sns_topic.example.arn
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SafeWithPrincipal",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
+    },
+    {
+      "Sid": "VulnerableNoPrincipal",
+      "Effect": "Allow",
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_sns_topic_policy" "jsonencoded" {
+  arn = aws_sns_topic.example.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "JsonEncodedNoPrincipal"
+        Effect   = "Allow"
+        Action   = "SNS:Publish"
+        Resource = "arn:aws:sns:us-east-1:123456789012:example"
+      }
+    ]
+  })
+}
+
+```
+
+```terraform
 provider "aws" {
   region = "us-east-1"
 }

--- a/documentation/rules/terraform/aws/rest_api_with_vulnerable_policy.md
+++ b/documentation/rules/terraform/aws/rest_api_with_vulnerable_policy.md
@@ -66,6 +66,55 @@ EOF
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_api_gateway_rest_api_policy" "multi_statement" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": ["execute-api:Invoke"],
+      "Resource": "${aws_api_gateway_rest_api.example.arn}"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "execute-api:*",
+      "Resource": "${aws_api_gateway_rest_api.example.arn}"
+    }
+  ]
+}
+EOF
+}
+
+```
+
+```terraform
+resource "aws_api_gateway_rest_api_policy" "jsonencoded" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "execute-api:*"
+        Resource  = aws_api_gateway_rest_api.example.arn
+      }
+    ]
+  })
+}
+
+```
+
+```terraform
 provider "aws" {
   region = "us-east-1"
 }

--- a/documentation/rules/terraform/aws/s3_bucket_policy_accepts_http_requests.md
+++ b/documentation/rules/terraform/aws/s3_bucket_policy_accepts_http_requests.md
@@ -166,6 +166,33 @@ EOF
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_s3_bucket_policy" "allow_http" {
+  bucket = aws_s3_bucket.example.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ExplicitlyAllowHTTP",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::example-bucket/*",
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+```
+
+```terraform
 resource "aws_s3_bucket" "b2" {
   bucket = "my-tf-test-bucket"
 
@@ -229,43 +256,6 @@ module "s3_bucket" {
     ]
 }
 EOF
-}
-
-```
-
-```terraform
-
-data "aws_iam_policy_document" "pos4" {
-
-  statement {
-    effect = "Deny"
-
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-
-    actions = [
-      "s3:*",
-    ]
-
-
-    resources = [
-      "arn:aws:s3:::a/*",
-      "arn:aws:s3:::a",
-    ]
-    condition {
-      test     = "Bool"
-      variable = "aws:SecureTransport"
-      values   = ["true"]
-    }
-  }
-}
-
-
-resource "aws_s3_bucket" "pos4" {
-  bucket = "a"
-  policy = data.aws_iam_policy_document.pos4.json
 }
 
 ```

--- a/documentation/rules/terraform/aws/s3_bucket_with_all_permissions.md
+++ b/documentation/rules/terraform/aws/s3_bucket_with_all_permissions.md
@@ -121,26 +121,50 @@ module "s3_bucket" {
 ```
 
 ```terraform
-resource "aws_s3_bucket" "positive1" {
-  bucket = "S3B_181355"
-  acl    = "private"
+resource "aws_s3_bucket_policy" "multi_statement" {
+  bucket = aws_s3_bucket.example.id
 
   policy = <<EOF
-	{
-	  "Id": "id113",
-	  "Version": "2012-10-17",
-	  "Statement": [
-		{
-		  "Action": [
-			"s3:*"
-		  ],
-		  "Effect": "Allow",
-		  "Resource": "arn:aws:s3:::S3B_181355/*",
-		  "Principal": "*"
-		}
-	  ]
-	}
-  EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::example-bucket/*"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "*",
+      "Resource": "arn:aws:s3:::example-bucket/*"
+    }
+  ]
+}
+EOF
+}
+
+```
+
+```terraform
+resource "aws_s3_bucket_policy" "jsonencoded" {
+  bucket = aws_s3_bucket.example.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "*"
+        Resource  = "arn:aws:s3:::example-bucket/*"
+      }
+    ]
+  })
 }
 
 ```

--- a/documentation/rules/terraform/aws/secrets_manager_with_vulnerable_policy.md
+++ b/documentation/rules/terraform/aws/secrets_manager_with_vulnerable_policy.md
@@ -60,6 +60,52 @@ POLICY
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_secretsmanager_secret_policy" "multi_statement" {
+  secret_arn = aws_secretsmanager_secret.example.arn
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": "secretsmanager:GetSecretValue"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "secretsmanager:*"
+    }
+  ]
+}
+POLICY
+}
+
+```
+
+```terraform
+resource "aws_secretsmanager_secret_policy" "jsonencoded" {
+  secret_arn = aws_secretsmanager_secret.example.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "secretsmanager:*"
+      }
+    ]
+  })
+}
+
+```
+
+```terraform
 provider "aws" {
   region = "us-east-1"
 }

--- a/documentation/rules/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously.md
+++ b/documentation/rules/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously.md
@@ -148,6 +148,52 @@ POLICY
 ```
 
 ```terraform
+resource "aws_sns_topic_policy" "multi_statement" {
+  arn = aws_sns_topic.example.arn
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "NotAction": "SNS:DeleteTopic",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_sns_topic_policy" "jsonencoded" {
+  arn = aws_sns_topic.example.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::123456789012:root" }
+        NotAction = "SNS:DeleteTopic"
+        Resource  = "arn:aws:sns:us-east-1:123456789012:example"
+      }
+    ]
+  })
+}
+
+```
+
+```terraform
 resource "aws_sns_topic" "positive1" {
   name = "my-topic-with-policy"
 }

--- a/documentation/rules/terraform/aws/sqs_queue_exposed.md
+++ b/documentation/rules/terraform/aws/sqs_queue_exposed.md
@@ -184,8 +184,8 @@ POLICY
 ```
 
 ```terraform
-resource "aws_sqs_queue" "positive1" {
-  name = "examplequeue"
+resource "aws_sqs_queue" "aws_wildcard" {
+  name = "aws-wildcard-queue"
 
   policy = <<POLICY
 {
@@ -193,16 +193,13 @@ resource "aws_sqs_queue" "positive1" {
   "Id": "sqspolicy",
   "Statement": [
     {
-      "Sid": "First",
+      "Sid": "AllowAnyAccount",
       "Effect": "Allow",
-      "Principal": "*",
+      "Principal": {
+        "AWS": "*"
+      },
       "Action": "sqs:SendMessage",
-      "Resource": "${aws_sqs_queue.q.arn}",
-      "Condition": {
-        "ArnEquals": {
-          "aws:SourceArn": "${aws_sns_topic.example.arn}"
-        }
-      }
+      "Resource": "arn:aws:sqs:us-east-1:123456789012:my-queue"
     }
   ]
 }

--- a/documentation/rules/terraform/aws/sso_policy_with_full_privileges.md
+++ b/documentation/rules/terraform/aws/sso_policy_with_full_privileges.md
@@ -90,6 +90,26 @@ POLICY
 ```
 ## Non-Compliant Code Examples
 ```terraform
+resource "aws_ssoadmin_permission_set_inline_policy" "jsonencoded" {
+  instance_arn       = aws_ssoadmin_permission_set.example.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.example.arn
+
+  inline_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "JsonEncodedVulnerable"
+        Effect   = "Allow"
+        Action   = "*"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+```
+
+```terraform
 resource "aws_ssoadmin_permission_set_inline_policy" "pos1" {
   instance_arn       = aws_ssoadmin_permission_set.example.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.example.arn


### PR DESCRIPTION
## Motivation

When working on the rules, it is common to create new test cases, or change the description. It is as common to forget and update the documentation accordingly. As the documentation is not automatically generated, forgetting to update is easy. This PR aims to add a workflow checking if the documentation is up to date or not. This allows flexibility:

- If the PR is already big, the user may decide to generate the documentation change in another PR
- If making a slight modification, the user may decide to make the documentation change a part of the same PR

## Changes

- Create a workflow that uses the documentation generation script to check if the documentation is up to date
- Make the documentation up to date
  - Four rules changed capital letters in name
  - The rest of the changes is about the compliant / non-compliant code examples

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [x] I have updated any relevant documentation (if applicable).

## QA Instruction

- [Example of failing run](https://github.com/DataDog/datadog-iac-scanner/actions/runs/24454659104/job/71452078425?pr=86)

## Blast Radius

datadog-iac-scanner

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
