### PR TITLE
Catch reusable workflows unpinned actions

### DIFF
--- a/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/query.rego
+++ b/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/query.rego
@@ -18,7 +18,26 @@ CxPolicy[result] {
 		"keyActualValue": "Action is not pinned to a full length commit SHA.",
 		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "uses"],[]),
 		"resourceType": "github_action",
-		"resourceName": input.document[i].jobs[j].steps[k].name
+		"resourceName": get_object_name(input.document[i].jobs[j].steps[k], "step", k)
+	}
+}
+
+CxPolicy[result] {
+
+	uses := input.document[i].jobs[j].uses
+	not isAllowed(uses)
+	not isPinned(uses)
+	not isRelative(uses)
+	
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("uses={{%s}}", [uses]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Action pinned to a full length commit SHA.",
+		"keyActualValue": "Action is not pinned to a full length commit SHA.",
+		"searchLine": common_lib.build_search_line(["jobs", j, "uses"],[]),
+		"resourceType": "github_action",
+		"resourceName": get_object_name(input.document[i].jobs[j], "job", j)
 	}
 }
 
@@ -60,3 +79,8 @@ isRelative(use){
     startswith(use,allowed[i])
 }
 
+get_object_name(object, object_title, index) := object_name {
+	object_name := object.name
+} else := object_name {
+	object_name := sprintf("%s-%d", [object_title, index])
+}

--- a/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/query.rego
+++ b/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/query.rego
@@ -82,5 +82,5 @@ isRelative(use){
 get_object_name(object, object_title, index) := object_name {
 	object_name := object.name
 } else := object_name {
-	object_name := sprintf("%s-%d", [object_title, index])
+	object_name := sprintf("%s-%v", [object_title, index])
 }

--- a/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/test/negative5.yaml
+++ b/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/test/negative5.yaml
@@ -1,4 +1,4 @@
-name: test-negative4
+name: test-negative5
 on:
   pull_request:
     types: [opened, synchronize, edited, reopened]

--- a/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/test/negative5.yaml
+++ b/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/test/negative5.yaml
@@ -1,0 +1,9 @@
+name: test-negative4
+on:
+  pull_request:
+    types: [opened, synchronize, edited, reopened]
+    branches:
+      - master
+jobs:
+  test-negative4:
+    uses: ./.github/workflows/pr-comment-thollander.yml

--- a/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/test/negative6.yaml
+++ b/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/test/negative6.yaml
@@ -1,0 +1,9 @@
+name: test-negative6
+on:
+  pull_request:
+    types: [opened, synchronize, edited, reopened]
+    branches:
+      - master
+jobs:
+  test-negative4:
+    uses: my-org/shared-github-actions/.github/workflows/pr-comment-thollander.yml@b07c7f86be67002023e6cb13f57df3f21cdd3411

--- a/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/test/positive3.yaml
+++ b/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/test/positive3.yaml
@@ -1,0 +1,9 @@
+name: test-positive
+on:
+  pull_request:
+    types: [opened, synchronize, edited, reopened]
+    branches: 
+      - master
+jobs:
+  test-positive:
+    uses: my-org/shared-github-actions/.github/workflows/pr-comment-thollander.yml@v3

--- a/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/unpinned_actions_full_length_commit_sha/test/positive_expected_result.json
@@ -10,5 +10,11 @@
     "severity": "LOW",
     "line": 7,
     "fileName": "positive2.yaml"
+  },
+  {
+    "queryName": "Unpinned actions full length commit SHA",
+    "severity": "LOW",
+    "line": 9,
+    "fileName": "positive3.yaml"
   }
 ]

--- a/documentation/rules/cicd/github/unpinned_actions_full_length_commit_sha.md
+++ b/documentation/rules/cicd/github/unpinned_actions_full_length_commit_sha.md
@@ -58,39 +58,44 @@ jobs:
 ```
 
 ```yaml
-name: test-positive
+name: test-negative4
 on:
   pull_request:
     types: [opened, synchronize, edited, reopened]
     branches:
       - master
 jobs:
-  test-positive:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v4
-      with:
-        persist-credentials: false
+  test-negative4:
+    uses: my-org/shared-github-actions/.github/workflows/pr-comment-thollander.yml@b07c7f86be67002023e6cb13f57df3f21cdd3411
 
 ```
 
 ```yaml
-name: test-negative3
+name: test-negative4
 on:
   pull_request:
     types: [opened, synchronize, edited, reopened]
     branches:
       - master
 jobs:
-  test-negative3:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Local action
-      uses: ./test.yml
+  test-negative4:
+    uses: ./.github/workflows/pr-comment-thollander.yml
 
 ```
 ## Non-Compliant Code Examples
+```yaml
+name: test-positive
+on:
+  pull_request:
+    types: [opened, synchronize, edited, reopened]
+    branches: 
+      - master
+jobs:
+  test-positive:
+    uses: my-org/shared-github-actions/.github/workflows/pr-comment-thollander.yml@v3
+
+```
+
 ```yaml
 name: test-positive
 on:

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -70,7 +70,6 @@ var (
 	serverlessProviderRegex                         = regexp.MustCompile(`(^|\n)provider\s*:`)
 	cicdOnRegex                                     = regexp.MustCompile(`\s*on:\s*`)
 	cicdJobsRegex                                   = regexp.MustCompile(`\s*jobs:\s*`)
-	cicdStepsRegex                                  = regexp.MustCompile(`\s*steps:\s*`)
 	githubActionManifestRunsRegex                   = regexp.MustCompile(`(^|\n)runs:\s*`)
 	githubActionManifestUsingRegex                  = regexp.MustCompile(`\s*using:\s*['"]?(composite|docker|node\d+)`)
 	dependabotVersionRegex                          = regexp.MustCompile(`\s*version:\s*`)
@@ -277,7 +276,6 @@ var types = map[string]regexSlice{
 		[]*regexp.Regexp{
 			cicdOnRegex,
 			cicdJobsRegex,
-			cicdStepsRegex,
 		},
 	},
 	"dependabot": {


### PR DESCRIPTION
## Motivation

Github actions have a reusable workflow feature which allows to use an entire job from the same repo or another one. This works exactly the same as using a GitHub action.

The unpinned reused workflows used under a `job` key are not flagged by the scanner. The goal of this PR is to correct this behaviour

## Changes

- Allow the scanner to scan GitHub actions that do not have a `step` key
- Allow anonymous jobs and steps to be flagged
- Refactored the rule to also flag the `uses` under job
- Added tests around this new detection
- Updated the documentation

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [x] I have updated any relevant documentation (if applicable).

## QA Instruction

- Check the logic of the rule
- Check the test cases: do they match what needs to be scanned?

## Blast Radius

iac-scanning - unpinned actions rule findings

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
