### PR TITLE
Fix SARIF location narrowing regression

### DIFF
--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -514,8 +514,12 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 				resourceStartLocation.Col = 1
 			}
 
-			if vulnerability.Remediation != "" &&
-				remediationStartLocation.Line >= resourceStartLocation.Line &&
+			// Always narrow the SARIF region to the remediation location when it falls
+			// within the resource block. The remediation location holds the precise
+			// attribute-level line even when no remediation
+			// string is present. Do NOT gate change this,
+			// that would cause rules without a fix to fall back to the full block range.
+			if remediationStartLocation.Line >= resourceStartLocation.Line &&
 				remediationEndLocation.Line <= resourceEndLocation.Line {
 				resourceStartLocation = remediationStartLocation
 				resourceEndLocation = remediationEndLocation

--- a/pkg/report/model/sarif_test.go
+++ b/pkg/report/model/sarif_test.go
@@ -536,7 +536,7 @@ var sarifTests = []sarifTest{
 		},
 	},
 	{
-		name: "Should keep resource location when remediation is empty",
+		name: "Should narrow to remediation location even when remediation string is empty",
 		vq: []model.QueryResult{
 			{
 				QueryName:   "test",
@@ -605,73 +605,73 @@ var sarifTests = []sarifTest{
 							ResultLocations: []SarifLocation{
 								{
 									PhysicalLocation: sarifPhysicalLocation{
-										ArtifactLocation: sarifArtifactLocation{ArtifactURI: "test.json"},
-										Region:           model.SarifRegion{StartLine: 1, EndLine: 5, StartColumn: 1, EndColumn: 2},
-									},
+									ArtifactLocation: sarifArtifactLocation{ArtifactURI: "test.json"},
+									Region:           model.SarifRegion{StartLine: 2, EndLine: 3, StartColumn: 1, EndColumn: 2},
 								},
 							},
-							ResultLevel: "warning",
-							ResultProperties: sarifProperties{
-								"tags": []string{"DATADOG_CATEGORY:", "IAC_RESOURCE_TYPE:test_resource_type", "IAC_RESOURCE_NAME:test_resource_name"},
-							},
-							PartialFingerprints: SarifPartialFingerprints{
-								DatadogFingerprint: GetDatadogFingerprintHash(
-									model.SCIInfo{
-										RepositoryCommitInfo: model.RepositoryCommitInfo{
-											RepositoryUrl: "",
-											Branch:        "",
-											CommitSHA:     "",
-										},
+						},
+						ResultLevel: "warning",
+						ResultProperties: sarifProperties{
+							"tags": []string{"DATADOG_CATEGORY:", "IAC_RESOURCE_TYPE:test_resource_type", "IAC_RESOURCE_NAME:test_resource_name"},
+						},
+						PartialFingerprints: SarifPartialFingerprints{
+							DatadogFingerprint: GetDatadogFingerprintHash(
+								model.SCIInfo{
+									RepositoryCommitInfo: model.RepositoryCommitInfo{
+										RepositoryUrl: "",
+										Branch:        "",
+										CommitSHA:     "",
 									},
-									"test.json",
-									"Terraform",
-									"test_resource_type",
-									"test_resource_name",
-									"1",
-									"",
-								),
+								},
+								"test.json",
+								"Terraform",
+								"test_resource_type",
+								"test_resource_name",
+								"1",
+								"",
+							),
+						},
+					},
+				},
+				Taxonomies: []sarifTaxonomy{
+					{
+						TaxonomyGUID:             "58cdcc6f-fe41-4724-bfb3-131a93df4c3f",
+						TaxonomyName:             "Categories",
+						TaxonomyFullDescription:  sarifMessage{Text: "Category is not defined"},
+						TaxonomyShortDescription: sarifMessage{Text: "Category is not defined"},
+						TaxonomyDefinitions: []taxonomyDefinitions{
+							{
+								DefinitionGUID:             "",
+								DefinitionName:             "Undefined Category",
+								DefinitionID:               "CAT000",
+								DefinitionShortDescription: cweMessage{Text: "Category is not defined"},
+								DefinitionFullDescription:  cweMessage{Text: "Category is not defined"},
+								HelpURI:                    "",
 							},
 						},
 					},
-					Taxonomies: []sarifTaxonomy{
-						{
-							TaxonomyGUID:             "58cdcc6f-fe41-4724-bfb3-131a93df4c3f",
-							TaxonomyName:             "Categories",
-							TaxonomyFullDescription:  sarifMessage{Text: "Category is not defined"},
-							TaxonomyShortDescription: sarifMessage{Text: "Category is not defined"},
-							TaxonomyDefinitions: []taxonomyDefinitions{
-								{
-									DefinitionGUID:             "",
-									DefinitionName:             "Undefined Category",
-									DefinitionID:               "CAT000",
-									DefinitionShortDescription: cweMessage{Text: "Category is not defined"},
-									DefinitionFullDescription:  cweMessage{Text: "Category is not defined"},
-									HelpURI:                    "",
-								},
-							},
-						},
-						{
-							TaxonomyGUID:                              "1489b0c4-d7ce-4d31-af66-6382a01202e3",
-							TaxonomyName:                              "CWE",
-							TaxonomyFullDescription:                   sarifMessage{Text: "The MITRE Common Weakness Enumeration"},
-							TaxonomyShortDescription:                  sarifMessage{Text: "The MITRE Common Weakness Enumeration"},
-							TaxonomyDownloadURI:                       "https://cwe.mitre.org/data/published/cwe_v4.13.pdf",
-							TaxonomyIsComprehensive:                   true,
-							TaxonomyLanguage:                          "en",
-							TaxonomyMinRequiredLocDataSemanticVersion: "4.13",
-							TaxonomyOrganization:                      "MITRE",
-							TaxonomyRealeaseDateUtc:                   "2023-10-26",
-							TaxonomyDefinitions: []taxonomyDefinitions{
-								{},
-							},
+					{
+						TaxonomyGUID:                              "1489b0c4-d7ce-4d31-af66-6382a01202e3",
+						TaxonomyName:                              "CWE",
+						TaxonomyFullDescription:                   sarifMessage{Text: "The MITRE Common Weakness Enumeration"},
+						TaxonomyShortDescription:                  sarifMessage{Text: "The MITRE Common Weakness Enumeration"},
+						TaxonomyDownloadURI:                       "https://cwe.mitre.org/data/published/cwe_v4.13.pdf",
+						TaxonomyIsComprehensive:                   true,
+						TaxonomyLanguage:                          "en",
+						TaxonomyMinRequiredLocDataSemanticVersion: "4.13",
+						TaxonomyOrganization:                      "MITRE",
+						TaxonomyRealeaseDateUtc:                   "2023-10-26",
+						TaxonomyDefinitions: []taxonomyDefinitions{
+							{},
 						},
 					},
 				},
 			},
 		},
 	},
-	{
-		name: "Should use remediation location when remediation is non-empty",
+},
+{
+	name: "Should use remediation location when remediation is non-empty",
 		vq: []model.QueryResult{
 			{
 				QueryName:   "test",


### PR DESCRIPTION
## Motivation

SARIF results were highlighting entire Terraform resource blocks instead of the precise vulnerable attribute line when remediation text is empty. This was caused by this precise [change](https://github.com/DataDog/datadog-iac-scanner/pull/80/changes#diff-adeaa7e7aecf27691585aa3f0444a4133e4688f20d168c360d8cec02a1f9c7d8R517), which shouldn't have been done.

## Changes

- Revert the change, and confirmed it works.
- Add regression test to prevent reintroducing the guard

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- Run `go test ./pkg/report/model/ -run TestBuildSarifIssue -count=1`
- Run the scanner on a Terraform file with `acl = \"public-read\"` and verify SARIF `region.startLine` points at the `acl` line.

## Blast Radius

- Reporting only: affects SARIF location ranges for findings.

## Additional Notes

I submit this contribution under the Apache-2.0 license.