### PR TITLE
Use run key instead of parsed_run object in searchKey

### DIFF
--- a/assets/queries/cicd/github/run_block_injection/query.rego
+++ b/assets/queries/cicd/github/run_block_injection/query.rego
@@ -251,6 +251,7 @@ CxPolicy[result] {
 CxPolicy[result] {
 	doc := input.document[i]
 	parsed_run := doc.jobs[j].steps[k]._parsed_expressions_run[_]
+	run := doc.jobs[j].steps[k].run
 
 	walk(parsed_run, [_, node])
 
@@ -261,7 +262,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("run={{%s}}", [parsed_run]),
+		"searchKey": sprintf("run={{%s}}", [run]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",


### PR DESCRIPTION
## Motivation

Inside the `run block injection` rule, the `parsed_run` object was used within the `searchKey`. This prevented the `searchKey` from finding the issue. The `searchLine` hid this as it is used in the `searchKey`'s stead when it exists. This also prevented any failure from the scanner which worked normally. This change is therefore mostly to keep the fallback working.

## Changes

Replaced `parsed_run` for `run` in `run block injection` rule on env injection check

## Author Checklist

- [x] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
  - Existing test cases showed the issue
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- Check that the run used is the actual run related to the parsed_run

## Blast Radius

- iac-scanning findings for run block injection, specifically for env expansion case where the `searchLine` did not work.

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
