### PR TITLE
Fix backend rule and configuration file parsing

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,11 +83,11 @@ func parseSchemaVersion(schema string) (version schemaVersion, err error) {
 	if !ok {
 		return schemaVersion{}, errors.New("schema must be in vX.Y format")
 	}
-	major64, err := strconv.ParseInt(majorStr, 10, 64)
+	major64, err := strconv.ParseInt(majorStr, 10, strconv.IntSize)
 	if err != nil {
 		return schemaVersion{}, errors.New("major version must be a number")
 	}
-	minor64, err := strconv.ParseInt(minorStr, 10, 64)
+	minor64, err := strconv.ParseInt(minorStr, 10, strconv.IntSize)
 	if err != nil {
 		return schemaVersion{}, errors.New("minor version must be a number")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,12 +11,12 @@ import (
 )
 
 type cfgFileYaml struct {
-	SchemaVersion string    `yaml:"schema-version"`
-	Iac           iacConfig `yaml:"iac,omitempty"`
-	Sast          any       `yaml:"sast,omitempty"`
-	Secrets       any       `yaml:"secrets,omitempty"`
-	Sca           any       `yaml:"sca,omitempty"`
-	Iast          any       `yaml:"iast,omitempty"`
+	SchemaVersion string     `yaml:"schema-version"`
+	Iac           *iacConfig `yaml:"iac,omitempty"`
+	Sast          any        `yaml:"sast,omitempty"`
+	Secrets       any        `yaml:"secrets,omitempty"`
+	Sca           any        `yaml:"sca,omitempty"`
+	Iast          any        `yaml:"iast,omitempty"`
 }
 
 type iacConfig struct {
@@ -42,9 +42,23 @@ func ParseConfig(cfgBytes []byte) (*IacConfig, error) {
 		return nil, fmt.Errorf("could not decode configuration file: %w", err)
 	}
 
-	if err := verifySchema(cfg.SchemaVersion); err != nil {
+	version, err := parseSchemaVersion(cfg.SchemaVersion)
+	if err != nil {
 		return nil, err
 	}
+	// Versions older than v1.2 can't have an IaC configuration
+	if version.compare(schemaVersion{1, 2}) < 0 {
+		return nil, nil
+	}
+	// Versions v2.0 and higher are not supported
+	if version.compare(schemaVersion{2, 0}) >= 0 {
+		return nil, fmt.Errorf("configuration schema version %s is not supported", version)
+	}
+
+	if cfg.Iac == nil {
+		return nil, nil
+	}
+
 	out := &IacConfig{
 		IgnoreRules:      cfg.Iac.IgnoreRules,
 		OnlyRules:        cfg.Iac.UseRules,
@@ -58,18 +72,41 @@ func ParseConfig(cfgBytes []byte) (*IacConfig, error) {
 	return out, nil
 }
 
-func verifySchema(schema string) error {
+func parseSchemaVersion(schema string) (version schemaVersion, err error) {
 	if schema == "" {
-		return errors.New("schema-version must be specified")
+		return schemaVersion{}, errors.New("schema must not be empty")
 	}
-	if schema[0] == 'v' {
-		if majorStr, minorStr, ok := strings.Cut(schema[1:], "."); ok {
-			major, _ := strconv.Atoi(majorStr)
-			minor, _ := strconv.Atoi(minorStr)
-			if major == 1 && minor >= 1 {
-				return nil
-			}
-		}
+	if schema[0] != 'v' {
+		return schemaVersion{}, errors.New("schema must be in vX.Y format")
 	}
-	return errors.New("schema-version must be \"v1.1\" or above")
+	majorStr, minorStr, ok := strings.Cut(schema[1:], ".")
+	if !ok {
+		return schemaVersion{}, errors.New("schema must be in vX.Y format")
+	}
+	major64, err := strconv.ParseInt(majorStr, 10, 64)
+	if err != nil {
+		return schemaVersion{}, errors.New("major version must be a number")
+	}
+	minor64, err := strconv.ParseInt(minorStr, 10, 64)
+	if err != nil {
+		return schemaVersion{}, errors.New("minor version must be a number")
+	}
+	return schemaVersion{major: int(major64), minor: int(minor64)}, nil
+}
+
+type schemaVersion struct {
+	major, minor int
+}
+
+// compare returns a positive number if this schema version is higher than the other schema version,
+// a negative number if it's smaller, or zero if they are equal
+func (v schemaVersion) compare(other schemaVersion) int {
+	if dif := v.major - other.major; dif != 0 {
+		return dif
+	}
+	return v.minor - other.minor
+}
+
+func (v schemaVersion) String() string {
+	return fmt.Sprintf("v%d.%d", v.major, v.minor)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -13,25 +13,28 @@ func TestParseHappyPath(t *testing.T) {
 }
 
 func TestParseSchemaVersion(t *testing.T) {
-	_, err := ParseConfig([]byte("iac:"))
+	_, err := ParseConfig([]byte(`iac: {ignore-rules: ["abc"]}`))
 	assert.Error(t, err, "Missing schema-version was expected to be rejected")
 
-	_, err = ParseConfig([]byte("schema-version: v1\niac:"))
+	_, err = ParseConfig([]byte("schema-version: v1\niac: {ignore-rules: [\"abc\"]}"))
 	assert.Error(t, err, "Invalid schema-version was expected to be rejected")
 
-	_, err = ParseConfig([]byte("schema-version: 1.1\niac:"))
+	_, err = ParseConfig([]byte("schema-version: 1.1\niac: {ignore-rules: [\"abc\"]}"))
 	assert.Error(t, err, "Invalid schema-version was expected to be rejected")
 
-	_, err = ParseConfig([]byte("schema-version: v1.0\niac:"))
-	assert.Error(t, err, "Too-low schema-version was expected to be rejected")
+	cfg, err := ParseConfig([]byte("schema-version: v1.0\niac: {ignore-rules: [\"abc\"]}"))
+	assert.Nil(t, cfg, "Too low schema-version should result in empty IaC config")
+	assert.NoError(t, err)
 
-	_, err = ParseConfig([]byte("schema-version: v1.1\niac:"))
-	assert.NoError(t, err, "The current schema-version was expected to be accepted")
+	cfg, err = ParseConfig([]byte("schema-version: v1.2\niac: {ignore-rules: [\"abc\"]}"))
+	assert.NotNil(t, cfg, "The current schema-version should result in parsed IaC config")
+	assert.NoError(t, err)
 
-	_, err = ParseConfig([]byte("schema-version: v1.2\niac:"))
-	assert.NoError(t, err, "The schema-version with future minor number was expected to be accepted")
+	_, err = ParseConfig([]byte("schema-version: v1.3\niac: {ignore-rules: [\"abc\"]}"))
+	assert.NotNil(t, cfg, "The schema-version with future minor number should result in parsed IaC config")
+	assert.NoError(t, err)
 
-	_, err = ParseConfig([]byte("schema-version: v2.1\niac:"))
+	_, err = ParseConfig([]byte("schema-version: v2.1\niac: {ignore-rules: [\"abc\"]}"))
 	assert.Error(t, err, "The schema-version with future major number was expected to be rejected")
 }
 

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -17,7 +17,10 @@ func ReadConfiguration(ctx context.Context, rootPath string) (*IacConfig, error)
 		if err != nil {
 			return nil, err
 		}
-		return ParseConfig(b)
+		cfg, err := ParseConfig(b)
+		if cfg != nil || err != nil {
+			return cfg, err
+		}
 	}
 
 	if _, found := fileExists(rootPath, LegacyConfigFileName); found {

--- a/pkg/config/reader_test.go
+++ b/pkg/config/reader_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const cfgFile = `
-schema-version: v1.1
+schema-version: v1.2
 iac:
   ignore-rules: [query1, query2]
   use-rules: [query3, query4]
@@ -50,6 +50,18 @@ var parsedLegacyCfg = IacConfig{
 	LegacyExcludeResults: []string{"res1", "res2"},
 }
 
+const emptyCfgFile = `
+schema-version: v1.2
+sast:
+  use-rulesets: [foo]
+`
+
+const oldCfgFile = `
+schema-version: v1.1
+iac:
+  use-rules: [foo]
+`
+
 func TestNoConfig(t *testing.T) {
 	tmp := t.TempDir()
 
@@ -70,6 +82,32 @@ func TestReadConfig(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, parsedCfgFile, *cfg)
+		})
+	}
+}
+
+func TestIgnoredConfigFile(t *testing.T) {
+	for _, tc := range []struct {
+		name, cfg string
+	}{
+		{
+			name: "empty IaC config",
+			cfg:  emptyCfgFile,
+		},
+		{
+			name: "old schema version",
+			cfg:  oldCfgFile,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(tmp, ConfigFileNameBase+".yaml"), []byte(tc.cfg), 0644))
+
+			cfg, err := ReadConfiguration(t.Context(), tmp)
+			assert.NoError(t, err)
+
+			expected := IacConfig{}
+			assert.Equal(t, expected, *cfg)
 		})
 	}
 }
@@ -105,4 +143,30 @@ func TestConfigFilePrecedence(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, parsedCfgFile, *cfg)
+}
+
+func TestConfigFilePrecedenceWithIgnoredConfigFile(t *testing.T) {
+	for _, tc := range []struct {
+		name, cfg string
+	}{
+		{
+			name: "empty IaC config",
+			cfg:  emptyCfgFile,
+		},
+		{
+			name: "old schema version",
+			cfg:  oldCfgFile,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(tmp, ConfigFileNameBase+".yaml"), []byte(tc.cfg), 0644))
+			require.NoError(t, os.WriteFile(filepath.Join(tmp, LegacyConfigFileName), []byte(legacyCfg), 0644))
+
+			cfg, err := ReadConfiguration(t.Context(), tmp)
+			assert.NoError(t, err)
+
+			assert.Equal(t, parsedLegacyCfg, *cfg)
+		})
+	}
 }

--- a/pkg/engine/source/datadog.go
+++ b/pkg/engine/source/datadog.go
@@ -2,6 +2,8 @@ package source
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -260,12 +262,16 @@ func isInCaseInsensitiveNotEmptyList(id string, list []string) bool {
 // nolint:gocyclo
 // ConvertRule converts a Datadog api [Rule] to a [model.QueryMetadata]
 func ConvertRule(rule *Rule) model.QueryMetadata {
+	id := rule.ID
+	if rule.LegacyId != nil {
+		id = *rule.LegacyId
+	}
 	out := model.QueryMetadata{
 		InputData: "{}",
 		Query:     rule.Name,
 		Content:   string(rule.RegoQuery),
 		Metadata: map[string]any{
-			"id":              rule.ID,
+			"id":              id,
 			"queryName":       rule.ShortDescription,
 			"descriptionText": rule.Description,
 			"platform":        rule.Platform,
@@ -276,14 +282,26 @@ func ConvertRule(rule *Rule) model.QueryMetadata {
 		Aggregation:  1,
 		Experimental: rule.IsTesting,
 	}
-	setStringPtr(out.Metadata, "descriptionUrl", rule.DocumentationUrl)
 	setStringPtr(out.Metadata, "providerUrl", rule.ProviderUrl)
 	setStringPtr(out.Metadata, "descriptionID", rule.DescriptionId)
 	setStringPtr(out.Metadata, "cloudProvider", rule.Provider)
-	if rule.Cwe == nil {
-		out.Metadata["cwe"] = ""
+	if rule.DescriptionId != nil {
+		out.Metadata["descriptionID"] = *rule.DescriptionId
 	} else {
+		sha := sha256.Sum256([]byte(rule.Name))
+		out.Metadata["descriptionID"] = hex.EncodeToString(sha[:4])
+	}
+	if rule.DocumentationUrl != nil {
+		out.Metadata["descriptionUrl"] = *rule.DocumentationUrl
+	} else if rule.Provider == nil {
+		out.Metadata["descriptionUrl"] = fmt.Sprintf("https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/%s/%s/", out.Platform, out.Query)
+	} else {
+		out.Metadata["descriptionUrl"] = fmt.Sprintf("https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/%s/%s/%s/", out.Platform, *rule.Provider, out.Query)
+	}
+	if rule.Cwe != nil {
 		out.Metadata["cwe"] = *rule.Cwe
+	} else {
+		out.Metadata["cwe"] = ""
 	}
 	if rule.Aggregation != nil {
 		out.Metadata["aggregation"] = *rule.Aggregation

--- a/pkg/engine/source/datadog.go
+++ b/pkg/engine/source/datadog.go
@@ -294,9 +294,13 @@ func ConvertRule(rule *Rule) model.QueryMetadata {
 	if rule.DocumentationUrl != nil {
 		out.Metadata["descriptionUrl"] = *rule.DocumentationUrl
 	} else if rule.Provider == nil {
-		out.Metadata["descriptionUrl"] = fmt.Sprintf("https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/%s/%s/", out.Platform, out.Query)
+		out.Metadata["descriptionUrl"] = fmt.Sprintf(
+			"https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/%s/%s/",
+			out.Platform, out.Query)
 	} else {
-		out.Metadata["descriptionUrl"] = fmt.Sprintf("https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/%s/%s/%s/", out.Platform, *rule.Provider, out.Query)
+		out.Metadata["descriptionUrl"] = fmt.Sprintf(
+			"https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/%s/%s/%s/",
+			out.Platform, *rule.Provider, out.Query)
 	}
 	if rule.Cwe != nil {
 		out.Metadata["cwe"] = *rule.Cwe

--- a/pkg/engine/source/datadog_test.go
+++ b/pkg/engine/source/datadog_test.go
@@ -392,6 +392,8 @@ var queries = []model.QueryMetadata{
 			"platform":        "Common",
 			"severity":        "MEDIUM",
 			"category":        "Backup",
+			"descriptionUrl":  "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/common/some-name/",
+			"descriptionID":   "59107c75",
 			"cwe":             "",
 		},
 		Platform:     "common",
@@ -411,6 +413,8 @@ var queries = []model.QueryMetadata{
 			"category":        "Supply-Chain",
 			"cloudProvider":   "common",
 			"aggregation":     2,
+			"descriptionUrl":  "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/grpc/common/rule-3/",
+			"descriptionID":   "868c4101",
 			"cwe":             "",
 			"override": map[string]any{
 				"1.0": map[string]any{


### PR DESCRIPTION
## Motivation

Fix bugs in the server-side rule and new configuration file parsing.

## Changes

For server-side rules, account for fields that are optional in the backend but mandatory in the client.

For the configuration file, account for files with an empty `iac` section or with an old schema version by allowing the client to fall back to the legacy configuration file.

## Author Checklist

- [X] I have reviewed my own PR.
- [X] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [X] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Tell the reviewer how they can make sure the PR is indeed working as intended. Tell them what they should be looking for.

## Blast Radius

What services will this change impact. Is it only DataDog IaC Scanner, internal services, the documentation or anything else?

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
