### PR TITLE
Precise SARIF regions for vulnerable policy and rules (pt 1)

### DIFF
--- a/assets/libraries/terraform.rego
+++ b/assets/libraries/terraform.rego
@@ -123,6 +123,36 @@ anyPrincipal(statement) {
   "*" == statement.Principal.Service[_]
 }
 
+# wildcard_principal_sub_path returns the path segments *under* `Principal` that
+# hold the wildcard `*`. It is meant to be used by rules that want to pinpoint
+# the narrowest offending key rather than the whole `Principal` block.
+#
+# Return values:
+#   ["AWS"]      when Principal.AWS is "*" or contains "*"
+#   ["Service"]  when Principal.Service is "*" or contains "*"
+#   []           when Principal itself is "*" or contains "*"
+#
+# Priority: explicit sub-keys (AWS, Service) take precedence over the flat form
+# so a statement with both still produces a single, deterministic finding.
+wildcard_principal_sub_path(statement) = ["AWS"] {
+  is_string(statement.Principal.AWS)
+  statement.Principal.AWS == "*"
+} else = ["AWS"] {
+  is_array(statement.Principal.AWS)
+  statement.Principal.AWS[_] == "*"
+} else = ["Service"] {
+  is_string(statement.Principal.Service)
+  statement.Principal.Service == "*"
+} else = ["Service"] {
+  is_array(statement.Principal.Service)
+  statement.Principal.Service[_] == "*"
+} else = [] {
+  statement.Principal == "*"
+} else = [] {
+  is_array(statement.Principal)
+  statement.Principal[_] == "*"
+}
+
 getSpecInfo(resource) = specInfo { # this one can be also used for the result
 	spec := resource.spec.job_template.spec.template.spec
 	specInfo := {"spec": spec, "path": "spec.job_template.spec.template.spec"}

--- a/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/query.rego
@@ -8,7 +8,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(resource.access_policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not common_lib.valid_key(statement, "Condition")
@@ -18,10 +18,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_cloudwatch_log_destination_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_cloudwatch_log_destination_policy[%s].access_policy", [name]),
+		"searchKey": sprintf("aws_cloudwatch_log_destination_policy[%s].access_policy.Statement[%d]", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_cloudwatch_log_destination_policy[%s].access_policy should not have wildcard in 'principals' and 'actions'", [name]),
 		"keyActualValue": sprintf("aws_cloudwatch_log_destination_policy[%s].access_policy has wildcard in 'principals' or 'actions'", [name]),
-		"searchLine": common_lib.build_search_line(["resource", "aws_cloudwatch_log_destination_policy", name, "access_policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_cloudwatch_log_destination_policy", name, "access_policy", "Statement", idx], []),
 	}
 }

--- a/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/test/positive2.tf
+++ b/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/test/positive2.tf
@@ -1,0 +1,23 @@
+resource "aws_cloudwatch_log_destination_policy" "multi_statement" {
+  destination_name = aws_cloudwatch_log_destination.example.name
+
+  access_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": ["logs:PutSubscriptionFilter"]
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["logs:*"]
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/test/positive3.tf
+++ b/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/test/positive3.tf
@@ -1,0 +1,15 @@
+resource "aws_cloudwatch_log_destination_policy" "jsonencoded" {
+  destination_name = aws_cloudwatch_log_destination.example.name
+
+  access_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = ["logs:*"]
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/test/positive_expected_result.json
@@ -4,5 +4,17 @@
     "severity": "LOW",
     "line": 22,
     "fileName": "positive.tf"
+  },
+  {
+    "queryName": "CloudWatch logs destination with vulnerable policy",
+    "severity": "LOW",
+    "line": 14,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "CloudWatch logs destination with vulnerable policy",
+    "severity": "LOW",
+    "line": 7,
+    "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/query.rego
@@ -8,7 +8,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(resource.policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not common_lib.valid_key(statement, "Condition")
@@ -18,10 +18,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_efs_file_system_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_efs_file_system_policy[%s].policy", [name]),
+		"searchKey": sprintf("aws_efs_file_system_policy[%s].policy.Statement[%d]", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_efs_file_system_policy[%s].policy should not have wildcard in 'Action' and 'Principal'", [name]),
 		"keyActualValue": sprintf("aws_efs_file_system_policy[%s].policy has wildcard in 'Action' or 'Principal'", [name]),
-		"searchLine": common_lib.build_search_line(["resource", "aws_efs_file_system_policy", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_efs_file_system_policy", name, "policy", "Statement", idx], []),
 	}
 }

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/positive2.tf
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/positive2.tf
@@ -1,0 +1,25 @@
+resource "aws_efs_file_system_policy" "multi_statement" {
+  file_system_id = aws_efs_file_system.example.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SafeStatement",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Action": ["elasticfilesystem:ClientRead"]
+    },
+    {
+      "Sid": "VulnerableStatement",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["elasticfilesystem:*"]
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/positive3.tf
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/positive3.tf
@@ -1,0 +1,15 @@
+resource "aws_efs_file_system_policy" "jsonencoded" {
+  file_system_id = aws_efs_file_system.example.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = ["elasticfilesystem:*"]
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/positive_expected_result.json
@@ -2,7 +2,19 @@
   {
     "queryName": "EFS with vulnerable policy",
     "severity": "MEDIUM",
-    "line": 16,
+    "line": 21,
     "fileName": "positive.tf"
+  },
+  {
+    "queryName": "EFS with vulnerable policy",
+    "severity": "MEDIUM",
+    "line": 16,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "EFS with vulnerable policy",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/query.rego
@@ -8,7 +8,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(resource.access_policies)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not common_lib.valid_key(statement, "Condition")
@@ -18,11 +18,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_elasticsearch_domain_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_elasticsearch_domain_policy[%s].access_policies", [name]),
+		"searchKey": sprintf("aws_elasticsearch_domain_policy[%s].access_policies.Statement[%d]", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_elasticsearch_domain_policy[%s].access_policies should not have wildcard in 'Action' and 'Principal'", [name]),
 		"keyActualValue": sprintf("aws_elasticsearch_domain_policy[%s].access_policies has wildcard in 'Action' or 'Principal'", [name]),
-		"searchLine": common_lib.build_search_line(["resource", "aws_elasticsearch_domain_policy", name, "access_policies"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_elasticsearch_domain_policy", name, "access_policies", "Statement", idx], []),
 	}
 }
 
@@ -34,7 +34,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(module[keyToCheck])
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not common_lib.valid_key(statement, "Condition")
@@ -44,10 +44,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
+		"searchKey": sprintf("module[%s].%s.Statement[%d]", [name, keyToCheck, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("module[%s].%s should not have wildcard in 'Action' and 'Principal'", [name, keyToCheck]),
 		"keyActualValue": sprintf("module[%s].%s has wildcard in 'Action' or 'Principal'", [name, keyToCheck]),
-		"searchLine": common_lib.build_search_line(["module", name, keyToCheck], []),
+		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx], []),
 	}
 }

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/positive2.tf
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/positive2.tf
@@ -1,0 +1,23 @@
+resource "aws_elasticsearch_domain_policy" "multi_statement" {
+  domain_name = aws_elasticsearch_domain.example.domain_name
+
+  access_policies = <<POLICIES
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": ["es:DescribeDomain"]
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["es:*"]
+    }
+  ]
+}
+POLICIES
+}

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/positive3.tf
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/positive3.tf
@@ -1,0 +1,15 @@
+resource "aws_elasticsearch_domain_policy" "jsonencoded" {
+  domain_name = aws_elasticsearch_domain.example.domain_name
+
+  access_policies = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = ["es:*"]
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/positive_expected_result.json
@@ -2,13 +2,25 @@
   {
     "queryName": "Elasticsearch domain with vulnerable policy",
     "severity": "MEDIUM",
-    "line": 18,
+    "line": 22,
     "fileName": "positive.tf"
   },
   {
     "queryName": "Elasticsearch domain with vulnerable policy",
     "severity": "MEDIUM",
-    "line": 16,
+    "line": 14,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "Elasticsearch domain with vulnerable policy",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive3.tf"
+  },
+  {
+    "queryName": "Elasticsearch domain with vulnerable policy",
+    "severity": "MEDIUM",
+    "line": 19,
     "fileName": "positive_module.tf"
   }
 ]

--- a/assets/queries/terraform/aws/glue_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/glue_with_vulnerable_policy/query.rego
@@ -8,7 +8,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(resource.policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not common_lib.valid_key(statement, "Condition")
@@ -18,11 +18,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_glue_resource_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_glue_resource_policy[%s].policy", [name]),
+		"searchKey": sprintf("aws_glue_resource_policy[%s].policy.Statement[%d]", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_glue_resource_policy[%s].policy should not have wildcard in 'principals' and 'actions'", [name]),
 		"keyActualValue": sprintf("aws_glue_resource_policy[%s].policy has wildcard in 'principals' or 'actions'", [name]),
-		"searchLine": common_lib.build_search_line(["resource", "aws_glue_resource_policy", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_glue_resource_policy", name, "policy", "Statement", idx], []),
 	}
 }
 
@@ -34,7 +34,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(module[keyToCheck])
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not common_lib.valid_key(statement, "Condition")
@@ -44,10 +44,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
+		"searchKey": sprintf("module[%s].%s.Statement[%d]", [name, keyToCheck, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("module[%s].%s should not have wildcard in 'principals' and 'actions'", [name, keyToCheck]),
 		"keyActualValue": sprintf("module[%s].%s has wildcard in 'principals' or 'actions'", [name, keyToCheck]),
-		"searchLine": common_lib.build_search_line(["module", name, keyToCheck], []),
+		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx], []),
 	}
 }

--- a/assets/queries/terraform/aws/glue_with_vulnerable_policy/test/positive2.tf
+++ b/assets/queries/terraform/aws/glue_with_vulnerable_policy/test/positive2.tf
@@ -1,0 +1,21 @@
+resource "aws_glue_resource_policy" "multi_statement" {
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": ["glue:GetTable"]
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["glue:*"]
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/glue_with_vulnerable_policy/test/positive3.tf
+++ b/assets/queries/terraform/aws/glue_with_vulnerable_policy/test/positive3.tf
@@ -1,0 +1,13 @@
+resource "aws_glue_resource_policy" "jsonencoded" {
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = ["glue:*"]
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/glue_with_vulnerable_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/glue_with_vulnerable_policy/test/positive_expected_result.json
@@ -8,7 +8,19 @@
   {
     "queryName": "Glue with vulnerable policy",
     "severity": "MEDIUM",
-    "line": 22,
+    "line": 12,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "Glue with vulnerable policy",
+    "severity": "MEDIUM",
+    "line": 5,
+    "fileName": "positive3.tf"
+  },
+  {
+    "queryName": "Glue with vulnerable policy",
+    "severity": "MEDIUM",
+    "line": 26,
     "fileName": "positive_module.tf"
   }
 ]

--- a/assets/queries/terraform/aws/iam_policies_with_full_privileges/query.rego
+++ b/assets/queries/terraform/aws/iam_policies_with_full_privileges/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 	policy := common_lib.json_unmarshal(resource.policy)
 
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[s_idx]
 
 	common_lib.is_allow_effect(statement)
 	common_lib.equalsOrInArray(statement.Resource, "*")
@@ -20,21 +20,21 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType[idx],
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("%s[%s].policy", [resourceType[idx], name]),
+		"searchKey": sprintf("%s[%s].policy.Statement[%d]", [resourceType[idx], name, s_idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement.Action' shouldn't contain '*'",
 		"keyActualValue": "'policy.Statement.Action' contains '*'",
-		"searchLine": common_lib.build_search_line(["resource", resourceType[idx], name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", resourceType[idx], name, "policy", "Statement", s_idx], []),
 	}
 }
 
 CxPolicy[result] {
 	resource := input.document[i].data.aws_iam_policy_document[name]
 
-    policy := {"Statement": resource.statement}
+	policy := {"Statement": resource.statement}
 
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[s_idx]
 
 	common_lib.is_allow_effect(statement)
 	common_lib.equalsOrInArray(statement.resources, "*")
@@ -44,10 +44,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_iam_policy_document",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_iam_policy_document[%s].policy", [name]),
+		"searchKey": sprintf("aws_iam_policy_document[%s].statement[%d]", [name, s_idx]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'policy.Statement.Action' shouldn't contain '*'",
-		"keyActualValue": "'policy.Statement.Action' contains '*'",
-		"searchLine": common_lib.build_search_line(["resource", "aws_iam_policy_document", name, "policy"], []),
+		"keyExpectedValue": "'statement.actions' shouldn't contain '*'",
+		"keyActualValue": "'statement.actions' contains '*'",
+		"searchLine": common_lib.build_search_line(["data", "aws_iam_policy_document", name, "statement", s_idx], []),
 	}
 }

--- a/assets/queries/terraform/aws/iam_policies_with_full_privileges/test/positive2.tf
+++ b/assets/queries/terraform/aws/iam_policies_with_full_privileges/test/positive2.tf
@@ -1,0 +1,24 @@
+resource "aws_iam_role_policy" "multi_statement" {
+  name = "multi-statement"
+  role = aws_iam_role.example.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::example-bucket/*"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/iam_policies_with_full_privileges/test/positive3.tf
+++ b/assets/queries/terraform/aws/iam_policies_with_full_privileges/test/positive3.tf
@@ -1,0 +1,30 @@
+resource "aws_iam_role_policy" "jsonencoded" {
+  name = "jsonencoded"
+  role = aws_iam_role.example.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "*"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+data "aws_iam_policy_document" "multi_statement" {
+  statement {
+    sid    = "Safe"
+    effect = "Allow"
+    actions = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::example-bucket/*"]
+  }
+  statement {
+    sid    = "Vulnerable"
+    effect = "Allow"
+    actions = ["*"]
+    resources = ["*"]
+  }
+}

--- a/assets/queries/terraform/aws/iam_policies_with_full_privileges/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_policies_with_full_privileges/test/positive_expected_result.json
@@ -2,13 +2,31 @@
   {
     "queryName": "IAM policies with full privileges",
     "severity": "MEDIUM",
-    "line": 5,
+    "line": 9,
     "fileName": "positive.tf"
   },
   {
     "queryName": "IAM policies with full privileges",
     "severity": "MEDIUM",
-    "line": 19,
+    "line": 20,
     "fileName": "positive.tf"
+  },
+  {
+    "queryName": "IAM policies with full privileges",
+    "severity": "MEDIUM",
+    "line": 15,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "IAM policies with full privileges",
+    "severity": "MEDIUM",
+    "line": 8,
+    "fileName": "positive3.tf"
+  },
+  {
+    "queryName": "IAM policies with full privileges",
+    "severity": "MEDIUM",
+    "line": 24,
+    "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/iam_policy_grants_full_permissions/query.rego
+++ b/assets/queries/terraform/aws/iam_policy_grants_full_permissions/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 	policy := common_lib.json_unmarshal(resource.policy)
 
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[s_idx]
 
 	common_lib.is_allow_effect(statement)
 	common_lib.equalsOrInArray(statement.Resource, "*")
@@ -20,10 +20,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType[idx],
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("%s[%s].policy", [resourceType[idx], name]),
+		"searchKey": sprintf("%s[%s].policy.Statement[%d]", [resourceType[idx], name, s_idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement.Resource' and 'policy.Statement.Action' should not equal '*'",
 		"keyActualValue": "'policy.Statement.Resource' and 'policy.Statement.Action' are equal to '*'",
-		"searchLine": common_lib.build_search_line(["resource", resourceType[idx], name, "access_policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", resourceType[idx], name, "policy", "Statement", s_idx], []),
 	}
 }

--- a/assets/queries/terraform/aws/iam_policy_grants_full_permissions/test/positive3.tf
+++ b/assets/queries/terraform/aws/iam_policy_grants_full_permissions/test/positive3.tf
@@ -1,0 +1,23 @@
+resource "aws_iam_policy" "multi_statement" {
+  name = "multi_statement"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::example-bucket/*"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/iam_policy_grants_full_permissions/test/positive4.tf
+++ b/assets/queries/terraform/aws/iam_policy_grants_full_permissions/test/positive4.tf
@@ -1,0 +1,15 @@
+resource "aws_iam_policy" "jsonencoded" {
+  name = "jsonencoded"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "JsonEncodedVulnerable"
+        Effect   = "Allow"
+        Action   = "*"
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/iam_policy_grants_full_permissions/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_policy_grants_full_permissions/test/positive_expected_result.json
@@ -2,13 +2,25 @@
   {
     "queryName": "IAM policy grants full permissions",
     "severity": "HIGH",
-    "line": 20,
+    "line": 24,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "IAM policy grants full permissions",
     "severity": "HIGH",
-    "line": 3,
+    "line": 7,
     "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "IAM policy grants full permissions",
+    "severity": "HIGH",
+    "line": 14,
+    "fileName": "positive3.tf"
+  },
+  {
+    "queryName": "IAM policy grants full permissions",
+    "severity": "HIGH",
+    "line": 7,
+    "fileName": "positive4.tf"
   }
 ]

--- a/assets/queries/terraform/aws/iam_role_with_full_privileges/query.rego
+++ b/assets/queries/terraform/aws/iam_role_with_full_privileges/query.rego
@@ -7,8 +7,8 @@ CxPolicy[result] {
 	resource := input.document[i].resource.aws_iam_role[name]
 
 	policy := common_lib.json_unmarshal(resource.assume_role_policy)
-		st := common_lib.get_statement(policy)
-	statement := st[_]
+	st := common_lib.get_statement(policy)
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	common_lib.equalsOrInArray(statement.Resource, "*")
@@ -18,10 +18,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_iam_role",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_iam_role[%s].assume_role_policy", [name]),
+		"searchKey": sprintf("aws_iam_role[%s].assume_role_policy.Statement[%d]", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "assume_role_policy.Statement.Action should not equal to, nor contain '*'",
 		"keyActualValue": "assume_role_policy.Statement.Action is equal to or contains '*'",
-		"searchLine": common_lib.build_search_line(["resource", "aws_iam_role", name, "assume_role_policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_iam_role", name, "assume_role_policy", "Statement", idx], []),
 	}
 }

--- a/assets/queries/terraform/aws/iam_role_with_full_privileges/test/positive2.tf
+++ b/assets/queries/terraform/aws/iam_role_with_full_privileges/test/positive2.tf
@@ -1,0 +1,42 @@
+resource "aws_iam_role" "multi_statement" {
+  name = "test_multi"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"Service": "ec2.amazonaws.com"},
+      "Action": "sts:AssumeRole",
+      "Resource": "*"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": {"Service": "ec2.amazonaws.com"},
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "jsonencoded" {
+  name = "test_jsonencoded"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = { Service = "ec2.amazonaws.com" }
+        Action    = "*"
+        Resource  = "*"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/iam_role_with_full_privileges/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_role_with_full_privileges/test/positive_expected_result.json
@@ -2,11 +2,25 @@
   {
     "queryName": "IAM role with full privileges",
     "severity": "HIGH",
-    "line": 4
+    "line": 8,
+    "fileName": "positive.tf"
   },
   {
     "queryName": "IAM role with full privileges",
     "severity": "HIGH",
-    "line": 29
+    "line": 33,
+    "fileName": "positive.tf"
+  },
+  {
+    "queryName": "IAM role with full privileges",
+    "severity": "HIGH",
+    "line": 15,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "IAM role with full privileges",
+    "severity": "HIGH",
+    "line": 33,
+    "fileName": "positive2.tf"
   }
 ]

--- a/assets/queries/terraform/aws/kms_key_with_full_permissions/query.rego
+++ b/assets/queries/terraform/aws/kms_key_with_full_permissions/query.rego
@@ -8,7 +8,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(resource.policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not common_lib.valid_key(statement, "Condition")
@@ -18,11 +18,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_kms_key",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_kms_key[%s].policy", [name]),
+		"searchKey": sprintf("aws_kms_key[%s].policy.Statement[%d]", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_kms_key[%s].policy should not have wildcard in 'Action' and 'Principal'", [name]),
 		"keyActualValue": sprintf("aws_kms_key[%s].policy has wildcard in 'Action' or 'Principal'", [name]),
-		"searchLine": common_lib.build_search_line(["resource", "aws_kms_key", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_kms_key", name, "policy", "Statement", idx], []),
 	}
 }
 
@@ -51,7 +51,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(module[keyToCheck])
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not common_lib.valid_key(statement, "Condition")
@@ -61,11 +61,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
+		"searchKey": sprintf("module[%s].%s.Statement[%d]", [name, keyToCheck, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("module[%s].%s should not have wildcard in 'Action' and 'Principal'", [name, keyToCheck]),
 		"keyActualValue": sprintf("module[%s].%s has wildcard in 'Action' or 'Principal'", [name, keyToCheck]),
-		"searchLine": common_lib.build_search_line(["module", name, keyToCheck], []),
+		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx], []),
 	}
 }
 

--- a/assets/queries/terraform/aws/kms_key_with_full_permissions/test/positive4.tf
+++ b/assets/queries/terraform/aws/kms_key_with_full_permissions/test/positive4.tf
@@ -1,0 +1,26 @@
+resource "aws_kms_key" "multi_statement" {
+  description             = "KMS multi-statement"
+  deletion_window_in_days = 7
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": ["kms:Encrypt"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["kms:*"],
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/kms_key_with_full_permissions/test/positive5.tf
+++ b/assets/queries/terraform/aws/kms_key_with_full_permissions/test/positive5.tf
@@ -1,0 +1,17 @@
+resource "aws_kms_key" "jsonencoded" {
+  description             = "KMS jsonencoded"
+  deletion_window_in_days = 7
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = ["kms:*"]
+        Resource  = "*"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/kms_key_with_full_permissions/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/kms_key_with_full_permissions/test/positive_expected_result.json
@@ -2,13 +2,13 @@
   {
     "queryName": "KMS key with vulnerable policy",
     "severity": "HIGH",
-    "line": 5,
+    "line": 9,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "KMS key with vulnerable policy",
     "severity": "HIGH",
-    "line": 5,
+    "line": 9,
     "fileName": "positive2.tf"
   },
   {
@@ -20,7 +20,19 @@
   {
     "queryName": "KMS key with vulnerable policy",
     "severity": "HIGH",
+    "line": 16,
+    "fileName": "positive4.tf"
+  },
+  {
+    "queryName": "KMS key with vulnerable policy",
+    "severity": "HIGH",
     "line": 8,
+    "fileName": "positive5.tf"
+  },
+  {
+    "queryName": "KMS key with vulnerable policy",
+    "severity": "HIGH",
+    "line": 13,
     "fileName": "positive_module.tf"
   }
 ]

--- a/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/query.rego
@@ -8,7 +8,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(resource.policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not common_lib.valid_key(statement, "Condition")
@@ -18,11 +18,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_api_gateway_rest_api_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_api_gateway_rest_api_policy[%s].policy", [name]),
+		"searchKey": sprintf("aws_api_gateway_rest_api_policy[%s].policy.Statement[%d]", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_api_gateway_rest_api_policy[%s].policy should not have wildcard in 'Action' and 'Principal'", [name]),
 		"keyActualValue": sprintf("aws_api_gateway_rest_api_policy[%s].policy has wildcard in 'Action' or 'Principal'", [name]),
-		"searchLine": common_lib.build_search_line(["resource", "aws_api_gateway_rest_api_policy", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_api_gateway_rest_api_policy", name, "policy", "Statement", idx], []),
 	}
 }
 
@@ -34,7 +34,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(module[keyToCheck])
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not common_lib.valid_key(statement, "Condition")
@@ -44,10 +44,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].policy", [name]),
+		"searchKey": sprintf("module[%s].%s.Statement[%d]", [name, keyToCheck, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("module[%s].%s should not have wildcard in 'Action' and 'Principal'", [name, keyToCheck]),
 		"keyActualValue": sprintf("module[%s].%s has wildcard in 'Action' or 'Principal'", [name, keyToCheck]),
-		"searchLine": common_lib.build_search_line(["module", name, keyToCheck], []),
+		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx], []),
 	}
 }

--- a/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/test/positive2.tf
+++ b/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/test/positive2.tf
@@ -1,0 +1,25 @@
+resource "aws_api_gateway_rest_api_policy" "multi_statement" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": ["execute-api:Invoke"],
+      "Resource": "${aws_api_gateway_rest_api.example.arn}"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "execute-api:*",
+      "Resource": "${aws_api_gateway_rest_api.example.arn}"
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/test/positive3.tf
+++ b/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/test/positive3.tf
@@ -1,0 +1,16 @@
+resource "aws_api_gateway_rest_api_policy" "jsonencoded" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "execute-api:*"
+        Resource  = aws_api_gateway_rest_api.example.arn
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/test/positive_expected_result.json
@@ -2,13 +2,25 @@
   {
     "queryName": "REST API with vulnerable policy",
     "severity": "MEDIUM",
-    "line": 15,
+    "line": 19,
     "fileName": "positive.tf"
   },
   {
     "queryName": "REST API with vulnerable policy",
     "severity": "MEDIUM",
     "line": 15,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "REST API with vulnerable policy",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive3.tf"
+  },
+  {
+    "queryName": "REST API with vulnerable policy",
+    "severity": "MEDIUM",
+    "line": 19,
     "fileName": "positive_module.tf"
   }
 ]

--- a/assets/queries/terraform/aws/s3_bucket_with_all_permissions/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_all_permissions/query.rego
@@ -9,17 +9,23 @@ CxPolicy[result] {
 	res_type := resource_type[_]
 	resource := input.document[i].resource[res_type][name]
 
-	all_permissions(resource.policy)
+	policy := common_lib.json_unmarshal(resource.policy)
+	st := common_lib.get_statement(policy)
+	statement := st[idx]
+
+	common_lib.is_allow_effect(statement)
+	common_lib.containsOrInArrayContains(statement.Action, "*")
+	common_lib.containsOrInArrayContains(statement.Principal, "*")
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": res_type,
 		"resourceName": tf_lib.get_specific_resource_name(resource, res_type, name),
-		"searchKey": sprintf("%s[%s].policy", [res_type,name]),
+		"searchKey": sprintf("%s[%s].policy.Statement[%d]", [res_type, name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement' should not allow all actions to all principal",
 		"keyActualValue": "'policy.Statement' allows all actions to all principal",
-		"searchLine": common_lib.build_search_line(["resource", res_type, name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", res_type, name, "policy", "Statement", idx], []),
 	}
 }
 
@@ -28,26 +34,22 @@ CxPolicy[result] {
 	res_type := resource_type[_]
 	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, res_type, "policy")
 
-	all_permissions(module[keyToCheck])
+	policy := common_lib.json_unmarshal(module[keyToCheck])
+	st := common_lib.get_statement(policy)
+	statement := st[idx]
+
+	common_lib.is_allow_effect(statement)
+	common_lib.containsOrInArrayContains(statement.Action, "*")
+	common_lib.containsOrInArrayContains(statement.Principal, "*")
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].policy", [name]),
+		"searchKey": sprintf("module[%s].%s.Statement[%d]", [name, keyToCheck, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement' should not allow all actions to all principal",
 		"keyActualValue": "'policy.Statement' allows all actions to all principal",
-		"searchLine": common_lib.build_search_line(["module", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx], []),
 	}
-}
-
-all_permissions(policyValue) {
-	policy := common_lib.json_unmarshal(policyValue)
-	st := common_lib.get_statement(policy)
-	statement := st[_]
-
-	common_lib.is_allow_effect(statement)
-	common_lib.containsOrInArrayContains(statement.Action, "*")
-	common_lib.containsOrInArrayContains(statement.Principal, "*")
 }

--- a/assets/queries/terraform/aws/s3_bucket_with_all_permissions/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_all_permissions/query.rego
@@ -9,13 +9,7 @@ CxPolicy[result] {
 	res_type := resource_type[_]
 	resource := input.document[i].resource[res_type][name]
 
-	policy := common_lib.json_unmarshal(resource.policy)
-	st := common_lib.get_statement(policy)
-	statement := st[idx]
-
-	common_lib.is_allow_effect(statement)
-	common_lib.containsOrInArrayContains(statement.Action, "*")
-	common_lib.containsOrInArrayContains(statement.Principal, "*")
+	idx := vulnerable_statement(resource.policy)
 
 	result := {
 		"documentId": input.document[i].id,
@@ -34,13 +28,7 @@ CxPolicy[result] {
 	res_type := resource_type[_]
 	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, res_type, "policy")
 
-	policy := common_lib.json_unmarshal(module[keyToCheck])
-	st := common_lib.get_statement(policy)
-	statement := st[idx]
-
-	common_lib.is_allow_effect(statement)
-	common_lib.containsOrInArrayContains(statement.Action, "*")
-	common_lib.containsOrInArrayContains(statement.Principal, "*")
+	idx := vulnerable_statement(module[keyToCheck])
 
 	result := {
 		"documentId": input.document[i].id,
@@ -52,4 +40,14 @@ CxPolicy[result] {
 		"keyActualValue": "'policy.Statement' allows all actions to all principal",
 		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx], []),
 	}
+}
+
+vulnerable_statement(policyValue) = idx {
+	policy := common_lib.json_unmarshal(policyValue)
+	st := common_lib.get_statement(policy)
+	statement := st[idx]
+
+	common_lib.is_allow_effect(statement)
+	common_lib.containsOrInArrayContains(statement.Action, "*")
+	common_lib.containsOrInArrayContains(statement.Principal, "*")
 }

--- a/assets/queries/terraform/aws/s3_bucket_with_all_permissions/test/positive3.tf
+++ b/assets/queries/terraform/aws/s3_bucket_with_all_permissions/test/positive3.tf
@@ -1,0 +1,25 @@
+resource "aws_s3_bucket_policy" "multi_statement" {
+  bucket = aws_s3_bucket.example.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::example-bucket/*"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "*",
+      "Resource": "arn:aws:s3:::example-bucket/*"
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_all_permissions/test/positive4.tf
+++ b/assets/queries/terraform/aws/s3_bucket_with_all_permissions/test/positive4.tf
@@ -1,0 +1,16 @@
+resource "aws_s3_bucket_policy" "jsonencoded" {
+  bucket = aws_s3_bucket.example.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "*"
+        Resource  = "arn:aws:s3:::example-bucket/*"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_all_permissions/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_with_all_permissions/test/positive_expected_result.json
@@ -2,13 +2,25 @@
   {
     "queryName": "S3 bucket with all permissions",
     "severity": "CRITICAL",
-    "line": 5,
+    "line": 9,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "S3 bucket with all permissions",
     "severity": "CRITICAL",
-    "line": 12,
+    "line": 16,
     "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "S3 bucket with all permissions",
+    "severity": "CRITICAL",
+    "line": 15,
+    "fileName": "positive3.tf"
+  },
+  {
+    "queryName": "S3 bucket with all permissions",
+    "severity": "CRITICAL",
+    "line": 7,
+    "fileName": "positive4.tf"
   }
 ]

--- a/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/query.rego
@@ -8,7 +8,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(resource.policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not common_lib.valid_key(statement, "Condition")
@@ -18,10 +18,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_secretsmanager_secret_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_secretsmanager_secret_policy[%s].policy", [name]),
+		"searchKey": sprintf("aws_secretsmanager_secret_policy[%s].policy.Statement[%d]", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_secretsmanager_secret_policy[%s].policy should not have wildcard in 'Principal' and 'Action'", [name]),
 		"keyActualValue": sprintf("aws_secretsmanager_secret_policy[%s].policy has wildcard in 'Principal' or 'Action'", [name]),
-		"searchLine": common_lib.build_search_line(["resource", "aws_secretsmanager_secret_policy", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_secretsmanager_secret_policy", name, "policy", "Statement", idx], []),
 	}
 }

--- a/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/test/positive2.tf
+++ b/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/test/positive2.tf
@@ -1,0 +1,23 @@
+resource "aws_secretsmanager_secret_policy" "multi_statement" {
+  secret_arn = aws_secretsmanager_secret.example.arn
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": "secretsmanager:GetSecretValue"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "secretsmanager:*"
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/test/positive3.tf
+++ b/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/test/positive3.tf
@@ -1,0 +1,15 @@
+resource "aws_secretsmanager_secret_policy" "jsonencoded" {
+  secret_arn = aws_secretsmanager_secret.example.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "secretsmanager:*"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/test/positive_expected_result.json
@@ -2,7 +2,19 @@
   {
     "queryName": "Secrets Manager with vulnerable policy",
     "severity": "HIGH",
-    "line": 12,
+    "line": 16,
     "fileName": "positive.tf"
+  },
+  {
+    "queryName": "Secrets Manager with vulnerable policy",
+    "severity": "HIGH",
+    "line": 14,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "Secrets Manager with vulnerable policy",
+    "severity": "HIGH",
+    "line": 7,
+    "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/sso_policy_with_full_privileges/query.rego
+++ b/assets/queries/terraform/aws/sso_policy_with_full_privileges/query.rego
@@ -7,8 +7,8 @@ CxPolicy[result] {
 	resource := input.document[i].resource.aws_ssoadmin_permission_set_inline_policy[name]
 
 	policy := common_lib.json_unmarshal(resource.inline_policy)
-		st := common_lib.get_statement(policy)
-	statement := st[_]
+	st := common_lib.get_statement(policy)
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	common_lib.equalsOrInArray(statement.Resource, "*")
@@ -18,10 +18,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_ssoadmin_permission_set_inline_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_ssoadmin_permission_set_inline_policy[%s].inline_policy", [name]),
+		"searchKey": sprintf("aws_ssoadmin_permission_set_inline_policy[%s].inline_policy.Statement[%d]", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "inline_policy.Statement.Action should not equal to, nor contain '*'",
 		"keyActualValue": "inline_policy.Statement.Action is equal to or contains '*'",
-		"searchLine": common_lib.build_search_line(["resource", "aws_ssoadmin_permission_set_inline_policy", name, "inline_policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_ssoadmin_permission_set_inline_policy", name, "inline_policy", "Statement", idx], []),
 	}
 }

--- a/assets/queries/terraform/aws/sso_policy_with_full_privileges/test/positive2.tf
+++ b/assets/queries/terraform/aws/sso_policy_with_full_privileges/test/positive2.tf
@@ -1,0 +1,16 @@
+resource "aws_ssoadmin_permission_set_inline_policy" "jsonencoded" {
+  instance_arn       = aws_ssoadmin_permission_set.example.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.example.arn
+
+  inline_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "JsonEncodedVulnerable"
+        Effect   = "Allow"
+        Action   = "*"
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/sso_policy_with_full_privileges/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sso_policy_with_full_privileges/test/positive_expected_result.json
@@ -2,7 +2,13 @@
   {
     "queryName": "SSO policy with full privileges",
     "severity": "MEDIUM",
-    "line": 4,
+    "line": 7,
     "fileName": "positive.tf"
+  },
+  {
+    "queryName": "SSO policy with full privileges",
+    "severity": "MEDIUM",
+    "line": 8,
+    "fileName": "positive2.tf"
   }
 ]

--- a/pkg/detector/terraform/terraform_detect.go
+++ b/pkg/detector/terraform/terraform_detect.go
@@ -174,54 +174,51 @@ func extractBlockSource(lines []string, start, end int) string {
 	return strings.Join(lines[start-1:end], "\n") + "\n"
 }
 
-// nolint:gocritic
-func calculateInsertionPoint(block *hclsyntax.Block, line int, lines []string) (int, int) {
+func calculateInsertionPoint(block *hclsyntax.Block, line int, lines []string) (insertionLine, col int) {
 	name, nestedStart, nestedEnd, isAttr := findContainingStructure(block, line)
 
-	var insertionLine int
 	var caseType string
 
 	if name != "" {
-		// Detect if this is a function call like merge(...) and avoid inserting inside it
+		// When the containing attribute is a function-call wrapper (e.g. jsonencode(...),
+		// merge(..., { ... })), we only push the anchor past the wrapper on the degenerate
+		// boundary where the identifying line coincides with the wrapper's closing line —
+		// otherwise injected HCL could corrupt a single-line wrapped expression. For every
+		// other case the identifying line lies inside the wrapped body, which is where both
+		// SARIF regions and attribute-level remediations should anchor.
 		lineText := strings.TrimSpace(lines[nestedStart.Line-1])
-		if isAttr && strings.Contains(lineText, "(") && strings.Contains(lineText, "{") {
-			// Likely a function call wrapping a block (e.g., merge(..., { ... }))
-			// We do not want to insert inside the nested structure
+		isFunctionCallWrapper := isAttr && strings.Contains(lineText, "(") && strings.Contains(lineText, "{")
+		switch {
+		case line == nestedEnd.Line && isFunctionCallWrapper:
 			insertionLine = nestedEnd.Line + 1
 			caseType = strBlockBody
-		} else {
-			// nolint:staticcheck
-			switch {
-			case line == nestedEnd.Line:
-				insertionLine = nestedEnd.Line - 1
-				caseType = strNestedEnd
-			case line == nestedStart.Line:
-				insertionLine = nestedStart.Line + 1
-				caseType = strNestedStart
-			default:
-				insertionLine = line
-				caseType = strNestedBody
-			}
-		}
-	} else {
-		if line == block.TypeRange.Start.Line {
-			insertionLine = block.Body.SrcRange.End.Line - 1
-			for i := insertionLine; i >= block.TypeRange.Start.Line; i-- {
-				_, s, e, attr := findContainingStructure(block, i)
-				if attr && e.Line >= insertionLine {
-					insertionLine = s.Line - 1
-				} else {
-					break
-				}
-			}
-			caseType = strBlockStart
-		} else {
+		case line == nestedEnd.Line:
+			insertionLine = nestedEnd.Line - 1
+			caseType = strNestedEnd
+		case line == nestedStart.Line:
+			insertionLine = nestedStart.Line + 1
+			caseType = strNestedStart
+		default:
 			insertionLine = line
-			caseType = strBlockBody
+			caseType = strNestedBody
 		}
+	} else if line == block.TypeRange.Start.Line {
+		insertionLine = block.Body.SrcRange.End.Line - 1
+		for i := insertionLine; i >= block.TypeRange.Start.Line; i-- {
+			_, s, e, attr := findContainingStructure(block, i)
+			if attr && e.Line >= insertionLine {
+				insertionLine = s.Line - 1
+			} else {
+				break
+			}
+		}
+		caseType = strBlockStart
+	} else {
+		insertionLine = line
+		caseType = strBlockBody
 	}
 
-	col := determineInsertionIndent(lines, insertionLine, caseType, nestedStart.Line, nestedEnd.Line) + 1
+	col = determineInsertionIndent(lines, insertionLine, caseType, nestedStart.Line, nestedEnd.Line) + 1
 	trimmed := strings.TrimSpace(lines[insertionLine-1])
 	if caseType == "block-start" && (strings.Contains(trimmed, "}") || isHeredocTerminator(trimmed, lines, insertionLine-1)) {
 		col = len(lines[insertionLine-1]) + 1

--- a/pkg/detector/terraform/terraform_detect_test.go
+++ b/pkg/detector/terraform/terraform_detect_test.go
@@ -987,6 +987,11 @@ func TestDetectLinePolicyStatementPrincipalJsonencode(t *testing.T) {
 	}
 	got := DetectKindLine{}.DetectLine(ctx, file, `aws_s3_bucket_policy[x].policy.Statement[0].Principal`, 3)
 	require.Equal(t, 8, got.Line)
+	// The remediation/region anchor must stay on the identifying line inside the
+	// jsonencode(...) body rather than being pushed past the wrapping `})`,
+	// otherwise SARIF would surface the wrong line for rules without an autofix.
+	require.Equal(t, 8, got.RemediationLocation.Start.Line)
+	require.Equal(t, 8, got.RemediationLocation.End.Line)
 }
 
 func TestDetectLinePolicyStatementPrincipalHeredocJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

Anchor SARIF regions inside `jsonencode(...)`-style wrapped bodies and scope 12 Terraform "vulnerable policy" / "full privileges" rules to the specific offending `Statement[idx]` instead of the whole `policy` / `access_policy` attribute.

Before, a single vulnerable statement in a multi-statement policy would report the entire `policy` attribute — reviewers saw a large region that included safe statements too. After, the region points at the offending statement only.

This is the part 1 of the fixes for the terraform policies rules.

## How to review

Each rule section below includes:

- a fixture path (in-repo, real test data)
- a small snippet of that fixture with the **new** reported line marked
- the **new** line range and the **old** one (from `main`)
- a short semantic note explaining why that line is the right one

Please sanity-check the *why* for each rule, that is where semantic mistakes would show up.

## Testing

```bash
go test ./pkg/detector/terraform/... ./test/... -count=1
```

All tests pass. Additionally, a representative end-to-end scan was run against a fixture set (multi-statement heredocs, `jsonencode`, `data "aws_iam_policy_document"`) and the emitted SARIF regions landed on the expected lines.

### Motivation example — SNS publicly-accessible (not in this PR, but same idea)

Previous SARIF region for an `aws_sns_topic.policy = jsonencode({...})` wrapper pointed at the closing `})` line of the `jsonencode` wrapper rather than the offending `Principal = "*"` line. The detector fix in commit 1 anchors the region inside the wrapped body, and the per-rule commits narrow it further to `Statement[idx]`.

## Per-rule review

<details>
<summary><code>efs_with_vulnerable_policy</code> — region is now the offending <code>Statement</code> object</summary>

**Fixture:** `assets/queries/terraform/aws/efs_with_vulnerable_policy/test/positive2.tf`

```hcl
  policy = <<POLICY
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "SafeStatement",
      "Effect": "Allow",
      "Principal": { "AWS": "arn:aws:iam::123456789012:root" },
      "Action": ["elasticfilesystem:ClientRead"]
    },
    {                                  // <-- new region: line 16
      "Sid": "VulnerableStatement",
      "Effect": "Allow",
      "Principal": "*",
      "Action": ["elasticfilesystem:*"]
    }
  ]
}
POLICY
```

- **New:** `positive2.tf` L16; `positive.tf` L21; `positive3.tf` L7 (`jsonencode`).
- **Old (`main`):** whole `policy` attribute, `positive.tf` L16.
- **Why:** violation is local to a single statement (no `Condition`, wildcard `Principal` + `elasticfilesystem:*`). Safe statement above must not be highlighted.

</details>

<details>
<summary><code>elasticsearch_domain_with_vulnerable_policy</code> — <code>access_policies.Statement[idx]</code></summary>

**Fixture:** `assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/positive2.tf`

```hcl
  access_policies = <<POLICIES
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "Safe", "Effect": "Allow",
      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
      "Action": ["es:DescribeDomain"]
    },
    {                                  // <-- new region: line 14
      "Sid": "Vulnerable", "Effect": "Allow",
      "Principal": "*", "Action": ["es:*"]
    }
  ]
}
POLICIES
```

- **New:** `positive2.tf` L14; `positive.tf` L22; `positive3.tf` L7 (`jsonencode`); `positive_module.tf` L19.
- **Old (`main`):** whole `access_policies`, `positive.tf` L18, module L16.
- **Why:** same pattern; `es:*` + `Principal: "*"` and no `Condition` makes the statement vulnerable in isolation.

</details>

<details>
<summary><code>glue_with_vulnerable_policy</code> — <code>policy.Statement[idx]</code></summary>

**Fixture:** `assets/queries/terraform/aws/glue_with_vulnerable_policy/test/positive2.tf`

```hcl
  policy = <<POLICY
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "Safe", "Effect": "Allow",
      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
      "Action": ["glue:GetTable"]
    },
    {                                  // <-- new region: line 12
      "Sid": "Vulnerable", "Effect": "Allow",
      "Principal": "*", "Action": ["glue:*"]
    }
  ]
}
POLICY
```

- **New:** `positive2.tf` L12; `positive.tf` L15; `positive3.tf` L5 (`jsonencode`); `positive_module.tf` L26.
- **Old (`main`):** whole `policy`, `positive.tf` L15, module L22.
- **Why:** `glue:*` + wildcard principal grants full Glue catalog access to anyone.

</details>

<details>
<summary><code>secrets_manager_with_vulnerable_policy</code> — <code>policy.Statement[idx]</code></summary>

**Fixture:** `assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/test/positive2.tf`

```hcl
  policy = <<POLICY
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "Safe", "Effect": "Allow",
      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
      "Action": "secretsmanager:GetSecretValue"
    },
    {                                  // <-- new region: line 14
      "Sid": "Vulnerable", "Effect": "Allow",
      "Principal": "*", "Action": "secretsmanager:*"
    }
  ]
}
POLICY
```

- **New:** `positive2.tf` L14; `positive.tf` L16; `positive3.tf` L7 (`jsonencode`).
- **Old (`main`):** whole `policy`, `positive.tf` L12.
- **Why:** `secretsmanager:*` for any principal means any AWS account can read or overwrite the secret.

</details>

<details>
<summary><code>cloudwatch_logs_destination_with_vulnerable_policy</code> — <code>access_policy.Statement[idx]</code></summary>

**Fixture:** `assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/test/positive2.tf`

```hcl
  access_policy = <<POLICY
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "Safe", "Effect": "Allow",
      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
      "Action": ["logs:PutSubscriptionFilter"]
    },
    {                                  // <-- new region: line 14
      "Sid": "Vulnerable", "Effect": "Allow",
      "Principal": "*", "Action": ["logs:*"]
    }
  ]
}
POLICY
```

- **New:** `positive2.tf` L14; `positive.tf` L22; `positive3.tf` L7 (`jsonencode`).
- **Old (`main`):** whole `access_policy`, `positive.tf` L22.
- **Why:** `logs:*` to wildcard principal lets any AWS account put arbitrary log subscriptions into this destination.

</details>

<details>
<summary><code>rest_api_with_vulnerable_policy</code> — <code>policy.Statement[idx]</code></summary>

**Fixture:** `assets/queries/terraform/aws/rest_api_with_vulnerable_policy/test/positive2.tf`

```hcl
  policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "Safe", "Effect": "Allow",
      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
      "Action": ["execute-api:Invoke"],
      "Resource": "${aws_api_gateway_rest_api.example.arn}"
    },
    {                                  // <-- new region: line 15
      "Sid": "Vulnerable", "Effect": "Allow",
      "Principal": "*", "Action": "execute-api:*",
      "Resource": "${aws_api_gateway_rest_api.example.arn}"
    }
  ]
}
EOF
```

- **New:** `positive2.tf` L15; `positive.tf` L19; `positive3.tf` L7 (`jsonencode`); `positive_module.tf` L19.
- **Old (`main`):** whole `policy`, `positive.tf` L15, module L15.
- **Why:** wildcard `Principal` + `execute-api:*` on the API’s ARN permits any account to invoke every method.

</details>

<details>
<summary><code>kms_key_with_full_permissions</code> — <code>policy.Statement[idx]</code></summary>

**Fixture:** `assets/queries/terraform/aws/kms_key_with_full_permissions/test/positive4.tf`

```hcl
  policy = <<POLICY
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "Safe", "Effect": "Allow",
      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
      "Action": ["kms:Encrypt"],
      "Resource": "*"
    },
    {                                  // <-- new region: line 16
      "Sid": "Vulnerable", "Effect": "Allow",
      "Principal": "*", "Action": ["kms:*"], "Resource": "*"
    }
  ]
}
POLICY
```

- **New:** `positive1.tf` L9; `positive2.tf` L9; `positive3.tf` L1; `positive4.tf` L16; `positive5.tf` L8 (`jsonencode`); `positive_module.tf` L13.
- **Old (`main`):** whole `policy`, `positive1.tf`/`positive2.tf` L5, `positive3.tf` L1, module L8.
- **Why:** `kms:*` with wildcard principal = full control (decrypt, schedule key deletion, rotate) from any account.

</details>

<details>
<summary><code>iam_policies_with_full_privileges</code> — heredoc <code>Statement[idx]</code> and <code>data.aws_iam_policy_document.statement[idx]</code></summary>

**Fixture:** `assets/queries/terraform/aws/iam_policies_with_full_privileges/test/positive.tf`

```hcl
resource "aws_iam_role_policy" "positive1" {
  name = "apigateway-cloudwatch-logging"
  role = aws_iam_role.apigateway_cloudwatch_logging.id

  policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {                                  // <-- new region: line 9
      "Effect": "Allow",
      "Action": ["*"],
      "Resource": "*"
    }
  ]
}
EOF
}

data "aws_iam_policy_document" "example" {
  statement {                          // <-- new region: line 20
    sid = "1"
    effect = "Allow"
    actions = ["*"]
    resources = ["*"]
  }
}
```

- **New:** `positive.tf` L9 (resource heredoc) and L20 (data source statement block); `positive2.tf` L15 (multi-statement); `positive3.tf` L8 and L24 (`jsonencode` + data source).
- **Old (`main`):** entire `policy` attribute (L5) and entire data source (L19).
- **Why:** both inline JSON `Action: "*"` and the HCL `actions = ["*"]` form must be pinpointed at the specific statement. This is the only rule with a **data source** branch — please pay extra attention to `positive3.tf` L24.

</details>

<details>
<summary><code>iam_policy_grants_full_permissions</code> — <code>policy.Statement[idx]</code></summary>

**Fixture:** `assets/queries/terraform/aws/iam_policy_grants_full_permissions/test/positive3.tf`

```hcl
resource "aws_iam_policy" "multi_statement" {
  name = "multi_statement"

  policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "Safe", "Effect": "Allow",
      "Action": ["s3:GetObject"],
      "Resource": "arn:aws:s3:::example-bucket/*"
    },
    {                                  // <-- new region: line 14
      "Sid": "Vulnerable", "Effect": "Allow",
      "Action": "*", "Resource": "*"
    }
  ]
}
EOF
}
```

- **New:** `positive1.tf` L24; `positive2.tf` L7; `positive3.tf` L14; `positive4.tf` L7 (`jsonencode`).
- **Old (`main`):** whole `policy`, `positive1.tf` L20, `positive2.tf` L3.
- **Why:** `Action: "*"` + `Resource: "*"` is full admin; pinpointing the statement highlights that the first one is unrelated and safe.

</details>

<details>
<summary><code>sso_policy_with_full_privileges</code> — <code>inline_policy.Statement[idx]</code></summary>

**Fixture:** `assets/queries/terraform/aws/sso_policy_with_full_privileges/test/positive2.tf`

```hcl
resource "aws_ssoadmin_permission_set_inline_policy" "jsonencoded" {
  instance_arn       = aws_ssoadmin_permission_set.example.instance_arn
  permission_set_arn = aws_ssoadmin_permission_set.example.arn

  inline_policy = jsonencode({
    Version = "2012-10-17"
    Statement = [
      {                                // <-- new region: line 8
        Sid      = "JsonEncodedVulnerable"
        Effect   = "Allow"
        Action   = "*"
        Resource = "*"
      }
    ]
  })
}
```

- **New:** `positive.tf` L7; `positive2.tf` L8 (`jsonencode`).
- **Old (`main`):** whole `inline_policy`, `positive.tf` L4.
- **Why:** the `jsonencode` fixture exercises the detector fix in commit 1 — in absence of it, the region would land on the `})` closing line.

</details>

<details>
<summary><code>iam_role_with_full_privileges</code> — <code>assume_role_policy.Statement[idx]</code></summary>

**Fixture:** `assets/queries/terraform/aws/iam_role_with_full_privileges/test/positive2.tf`

```hcl
resource "aws_iam_role" "multi_statement" {
  name = "test_multi"

  assume_role_policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "Safe", "Effect": "Allow",
      "Principal": {"Service": "ec2.amazonaws.com"},
      "Action": "sts:AssumeRole", "Resource": "*"
    },
    {                                  // <-- new region: line 15
      "Sid": "Vulnerable", "Effect": "Allow",
      "Principal": {"Service": "ec2.amazonaws.com"},
      "Action": "*", "Resource": "*"
    }
  ]
}
EOF
}

resource "aws_iam_role" "jsonencoded" {
  name = "test_jsonencoded"

  assume_role_policy = jsonencode({
    Version = "2012-10-17"
    Statement = [
      {                                // <-- new region: line 33
        Sid       = "JsonEncodedVulnerable"
        Effect    = "Allow"
        Principal = { Service = "ec2.amazonaws.com" }
        Action    = "*"
        Resource  = "*"
      }
    ]
  })
}
```

- **New:** `positive.tf` L8 and L33; `positive2.tf` L15 and L33 (covers both heredoc and `jsonencode` in one file).
- **Old (`main`):** entire `assume_role_policy`, L4 and L29.
- **Why:** `Action: "*"` in an assume-role trust policy gives every session all permissions on the role; each occurrence is independent.

</details>

<details>
<summary><code>s3_bucket_with_all_permissions</code> — <code>policy.Statement[idx]</code></summary>

**Fixture:** `assets/queries/terraform/aws/s3_bucket_with_all_permissions/test/positive3.tf`

```hcl
resource "aws_s3_bucket_policy" "multi_statement" {
  bucket = aws_s3_bucket.example.id

  policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "Safe", "Effect": "Allow",
      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
      "Action": ["s3:GetObject"],
      "Resource": "arn:aws:s3:::example-bucket/*"
    },
    {                                  // <-- new region: line 15
      "Sid": "Vulnerable", "Effect": "Allow",
      "Principal": "*", "Action": "*",
      "Resource": "arn:aws:s3:::example-bucket/*"
    }
  ]
}
EOF
}
```

- **New:** `positive1.tf` L9; `positive2.tf` L16; `positive3.tf` L15; `positive4.tf` L7 (`jsonencode`).
- **Old (`main`):** whole `policy`, `positive1.tf` L5, `positive2.tf` L12.
- **Why:** wildcard `Principal` with `Action: "*"` on the bucket ARN grants public full control; other statements in the policy may be benign.

</details>
