### PR TITLE
Precise SARIF regions for vulnerable policy and rules (pt 2)

### DIFF
--- a/assets/queries/terraform/alicloud/oss_buckets_securetransport_disabled/query.rego
+++ b/assets/queries/terraform/alicloud/oss_buckets_securetransport_disabled/query.rego
@@ -9,24 +9,58 @@ CxPolicy[result] {
 
 	not is_secure_transport(policy)
 
+	policy_doc := common_lib.json_unmarshal(policy)
+	st := common_lib.get_statement(policy_doc)
+	statement := st[idx]
+
+	statement.Effect == "Allow"
+	tf_lib.anyPrincipal(statement)
+	is_equal(statement.Condition.Bool["acs:SecureTransport"], "false")
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "alicloud_oss_bucket",
 		"resourceName": tf_lib.get_specific_resource_name(resource, "alicloud_oss_bucket", name),
-		"searchKey": sprintf("alicloud_oss_bucket[%s].policy",[name]),
+		"searchKey": sprintf("alicloud_oss_bucket[%s].policy.Statement[%d].Condition.Bool.acs:SecureTransport", [name, idx]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("%s[%s].policy should not accept HTTP Requests",[name]),
-		"keyActualValue": sprintf("%s[%s].policy accepts HTTP Requests",[name]),
-        "searchLine":common_lib.build_search_line(["resource", "alicloud_oss_bucket", name, "policy"], []),
+		"keyExpectedValue": sprintf("%s[%s].policy should not accept HTTP Requests", [name, name]),
+		"keyActualValue": sprintf("%s[%s].policy accepts HTTP Requests", [name, name]),
+		"searchLine": common_lib.build_search_line(["resource", "alicloud_oss_bucket", name, "policy", "Statement", idx, "Condition", "Bool", "acs:SecureTransport"], []),
 	}
 }
 
-is_equal(secure, target)
-{
-    secure == target
-}else {
-    secure[_]==target
+CxPolicy[result] {
+	resource := input.document[i].resource.alicloud_oss_bucket[name]
+	policy := resource.policy
+
+	not is_secure_transport(policy)
+	not has_actively_wrong_statement(policy)
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "alicloud_oss_bucket",
+		"resourceName": tf_lib.get_specific_resource_name(resource, "alicloud_oss_bucket", name),
+		"searchKey": sprintf("alicloud_oss_bucket[%s].policy", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].policy should not accept HTTP Requests", [name, name]),
+		"keyActualValue": sprintf("%s[%s].policy accepts HTTP Requests", [name, name]),
+		"searchLine": common_lib.build_search_line(["resource", "alicloud_oss_bucket", name, "policy"], []),
+	}
+}
+
+has_actively_wrong_statement(policyValue) {
+	policy := common_lib.json_unmarshal(policyValue)
+	st := common_lib.get_statement(policy)
+	statement := st[_]
+	statement.Effect == "Allow"
+	tf_lib.anyPrincipal(statement)
+	is_equal(statement.Condition.Bool["acs:SecureTransport"], "false")
+}
+
+is_equal(secure, target) {
+	secure == target
+} else {
+	secure[_] == target
 }
 
 is_secure_transport(policyValue) {
@@ -35,15 +69,12 @@ is_secure_transport(policyValue) {
 	statement := st[_]
 	statement.Effect == "Deny"
 	is_equal(statement.Condition.Bool["acs:SecureTransport"], "false")
-    tf_lib.anyPrincipal(statement)
-}else {
-    policy := common_lib.json_unmarshal(policyValue)
+	tf_lib.anyPrincipal(statement)
+} else {
+	policy := common_lib.json_unmarshal(policyValue)
 	st := common_lib.get_statement(policy)
 	statement := st[_]
 	statement.Effect == "Allow"
 	is_equal(statement.Condition.Bool["acs:SecureTransport"], "true")
-    tf_lib.anyPrincipal(statement)
+	tf_lib.anyPrincipal(statement)
 }
-
-
-

--- a/assets/queries/terraform/alicloud/oss_buckets_securetransport_disabled/test/positive3.tf
+++ b/assets/queries/terraform/alicloud/oss_buckets_securetransport_disabled/test/positive3.tf
@@ -1,0 +1,31 @@
+resource "alicloud_oss_bucket" "multi_statement" {
+  policy = <<POLICY
+{
+  "Version": "1",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      "Principal": ["*"],
+      "Action": ["oss:*"],
+      "Resource": ["acs:oss:*:*:bucket/*"],
+      "Condition": {
+        "Bool": {
+          "acs:SecureTransport": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": ["*"],
+      "Action": ["oss:GetObject"],
+      "Resource": ["acs:oss:*:*:bucket/*"],
+      "Condition": {
+        "Bool": {
+          "acs:SecureTransport": "false"
+        }
+      }
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/alicloud/oss_buckets_securetransport_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/alicloud/oss_buckets_securetransport_disabled/test/positive_expected_result.json
@@ -2,7 +2,7 @@
 	{
 		"queryName": "OSS buckets secure transport disabled",
 		"severity": "MEDIUM",
-		"line": 2,
+		"line": 40,
 		"fileName": "positive1.tf"
 	},
 	{
@@ -10,5 +10,11 @@
 		"severity": "MEDIUM",
 		"line": 5,
 		"fileName": "positive2.tf"
+	},
+	{
+		"queryName": "OSS buckets secure transport disabled",
+		"severity": "MEDIUM",
+		"line": 24,
+		"fileName": "positive3.tf"
 	}
 ]

--- a/assets/queries/terraform/aws/authentication_without_mfa/query.rego
+++ b/assets/queries/terraform/aws/authentication_without_mfa/query.rego
@@ -9,7 +9,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(resource.policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not_exists_mfa(statement) == "undefined"
@@ -18,11 +18,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_iam_user_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_iam_user_policy[%s].policy", [name]),
+		"searchKey": sprintf("aws_iam_user_policy[%s].policy.Statement[%d]", [name, idx]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "The attributes 'policy.Statement.Condition', 'policy.Statement.Condition.BoolIfExists', and 'policy.Statement.Condition.BoolIfExists.aws:MultiFactorAuthPresent' should be defined and not null",
 		"keyActualValue": "The attribute(s) 'policy.Statement.Condition' or/and 'policy.Statement.Condition.BoolIfExists' or/and 'policy.Statement.Condition.BoolIfExists.aws:MultiFactorAuthPresent' is/are undefined or null",
-		"searchLine": common_lib.build_search_line(["resource", "aws_iam_user_policy", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_iam_user_policy", name, "policy", "Statement", idx], []),
 	}
 }
 
@@ -32,7 +32,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(resource.policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not_exists_mfa(statement) == "false"
@@ -41,11 +41,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_iam_user_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_iam_user_policy[%s].policy", [name]),
+		"searchKey": sprintf("aws_iam_user_policy[%s].policy.Statement[%d]", [name, idx]),
 		"issueType": "IncorrectValue",
-	    "keyExpectedValue": "'policy.Statement.Principal.AWS' should contain ':mfa/' or 'policy.Statement.Condition.BoolIfExists.aws:MultiFactorAuthPresent' should be set to true",
+		"keyExpectedValue": "'policy.Statement.Principal.AWS' should contain ':mfa/' or 'policy.Statement.Condition.BoolIfExists.aws:MultiFactorAuthPresent' should be set to true",
 		"keyActualValue": "'policy.Statement.Principal.AWS' doesn't contain ':mfa/' or 'policy.Statement.Condition.BoolIfExists.aws:MultiFactorAuthPresent' is set to false",
-		"searchLine": common_lib.build_search_line(["resource", "aws_iam_user_policy", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_iam_user_policy", name, "policy", "Statement", idx], []),
 	}
 }
 
@@ -74,4 +74,3 @@ not_exists_mfa(statement) = mfa {
 	not contains(user, ":mfa/")
 	mfa := "false"
 }
-

--- a/assets/queries/terraform/aws/authentication_without_mfa/test/positive3.tf
+++ b/assets/queries/terraform/aws/authentication_without_mfa/test/positive3.tf
@@ -1,0 +1,31 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_iam_user_policy" "multi_statement" {
+  name = "multi-statement-policy"
+  user = aws_iam_user.positive3.name
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "${aws_iam_user.positive3.arn}",
+      "Condition": {
+        "BoolIfExists": {
+          "aws:MultiFactorAuthPresent": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "${aws_iam_user.positive3.arn}"
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/authentication_without_mfa/test/positive4.tf
+++ b/assets/queries/terraform/aws/authentication_without_mfa/test/positive4.tf
@@ -1,0 +1,24 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_iam_user_policy" "jsonencoded" {
+  name = "jsonencoded-policy"
+  user = aws_iam_user.positive4.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
+        Resource = aws_iam_user.positive4.arn
+        Condition = {
+          BoolIfExists = {
+            "aws:MultiFactorAuthPresent" = "false"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/authentication_without_mfa/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/authentication_without_mfa/test/positive_expected_result.json
@@ -2,13 +2,25 @@
   {
     "queryName": "Authentication without MFA",
     "severity": "LOW",
-    "line": 23,
+    "line": 27,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "Authentication without MFA",
     "severity": "LOW",
-    "line": 19,
+    "line": 23,
     "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "Authentication without MFA",
+    "severity": "LOW",
+    "line": 23,
+    "fileName": "positive3.tf"
+  },
+  {
+    "queryName": "Authentication without MFA",
+    "severity": "LOW",
+    "line": 12,
+    "fileName": "positive4.tf"
   }
 ]

--- a/assets/queries/terraform/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/query.rego
+++ b/assets/queries/terraform/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/query.rego
@@ -9,7 +9,7 @@ CxPolicy[result] {
 	policy := common_lib.json_unmarshal(resource.assume_role_policy)
 
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 
@@ -23,11 +23,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_iam_role",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_iam_role[%s].assume_role_policy", [name]),
+		"searchKey": sprintf("aws_iam_role[%s].assume_role_policy.Statement[%d]", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'assume_role_policy' requires external ID or MFA",
 		"keyActualValue": "'assume_role_policy' does not require external ID or MFA",
-		"searchLine": common_lib.build_search_line(["resource", "aws_iam_role", name, "assume_role_policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_iam_role", name, "assume_role_policy", "Statement", idx], []),
 	}
 }
 

--- a/assets/queries/terraform/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/positive4.tf
+++ b/assets/queries/terraform/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/positive4.tf
@@ -1,0 +1,42 @@
+resource "aws_iam_role" "multi_statement" {
+  name = "multi_statement"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SafeWithMFA",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::111111111111:root"},
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "Bool": {"aws:MultiFactorAuthPresent": "true"}
+      }
+    },
+    {
+      "Sid": "VulnerableCrossAccountWithoutMFA",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::222222222222:root"},
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "jsonencoded" {
+  name = "jsonencoded"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::333333333333:root" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/positive_expected_result.json
@@ -2,19 +2,31 @@
   {
     "queryName": "Cross-account IAM assume role policy without external id or MFA",
     "severity": "HIGH",
-    "line": 4,
+    "line": 8,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "Cross-account IAM assume role policy without external id or MFA",
     "severity": "HIGH",
-    "line": 4,
+    "line": 7,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "Cross-account IAM assume role policy without external id or MFA",
     "severity": "HIGH",
-    "line": 4,
+    "line": 7,
     "fileName": "positive3.tf"
+  },
+  {
+    "queryName": "Cross-account IAM assume role policy without external id or MFA",
+    "severity": "HIGH",
+    "line": 17,
+    "fileName": "positive4.tf"
+  },
+  {
+    "queryName": "Cross-account IAM assume role policy without external id or MFA",
+    "severity": "HIGH",
+    "line": 34,
+    "fileName": "positive4.tf"
   }
 ]

--- a/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/query.rego
+++ b/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/query.rego
@@ -10,16 +10,21 @@ CxPolicy[result] {
 	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
-	tf_lib.anyPrincipal(statement)
+	sub_path := tf_lib.wildcard_principal_sub_path(statement)
+
+	principal_path := concat(".", array.concat(["Principal"], sub_path))
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_ecr_repository_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_ecr_repository_policy[%s].policy.Statement[%d].Principal", [name, idx]),
+		"searchKey": sprintf("aws_ecr_repository_policy[%s].policy.Statement[%d].%s", [name, idx, principal_path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'Statement.Principal' shouldn't contain '*'",
-		"keyActualValue": "'Statement.Principal' contains '*'",
-		"searchLine": common_lib.build_search_line(["resource", "aws_ecr_repository_policy", name, "policy", "Statement", idx, "Principal"], []),
+		"keyExpectedValue": sprintf("'Statement.%s' shouldn't contain '*'", [principal_path]),
+		"keyActualValue": sprintf("'Statement.%s' contains '*'", [principal_path]),
+		"searchLine": common_lib.build_search_line(
+			array.concat(["resource", "aws_ecr_repository_policy", name, "policy", "Statement", idx, "Principal"], sub_path),
+			[],
+		),
 	}
 }

--- a/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/test/positive3.tf
+++ b/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/test/positive3.tf
@@ -1,0 +1,26 @@
+resource "aws_ecr_repository" "aws_wildcard" {
+  name = "aws-wildcard-repo"
+}
+
+resource "aws_ecr_repository_policy" "aws_wildcard" {
+  repository = aws_ecr_repository.aws_wildcard.name
+
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowAnyAccount",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/test/positive_expected_result.json
@@ -9,5 +9,11 @@
     "severity": "CRITICAL",
     "line": 26,
     "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "ECR repository is publicly accessible",
+    "severity": "CRITICAL",
+    "line": 16,
+    "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/query.rego
+++ b/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/query.rego
@@ -12,16 +12,21 @@ CxPolicy[result] {
 	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
-	tf_lib.anyPrincipal(statement)
+	sub_path := tf_lib.wildcard_principal_sub_path(statement)
+
+	principal_path := concat(".", array.concat(["Principal"], sub_path))
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_iam_role",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_iam_role[%s].assume_role_policy.Statement[%d].Principal", [name, idx]),
+		"searchKey": sprintf("aws_iam_role[%s].assume_role_policy.Statement[%d].%s", [name, idx, principal_path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'assume_role_policy.Statement.Principal' shouldn't contain '*'",
-		"keyActualValue": "'assume_role_policy.Statement.Principal' contains '*'",
-		"searchLine": common_lib.build_search_line(["resource", "aws_iam_role", name, "assume_role_policy", "Statement", idx, "Principal"], []),
+		"keyExpectedValue": sprintf("'assume_role_policy.Statement.%s' shouldn't contain '*'", [principal_path]),
+		"keyActualValue": sprintf("'assume_role_policy.Statement.%s' contains '*'", [principal_path]),
+		"searchLine": common_lib.build_search_line(
+			array.concat(["resource", "aws_iam_role", name, "assume_role_policy", "Statement", idx, "Principal"], sub_path),
+			[],
+		),
 	}
 }

--- a/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/test/positive3.tf
+++ b/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/test/positive3.tf
@@ -1,0 +1,20 @@
+//  Role whose assume-role policy grants trust to every AWS service.
+resource "aws_iam_role" "service_wildcard" {
+  name = "service-wildcard-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "*"
+      },
+      "Effect": "Allow",
+      "Sid": "AllowAnyService"
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/test/positive_expected_result.json
@@ -2,17 +2,23 @@
   {
     "queryName": "IAM policy grants 'AssumeRole' permission across all services",
     "severity": "MEDIUM",
-    "line": 13
+    "line": 15
   },
   {
     "queryName": "IAM policy grants 'AssumeRole' permission across all services",
     "severity": "MEDIUM",
-    "line": 76
+    "line": 78
   },
   {
     "queryName": "IAM policy grants 'AssumeRole' permission across all services",
     "severity": "MEDIUM",
-    "line": 18,
+    "line": 20,
     "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "IAM policy grants 'AssumeRole' permission across all services",
+    "severity": "MEDIUM",
+    "line": 12,
+    "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/iam_role_allows_all_principals_to_assume/query.rego
+++ b/assets/queries/terraform/aws/iam_role_allows_all_principals_to_assume/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 	policy := common_lib.json_unmarshal(policyResource)
 
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 	aws := statement.Principal.AWS
 
 	common_lib.is_allow_effect(statement)
@@ -20,10 +20,10 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_iam_role",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_iam_role[%s].assume_role_policy.Principal.AWS", [name]),
+		"searchKey": sprintf("aws_iam_role[%s].assume_role_policy.Statement[%d].Principal.AWS", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'assume_role_policy.Statement.Principal.AWS' should not contain ':root'",
 		"keyActualValue": "'assume_role_policy.Statement.Principal.AWS' contains ':root'",
-		"searchLine": common_lib.build_search_line(["resource", "aws_iam_role", name, "assume_role_policy", "Principal", "AWS"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_iam_role", name, "assume_role_policy", "Statement", idx, "Principal", "AWS"], []),
 	}
 }

--- a/assets/queries/terraform/aws/iam_role_allows_all_principals_to_assume/test/positive2.tf
+++ b/assets/queries/terraform/aws/iam_role_allows_all_principals_to_assume/test/positive2.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_role" "multi_statement" {
+  name = "multi-statement-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow"
+    },
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:root"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/iam_role_allows_all_principals_to_assume/test/positive3.tf
+++ b/assets/queries/terraform/aws/iam_role_allows_all_principals_to_assume/test/positive3.tf
@@ -1,0 +1,16 @@
+resource "aws_iam_role" "jsonencoded" {
+  name = "jsonencoded-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Principal = {
+          AWS = "arn:aws:iam::123456789012:root"
+        }
+        Effect = "Allow"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/iam_role_allows_all_principals_to_assume/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_role_allows_all_principals_to_assume/test/positive_expected_result.json
@@ -2,6 +2,19 @@
   {
     "queryName": "IAM role allows all principals to assume",
     "severity": "MEDIUM",
-    "line": 37
+    "line": 37,
+    "fileName": "positive.tf"
+  },
+  {
+    "queryName": "IAM role allows all principals to assume",
+    "severity": "MEDIUM",
+    "line": 18,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "IAM role allows all principals to assume",
+    "severity": "MEDIUM",
+    "line": 10,
+    "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/query.rego
+++ b/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/query.rego
@@ -9,7 +9,7 @@ CxPolicy[result] {
 
 	out := common_lib.json_unmarshal(policy)
 	st := common_lib.get_statement(out)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	check_passrole(statement)
@@ -18,11 +18,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_iam_role_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_iam_role_policy[%s].policy", [name]),
+		"searchKey": sprintf("aws_iam_role_policy[%s].policy.Statement[%d]", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'aws_iam_role_policy.policy.Statement.Action' iam:passrole shouldn't have Resource '*'",
 		"keyActualValue": "'aws_iam_role_policy.policy.Statement.Action' iam:passrole has Resource '*'",
-		"searchLine": common_lib.build_search_line(["resource", "aws_iam_role_policy", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_iam_role_policy", name, "policy", "Statement", idx], []),
 	}
 }
 

--- a/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/test/positive2.tf
+++ b/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/test/positive2.tf
@@ -1,0 +1,41 @@
+resource "aws_iam_role_policy" "multi_statement" {
+  name = "multi_statement"
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "Safe",
+        "Effect": "Allow",
+        "Action": "iam:passrole",
+        "Resource": "arn:aws:iam::123456789012:role/example-role"
+      },
+      {
+        "Sid": "Vulnerable",
+        "Effect": "Allow",
+        "Action": "iam:passrole",
+        "Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role_policy" "jsonencoded" {
+  name = "jsonencoded"
+  role = aws_iam_role.test_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "JsonEncodedVulnerable"
+        Effect   = "Allow"
+        Action   = "iam:passrole"
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/test/positive_expected_result.json
@@ -2,7 +2,19 @@
   {
     "queryName": "IAM role policy passrole allows all",
     "severity": "MEDIUM",
-    "line": 5,
+    "line": 9,
     "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "IAM role policy passrole allows all",
+    "severity": "MEDIUM",
+    "line": 15,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "IAM role policy passrole allows all",
+    "severity": "MEDIUM",
+    "line": 33,
+    "fileName": "positive2.tf"
   }
 ]

--- a/assets/queries/terraform/aws/iam_user_policy_without_mfa/query.rego
+++ b/assets/queries/terraform/aws/iam_user_policy_without_mfa/query.rego
@@ -8,7 +8,7 @@ CxPolicy[result] {
 
 	policy := common_lib.json_unmarshal(resource.policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := st[idx]
 
 	statement.Action == "sts:AssumeRole"
 	common_lib.is_allow_effect(statement)
@@ -19,11 +19,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_iam_user_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_iam_user_policy[%s].policy", [name]),
+		"searchKey": sprintf("aws_iam_user_policy[%s].policy.Statement[%d]", [name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement.Principal.AWS' should contain ':mfa/' or 'policy.Statement.Condition.BoolIfExists.aws:MultiFactorAuthPresent' should be set to true",
 		"keyActualValue": "'policy.Statement.Principal.AWS' doesn't contain ':mfa/' or 'policy.Statement.Condition.BoolIfExists.aws:MultiFactorAuthPresent' is set to false",
-		"searchLine": common_lib.build_search_line(["resource", "aws_iam_user_policy", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", "aws_iam_user_policy", name, "policy", "Statement", idx], []),
 	}
 }
 

--- a/assets/queries/terraform/aws/iam_user_policy_without_mfa/test/positive2.tf
+++ b/assets/queries/terraform/aws/iam_user_policy_without_mfa/test/positive2.tf
@@ -1,0 +1,24 @@
+resource "aws_iam_user_policy" "mfa_false" {
+  name = "test-mfa-false"
+  user = aws_iam_user.lb.name
+
+  policy = <<EOF
+{
+   "Version": "2012-10-17",
+   "Statement": [
+     {
+       "Effect": "Allow",
+       "Principal": {
+         "AWS": "arn:aws:iam::111122223333:root"
+       },
+       "Action": "sts:AssumeRole",
+       "Condition": {
+         "BoolIfExists": {
+           "aws:MultiFactorAuthPresent": "false"
+         }
+       }
+     }
+   ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/iam_user_policy_without_mfa/test/positive3.tf
+++ b/assets/queries/terraform/aws/iam_user_policy_without_mfa/test/positive3.tf
@@ -1,0 +1,17 @@
+resource "aws_iam_user_policy" "wildcard_principal" {
+  name = "test-wildcard"
+  user = aws_iam_user.lb.name
+
+  policy = <<EOF
+{
+   "Version": "2012-10-17",
+   "Statement": [
+     {
+       "Effect": "Allow",
+       "Principal": "*",
+       "Action": "sts:AssumeRole"
+     }
+   ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/iam_user_policy_without_mfa/test/positive4.tf
+++ b/assets/queries/terraform/aws/iam_user_policy_without_mfa/test/positive4.tf
@@ -1,0 +1,26 @@
+resource "aws_iam_user_policy" "multi_statement" {
+  name = "test-multi"
+  user = aws_iam_user.lb.name
+
+  policy = <<EOF
+{
+   "Version": "2012-10-17",
+   "Statement": [
+     {
+       "Effect": "Allow",
+       "Principal": {
+         "AWS": "arn:aws:iam::mfa/111122223333:user"
+       },
+       "Action": "sts:AssumeRole"
+     },
+     {
+       "Effect": "Allow",
+       "Principal": {
+         "AWS": "arn:aws:iam::111122223333:root"
+       },
+       "Action": "sts:AssumeRole"
+     }
+   ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/iam_user_policy_without_mfa/test/positive5.tf
+++ b/assets/queries/terraform/aws/iam_user_policy_without_mfa/test/positive5.tf
@@ -1,0 +1,17 @@
+resource "aws_iam_user_policy" "jsonencoded" {
+  name = "test-jsonencoded"
+  user = aws_iam_user.lb.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::111122223333:root"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/iam_user_policy_without_mfa/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_user_policy_without_mfa/test/positive_expected_result.json
@@ -2,6 +2,31 @@
   {
     "queryName": "IAM user policy without MFA",
     "severity": "LOW",
-    "line": 18
+    "line": 22,
+    "fileName": "positive.tf"
+  },
+  {
+    "queryName": "IAM user policy without MFA",
+    "severity": "LOW",
+    "line": 9,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "IAM user policy without MFA",
+    "severity": "LOW",
+    "line": 9,
+    "fileName": "positive3.tf"
+  },
+  {
+    "queryName": "IAM user policy without MFA",
+    "severity": "LOW",
+    "line": 16,
+    "fileName": "positive4.tf"
+  },
+  {
+    "queryName": "IAM user policy without MFA",
+    "severity": "LOW",
+    "line": 8,
+    "fileName": "positive5.tf"
   }
 ]

--- a/assets/queries/terraform/aws/lambda_iam_invokefunction_misconfigured/query.rego
+++ b/assets/queries/terraform/aws/lambda_iam_invokefunction_misconfigured/query.rego
@@ -9,20 +9,20 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType[idx]][name]
 	policy := common_lib.json_unmarshal(resource.policy)
 	st := common_lib.get_statement(policy)
-	statement := st[_]
- 
+	statement := st[s_idx]
 
 	check_iam_action(statement) == true
 	not check_iam_resource(statement)
 
-    result := {
+	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType[idx],
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("%s[%s].policy", [resourceType[idx], name]),
+		"searchKey": sprintf("%s[%s].policy.Statement[%d]", [resourceType[idx], name, s_idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("[%s].policy should be misconfigured", [name]),
-		"keyActualValue": sprintf("[%s].policy allows access to function (unqualified ARN) and its sub-resources, add another statement with \":*\" to function name", [name])
+		"keyActualValue": sprintf("[%s].policy allows access to function (unqualified ARN) and its sub-resources, add another statement with \":*\" to function name", [name]),
+		"searchLine": common_lib.build_search_line(["resource", resourceType[idx], name, "policy", "Statement", s_idx], []),
 	}
 }
 

--- a/assets/queries/terraform/aws/lambda_iam_invokefunction_misconfigured/test/positive7.tf
+++ b/assets/queries/terraform/aws/lambda_iam_invokefunction_misconfigured/test/positive7.tf
@@ -1,0 +1,24 @@
+resource "aws_iam_policy" "multi_statement" {
+  name = "multi_statement"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Safe"
+        Effect = "Allow"
+        Action = "lambda:InvokeFunction"
+        Resource = [
+          "arn:aws:lambda:*:*:function:safe-function",
+          "arn:aws:lambda:*:*:function:safe-function:*"
+        ]
+      },
+      {
+        Sid      = "Vulnerable"
+        Effect   = "Allow"
+        Action   = "lambda:InvokeFunction"
+        Resource = "arn:aws:lambda:*:*:function:vulnerable-function"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/lambda_iam_invokefunction_misconfigured/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/lambda_iam_invokefunction_misconfigured/test/positive_expected_result.json
@@ -2,19 +2,19 @@
   {
     "queryName": "Lambda IAM InvokeFunction misconfigured",
     "severity": "LOW",
-    "line": 8,
+    "line": 11,
     "filename": "positive1.tf"
   },
   {
     "queryName": "Lambda IAM InvokeFunction misconfigured",
     "severity": "LOW",
-    "line": 8,
+    "line": 11,
     "filename": "positive2.tf"
   },
   {
     "queryName": "Lambda IAM InvokeFunction misconfigured",
     "severity": "LOW",
-    "line": 8,
+    "line": 11,
     "filename": "positive3.tf"
   },
   {
@@ -26,13 +26,19 @@
   {
     "queryName": "Lambda IAM InvokeFunction misconfigured",
     "severity": "LOW",
-    "line": 8,
+    "line": 11,
     "filename": "positive5.tf"
   },
   {
     "queryName": "Lambda IAM InvokeFunction misconfigured",
     "severity": "LOW",
-    "line": 8,
+    "line": 11,
     "filename": "positive6.tf"
+  },
+  {
+    "queryName": "Lambda IAM InvokeFunction misconfigured",
+    "severity": "LOW",
+    "line": 16,
+    "filename": "positive7.tf"
   }
 ]

--- a/assets/queries/terraform/aws/policy_without_principal/query.rego
+++ b/assets/queries/terraform/aws/policy_without_principal/query.rego
@@ -9,7 +9,8 @@ CxPolicy[result] {
 	not is_iam_identity_based_policy(path[0])
 
 	policy := common_lib.json_unmarshal(value.policy)
-	statement := common_lib.get_statement(policy)[_]
+	st := common_lib.get_statement(policy)
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	not has_principal(statement)
@@ -18,11 +19,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": path[0],
 		"resourceName": path[1],
-		"searchKey": sprintf("%s[%s].policy", [path[0], path[1]]),
+		"searchKey": sprintf("%s[%s].policy.Statement[%d]", [path[0], path[1], idx]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'Principal' should be defined",
 		"keyActualValue": "'Principal' is undefined",
-		"searchLine": common_lib.build_search_line(["resource", path[0], path[1], "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", path[0], path[1], "policy", "Statement", idx], []),
 	}
 }
 

--- a/assets/queries/terraform/aws/policy_without_principal/test/positive2.tf
+++ b/assets/queries/terraform/aws/policy_without_principal/test/positive2.tf
@@ -1,0 +1,40 @@
+resource "aws_sns_topic_policy" "multi_statement" {
+  arn = aws_sns_topic.example.arn
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SafeWithPrincipal",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
+    },
+    {
+      "Sid": "VulnerableNoPrincipal",
+      "Effect": "Allow",
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_sns_topic_policy" "jsonencoded" {
+  arn = aws_sns_topic.example.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "JsonEncodedNoPrincipal"
+        Effect   = "Allow"
+        Action   = "SNS:Publish"
+        Resource = "arn:aws:sns:us-east-1:123456789012:example"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/policy_without_principal/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/policy_without_principal/test/positive_expected_result.json
@@ -2,7 +2,19 @@
   {
     "queryName": "Policy without principal",
     "severity": "MEDIUM",
-    "line": 9,
+    "line": 13,
     "fileName": "positive.tf"
+  },
+  {
+    "queryName": "Policy without principal",
+    "severity": "MEDIUM",
+    "line": 15,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "Policy without principal",
+    "severity": "MEDIUM",
+    "line": 32,
+    "fileName": "positive2.tf"
   }
 ]

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
@@ -9,17 +9,24 @@ CxPolicy[result] {
 	resourceType := pl[r]
 	resource := input.document[i].resource[resourceType][name]
 
-	idx := access_to_any_principal(resource.policy)[_]
+	entry := access_to_any_principal(resource.policy)[_]
+	idx := entry.idx
+	sub_path := entry.sub_path
+
+	principal_path := concat(".", array.concat(["Principal"], sub_path))
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
 		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
-		"searchKey": sprintf("%s[%s].policy.Statement[%d].Principal", [resourceType, name, idx]),
+		"searchKey": sprintf("%s[%s].policy.Statement[%d].%s", [resourceType, name, idx, principal_path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("%s[%s].policy.Principal should not equal to, nor contain '*'", [resourceType, name]),
-		"keyActualValue": sprintf("%s[%s].policy.Principal is equal to or contains '*'", [resourceType, name]),
-		"searchLine": common_lib.build_search_line(["resource", resourceType, name, "policy", "Statement", idx, "Principal"], []),
+		"keyExpectedValue": sprintf("%s[%s].policy.%s should not equal to, nor contain '*'", [resourceType, name, principal_path]),
+		"keyActualValue": sprintf("%s[%s].policy.%s is equal to or contains '*'", [resourceType, name, principal_path]),
+		"searchLine": common_lib.build_search_line(
+			array.concat(["resource", resourceType, name, "policy", "Statement", idx, "Principal"], sub_path),
+			[],
+		),
 	}
 }
 
@@ -28,27 +35,34 @@ CxPolicy[result] {
 	resourceType := pl[r]
 	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, resourceType, "policy")
 
-	idx := access_to_any_principal(module[keyToCheck])[_]
+	entry := access_to_any_principal(module[keyToCheck])[_]
+	idx := entry.idx
+	sub_path := entry.sub_path
+
+	principal_path := concat(".", array.concat(["Principal"], sub_path))
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].policy.Statement[%d].Principal", [name, idx]),
+		"searchKey": sprintf("module[%s].policy.Statement[%d].%s", [name, idx, principal_path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'policy.Principal' should not equal to, nor contain '*'",
-		"keyActualValue": "'policy.Principal' is equal to or contains '*'",
-		"searchLine": common_lib.build_search_line(["module", name, "policy", "Statement", idx, "Principal"], []),
+		"keyExpectedValue": sprintf("'policy.%s' should not equal to, nor contain '*'", [principal_path]),
+		"keyActualValue": sprintf("'policy.%s' is equal to or contains '*'", [principal_path]),
+		"searchLine": common_lib.build_search_line(
+			array.concat(["module", name, "policy", "Statement", idx, "Principal"], sub_path),
+			[],
+		),
 	}
 }
 
-access_to_any_principal(policyValue) = indices {
+access_to_any_principal(policyValue) = entries {
 	policy := common_lib.json_unmarshal(policyValue)
 	st := common_lib.get_statement(policy)
-	indices := [idx |
+	entries := [{"idx": idx, "sub_path": sub_path} |
 		statement := st[idx]
 		common_lib.is_allow_effect(statement)
-		tf_lib.anyPrincipal(statement)
+		sub_path := tf_lib.wildcard_principal_sub_path(statement)
 	]
-	count(indices) > 0
+	count(entries) > 0
 }

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive_expected_result.json
@@ -2,19 +2,19 @@
   {
     "queryName": "S3 bucket access to any principal",
     "severity": "CRITICAL",
-    "line": 12,
+    "line": 13,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "S3 bucket access to any principal",
     "severity": "CRITICAL",
-    "line": 20,
+    "line": 21,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "S3 bucket access to any principal",
     "severity": "CRITICAL",
-    "line": 45,
+    "line": 46,
     "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
@@ -5,12 +5,40 @@ import data.generic.terraform as tf_lib
 
 resources := {"aws_s3_bucket_policy", "aws_s3_bucket"}
 
+# CxPolicy 1: actively wrong statement (Allow+SecureTransport:false or Deny+SecureTransport:true)
+# — pinpoint the specific offending Condition.
 CxPolicy[result] {
 	resourceType := resources[r]
 	resource := input.document[i].resource[resourceType][name]
 
 	policy_unmarshaled := common_lib.json_unmarshal(resource.policy)
 	not deny_http_requests(policy_unmarshaled)
+
+	st := common_lib.get_statement(policy_unmarshaled)
+	statement := st[idx]
+	check_action(statement)
+	actively_wrong(statement)
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": resourceType,
+		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
+		"searchKey": sprintf("%s[%s].policy.Statement[%d].Condition.Bool.aws:SecureTransport", [resourceType, name, idx]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].policy should not accept HTTP Requests", [resourceType, name]),
+		"keyActualValue": sprintf("%s[%s].policy accepts HTTP Requests", [resourceType, name]),
+		"searchLine": common_lib.build_search_line(["resource", resourceType, name, "policy", "Statement", idx, "Condition", "Bool", "aws:SecureTransport"], []),
+	}
+}
+
+# CxPolicy 2: policy-level absence of HTTPS enforcement (no actively wrong statement either).
+CxPolicy[result] {
+	resourceType := resources[r]
+	resource := input.document[i].resource[resourceType][name]
+
+	policy_unmarshaled := common_lib.json_unmarshal(resource.policy)
+	not deny_http_requests(policy_unmarshaled)
+	not has_actively_wrong(policy_unmarshaled)
 
 	result := {
 		"documentId": input.document[i].id,
@@ -38,11 +66,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].policy", [name]),
+		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy' should not accept HTTP Requests",
 		"keyActualValue": "'policy' accepts HTTP Requests",
-		"searchLine": common_lib.build_search_line(["module", name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["module", name, keyToCheck], []),
 	}
 }
 
@@ -80,4 +108,20 @@ deny_http_requests(policyValue) {
     check_action(statement)
     statement.Effect == "Allow"
     is_equal(statement.Condition.Bool["aws:SecureTransport"], "true")
+}
+
+# An actively wrong statement is one that explicitly permits HTTP or denies HTTPS.
+actively_wrong(statement) {
+    statement.Effect == "Allow"
+    is_equal(statement.Condition.Bool["aws:SecureTransport"], "false")
+} else {
+    statement.Effect == "Deny"
+    is_equal(statement.Condition.Bool["aws:SecureTransport"], "true")
+}
+
+has_actively_wrong(policyValue) {
+    st := common_lib.get_statement(policyValue)
+    statement := st[_]
+    check_action(statement)
+    actively_wrong(statement)
 }

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive6.tf
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive6.tf
@@ -1,0 +1,23 @@
+resource "aws_s3_bucket_policy" "allow_http" {
+  bucket = aws_s3_bucket.example.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ExplicitlyAllowHTTP",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::example-bucket/*",
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      }
+    }
+  ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive7.tf
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive7.tf
@@ -1,0 +1,21 @@
+resource "aws_s3_bucket_policy" "allow_http_jsonencoded" {
+  bucket = aws_s3_bucket.example.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "ExplicitlyAllowHTTP"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "arn:aws:s3:::example-bucket/*"
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive_expected_result.json
@@ -28,5 +28,17 @@
     "severity": "MEDIUM",
     "line": 32,
     "fileName": "positive5.tf"
+  },
+  {
+    "queryName": "S3 bucket policy accepts HTTP requests",
+    "severity": "MEDIUM",
+    "line": 16,
+    "fileName": "positive6.tf"
+  },
+  {
+    "queryName": "S3 bucket policy accepts HTTP requests",
+    "severity": "MEDIUM",
+    "line": 15,
+    "fileName": "positive7.tf"
   }
 ]

--- a/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/query.rego
+++ b/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/query.rego
@@ -14,17 +14,22 @@ CxPolicy[result] {
 	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
-	tf_lib.anyPrincipal(statement)
+	sub_path := tf_lib.wildcard_principal_sub_path(statement)
+
+	principal_path := concat(".", array.concat(["Principal"], sub_path))
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": res_type,
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("%s[%s].policy.Statement[%d].Principal", [res_type, name, idx]),
+		"searchKey": sprintf("%s[%s].policy.Statement[%d].%s", [res_type, name, idx, principal_path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'Statement.Principal.AWS' shouldn't contain '*'",
-		"keyActualValue": "'Statement.Principal.AWS' contains '*'",
-		"searchLine": common_lib.build_search_line(["resource", res_type, name, "policy", "Statement", idx, "Principal"], []),
+		"keyExpectedValue": sprintf("'Statement.%s' shouldn't contain '*'", [principal_path]),
+		"keyActualValue": sprintf("'Statement.%s' contains '*'", [principal_path]),
+		"searchLine": common_lib.build_search_line(
+			array.concat(["resource", res_type, name, "policy", "Statement", idx, "Principal"], sub_path),
+			[],
+		),
 	}
 }
 
@@ -39,16 +44,21 @@ CxPolicy[result] {
 	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
-	tf_lib.anyPrincipal(statement)
+	sub_path := tf_lib.wildcard_principal_sub_path(statement)
+
+	principal_path := concat(".", array.concat(["Principal"], sub_path))
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].%s.Statement[%d].Principal", [name, keyToCheck, idx]),
+		"searchKey": sprintf("module[%s].%s.Statement[%d].%s", [name, keyToCheck, idx, principal_path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'Statement.Principal.AWS' shouldn't contain '*'",
-		"keyActualValue": "'Statement.Principal.AWS' contains '*'",
-		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx, "Principal"], []),
+		"keyExpectedValue": sprintf("'Statement.%s' shouldn't contain '*'", [principal_path]),
+		"keyActualValue": sprintf("'Statement.%s' contains '*'", [principal_path]),
+		"searchLine": common_lib.build_search_line(
+			array.concat(["module", name, keyToCheck, "Statement", idx, "Principal"], sub_path),
+			[],
+		),
 	}
 }

--- a/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/positive_expected_result.json
@@ -2,13 +2,13 @@
   {
     "queryName": "SNS topic is publicly accessible",
     "severity": "CRITICAL",
-    "line": 8,
+    "line": 9,
     "fileName": "positive.tf"
   },
   {
     "queryName": "SNS topic is publicly accessible",
     "severity": "CRITICAL",
-    "line": 29,
+    "line": 30,
     "fileName": "positive_module.tf"
   },
   {

--- a/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/query.rego
+++ b/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 
 	pol := common_lib.json_unmarshal(policy)
 	st := common_lib.get_statement(pol)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	statement.NotAction
@@ -22,11 +22,11 @@ CxPolicy[result] {
 		"documentId": document.id,
 		"resourceType": resources[r],
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("%s[%s].policy", [resources[r], name]),
+		"searchKey": sprintf("%s[%s].policy.Statement[%d].NotAction", [resources[r], name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy shouldn't have 'Effect: Allow' and 'NotAction' simultaneously", [resources[r], name]),
 		"keyActualValue": sprintf("%s[%s].policy has 'Effect: Allow' and 'NotAction' simultaneously", [resources[r], name]),
-		"searchLine": common_lib.build_search_line(["resource", resources[r], name, "policy"], []),
+		"searchLine": common_lib.build_search_line(["resource", resources[r], name, "policy", "Statement", idx, "NotAction"], []),
 	}
 }
 
@@ -40,7 +40,7 @@ CxPolicy[result] {
 
 	pol := common_lib.json_unmarshal(policy)
 	st := common_lib.get_statement(pol)
-	statement := st[_]
+	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
 	statement.NotAction
@@ -49,11 +49,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].policy", [name]),
+		"searchKey": sprintf("module[%s].%s.Statement[%d].NotAction", [name, keyToCheck, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("module[%s].policy shouldn't have 'Effect: Allow' and 'NotAction' simultaneously", [name]),
 		"keyActualValue": sprintf("module[%s].policy has 'Effect: Allow' and 'NotAction' simultaneously", [name]),
-		"searchLine": common_lib.build_search_line(["module", name, keyToCheck], []),
+		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx, "NotAction"], []),
 	}
 }
 

--- a/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/test/positive3.tf
+++ b/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/test/positive3.tf
@@ -1,0 +1,42 @@
+resource "aws_sns_topic_policy" "multi_statement" {
+  arn = aws_sns_topic.example.arn
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Safe",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
+    },
+    {
+      "Sid": "Vulnerable",
+      "Effect": "Allow",
+      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+      "NotAction": "SNS:DeleteTopic",
+      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_sns_topic_policy" "jsonencoded" {
+  arn = aws_sns_topic.example.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "JsonEncodedVulnerable"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::123456789012:root" }
+        NotAction = "SNS:DeleteTopic"
+        Resource  = "arn:aws:sns:us-east-1:123456789012:example"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/test/positive_expected_result.json
@@ -2,13 +2,25 @@
   {
     "queryName": "SNS topic publicity has allow and NotAction simultaneously",
     "severity": "MEDIUM",
-    "line": 8,
+    "line": 14,
     "filename": "positive1.tf"
   },
   {
     "queryName": "SNS topic publicity has allow and NotAction simultaneously",
     "severity": "MEDIUM",
-    "line": 12,
+    "line": 18,
     "filename": "positive2.tf"
+  },
+  {
+    "queryName": "SNS topic publicity has allow and NotAction simultaneously",
+    "severity": "MEDIUM",
+    "line": 19,
+    "filename": "positive3.tf"
+  },
+  {
+    "queryName": "SNS topic publicity has allow and NotAction simultaneously",
+    "severity": "MEDIUM",
+    "line": 37,
+    "filename": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/sqs_policy_with_public_access/query.rego
+++ b/assets/queries/terraform/aws/sqs_policy_with_public_access/query.rego
@@ -11,18 +11,22 @@ CxPolicy[result] {
 	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
-	check_principal(statement.Principal, "*")
-	tf_lib.anyPrincipal(statement)
+	sub_path := tf_lib.wildcard_principal_sub_path(statement)
+
+	principal_path := concat(".", array.concat(["Principal"], sub_path))
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_sqs_queue_policy",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_sqs_queue_policy[%s].policy.Statement[%d].Principal", [name, idx]),
+		"searchKey": sprintf("aws_sqs_queue_policy[%s].policy.Statement[%d].%s", [name, idx, principal_path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'policy.Statement.Principal.AWS' should not equal '*'",
-		"keyActualValue": "'policy.Statement.Principal.AWS' is equal '*'",
-		"searchLine": common_lib.build_search_line(["resource", "aws_sqs_queue_policy", name, "policy", "Statement", idx, "Principal"], []),
+		"keyExpectedValue": sprintf("'policy.Statement.%s' should not equal '*'", [principal_path]),
+		"keyActualValue": sprintf("'policy.Statement.%s' is equal '*'", [principal_path]),
+		"searchLine": common_lib.build_search_line(
+			array.concat(["resource", "aws_sqs_queue_policy", name, "policy", "Statement", idx, "Principal"], sub_path),
+			[],
+		),
 	}
 }
 
@@ -37,26 +41,21 @@ CxPolicy[result] {
 	statement := st[idx]
 
 	common_lib.is_allow_effect(statement)
-	check_principal(statement.Principal, "*")
-	tf_lib.anyPrincipal(statement)
+	sub_path := tf_lib.wildcard_principal_sub_path(statement)
+
+	principal_path := concat(".", array.concat(["Principal"], sub_path))
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].%s.Statement[%d].Principal", [name, keyToCheck, idx]),
+		"searchKey": sprintf("module[%s].%s.Statement[%d].%s", [name, keyToCheck, idx, principal_path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'module[%s].%s.Statement.Principal.AWS' should not equal '*'", [name, keyToCheck]),
-		"keyActualValue": sprintf("'module[%s].%s.Statement.Principal.AWS' is equal '*'", [name, keyToCheck]),
-		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx, "Principal"], []),
+		"keyExpectedValue": sprintf("'module[%s].%s.Statement.%s' should not equal '*'", [name, keyToCheck, principal_path]),
+		"keyActualValue": sprintf("'module[%s].%s.Statement.%s' is equal '*'", [name, keyToCheck, principal_path]),
+		"searchLine": common_lib.build_search_line(
+			array.concat(["module", name, keyToCheck, "Statement", idx, "Principal"], sub_path),
+			[],
+		),
 	}
-}
-
-check_principal(field, value) {
-	is_object(field)
-	some i
-	val := [x | x := field[i]; common_lib.containsOrInArrayContains(x, value)]
-	count(val) > 0
-} else {
-	common_lib.containsOrInArrayContains(field, "*")
 }

--- a/assets/queries/terraform/aws/sqs_policy_with_public_access/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sqs_policy_with_public_access/test/positive_expected_result.json
@@ -7,17 +7,17 @@
   {
     "queryName": "SQS policy with public access",
     "severity": "MEDIUM",
-    "line": 46
+    "line": 47
   },
   {
     "queryName": "SQS policy with public access",
     "severity": "MEDIUM",
-    "line": 71
+    "line": 72
   },
   {
     "queryName": "SQS policy with public access",
     "severity": "MEDIUM",
-    "line": 14,
+    "line": 15,
     "fileName": "positive_module.tf"
   },
   {

--- a/assets/queries/terraform/aws/sqs_queue_exposed/query.rego
+++ b/assets/queries/terraform/aws/sqs_queue_exposed/query.rego
@@ -6,17 +6,24 @@ import data.generic.terraform as tf_lib
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_sqs_queue[name]
 
-	idx := exposed_statement_indices(resource.policy)[_]
+	entry := exposed_statement_entries(resource.policy)[_]
+	idx := entry.idx
+	sub_path := entry.sub_path
+
+	principal_path := concat(".", array.concat(["Principal"], sub_path))
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_sqs_queue",
 		"resourceName": tf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("aws_sqs_queue[%s].policy.Statement[%d].Principal", [name, idx]),
+		"searchKey": sprintf("aws_sqs_queue[%s].policy.Statement[%d].%s", [name, idx, principal_path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("resource.aws_sqs_queue[%s].policy.Principal shouldn't get the queue publicly accessible", [name]),
-		"keyActualValue": sprintf("resource.aws_sqs_queue[%s].policy.Principal does get the queue publicly accessible", [name]),
-		"searchLine": common_lib.build_search_line(["resource", "aws_sqs_queue", name, "policy", "Statement", idx, "Principal"], []),
+		"keyExpectedValue": sprintf("resource.aws_sqs_queue[%s].policy.%s shouldn't get the queue publicly accessible", [name, principal_path]),
+		"keyActualValue": sprintf("resource.aws_sqs_queue[%s].policy.%s does get the queue publicly accessible", [name, principal_path]),
+		"searchLine": common_lib.build_search_line(
+			array.concat(["resource", "aws_sqs_queue", name, "policy", "Statement", idx, "Principal"], sub_path),
+			[],
+		),
 	}
 }
 
@@ -24,27 +31,34 @@ CxPolicy[result] {
 	module := input.document[i].module[name]
 	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, "aws_sqs_queue", "policy")
 
-	idx := exposed_statement_indices(module[keyToCheck])[_]
+	entry := exposed_statement_entries(module[keyToCheck])[_]
+	idx := entry.idx
+	sub_path := entry.sub_path
+
+	principal_path := concat(".", array.concat(["Principal"], sub_path))
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "module",
 		"resourceName": sprintf("%s", [name]),
-		"searchKey": sprintf("module[%s].%s.Statement[%d].Principal", [name, keyToCheck, idx]),
+		"searchKey": sprintf("module[%s].%s.Statement[%d].%s", [name, keyToCheck, idx, principal_path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'policy.Principal' shouldn't get the queue publicly accessible",
-		"keyActualValue": "'policy.Principal' does get the queue publicly accessible",
-		"searchLine": common_lib.build_search_line(["module", name, keyToCheck, "Statement", idx, "Principal"], []),
+		"keyExpectedValue": sprintf("'policy.%s' shouldn't get the queue publicly accessible", [principal_path]),
+		"keyActualValue": sprintf("'policy.%s' does get the queue publicly accessible", [principal_path]),
+		"searchLine": common_lib.build_search_line(
+			array.concat(["module", name, keyToCheck, "Statement", idx, "Principal"], sub_path),
+			[],
+		),
 	}
 }
 
-exposed_statement_indices(policyValue) = indices {
+exposed_statement_entries(policyValue) = entries {
 	policy := common_lib.json_unmarshal(policyValue)
 	st := common_lib.get_statement(policy)
-	indices := [idx |
+	entries := [{"idx": idx, "sub_path": sub_path} |
 		statement := st[idx]
 		common_lib.is_allow_effect(statement)
-		tf_lib.anyPrincipal(statement)
+		sub_path := tf_lib.wildcard_principal_sub_path(statement)
 	]
-	count(indices) > 0
+	count(entries) > 0
 }

--- a/assets/queries/terraform/aws/sqs_queue_exposed/test/positive4.tf
+++ b/assets/queries/terraform/aws/sqs_queue_exposed/test/positive4.tf
@@ -1,0 +1,21 @@
+resource "aws_sqs_queue" "aws_wildcard" {
+  name = "aws-wildcard-queue"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "sqspolicy",
+  "Statement": [
+    {
+      "Sid": "AllowAnyAccount",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:aws:sqs:us-east-1:123456789012:my-queue"
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/sqs_queue_exposed/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sqs_queue_exposed/test/positive_expected_result.json
@@ -16,5 +16,11 @@
     "severity": "HIGH",
     "line": 21,
     "fileName": "positive3.tf"
+  },
+  {
+    "queryName": "SQS queue exposed",
+    "severity": "HIGH",
+    "line": 13,
+    "fileName": "positive4.tf"
   }
 ]


### PR DESCRIPTION
## Summary

Follow-up to part 1. Scope 16 additional Terraform policy rules so SARIF regions pinpoint the exact offending `Statement[idx]` (or a specific sub-attribute such as `NotAction` or `Condition.Bool.aws:SecureTransport`) rather than the whole `policy` attribute.

This is the second and last part of the fixes for the terraform policies rules.

## How to review

Same format as #98. Each rule section below has:

- fixture path
- small HCL snippet with the new reported line marked
- new line numbers for every positive fixture in the rule, old line numbers on `main`
- a short semantic note explaining *why* the line is the right one

Please sanity-check the *why* per rule — that is where a semantic mistake would show up.

## Testing

```bash
go test ./pkg/detector/terraform/... ./test/... -count=1
```

All tests pass.

## Per-rule review

<details>
<summary><code>alicloud/oss_buckets_securetransport_disabled</code> — actively-wrong statement pinpointed at <code>Condition</code></summary>

**Fixture:** `assets/queries/terraform/alicloud/oss_buckets_securetransport_disabled/test/positive3.tf`

```hcl
  policy = <<POLICY
{
  "Version": "1",
  "Statement": [
    {
      "Effect": "Deny", "Principal": ["*"], "Action": ["oss:*"],
      "Resource": ["acs:oss:*:*:bucket/*"],
      "Condition": { "Bool": { "acs:SecureTransport": "true" } }  // safe
    },
    {
      "Effect": "Allow", "Principal": ["*"], "Action": ["oss:GetObject"],
      "Resource": ["acs:oss:*:*:bucket/*"],
      "Condition": {
        "Bool": {
          "acs:SecureTransport": "false"            // <-- new region: line 24
        }
      }
    }
  ]
}
POLICY
```

- **New:** `positive1.tf` L40; `positive2.tf` L5; `positive3.tf` L24.
- **Old (`main`):** whole `policy`, `positive1.tf` L2; `positive2.tf` L5.
- **Why:** an `Allow` + `acs:SecureTransport: "false"` is the statement actively permitting HTTP. Pointing at the condition key makes the fix obvious (flip to `true` or remove).

</details>

<details>
<summary><code>authentication_without_mfa</code> — <code>policy.Statement[idx]</code> (heredoc and <code>jsonencode</code>)</summary>

**Fixture:** `assets/queries/terraform/aws/authentication_without_mfa/test/positive3.tf`

```hcl
  policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow", "Action": "sts:AssumeRole",
      "Resource": "${aws_iam_user.positive3.arn}",
      "Condition": {
        "BoolIfExists": { "aws:MultiFactorAuthPresent": "true" }   // safe
      }
    },
    {                                    // <-- new region: line 23
      "Effect": "Allow",
      "Action": "sts:AssumeRole",
      "Resource": "${aws_iam_user.positive3.arn}"
    }
  ]
}
EOF
```

- **New:** `positive1.tf` L27; `positive2.tf` L23; `positive3.tf` L23; `positive4.tf` L12 (`jsonencode`).
- **Old (`main`):** whole `policy`, `positive1.tf` L23; `positive2.tf` L19.
- **Why:** an `sts:AssumeRole` with no `aws:MultiFactorAuthPresent` condition (or set to `false`) is exactly the non-MFA statement; the sibling statement that enforces MFA must not be highlighted.

</details>

<details>
<summary><code>cross_account_iam_assume_role_policy_without_external_id_or_mfa</code> — <code>assume_role_policy.Statement[idx]</code></summary>

**Fixture:** `assets/queries/terraform/aws/cross_account_iam_assume_role_policy_without_external_id_or_mfa/test/positive4.tf`

```hcl
  assume_role_policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "SafeWithMFA", "Effect": "Allow",
      "Principal": {"AWS": "arn:aws:iam::111111111111:root"},
      "Action": "sts:AssumeRole",
      "Condition": { "Bool": {"aws:MultiFactorAuthPresent": "true"} }
    },
    {                                   // <-- new region: line 17
      "Sid": "VulnerableCrossAccountWithoutMFA", "Effect": "Allow",
      "Principal": {"AWS": "arn:aws:iam::222222222222:root"},
      "Action": "sts:AssumeRole"
    }
  ]
}
EOF
}

resource "aws_iam_role" "jsonencoded" {
  ...
  assume_role_policy = jsonencode({
    Version = "2012-10-17"
    Statement = [
      {                                 // <-- new region: line 34
        Sid       = "JsonEncodedVulnerable"
        Effect    = "Allow"
        Principal = { AWS = "arn:aws:iam::333333333333:root" }
        Action    = "sts:AssumeRole"
      }
    ]
  })
}
```

- **New:** `positive1.tf` L8; `positive2.tf` L7; `positive3.tf` L7; `positive4.tf` L17 and L34.
- **Old (`main`):** whole `assume_role_policy`, `positive1..3.tf` L4.
- **Why:** cross-account trust without `ExternalId` or MFA condition is the exact unsafe statement; the sibling with MFA is fine.

</details>

<details>
<summary><code>ecr_repository_is_publicly_accessible</code> — <code>policy.Statement[idx].Principal.AWS</code></summary>

**Fixture:** `assets/queries/terraform/aws/ecr_repository_is_publicly_accessible/test/positive3.tf`

```hcl
  policy = <<EOF
{
  "Version": "2008-10-17",
  "Statement": [
    {
      "Sid": "AllowAnyAccount",
      "Effect": "Allow",
      "Principal": {
        "AWS": "*"                     // <-- new region: line 16
      },
      "Action": [ "ecr:GetDownloadUrlForLayer", "ecr:BatchGetImage" ]
    }
  ]
}
EOF
```

- **New:** `positive1.tf` L15; `positive2.tf` L26; `positive3.tf` L16.
- **Old (`main`):** same top-level resource line on existing fixtures; `positive3.tf` is new and covers wildcard `Principal.AWS`.
- **Why:** `Principal.AWS: "*"` explicitly makes the ECR repo world-readable; region on that line makes the fix a one-character edit.

</details>

<details>
<summary><code>iam_policy_grants_assumerole_permission_across_all_services</code> — <code>assume_role_policy.Statement[idx].Principal.Service</code></summary>

**Fixture:** `assets/queries/terraform/aws/iam_policy_grants_assumerole_permission_across_all_services/test/positive3.tf`

```hcl
  assume_role_policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": "sts:AssumeRole",
      "Principal": {
        "Service": "*"                  // <-- new region: line 12
      },
      "Effect": "Allow",
      "Sid": "AllowAnyService"
    }
  ]
}
EOF
```

- **New:** `positive1.tf` L15 and L78; `positive2.tf` L20; `positive3.tf` L12.
- **Old (`main`):** `positive1.tf` L13 and L76; `positive2.tf` L18.
- **Why:** wildcard `Principal.Service` means every AWS service can assume the role. The region sits on the wildcard itself.

</details>

<details>
<summary><code>iam_role_allows_all_principals_to_assume</code> — <code>assume_role_policy.Statement[idx].Principal.AWS</code></summary>

**Fixture:** `assets/queries/terraform/aws/iam_role_allows_all_principals_to_assume/test/positive2.tf`

```hcl
  assume_role_policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": "sts:AssumeRole",
      "Principal": { "Service": "ec2.amazonaws.com" },     // safe
      "Effect": "Allow"
    },
    {
      "Action": "sts:AssumeRole",
      "Principal": {
        "AWS": "arn:aws:iam::123456789012:root"            // <-- new region: line 18
      },
      "Effect": "Allow"
    }
  ]
}
EOF
```

- **New:** `positive.tf` L37; `positive2.tf` L18; `positive3.tf` L10 (`jsonencode`).
- **Old (`main`):** `positive.tf` L37 (no filename on original entry).
- **Why:** an `:root` ARN in `Principal.AWS` grants trust to every principal in that account — the rule message literally says `contains ':root'`, so the region must land on the ARN itself.

</details>

<details>
<summary><code>iam_role_policy_passrole_allows_all</code> — <code>policy.Statement[idx]</code> (heredoc and <code>jsonencode</code>)</summary>

**Fixture:** `assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/test/positive2.tf`

```hcl
  policy = <<-EOF
  {
    "Version": "2012-10-17",
    "Statement": [
      {
        "Sid": "Safe", "Effect": "Allow",
        "Action": "iam:passrole",
        "Resource": "arn:aws:iam::123456789012:role/example-role"
      },
      {                                 // <-- new region: line 15
        "Sid": "Vulnerable", "Effect": "Allow",
        "Action": "iam:passrole",
        "Resource": "*"
      }
    ]
  }
  EOF
}

resource "aws_iam_role_policy" "jsonencoded" {
  ...
  policy = jsonencode({
    Version = "2012-10-17"
    Statement = [
      {                                 // <-- new region: line 33
        Sid      = "JsonEncodedVulnerable"
        Effect   = "Allow"
        Action   = "iam:passrole"
        Resource = "*"
      }
    ]
  })
}
```

- **New:** `positive1.tf` L9; `positive2.tf` L15 and L33.
- **Old (`main`):** whole `policy`, `positive1.tf` L5.
- **Why:** `iam:PassRole` + `Resource: "*"` lets any role be passed anywhere; the Safe statement above has a specific role ARN and should not be flagged.

</details>

<details>
<summary><code>iam_user_policy_without_mfa</code> — <code>policy.Statement[idx]</code> (heredoc and <code>jsonencode</code>)</summary>

**Fixture:** `assets/queries/terraform/aws/iam_user_policy_without_mfa/test/positive4.tf`

```hcl
  policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": { "AWS": "arn:aws:iam::mfa/111122223333:user" },  // safe
      "Action": "sts:AssumeRole"
    },
    {                                   // <-- new region: line 16
      "Effect": "Allow",
      "Principal": { "AWS": "arn:aws:iam::111122223333:root" },
      "Action": "sts:AssumeRole"
    }
  ]
}
EOF
```

- **New:** `positive.tf` L22; `positive2.tf` L9; `positive3.tf` L9; `positive4.tf` L16; `positive5.tf` L8 (`jsonencode`).
- **Old (`main`):** whole `policy`, `positive.tf` L18.
- **Why:** the statement without an MFA `Condition` (or an `mfa/…` principal) is exactly the one allowing AssumeRole without MFA; per-statement pinpointing keeps the safe sibling out of the region.

</details>

<details>
<summary><code>lambda_iam_invokefunction_misconfigured</code> — <code>policy.Statement[idx]</code></summary>

**Fixture:** `assets/queries/terraform/aws/lambda_iam_invokefunction_misconfigured/test/positive7.tf`

```hcl
  policy = jsonencode({
    Version = "2012-10-17"
    Statement = [
      {
        Sid    = "Safe", Effect = "Allow", Action = "lambda:InvokeFunction"
        Resource = [
          "arn:aws:lambda:*:*:function:safe-function",
          "arn:aws:lambda:*:*:function:safe-function:*"
        ]                                                               // safe
      },
      {                                                                 // <-- new region: line 16
        Sid      = "Vulnerable", Effect = "Allow",
        Action   = "lambda:InvokeFunction"
        Resource = "arn:aws:lambda:*:*:function:vulnerable-function"    // missing ":*"
      }
    ]
  })
```

- **New:** `positive1..3.tf` L11; `positive4.tf` L5 (HCL data source, unchanged); `positive5.tf` L11; `positive6.tf` L11; `positive7.tf` L16.
- **Old (`main`):** `positive1..6.tf` L8.
- **Why:** InvokeFunction with a function ARN **without** the alias-qualifier form can be aliased around at runtime; the rule checks both the qualified and unqualified forms, so an `Allow` must list **both** — the Safe statement uses an array to satisfy that, and only the second statement is actually misconfigured.

</details>

<details>
<summary><code>policy_without_principal</code> — <code>policy.Statement[idx]</code> (heredoc and <code>jsonencode</code>)</summary>

**Fixture:** `assets/queries/terraform/aws/policy_without_principal/test/positive2.tf`

```hcl
  policy = <<POLICY
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "SafeWithPrincipal", "Effect": "Allow",
      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
      "Action": "SNS:Publish",
      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
    },
    {                                   // <-- new region: line 15
      "Sid": "VulnerableNoPrincipal", "Effect": "Allow",
      "Action": "SNS:Publish",
      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
    }
  ]
}
POLICY
}

resource "aws_sns_topic_policy" "jsonencoded" {
  ...
  policy = jsonencode({
    ...
    Statement = [
      {                                 // <-- new region: line 32
        Sid      = "JsonEncodedNoPrincipal"
        Effect   = "Allow"
        Action   = "SNS:Publish"
        Resource = "arn:aws:sns:us-east-1:123456789012:example"
      }
    ]
  })
}
```

- **New:** `positive.tf` L13; `positive2.tf` L15 and L32.
- **Old (`main`):** whole `policy`, `positive.tf` L9.
- **Why:** in an identity-based policy an `Allow` with no `Principal` is legal on the account's own resources, but on a resource-based policy (e.g. SNS topic policy) it is either a bug or overbroad. Per-statement region makes clear which statement forgot the principal.

</details>

<details>
<summary><code>s3_bucket_access_to_any_principal</code> — <code>policy.Statement[idx]</code> at the wildcard principal</summary>

**Fixture:** `assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive1.tf`

```hcl
  policy = <<POLICY
{
  "Version": "2012-10-17", "Id": "MYBUCKETPOLICY",
  "Statement": [
    {
      "Sid": "IPAllow", "Effect": "Allow",
      "Principal": {
        "AWS": "*"                      // <-- new region: line 13
      },
      "Action": "s3:*",
      "Resource": "arn:aws:s3:::my_tf_test_bucket/*",
      "Condition": {
        "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
      }
    }
  ]
}
POLICY
```

- **New:** `positive1.tf` L13; `positive2.tf` L21; `positive3.tf` L46.
- **Old (`main`):** `positive1.tf` L12; `positive2.tf` L20; `positive3.tf` L45 (all 1 line off; the old region landed on the enclosing `"Principal": {` brace).
- **Why:** `Principal.AWS: "*"` with `s3:*` on a bucket is world-writable. Region on the wildcard itself, not the `Principal` key, makes the fix obvious.

</details>

<details>
<summary><code>s3_bucket_policy_accepts_http_requests</code> — two <code>CxPolicy</code> blocks: actively-wrong statement vs policy without HTTPS enforcement</summary>

**Fixture A (actively wrong):** `assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive6.tf`

```hcl
  policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "ExplicitlyAllowHTTP", "Effect": "Allow",
      "Principal": "*", "Action": "s3:GetObject",
      "Resource": "arn:aws:s3:::example-bucket/*",
      "Condition": {
        "Bool": {
          "aws:SecureTransport": "false"   // <-- new region: line 16
        }
      }
    }
  ]
}
EOF
```

**Fixture B (`jsonencode`):** `assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive7.tf`

```hcl
  policy = jsonencode({
    Version = "2012-10-17"
    Statement = [
      {
        ...
        Condition = {
          Bool = {
            "aws:SecureTransport" = "false"     // <-- new region: line 15
          }
        }
      }
    ]
  })
```

- **New:** existing positives (`1..5`) unchanged; `positive6.tf` L16; `positive7.tf` L15.
- **Old (`main`):** same for `1..5` (policy-level region); no existing coverage for the actively-wrong case before this PR.
- **Why:** split into two `CxPolicy` blocks so we can be precise **when the statement is actively wrong** (Allow+`SecureTransport:false` or Deny+`SecureTransport:true`) and still emit a policy-level finding when the bucket simply lacks HTTPS enforcement. Please eyeball both fixtures — this is the only rule with two distinct findings.

</details>

<details>
<summary><code>sns_topic_is_publicly_accessible</code> — <code>policy.Statement[idx]</code> at <code>Principal.AWS</code></summary>

**Fixture:** `assets/queries/terraform/aws/sns_topic_is_publicly_accessible/test/positive.tf`

```hcl
resource "aws_sns_topic" "positive1" {
policy = <<EOF
{
"Version": "2012-10-17",
"Statement": [
{
"Action": "*",
"Principal": {
  "AWS": "*"                          // <-- new region: line 9
},
"Effect": "Allow",
"Sid": ""
}
]
}
EOF
}
```

- **New:** `positive.tf` L9; `positive2.tf` L11; `positive3.tf` L20; `positive_module.tf` L30.
- **Old (`main`):** same fixtures, each 1 line off (region on the previous `Principal` key brace).
- **Why:** wildcard `Principal.AWS` on an SNS topic makes the topic world-subscribable; region lands on the wildcard so the fix is a one-character edit.

</details>

<details>
<summary><code>sns_topic_publicity_has_allow_and_not_action_simultaneously</code> — <code>Statement[idx].NotAction</code></summary>

**Fixture:** `assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/test/positive3.tf`

```hcl
  policy = <<POLICY
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "Safe", "Effect": "Allow",
      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
      "Action": "SNS:Publish",
      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
    },
    {
      "Sid": "Vulnerable", "Effect": "Allow",
      "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
      "NotAction": "SNS:DeleteTopic",   // <-- new region: line 19
      "Resource": "arn:aws:sns:us-east-1:123456789012:example"
    }
  ]
}
POLICY
}

resource "aws_sns_topic_policy" "jsonencoded" {
  ...
  policy = jsonencode({
    ...
    Statement = [
      {
        ...
        NotAction = "SNS:DeleteTopic"   // <-- new region: line 37
        ...
      }
    ]
  })
}
```

- **New:** `positive1.tf` L14; `positive2.tf` L18; `positive3.tf` L19 and L37.
- **Old (`main`):** whole `policy`, `positive1.tf` L8; `positive2.tf` L12.
- **Why:** `Allow` + `NotAction` is a known anti-pattern (it grants everything except the listed actions, often unintended). Pointing at `NotAction` makes the anti-pattern explicit.

</details>

<details>
<summary><code>sqs_policy_with_public_access</code> — <code>policy.Statement[idx]</code> at wildcard principal</summary>

**Fixture:** `assets/queries/terraform/aws/sqs_policy_with_public_access/test/positive.tf`

```hcl
resource "aws_sqs_queue_policy" "test" {
  queue_url = aws_sqs_queue.q.id

  policy = <<EOF
{
  "Version": "2012-10-17",
  "Id": "Queue1_Policy_UUID",
  "Statement": [{
      "Sid":"Queue1_AnonymousAccess_AllActions_AllowlistIP",
      "Effect": "Allow",
      "Principal": "*",                 // <-- new region: line 15
      "Action": "sqs:*",
      "Resource": "arn:aws:sqs:*:111122223333:queue1",
      "Condition" : { "IpAddress": {"aws:SourceIp":"192.168.143.0/24"} }
  }]
}
EOF
}
```

- **New:** `positive.tf` L15, L47, L72; `positive_module.tf` L15; `positive2.tf` L25.
- **Old (`main`):** same fixtures, most 1 line off.
- **Why:** wildcard `Principal` on an SQS queue policy opens it publicly. Pinpointing the statement keeps other queue policies in the same file out of the region.

</details>

<details>
<summary><code>sqs_queue_exposed</code> — <code>policy.Statement[idx]</code> at <code>Principal.AWS</code></summary>

**Fixture:** `assets/queries/terraform/aws/sqs_queue_exposed/test/positive4.tf`

```hcl
resource "aws_sqs_queue" "aws_wildcard" {
  name = "aws-wildcard-queue"

  policy = <<POLICY
{
  "Version": "2012-10-17", "Id": "sqspolicy",
  "Statement": [
    {
      "Sid": "AllowAnyAccount", "Effect": "Allow",
      "Principal": {
        "AWS": "*"                      // <-- new region: line 13
      },
      "Action": "sqs:SendMessage",
      "Resource": "arn:aws:sqs:us-east-1:123456789012:my-queue"
    }
  ]
}
POLICY
}
```

- **New:** `positive1.tf` L12; `positive2.tf` L20; `positive3.tf` L21; `positive4.tf` L13.
- **Old (`main`):** same as new for `positive1..3.tf`; `positive4.tf` is new and covers wildcard `Principal.AWS`.
- **Why:** `Principal.AWS: "*"` on the inline `aws_sqs_queue.policy` attribute exposes the queue to any AWS account.

</details>
