### PR TITLE
Resolve S3 companion resource names to bucket name in Terraform findings

### DIFF
--- a/assets/libraries/terraform.rego
+++ b/assets/libraries/terraform.rego
@@ -642,11 +642,43 @@ get_resource_name(resource, resourceDefinitionName) = final_name {
     final_name := resourceDefinitionName
 }
 
+# String safe to use as resourceName: no "${" interpolation fragments.
+is_literal_string(s) {
+	is_string(s)
+	not contains(s, "${")
+}
+
 get_specific_resource_name(resource, resourceType, resourceDefinitionName) = name {
 	field := resourceFieldName[resourceType]
 	name := resource[field]
+	is_literal_string(name)
 } else = name {
 	name := get_resource_name(resource, resourceDefinitionName)
+}
+
+# Literal attr value, or `${parent_type}.<name>.*` resolved via input.document + resourceFieldName; else fallback (never `${...}`).
+resolve_reference_name(resource, attr, parent_type, fallback) = out {
+	val := resource[attr]
+	is_literal_string(val)
+	out := val
+} else = out {
+	ref := resource[attr]
+	is_string(ref)
+	startswith(ref, sprintf("${%s.", [parent_type]))
+	parts := split(trim_suffix(trim_prefix(ref, "${"), "}"), ".")
+	count(parts) >= 2
+	parts[0] == parent_type
+	target := input.document[_].resource[parent_type][parts[1]]
+	candidate := get_specific_resource_name(target, parent_type, parts[1])
+	is_literal_string(candidate)
+	out := candidate
+} else = out {
+	out := fallback
+}
+
+# S3 `bucket` -> resolved name (same-scan aws_s3_bucket refs); else fallback.
+resolve_bucket_name(resource, fallback) = name {
+	name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", fallback)
 }
 
 check_key_empty(disk_encryption_key) = key {

--- a/assets/libraries/terraform.rego
+++ b/assets/libraries/terraform.rego
@@ -677,7 +677,7 @@ resolve_reference_name(resource, attr, parent_type, fallback) = out {
 }
 
 # S3 `bucket` -> resolved name (same-scan aws_s3_bucket refs); else fallback.
-resolve_bucket_name(resource, fallback) = name {
+resolve_s3_bucket_name(resource, fallback) = name {
 	name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", fallback)
 }
 

--- a/assets/libraries/test/terraform_test.rego
+++ b/assets/libraries/test/terraform_test.rego
@@ -522,3 +522,148 @@ test_get_specific_resource_name_fallback {
     name := get_specific_resource_name(resource, "aws_instance", "my_instance")
     name == "my_instance"
 }
+
+test_get_specific_resource_name_rejects_interpolation {
+    resource := {"bucket": "${aws_s3_bucket.foo.id}"}
+    name := get_specific_resource_name(resource, "aws_s3_bucket", "my_bucket")
+    name == "my_bucket"
+}
+
+test_get_specific_resource_name_rejects_composite_interpolation {
+    resource := {"bucket": "prefix-${var.env}-suffix"}
+    name := get_specific_resource_name(resource, "aws_s3_bucket", "my_bucket")
+    name == "my_bucket"
+}
+
+# Test resolve_reference_name function
+test_resolve_reference_name_literal {
+    resource := {"bucket": "my-bucket"}
+    name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
+    name == "my-bucket"
+}
+
+test_resolve_reference_name_composite_interpolation_falls_back {
+    resource := {"bucket": "prefix-${var.env}-suffix"}
+    name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
+    name == "fallback_logical"
+}
+
+test_resolve_reference_name_unknown_reference_falls_back {
+    resource := {"bucket": "${module.x.bucket_id}"}
+    name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
+    name == "fallback_logical"
+}
+
+test_resolve_reference_name_missing_attribute_falls_back {
+    resource := {"other": "value"}
+    name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
+    name == "fallback_logical"
+}
+
+test_resolve_reference_name_var_without_default_falls_back {
+    resource := {"bucket": "${var.bucket_name}"}
+    name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
+    name == "fallback_logical"
+}
+
+# Test resolve_bucket_name function against mock input.document shape
+test_resolve_bucket_name_literal {
+    resource := {"bucket": "my-literal-bucket"}
+    name := resolve_bucket_name(resource, "policy_logical_name") with input as {}
+    name == "my-literal-bucket"
+}
+
+test_resolve_bucket_name_same_document_reference {
+    mock_input := {
+        "document": [{
+            "resource": {
+                "aws_s3_bucket": {
+                    "my_bucket": {"bucket": "shopist-prod"},
+                },
+                "aws_s3_bucket_policy": {
+                    "my_policy": {"bucket": "${aws_s3_bucket.my_bucket.id}"},
+                },
+            },
+        }],
+    }
+    policy := mock_input.document[0].resource.aws_s3_bucket_policy.my_policy
+    name := resolve_bucket_name(policy, "my_policy") with input as mock_input
+    name == "shopist-prod"
+}
+
+test_resolve_bucket_name_cross_document_reference {
+    mock_input := {
+        "document": [
+            {
+                "resource": {
+                    "aws_s3_bucket": {
+                        "my_bucket": {"bucket": "shopist-cross-file"},
+                    },
+                },
+            },
+            {
+                "resource": {
+                    "aws_s3_bucket_policy": {
+                        "my_policy": {"bucket": "${aws_s3_bucket.my_bucket.id}"},
+                    },
+                },
+            },
+        ],
+    }
+    policy := mock_input.document[1].resource.aws_s3_bucket_policy.my_policy
+    name := resolve_bucket_name(policy, "my_policy") with input as mock_input
+    name == "shopist-cross-file"
+}
+
+test_resolve_bucket_name_reference_to_missing_bucket_falls_back {
+    mock_input := {
+        "document": [{
+            "resource": {
+                "aws_s3_bucket_policy": {
+                    "orphan_policy": {"bucket": "${aws_s3_bucket.not_there.id}"},
+                },
+            },
+        }],
+    }
+    policy := mock_input.document[0].resource.aws_s3_bucket_policy.orphan_policy
+    name := resolve_bucket_name(policy, "orphan_policy") with input as mock_input
+    name == "orphan_policy"
+}
+
+test_resolve_bucket_name_reference_to_bucket_without_literal_name_returns_target_logical_name {
+    # When the referenced aws_s3_bucket exists in the scan but its `bucket`
+    # attribute is itself unresolvable (e.g. "${var.bucket_name}" with no
+    # default), prefer the target bucket's Terraform logical name over the
+    # companion resource's own logical name -- it is one step closer to the
+    # runtime asset and still jump-to-code-friendly.
+    mock_input := {
+        "document": [{
+            "resource": {
+                "aws_s3_bucket": {
+                    "dynamic": {"bucket": "${var.bucket_name}"},
+                },
+                "aws_s3_bucket_policy": {
+                    "its_policy": {"bucket": "${aws_s3_bucket.dynamic.id}"},
+                },
+            },
+        }],
+    }
+    policy := mock_input.document[0].resource.aws_s3_bucket_policy.its_policy
+    name := resolve_bucket_name(policy, "its_policy") with input as mock_input
+    name == "dynamic"
+}
+
+test_resolve_bucket_name_module_reference_falls_back {
+    mock_input := {
+        "document": [{
+            "resource": {
+                "aws_s3_bucket_policy": {
+                    "modular_policy": {"bucket": "${module.shopist.bucket_id}"},
+                },
+            },
+        }],
+    }
+    policy := mock_input.document[0].resource.aws_s3_bucket_policy.modular_policy
+    name := resolve_bucket_name(policy, "modular_policy") with input as mock_input
+    name == "modular_policy"
+}

--- a/assets/libraries/test/terraform_test.rego
+++ b/assets/libraries/test/terraform_test.rego
@@ -566,14 +566,14 @@ test_resolve_reference_name_var_without_default_falls_back {
     name == "fallback_logical"
 }
 
-# Test resolve_bucket_name function against mock input.document shape
-test_resolve_bucket_name_literal {
+# Test resolve_s3_bucket_name function against mock input.document shape
+test_resolve_s3_bucket_name_literal {
     resource := {"bucket": "my-literal-bucket"}
-    name := resolve_bucket_name(resource, "policy_logical_name") with input as {}
+    name := resolve_s3_bucket_name(resource, "policy_logical_name") with input as {}
     name == "my-literal-bucket"
 }
 
-test_resolve_bucket_name_same_document_reference {
+test_resolve_s3_bucket_name_same_document_reference {
     mock_input := {
         "document": [{
             "resource": {
@@ -587,11 +587,11 @@ test_resolve_bucket_name_same_document_reference {
         }],
     }
     policy := mock_input.document[0].resource.aws_s3_bucket_policy.my_policy
-    name := resolve_bucket_name(policy, "my_policy") with input as mock_input
+    name := resolve_s3_bucket_name(policy, "my_policy") with input as mock_input
     name == "shopist-prod"
 }
 
-test_resolve_bucket_name_cross_document_reference {
+test_resolve_s3_bucket_name_cross_document_reference {
     mock_input := {
         "document": [
             {
@@ -611,11 +611,11 @@ test_resolve_bucket_name_cross_document_reference {
         ],
     }
     policy := mock_input.document[1].resource.aws_s3_bucket_policy.my_policy
-    name := resolve_bucket_name(policy, "my_policy") with input as mock_input
+    name := resolve_s3_bucket_name(policy, "my_policy") with input as mock_input
     name == "shopist-cross-file"
 }
 
-test_resolve_bucket_name_reference_to_missing_bucket_falls_back {
+test_resolve_s3_bucket_name_reference_to_missing_bucket_falls_back {
     mock_input := {
         "document": [{
             "resource": {
@@ -626,11 +626,11 @@ test_resolve_bucket_name_reference_to_missing_bucket_falls_back {
         }],
     }
     policy := mock_input.document[0].resource.aws_s3_bucket_policy.orphan_policy
-    name := resolve_bucket_name(policy, "orphan_policy") with input as mock_input
+    name := resolve_s3_bucket_name(policy, "orphan_policy") with input as mock_input
     name == "orphan_policy"
 }
 
-test_resolve_bucket_name_reference_to_bucket_without_literal_name_returns_target_logical_name {
+test_resolve_s3_bucket_name_reference_to_bucket_without_literal_name_returns_target_logical_name {
     # When the referenced aws_s3_bucket exists in the scan but its `bucket`
     # attribute is itself unresolvable (e.g. "${var.bucket_name}" with no
     # default), prefer the target bucket's Terraform logical name over the
@@ -649,11 +649,11 @@ test_resolve_bucket_name_reference_to_bucket_without_literal_name_returns_target
         }],
     }
     policy := mock_input.document[0].resource.aws_s3_bucket_policy.its_policy
-    name := resolve_bucket_name(policy, "its_policy") with input as mock_input
+    name := resolve_s3_bucket_name(policy, "its_policy") with input as mock_input
     name == "dynamic"
 }
 
-test_resolve_bucket_name_module_reference_falls_back {
+test_resolve_s3_bucket_name_module_reference_falls_back {
     mock_input := {
         "document": [{
             "resource": {
@@ -664,6 +664,6 @@ test_resolve_bucket_name_module_reference_falls_back {
         }],
     }
     policy := mock_input.document[0].resource.aws_s3_bucket_policy.modular_policy
-    name := resolve_bucket_name(policy, "modular_policy") with input as mock_input
+    name := resolve_s3_bucket_name(policy, "modular_policy") with input as mock_input
     name == "modular_policy"
 }

--- a/assets/queries/terraform/aws/cloudtrail_log_files_s3_bucket_is_publicly_accessible/query.rego
+++ b/assets/queries/terraform/aws/cloudtrail_log_files_s3_bucket_is_publicly_accessible/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(bucket, s3BucketName),
+		"resourceName": tf_lib.resolve_s3_bucket_name(bucket, s3BucketName),
 		"searchKey": sprintf("aws_s3_bucket[%s].acl", [s3BucketName]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_s3_bucket[%s] to not be publicly accessible", [s3BucketName]),
@@ -53,7 +53,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_acl",
-		"resourceName": tf_lib.resolve_bucket_name(acl, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(acl, name),
 		"searchKey": sprintf("aws_s3_bucket_acl[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_s3_bucket_acl[%s] to not be publicly accessible", [name]),

--- a/assets/queries/terraform/aws/cloudtrail_log_files_s3_bucket_is_publicly_accessible/query.rego
+++ b/assets/queries/terraform/aws/cloudtrail_log_files_s3_bucket_is_publicly_accessible/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(bucket, "aws_s3_bucket", s3BucketName),
+		"resourceName": tf_lib.resolve_bucket_name(bucket, s3BucketName),
 		"searchKey": sprintf("aws_s3_bucket[%s].acl", [s3BucketName]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_s3_bucket[%s] to not be publicly accessible", [s3BucketName]),
@@ -53,7 +53,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_acl",
-		"resourceName": tf_lib.get_resource_name(acl, name),
+		"resourceName": tf_lib.resolve_bucket_name(acl, name),
 		"searchKey": sprintf("aws_s3_bucket_acl[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_s3_bucket_acl[%s] to not be publicly accessible", [name]),

--- a/assets/queries/terraform/aws/cloudtrail_log_files_s3_bucket_with_logging_disabled/query.rego
+++ b/assets/queries/terraform/aws/cloudtrail_log_files_s3_bucket_with_logging_disabled/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(bucket, "aws_s3_bucket", s3BucketName),
+		"resourceName": tf_lib.resolve_bucket_name(bucket, s3BucketName),
 		"searchKey": sprintf("aws_s3_bucket[%s]", [s3BucketName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("aws_s3_bucket[%s] to have 'logging' defined", [s3BucketName]),

--- a/assets/queries/terraform/aws/cloudtrail_log_files_s3_bucket_with_logging_disabled/query.rego
+++ b/assets/queries/terraform/aws/cloudtrail_log_files_s3_bucket_with_logging_disabled/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(bucket, s3BucketName),
+		"resourceName": tf_lib.resolve_s3_bucket_name(bucket, s3BucketName),
 		"searchKey": sprintf("aws_s3_bucket[%s]", [s3BucketName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("aws_s3_bucket[%s] to have 'logging' defined", [s3BucketName]),

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy.Statement[%d].%s", [resourceType, name, idx, principal_path]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy.%s should not equal to, nor contain '*'", [resourceType, name, principal_path]),

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy.Statement[%d].%s", [resourceType, name, idx, principal_path]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy.%s should not equal to, nor contain '*'", [resourceType, name, principal_path]),

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive4_bucket.tf
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive4_bucket.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "cross_file_bucket" {
+  bucket = "cross-file-bucket-name"
+}

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive4_policy.tf
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive4_policy.tf
@@ -1,0 +1,14 @@
+resource "aws_s3_bucket_policy" "cross_file_policy" {
+  bucket = aws_s3_bucket.cross_file_bucket.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.cross_file_bucket.arn}/*"
+      }
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_access_to_any_principal/test/positive_expected_result.json
@@ -16,5 +16,11 @@
     "severity": "CRITICAL",
     "line": 46,
     "fileName": "positive3.tf"
+  },
+  {
+    "queryName": "S3 bucket access to any principal",
+    "severity": "CRITICAL",
+    "line": 8,
+    "fileName": "positive4_policy.tf"
   }
 ]

--- a/assets/queries/terraform/aws/s3_bucket_acl_allows_read_or_write_to_all_users/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_acl_allows_read_or_write_to_all_users/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].acl=%s", [name, resource.acl]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'acl' should equal to 'private'",
@@ -50,7 +50,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_acl",
-		"resourceName": tf_lib.resolve_bucket_name(acl, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(acl, name),
 		"searchKey": sprintf("aws_s3_bucket_acl[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_s3_bucket_acl[%s].acl should be private", [name]),

--- a/assets/queries/terraform/aws/s3_bucket_acl_allows_read_or_write_to_all_users/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_acl_allows_read_or_write_to_all_users/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].acl=%s", [name, resource.acl]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'acl' should equal to 'private'",
@@ -50,7 +50,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_acl",
-		"resourceName": tf_lib.get_resource_name(acl, name),
+		"resourceName": tf_lib.resolve_bucket_name(acl, name),
 		"searchKey": sprintf("aws_s3_bucket_acl[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_s3_bucket_acl[%s].acl should be private", [name]),

--- a/assets/queries/terraform/aws/s3_bucket_acl_allows_read_to_any_authenticated_user/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_acl_allows_read_to_any_authenticated_user/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_s3_bucket[%s].acl should be private", [name]),
@@ -50,7 +50,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_acl",
-		"resourceName": tf_lib.resolve_bucket_name(acl, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(acl, name),
 		"searchKey": sprintf("aws_s3_bucket_acl[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_s3_bucket_acl[%s].acl should be private", [name]),

--- a/assets/queries/terraform/aws/s3_bucket_acl_allows_read_to_any_authenticated_user/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_acl_allows_read_to_any_authenticated_user/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_s3_bucket[%s].acl should be private", [name]),
@@ -50,7 +50,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_acl",
-		"resourceName": tf_lib.get_resource_name(acl, name),
+		"resourceName": tf_lib.resolve_bucket_name(acl, name),
 		"searchKey": sprintf("aws_s3_bucket_acl[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_s3_bucket_acl[%s].acl should be private", [name]),

--- a/assets/queries/terraform/aws/s3_bucket_acl_grants_write_acp_permission/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_acl_grants_write_acp_permission/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_acl",
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("aws_s3_bucket_acl[%s].access_control_policy.grant[%d].permission", [name, grant_index ]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Should not be granted Write_ACP permission to the aws_s3_bucket_acl",
@@ -32,7 +32,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_acl",
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("aws_s3_bucket_acl[%s].access_control_policy.grant.permission", [name ]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Should not be granted Write_ACP permission to the aws_s3_bucket_acl",

--- a/assets/queries/terraform/aws/s3_bucket_acl_grants_write_acp_permission/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_acl_grants_write_acp_permission/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_acl",
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket_acl", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("aws_s3_bucket_acl[%s].access_control_policy.grant[%d].permission", [name, grant_index ]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Should not be granted Write_ACP permission to the aws_s3_bucket_acl",
@@ -32,7 +32,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_acl",
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket_acl", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("aws_s3_bucket_acl[%s].access_control_policy.grant.permission", [name ]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Should not be granted Write_ACP permission to the aws_s3_bucket_acl",

--- a/assets/queries/terraform/aws/s3_bucket_allows_access_to_all_authenticated_users/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_access_to_all_authenticated_users/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
         "resourceType": "aws_s3_bucket_acl",
-        "resourceName": tf_lib.resolve_bucket_name(resource, name),
+        "resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
         "searchKey": sprintf("aws_s3_bucket_acl[%s].access_control_policy.grant[%d].grantee.uri", [name, grant_index]),
         "issueType": "IncorrectValue",
         "keyExpectedValue": "aws_s3_bucket_acl.access_control_policy.grant[*].grantee.uri should not be 'http://acs.amazonaws.com/groups/global/AuthenticatedUsers'",
@@ -42,7 +42,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
         "resourceType": "aws_s3_bucket_acl",
-        "resourceName": tf_lib.resolve_bucket_name(resource, name),
+        "resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
         "searchKey": sprintf("aws_s3_bucket_acl[%s].access_control_policy.grant.grantee.uri", [name]),
         "issueType": "IncorrectValue",
         "keyExpectedValue": "aws_s3_bucket_acl.access_control_policy.grant.grantee.uri should not be 'http://acs.amazonaws.com/groups/global/AuthenticatedUsers'",

--- a/assets/queries/terraform/aws/s3_bucket_allows_access_to_all_authenticated_users/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_access_to_all_authenticated_users/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
         "resourceType": "aws_s3_bucket_acl",
-        "resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket_acl", name),
+        "resourceName": tf_lib.resolve_bucket_name(resource, name),
         "searchKey": sprintf("aws_s3_bucket_acl[%s].access_control_policy.grant[%d].grantee.uri", [name, grant_index]),
         "issueType": "IncorrectValue",
         "keyExpectedValue": "aws_s3_bucket_acl.access_control_policy.grant[*].grantee.uri should not be 'http://acs.amazonaws.com/groups/global/AuthenticatedUsers'",
@@ -42,7 +42,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
         "resourceType": "aws_s3_bucket_acl",
-        "resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket_acl", name),
+        "resourceName": tf_lib.resolve_bucket_name(resource, name),
         "searchKey": sprintf("aws_s3_bucket_acl[%s].access_control_policy.grant.grantee.uri", [name]),
         "issueType": "IncorrectValue",
         "keyExpectedValue": "aws_s3_bucket_acl.access_control_policy.grant.grantee.uri should not be 'http://acs.amazonaws.com/groups/global/AuthenticatedUsers'",

--- a/assets/queries/terraform/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy", [resourceType, name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy.Action should not be a 'Delete' action", [resourceType, name]),

--- a/assets/queries/terraform/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy", [resourceType, name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy.Action should not be a 'Delete' action", [resourceType, name]),

--- a/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": pl[r],
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy.Action", [pl[r], name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy.Action should not be a 'Get' action", [pl[r], name]),

--- a/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": pl[r],
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy.Action", [pl[r], name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy.Action should not be a 'Get' action", [pl[r], name]),

--- a/assets/queries/terraform/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy", [resourceType, name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement.Action' should not be a 'List' action when 'policy.Statement.Principal' contains '*'",

--- a/assets/queries/terraform/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy", [resourceType, name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement.Action' should not be a 'List' action when 'policy.Statement.Principal' contains '*'",

--- a/assets/queries/terraform/aws/s3_bucket_allows_public_acl/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_public_acl/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'block_public_acls' should equal 'true'",
@@ -29,7 +29,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s].block_public_acls", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'block_public_acls' should equal 'true'",

--- a/assets/queries/terraform/aws/s3_bucket_allows_public_acl/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_public_acl/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.get_resource_name(pubACL, name),
+		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'block_public_acls' should equal 'true'",
@@ -29,7 +29,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.get_resource_name(pubACL, name),
+		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s].block_public_acls", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'block_public_acls' should equal 'true'",

--- a/assets/queries/terraform/aws/s3_bucket_allows_put_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_put_action_from_all_principals/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy", [resourceType, name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy.Statement.Action should not be a 'Put' action", [resourceType, name]),

--- a/assets/queries/terraform/aws/s3_bucket_allows_put_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_put_action_from_all_principals/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy", [resourceType, name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy.Statement.Action should not be a 'Put' action", [resourceType, name]),

--- a/assets/queries/terraform/aws/s3_bucket_logging_disabled/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_logging_disabled/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
         "resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(s3, "aws_s3_bucket", bucketName),
+		"resourceName": tf_lib.resolve_bucket_name(s3, bucketName),
         "searchKey": sprintf("aws_s3_bucket[%s]", [bucketName]),
         "issueType": "MissingAttribute",
         "keyExpectedValue": "'logging' should be defined and not null",

--- a/assets/queries/terraform/aws/s3_bucket_logging_disabled/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_logging_disabled/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
         "resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(s3, bucketName),
+		"resourceName": tf_lib.resolve_s3_bucket_name(s3, bucketName),
         "searchKey": sprintf("aws_s3_bucket[%s]", [bucketName]),
         "issueType": "MissingAttribute",
         "keyExpectedValue": "'logging' should be defined and not null",

--- a/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_object",
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("aws_s3_bucket_object[{{%s}}]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_s3_bucket_object.server_side_encryption should be defined and not null",

--- a/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_object",
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("aws_s3_bucket_object[{{%s}}]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_s3_bucket_object.server_side_encryption should be defined and not null",

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
@@ -22,7 +22,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy.Statement[%d].Condition.Bool.aws:SecureTransport", [resourceType, name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy should not accept HTTP Requests", [resourceType, name]),
@@ -43,7 +43,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy", [resourceType, name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy should not accept HTTP Requests", [resourceType, name]),

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
@@ -22,7 +22,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy.Statement[%d].Condition.Bool.aws:SecureTransport", [resourceType, name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy should not accept HTTP Requests", [resourceType, name]),
@@ -43,7 +43,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": resourceType,
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy", [resourceType, name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy should not accept HTTP Requests", [resourceType, name]),

--- a/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/query.rego
@@ -19,7 +19,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "S3 Bucket public ACL to not be overridden by S3 bucket Public Access Block",
@@ -69,7 +69,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_acl",
-		"resourceName": tf_lib.resolve_bucket_name(acl, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(acl, name),
 		"searchKey": sprintf("aws_s3_bucket_acl[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "S3 Bucket public ACL to not be overridden by S3 bucket Public Access Block",

--- a/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/query.rego
@@ -19,7 +19,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "S3 Bucket public ACL to not be overridden by S3 bucket Public Access Block",
@@ -69,7 +69,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_acl",
-		"resourceName": tf_lib.get_resource_name(acl, name),
+		"resourceName": tf_lib.resolve_bucket_name(acl, name),
 		"searchKey": sprintf("aws_s3_bucket_acl[%s].acl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "S3 Bucket public ACL to not be overridden by S3 bucket Public Access Block",

--- a/assets/queries/terraform/aws/s3_bucket_with_all_permissions/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_all_permissions/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": res_type,
-		"resourceName": tf_lib.get_specific_resource_name(resource, res_type, name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy.Statement[%d]", [res_type, name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement' should not allow all actions to all principal",

--- a/assets/queries/terraform/aws/s3_bucket_with_all_permissions/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_all_permissions/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": res_type,
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("%s[%s].policy.Statement[%d]", [res_type, name, idx]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement' should not allow all actions to all principal",

--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.get_resource_name(pubACL, name),
+		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s].block_public_policy", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'block_public_policy' should equal 'true'",
@@ -27,7 +27,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.get_resource_name(pubACL, name),
+		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s].block_public_policy", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'block_public_policy' should equal 'true'",

--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s].block_public_policy", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'block_public_policy' should equal 'true'",
@@ -27,7 +27,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s].block_public_policy", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'block_public_policy' should equal 'true'",

--- a/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(bucket, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(bucket, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].cors_rule", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'cors_rule' to not allow all methods, all headers or several origins",
@@ -32,7 +32,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(bucket, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(bucket, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].cors_rule", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'cors_rule' to not allow all methods, all headers or several origins",
@@ -71,7 +71,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_cors_configuration",
-		"resourceName": tf_lib.get_resource_name(cors_configuration, name),
+		"resourceName": tf_lib.resolve_bucket_name(cors_configuration, name),
 		"searchKey": sprintf("aws_s3_bucket_cors_configuration[%s].cors_rule", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'cors_rule' to not allow all methods, all headers or several origins",
@@ -92,7 +92,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_cors_configuration",
-		"resourceName": tf_lib.get_resource_name(cors_configuration, name),
+		"resourceName": tf_lib.resolve_bucket_name(cors_configuration, name),
 		"searchKey": sprintf("aws_s3_bucket_cors_configuration[%s].cors_rule", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'cors_rule' to not allow all methods, all headers or several origins",

--- a/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(bucket, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(bucket, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].cors_rule", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'cors_rule' to not allow all methods, all headers or several origins",
@@ -32,7 +32,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(bucket, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(bucket, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].cors_rule", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'cors_rule' to not allow all methods, all headers or several origins",
@@ -71,7 +71,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_cors_configuration",
-		"resourceName": tf_lib.resolve_bucket_name(cors_configuration, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(cors_configuration, name),
 		"searchKey": sprintf("aws_s3_bucket_cors_configuration[%s].cors_rule", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'cors_rule' to not allow all methods, all headers or several origins",
@@ -92,7 +92,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_cors_configuration",
-		"resourceName": tf_lib.resolve_bucket_name(cors_configuration, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(cors_configuration, name),
 		"searchKey": sprintf("aws_s3_bucket_cors_configuration[%s].cors_rule", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'cors_rule' to not allow all methods, all headers or several origins",

--- a/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(bucket, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(bucket, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].versioning", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'%s' should be set to true", [checkedFields[j]]),
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(bucket, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(bucket, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].versioning.%s", [name, checkedFields[j]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s' should be set to true", [checkedFields[j]]),
@@ -95,7 +95,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_versioning",
-		"resourceName": tf_lib.resolve_bucket_name(bucket_versioning, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(bucket_versioning, name),
 		"searchKey": sprintf("aws_s3_bucket_versioning[%s].versioning_configuration.mfa_delete", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'versioning_configuration.mfa_delete' should be set to 'Enabled'",
@@ -117,7 +117,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_versioning",
-		"resourceName": tf_lib.resolve_bucket_name(bucket_versioning, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(bucket_versioning, name),
 		"searchKey": sprintf("aws_s3_bucket_versioning[%s].versioning_configuration.status", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'versioning_configuration.status' should be set to 'Enabled'",
@@ -139,7 +139,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_versioning",
-		"resourceName": tf_lib.resolve_bucket_name(bucket_versioning, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(bucket_versioning, name),
 		"searchKey": sprintf("aws_s3_bucket_versioning[%s].versioning_configuration", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'versioning_configuration.mfa_delete' should be defined and not null",

--- a/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(bucket, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(bucket, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].versioning", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'%s' should be set to true", [checkedFields[j]]),
@@ -35,7 +35,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(bucket, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(bucket, name),
 		"searchKey": sprintf("aws_s3_bucket[%s].versioning.%s", [name, checkedFields[j]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s' should be set to true", [checkedFields[j]]),
@@ -95,7 +95,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_versioning",
-		"resourceName": tf_lib.get_resource_name(bucket_versioning, name),
+		"resourceName": tf_lib.resolve_bucket_name(bucket_versioning, name),
 		"searchKey": sprintf("aws_s3_bucket_versioning[%s].versioning_configuration.mfa_delete", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'versioning_configuration.mfa_delete' should be set to 'Enabled'",
@@ -117,7 +117,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_versioning",
-		"resourceName": tf_lib.get_resource_name(bucket_versioning, name),
+		"resourceName": tf_lib.resolve_bucket_name(bucket_versioning, name),
 		"searchKey": sprintf("aws_s3_bucket_versioning[%s].versioning_configuration.status", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'versioning_configuration.status' should be set to 'Enabled'",
@@ -139,7 +139,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_versioning",
-		"resourceName": tf_lib.get_resource_name(bucket_versioning, name),
+		"resourceName": tf_lib.resolve_bucket_name(bucket_versioning, name),
 		"searchKey": sprintf("aws_s3_bucket_versioning[%s].versioning_configuration", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'versioning_configuration.mfa_delete' should be defined and not null",

--- a/assets/queries/terraform/aws/s3_bucket_without_ignore_public_acl/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_ignore_public_acl/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.get_resource_name(pubACL, name),
+		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s].ignore_public_acls", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'ignore_public_acls' should equal 'true'",
@@ -31,7 +31,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.get_resource_name(pubACL, name),
+		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'ignore_public_acls' should equal 'true'",

--- a/assets/queries/terraform/aws/s3_bucket_without_ignore_public_acl/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_ignore_public_acl/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s].ignore_public_acls", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'ignore_public_acls' should equal 'true'",
@@ -31,7 +31,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'ignore_public_acls' should equal 'true'",

--- a/assets/queries/terraform/aws/s3_bucket_without_restriction_of_public_bucket/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_restriction_of_public_bucket/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s].restrict_public_buckets", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'restrict_public_buckets' should equal 'true'",
@@ -31,7 +31,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'restrict_public_buckets' should equal 'true'",

--- a/assets/queries/terraform/aws/s3_bucket_without_restriction_of_public_bucket/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_restriction_of_public_bucket/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.get_resource_name(pubACL, name),
+		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s].restrict_public_buckets", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'restrict_public_buckets' should equal 'true'",
@@ -31,7 +31,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket_public_access_block",
-		"resourceName": tf_lib.get_resource_name(pubACL, name),
+		"resourceName": tf_lib.resolve_bucket_name(pubACL, name),
 		"searchKey": sprintf("aws_s3_bucket_public_access_block[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'restrict_public_buckets' should equal 'true'",

--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
         "resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(bucket, bucketName),
+		"resourceName": tf_lib.resolve_s3_bucket_name(bucket, bucketName),
         "searchKey": sprintf("aws_s3_bucket[%s]", [bucketName]),
         "issueType": "MissingAttribute",
         "keyExpectedValue": "'versioning' should be true",
@@ -52,7 +52,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
         "resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(bucket, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(bucket, name),
         "searchKey": sprintf("aws_s3_bucket[%s].versioning", [name]),
         "issueType": "MissingAttribute",
         "keyExpectedValue": "'versioning.enabled' should be true",
@@ -92,7 +92,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
         "resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(bucket, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(bucket, name),
         "searchKey": sprintf("aws_s3_bucket[%s].versioning.enabled", [name]),
         "issueType": "IncorrectValue",
         "keyExpectedValue": "'versioning.enabled' should be true",
@@ -140,7 +140,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
        "resourceType": "aws_s3_bucket_versioning",
-		"resourceName": tf_lib.resolve_bucket_name(bucket_versioning, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(bucket_versioning, name),
         "searchKey": sprintf("aws_s3_bucket_versioning[%s].versioning_configuration.status", [name]),
         "issueType": "IncorrectValue",
         "keyExpectedValue": "'versioning_configuration.status' should be set to 'Enabled'",

--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
         "resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(bucket, "aws_s3_bucket", bucketName),
+		"resourceName": tf_lib.resolve_bucket_name(bucket, bucketName),
         "searchKey": sprintf("aws_s3_bucket[%s]", [bucketName]),
         "issueType": "MissingAttribute",
         "keyExpectedValue": "'versioning' should be true",
@@ -52,7 +52,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
         "resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(bucket, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(bucket, name),
         "searchKey": sprintf("aws_s3_bucket[%s].versioning", [name]),
         "issueType": "MissingAttribute",
         "keyExpectedValue": "'versioning.enabled' should be true",
@@ -92,7 +92,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
         "resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(bucket, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(bucket, name),
         "searchKey": sprintf("aws_s3_bucket[%s].versioning.enabled", [name]),
         "issueType": "IncorrectValue",
         "keyExpectedValue": "'versioning.enabled' should be true",
@@ -140,7 +140,7 @@ CxPolicy[result] {
     result := {
         "documentId": input.document[i].id,
        "resourceType": "aws_s3_bucket_versioning",
-		"resourceName": tf_lib.get_resource_name(bucket_versioning, name),
+		"resourceName": tf_lib.resolve_bucket_name(bucket_versioning, name),
         "searchKey": sprintf("aws_s3_bucket_versioning[%s].versioning_configuration.status", [name]),
         "issueType": "IncorrectValue",
         "keyExpectedValue": "'versioning_configuration.status' should be set to 'Enabled'",

--- a/assets/queries/terraform/aws/s3_static_website_host_enabled/query.rego
+++ b/assets/queries/terraform/aws/s3_static_website_host_enabled/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", name),
+		"resourceName": tf_lib.resolve_bucket_name(resource, name),
 		"searchKey": sprintf("resource.aws_s3_bucket[%s].website", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("resource.aws_s3_bucket[%s].website to not have static websites inside", [name]),
@@ -48,7 +48,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.get_specific_resource_name(resource, "aws_s3_bucket", bucketName),
+		"resourceName": tf_lib.resolve_bucket_name(resource, bucketName),
 		"searchKey": sprintf("aws_s3_bucket[%s]", [bucketName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'aws_s3_bucket' to not have 'aws_s3_bucket_website_configuration' associated",

--- a/assets/queries/terraform/aws/s3_static_website_host_enabled/query.rego
+++ b/assets/queries/terraform/aws/s3_static_website_host_enabled/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(resource, name),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
 		"searchKey": sprintf("resource.aws_s3_bucket[%s].website", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("resource.aws_s3_bucket[%s].website to not have static websites inside", [name]),
@@ -48,7 +48,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",
-		"resourceName": tf_lib.resolve_bucket_name(resource, bucketName),
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, bucketName),
 		"searchKey": sprintf("aws_s3_bucket[%s]", [bucketName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'aws_s3_bucket' to not have 'aws_s3_bucket_website_configuration' associated",

--- a/assets/queries/terraform/aws_bom/s3_bucket/query.rego
+++ b/assets/queries/terraform/aws_bom/s3_bucket/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 
 	bom_output = {
 		"resource_type": "aws_s3_bucket",
-		"resource_name": tf_lib.resolve_bucket_name(bucket_resource, name),
+		"resource_name": tf_lib.resolve_s3_bucket_name(bucket_resource, name),
 		"resource_accessibility": info.accessibility,
 		"resource_encryption": get_encryption_if_exists(bucket_resource, name),
 		"resource_vendor": "AWS",

--- a/assets/queries/terraform/aws_bom/s3_bucket/query.rego
+++ b/assets/queries/terraform/aws_bom/s3_bucket/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 
 	bom_output = {
 		"resource_type": "aws_s3_bucket",
-		"resource_name": tf_lib.get_specific_resource_name(bucket_resource, "aws_s3_bucket", name),
+		"resource_name": tf_lib.resolve_bucket_name(bucket_resource, name),
 		"resource_accessibility": info.accessibility,
 		"resource_encryption": get_encryption_if_exists(bucket_resource, name),
 		"resource_vendor": "AWS",


### PR DESCRIPTION
## Motivation

Companion S3 resources (for example `aws_s3_bucket_policy`) often set `bucket` to a Terraform reference; findings then surfaced raw `${...}` strings as `resourceName` instead of the resolved bucket name, which hurts correlation with cloud inventory. This PR resolves same-scan `aws_s3_bucket.*` references where possible and falls back to the logical resource name otherwise.

## Changes

- Terraform library: `is_literal_string`, `resolve_reference_name`, `resolve_bucket_name`, and stricter `get_specific_resource_name` (no interpolation fragments in reported names), with Rego unit tests.
- AWS S3-related Terraform rules (plus CloudTrail log-bucket and S3 BOM queries) now use `resolve_bucket_name` for `resourceName`; cross-file fixture added for `s3_bucket_access_to_any_principal`.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run `go test ./test -count=1` from the repo root; optionally scan a sample Terraform tree with `aws_s3_bucket` + `aws_s3_bucket_policy` split across files and confirm SARIF `IAC_RESOURCE_NAME` shows the literal bucket name when resolvable.

## Blast Radius

This PR impacts Terraform query evaluation only: reported `resourceName` (and thus SARIF tags) for the touched rules when the bucket attribute is a resolvable same-scan reference.

## Additional Notes

I submit this contribution under the Apache-2.0 license.
