### PR TITLE
Remove CWE prefix in two gcp rules

### DIFF
--- a/assets/queries/terraform/gcp/legacy_networks_exist_for_project/metadata.json
+++ b/assets/queries/terraform/gcp/legacy_networks_exist_for_project/metadata.json
@@ -8,7 +8,7 @@
   "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/terraform/gcp/legacy_networks_exist_for_project",
   "platform": "Terraform",
   "cloudProvider": "GCP",
-  "cwe": "CWE-400",
+  "cwe": "400",
   "oldDescriptionText": "Ensures that no legacy networks with auto_create_subnetworks enabled exist in a project.",
   "providerUrl": "https://cloud.google.com/vpc/docs/legacy"
 }

--- a/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/metadata.json
+++ b/assets/queries/terraform/gcp/service_has_non_gcp_managed_service_account_keys/metadata.json
@@ -8,7 +8,7 @@
   "descriptionUrl": "https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/terraform/gcp/service_has_non_gcp_managed_service_account_keys",
   "platform": "Terraform",
   "cloudProvider": "GCP",
-  "cwe": "CWE-522",
+  "cwe": "522",
   "oldDescriptionText": "Ensures that only GCP-managed service account keys are used, preventing manually created keys that pose security risks.",
   "providerUrl": "https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys",
   "defaultFrameworks": [


### PR DESCRIPTION
## Motivation

I noticed `legacy_networks_exist_for_project` and `service_has_non_gcp_managed_service_account_keys` were the only rules where the CWE was prefixed with CWE- instead of the raw number, like all the other rules

## Changes

Remove from these two rules the CWE prefix

## Author Checklist

- [x] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

`go test ./test -run "TestQueries.*/legacy_networks_exist_for_project" -v -count=1` (optional; metadata-only change).

## Blast Radius

Single Terraform GCP rule metadata file.

## Additional Notes

I submit this contribution under the Apache-2.0 license.
