### PR TITLE
Kustomize foundations: model, bounded filesystem, Helm renderer

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -370,7 +370,7 @@ func getFeatureFlagEvaluator(_ *cli.Command) featureflags.FlagEvaluator {
 	overrides := map[string]bool{}
 	// Parallel parsing disabled: triggers race conditions in concurrent
 	// query workers causing non-deterministic violation counts.
-	// overrides[featureflags.IaCEnableKicsParallelFileParsing] = c.Bool("x-parallelparsing")
+	// overrides[featureflags.IacEnableKicsParallelFileParsing] = c.Bool("x-parallelparsing")
 	return featureflags.NewLocalEvaluatorWithOverrides(overrides)
 }
 

--- a/pkg/detector/default_detect.go
+++ b/pkg/detector/default_detect.go
@@ -100,3 +100,16 @@ func (d defaultDetectLine) prepareResolvedFiles(resFiles map[string]model.Resolv
 	}
 	return resolvedFiles
 }
+
+// DefaultYAMLDetectLine is the shared YAML/JSON line detector for subpackages (e.g. kustomize).
+type DefaultYAMLDetectLine struct{}
+
+// DetectLine forwards to the default path-based YAML detector.
+func (DefaultYAMLDetectLine) DetectLine(
+	ctx context.Context,
+	file *model.FileMetadata,
+	searchKey string,
+	outputLines int,
+) model.VulnerabilityLines {
+	return defaultDetectLine{}.DetectLine(ctx, file, searchKey, outputLines)
+}

--- a/pkg/featureflags/evaluator.go
+++ b/pkg/featureflags/evaluator.go
@@ -6,7 +6,8 @@ const (
 	IacDisableKicsRule               = "k9-iac-disable-kics-rule"
 	IacEnableKicsPlatform            = "k9-iac-enable-kics-platform"
 	IacEnableKicsHelmResolver        = "k9-iac-enable-kics-helm-resolver"
-	IaCEnableKicsParallelFileParsing = "k9-iac-enable-kics-parallel-file-parsing"
+	IacEnableKustomizeResolver       = "k9-iac-enable-kustomize-resolver"
+	IacEnableKicsParallelFileParsing = "k9-iac-enable-kics-parallel-file-parsing"
 )
 
 type FlagEvaluator interface {

--- a/pkg/featureflags/local_evaluator.go
+++ b/pkg/featureflags/local_evaluator.go
@@ -11,7 +11,8 @@ func NewLocalEvaluatorWithOverrides(overrides map[string]bool) *LocalEvaluator {
 		IacDisableKicsRule:               false,
 		IacEnableKicsPlatform:            true,
 		IacEnableKicsHelmResolver:        true,
-		IaCEnableKicsParallelFileParsing: false,
+		IacEnableKustomizeResolver:       false,
+		IacEnableKicsParallelFileParsing: false,
 	}
 
 	for k, v := range overrides {

--- a/pkg/kics/resolver_sink.go
+++ b/pkg/kics/resolver_sink.go
@@ -37,20 +37,25 @@ func (s *Service) resolverSink(
 
 	for _, rfile := range resFiles.File {
 		s.Tracker.TrackFileFound(rfile.FileName)
+		metadataPath := rfile.MetadataPath
+		if metadataPath == "" {
+			metadataPath = rfile.FileName
+		}
 
 		isMinified := minified.IsMinified(rfile.FileName, rfile.Content)
 		documents, err := s.Parser.Parse(ctx, rfile.FileName, rfile.Content, openAPIResolveReferences, isMinified, maxResolverDepth)
 		if err != nil {
-			if documents.Kind == "break" {
-				return []string{}, nil
+			// Skip this doc but keep iterating so resFiles.Excluded still propagates;
+			// otherwise the walker re-scans patches / generator inputs as raw YAML.
+			if documents.Kind != "break" {
+				contextLogger.Error().Msgf("failed to parse file content '%s' with fileType '%s'", rfile.FileName, kind)
 			}
-			contextLogger.Error().Msgf("failed to parse file content '%s' with fileType '%s'", rfile.FileName, kind)
-			return []string{}, nil
+			continue
 		}
 
 		if kind == model.KindHELM {
 			ignoreList, errorIL := s.getOriginalIgnoreLines(ctx,
-				rfile.FileName, rfile.OriginalData,
+				metadataPath, rfile.OriginalData,
 				openAPIResolveReferences, isMinified, maxResolverDepth)
 			if errorIL == nil {
 				documents.IgnoreLines = ignoreList
@@ -62,7 +67,7 @@ func (s *Service) resolverSink(
 			documents.CountLines = bytes.Count(rfile.OriginalData, []byte{'\n'}) + 1
 		}
 
-		fileCommands := s.Parser.CommentsCommands(ctx, rfile.FileName, rfile.OriginalData)
+		fileCommands := s.Parser.CommentsCommands(ctx, metadataPath, rfile.OriginalData)
 
 		for _, document := range documents.Docs {
 			_, err = json.Marshal(document)
@@ -89,6 +94,7 @@ func (s *Service) resolverSink(
 				ResolvedFiles:     documents.ResolvedFiles,
 				LinesOriginalData: utils.SplitLines(string(rfile.OriginalData)),
 				IsMinified:        documents.IsMinified,
+				KustomizeOrigin:   rfile.Origin,
 			}
 			s.saveToFile(ctx, &file)
 		}

--- a/pkg/kics/service.go
+++ b/pkg/kics/service.go
@@ -80,7 +80,7 @@ func (s *Service) PrepareSources(ctx context.Context,
 	contextLogger.Info().Msgf("Getting sources")
 	var err error
 	// TODO: Remove this if / else upon finishing dogfooding phase
-	if ok := flagEvaluator.EvaluateWithOrgAndEnv(featureflags.IaCEnableKicsParallelFileParsing); ok {
+	if ok := flagEvaluator.EvaluateWithOrgAndEnv(featureflags.IacEnableKicsParallelFileParsing); ok {
 		err = s.SourceProvider.GetParallelSources(
 			ctx,
 			s.Parser.SupportedExtensions(),
@@ -248,7 +248,11 @@ func prepareScanDocumentValue(bodyType map[string]interface{}, kind model.FileKi
 				prepareScanDocumentRoot(indx, kind)
 			}
 		case string:
-			if field, ok := lines[kind]; ok && utils.Contains(key, field) {
+			lookupKind := kind
+			if kind == model.KindKUSTOMIZE {
+				lookupKind = model.KindYAML
+			}
+			if field, ok := lines[lookupKind]; ok && utils.Contains(key, field) {
 				bodyType[key] = resolveJSONFilter(value)
 			}
 		}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -26,6 +26,7 @@ const (
 	KindPROTO     FileKind = "PROTO"
 	KindCOMMON    FileKind = "*"
 	KindHELM      FileKind = "HELM"
+	KindKUSTOMIZE FileKind = "KUSTOMIZE"
 	KindBUILDAH   FileKind = "SH"
 	KindCFG       FileKind = "CFG"
 	KindINI       FileKind = "INI"
@@ -151,6 +152,7 @@ type FileMetadata struct {
 	ResolvedFiles     map[string]ResolvedFile
 	LinesOriginalData *[]string
 	IsMinified        bool
+	KustomizeOrigin   *KustomizeOrigin
 }
 
 // QueryMetadata is a representation of general information about a query
@@ -227,17 +229,70 @@ type QueryConfig struct {
 
 // ResolvedFiles keeps the information of all file/template resolved
 type ResolvedFiles struct {
-	File     []ResolvedHelm
+	File     []ResolvedVirtual
 	Excluded []string
 }
 
-// ResolvedHelm keeps the information of a file/template resolved
-type ResolvedHelm struct {
+// ResolvedVirtual is one rendered virtual file from a preprocessor (Helm, Kustomize, …).
+type ResolvedVirtual struct {
 	FileName     string
+	MetadataPath string
 	Content      []byte
 	OriginalData []byte
 	SplitID      string
 	IDInfo       map[int]interface{}
+	Origin       *KustomizeOrigin
+}
+
+// ResolvedHelm is a legacy alias for ResolvedVirtual.
+type ResolvedHelm = ResolvedVirtual
+
+// KustomizeTransformation records a transformer step for provenance.
+type KustomizeTransformation struct {
+	TransformerPath string
+	ConfiguredIn    string
+	FieldPath       string
+}
+
+// KustomizeOrigin is provenance for a Kustomize-built resource.
+type KustomizeOrigin struct {
+	OriginKind          KustomizeOriginKind
+	SourceFile          string
+	SourceRepo          string
+	SourceRef           string
+	OriginalSourceFile  string
+	OriginalSourceRepo  string
+	OriginalSourceRef   string
+	GeneratorKind       string
+	ConfiguredByKind    string
+	ConfiguredByName    string
+	GeneratorConfigFile string
+	Transformations     []KustomizeTransformation
+	ResourceGVK         string
+	ResourceName        string
+}
+
+// KustomizeOriginKind classifies provenance back to source.
+type KustomizeOriginKind string
+
+const (
+	KustomizeOriginDirect       KustomizeOriginKind = "direct"
+	KustomizeOriginGenerator    KustomizeOriginKind = "generator"
+	KustomizeOriginTransformer  KustomizeOriginKind = "transformer"
+	KustomizeOriginHelmInflated KustomizeOriginKind = "helm_inflated"
+)
+
+// RequiresDetailedLineMapping skips the searchLine fast path (detector maps lines).
+func (o *KustomizeOrigin) RequiresDetailedLineMapping() bool {
+	if o == nil {
+		return false
+	}
+	switch o.OriginKind {
+	case KustomizeOriginGenerator, KustomizeOriginTransformer:
+		return true
+	default:
+		return false
+	}
 }
 
 // Extensions represents a list of supported extensions

--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -23,12 +23,8 @@ import (
 
 // credit: https://github.com/helm/helm
 
-var (
-	settings = cli.New()
-)
-
 func runInstall(ctx context.Context, args []string, client *action.Install,
-	valueOpts *values.Options) (*release.Release, []string, error) {
+	valueOpts *values.Options, opts *RenderOptions) (*release.Release, []string, error) {
 	contextLogger := logger.FromContext(ctx)
 	log.SetOutput(io.Discard)
 	defer log.SetOutput(os.Stderr)
@@ -46,16 +42,31 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 		return nil, []string{}, err
 	}
 	contextLogger.Debug().Msgf("Parsed chart name: '%s', chart path: '%s'", name, charts)
-	client.ReleaseName = name
+	if strings.TrimSpace(client.ReleaseName) == "" || client.GenerateName {
+		client.ReleaseName = name
+	}
 
-	cp, err := client.LocateChart(charts, settings)
+	helmSettings := cli.New()
+	repositoryConfig := strings.TrimSpace(opts.RepositoryConfig)
+	if repositoryConfig != "" {
+		helmSettings.RepositoryConfig = repositoryConfig
+	}
+	repositoryCache := strings.TrimSpace(opts.RepositoryCache)
+	if repositoryCache != "" {
+		helmSettings.RepositoryCache = repositoryCache
+	}
+	registryConfig := strings.TrimSpace(opts.RegistryConfig)
+	if registryConfig != "" {
+		helmSettings.RegistryConfig = registryConfig
+	}
+	cp, err := client.LocateChart(charts, helmSettings)
 	if err != nil {
 		contextLogger.Error().Msgf("failed to locate chart '%s': %s", charts, err)
 		return nil, []string{}, err
 	}
 	contextLogger.Debug().Msgf("Located chart at path: '%s'", cp)
 
-	p := getter.All(settings)
+	p := getter.All(helmSettings)
 	vals, err := valueOpts.MergeValues(p)
 	if err != nil {
 		contextLogger.Error().Msgf("failed to merge helm values: %s", err)
@@ -81,7 +92,6 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 	}
 	contextLogger.Debug().Msg("Chart installability check passed")
 
-	client.Namespace = "kics-namespace"
 	contextLogger.Debug().Msgf("Running helm chart with namespace: '%s', release name: '%s'", client.Namespace, client.ReleaseName)
 	helmRelease, err := client.Run(chartRequested, vals)
 	if err != nil {
@@ -105,8 +115,8 @@ func checkIfInstallable(ch *chart.Chart) error {
 	return errors.Errorf("%s charts are not installable (only 'application' type charts are supported)", ch.Metadata.Type)
 }
 
-// newClient will create a new instance on helm client used to render the chart
-func newClient(ctx context.Context) *action.Install {
+// newClient creates a Helm install client used to render the chart (dry-run).
+func newClient(ctx context.Context, opts *RenderOptions) *action.Install {
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("Creating new helm client for chart rendering")
 
@@ -114,13 +124,36 @@ func newClient(ctx context.Context) *action.Install {
 	client := action.NewInstall(cfg)
 	client.DryRun = true
 	client.ReleaseName = "kics-helm"
+	releaseName := strings.TrimSpace(opts.ReleaseName)
+	if releaseName != "" {
+		client.ReleaseName = releaseName
+	}
+	client.GenerateName = releaseName == ""
 	client.Replace = true // Skip the name check
 	client.ClientOnly = true
-	client.APIVersions = chartutil.VersionSet([]string{})
-	client.IncludeCRDs = false
+	client.APIVersions = chartutil.VersionSet(opts.APIVersions)
+	client.IncludeCRDs = opts.IncludeCRDs
+	client.DisableHooks = opts.SkipHooks
+	client.NameTemplate = strings.TrimSpace(opts.NameTemplate)
+	client.RepoURL = strings.TrimSpace(opts.ChartRepo)
+	client.Version = strings.TrimSpace(opts.Version)
+	client.Devel = opts.Devel
+	kubeVersion := strings.TrimSpace(opts.KubeVersion)
+	if kubeVersion != "" {
+		if kv, err := chartutil.ParseKubeVersion(kubeVersion); err == nil {
+			client.KubeVersion = kv
+		}
+	}
+	namespace := strings.TrimSpace(opts.Namespace)
+	if namespace != "" {
+		client.Namespace = namespace
+	} else {
+		client.Namespace = "kics-namespace"
+	}
 
-	contextLogger.Debug().Msgf("Configured helm client - DryRun: %t, ClientOnly: %t, IncludeCRDs: %t, ReleaseName: '%s'",
-		client.DryRun, client.ClientOnly, client.IncludeCRDs, client.ReleaseName)
+	contextLogger.Debug().
+		Msgf("Configured helm client - DryRun: %t, ClientOnly: %t, IncludeCRDs: %t, ReleaseName: '%s', Namespace: '%s', DisableHooks: %t",
+			client.DryRun, client.ClientOnly, client.IncludeCRDs, client.ReleaseName, client.Namespace, client.DisableHooks)
 
 	return client
 }

--- a/pkg/resolver/helm/render.go
+++ b/pkg/resolver/helm/render.go
@@ -1,0 +1,369 @@
+package helm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/cli/values"
+	"helm.sh/helm/v3/pkg/release"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
+	"sigs.k8s.io/kustomize/kyaml/yaml/merge2"
+)
+
+const (
+	kicsHelmID = "# KICS_HELM_ID_"
+
+	valuesMergeMerge    = "merge"
+	valuesMergeOverride = "override"
+	valuesMergeReplace  = "replace"
+)
+
+// splitManifest holds one manifest slice split by source.
+type splitManifest struct {
+	path       string
+	content    []byte
+	original   []byte
+	splitID    string
+	splitIDMap map[int]interface{}
+}
+
+// RenderOptions configures Helm chart rendering (dry-run template).
+type RenderOptions struct {
+	ChartPath        string
+	ChartRepo        string
+	ReleaseName      string
+	NameTemplate     string
+	Namespace        string
+	ValuesFiles      []string
+	SetValues        []string
+	ValuesInline     map[string]interface{}
+	ValuesMerge      string
+	IncludeCRDs      bool
+	SkipHooks        bool
+	SkipTests        bool
+	APIVersions      []string
+	KubeVersion      string
+	Version          string
+	Devel            bool
+	RepositoryConfig string
+	RepositoryCache  string
+	RegistryConfig   string
+}
+
+// RenderedChart is the output of RenderChart.
+type RenderedChart struct {
+	Resources []RenderedResource
+	Excluded  []string
+}
+
+// RenderedResource is one manifest document from a rendered chart.
+type RenderedResource struct {
+	SourceFile string
+	Content    []byte
+	Original   []byte
+	SplitID    string
+	IDInfo     map[int]interface{}
+}
+
+// RenderChart renders a chart at ChartPath using the Helm SDK (dry-run).
+func RenderChart(ctx context.Context, opts *RenderOptions) (*RenderedChart, error) {
+	if opts == nil {
+		return nil, errors.New("helm RenderOptions is nil")
+	}
+	contextLogger := logger.FromContext(ctx)
+	client := newClient(ctx, opts)
+	// Confine values files to the chart tree before they reach Helm; Helm's MergeValues
+	// would otherwise resolve relative paths against the scanner CWD and accept any absolute path.
+	normalizedFiles, err := normalizeValuesFiles(opts.ChartPath, opts.ValuesFiles)
+	if err != nil {
+		return nil, err
+	}
+	valueOpts := &values.Options{
+		ValueFiles: normalizedFiles,
+		Values:     opts.SetValues,
+	}
+	cleanup := func() {}
+	if len(opts.ValuesInline) > 0 {
+		var err error
+		cleanup, err = applyValuesInline(ctx, valueOpts, opts, normalizedFiles)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer cleanup()
+	manifest, excluded, err := runInstall(ctx, []string{opts.ChartPath}, client, valueOpts, opts)
+	if err != nil {
+		contextLogger.Error().Msgf("failed to run helm install for '%s': %s", opts.ChartPath, err)
+		return nil, errors.Wrap(err, "helm render")
+	}
+	splits, err := splitManifestYAML(manifest)
+	if err != nil {
+		return nil, err
+	}
+	out := &RenderedChart{Excluded: excluded}
+	for _, sp := range splits {
+		if opts.SkipTests && isHelmTestTemplate(sp.path) {
+			continue
+		}
+		out.Resources = append(out.Resources, RenderedResource{
+			SourceFile: sp.path,
+			Content:    sp.content,
+			Original:   sp.original,
+			SplitID:    sp.splitID,
+			IDInfo:     sp.splitIDMap,
+		})
+	}
+	return out, nil
+}
+
+func applyValuesInline(ctx context.Context, valueOpts *values.Options, opts *RenderOptions, normalizedFiles []string) (func(), error) {
+	if opts == nil {
+		return func() {}, errors.New("helm RenderOptions is nil")
+	}
+	contextLogger := logger.FromContext(ctx)
+	inlineBytes, err := mergedValuesInlineBytes(opts, normalizedFiles)
+	if err != nil {
+		return func() {}, err
+	}
+	if len(inlineBytes) == 0 {
+		return func() {}, nil
+	}
+	f, err := os.CreateTemp("", "iac-scanner-helm-values-*.yaml")
+	if err != nil {
+		return func() {}, errors.Wrap(err, "create helm values temp file")
+	}
+	if _, err := f.Write(inlineBytes); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return func() {}, errors.Wrap(err, "write merged inline helm values")
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return func() {}, errors.Wrap(err, "close merged inline helm values")
+	}
+	contextLogger.Debug().Msgf("wrote inline helm values to %s", f.Name())
+	// Single temp file replaces ValueFiles so inline merge is not applied twice.
+	valueOpts.ValueFiles = []string{f.Name()}
+	return func() {
+		_ = os.Remove(f.Name())
+	}, nil
+}
+
+func mergedValuesInlineBytes(opts *RenderOptions, normalizedFiles []string) ([]byte, error) {
+	if opts == nil {
+		return nil, errors.New("helm RenderOptions is nil")
+	}
+	mergeMode := strings.TrimSpace(opts.ValuesMerge)
+	if mergeMode == "" {
+		mergeMode = valuesMergeOverride
+	}
+	switch mergeMode {
+	case valuesMergeReplace:
+		return kyaml.Marshal(opts.ValuesInline)
+	case valuesMergeMerge, valuesMergeOverride:
+	default:
+		return nil, errors.Errorf("invalid helm valuesMerge %q", opts.ValuesMerge)
+	}
+	if len(normalizedFiles) == 0 {
+		return kyaml.Marshal(opts.ValuesInline)
+	}
+	baseNode, err := mergeHelmValueFilesToBaseNode(normalizedFiles)
+	if err != nil {
+		return nil, err
+	}
+	return mergeInlineYAMLWithBase(mergeMode, baseNode, opts.ValuesInline)
+}
+
+// mergeHelmValueFilesToBaseNode merges valueFiles in order (later wins).
+// Paths must already be confined to the chart tree by normalizeValuesFiles.
+func mergeHelmValueFilesToBaseNode(valueFiles []string) (*kyaml.RNode, error) {
+	var baseNode *kyaml.RNode
+	for i, safePath := range valueFiles {
+		baseBytes, err := readChartContainedValuesFile(safePath)
+		if err != nil {
+			return nil, errors.Wrap(err, "read helm base values file")
+		}
+		currentNode, err := kyaml.Parse(string(baseBytes))
+		if err != nil {
+			return nil, errors.Wrap(err, "parse helm base values file")
+		}
+		if i == 0 {
+			baseNode = currentNode
+			continue
+		}
+		// Later values files win over earlier ones (Helm precedence), then inline merges on top.
+		baseNode, err = merge2.Merge(currentNode, baseNode.Copy(), kyaml.MergeOptions{})
+		if err != nil {
+			return nil, errors.Wrap(err, "merge helm base values files")
+		}
+	}
+	return baseNode, nil
+}
+
+func mergeInlineYAMLWithBase(mergeMode string, baseNode *kyaml.RNode, inline map[string]interface{}) ([]byte, error) {
+	inlineNode, err := kyaml.FromMap(inline)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse inline helm values")
+	}
+	var outValues *kyaml.RNode
+	switch mergeMode {
+	case valuesMergeOverride:
+		outValues, err = merge2.Merge(inlineNode, baseNode.Copy(), kyaml.MergeOptions{})
+	case valuesMergeMerge:
+		outValues, err = merge2.Merge(baseNode, inlineNode.Copy(), kyaml.MergeOptions{})
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "merge helm inline values")
+	}
+	return []byte(outValues.MustString()), nil
+}
+
+// readChartContainedValuesFile reads bytes from absPath; absPath must come from valuesFilePathForRead.
+func readChartContainedValuesFile(absPath string) ([]byte, error) {
+	//nolint:gosec // G304: absPath is only ever valuesFilePathForRead output (under chart directory).
+	return os.ReadFile(absPath)
+}
+
+// normalizeValuesFiles returns chart-tree-confined absolute paths for each entry, preserving order.
+// Returns nil for an empty input so callers can treat it as "no values files".
+func normalizeValuesFiles(chartPath string, files []string) ([]string, error) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(files))
+	for _, f := range files {
+		safe, err := valuesFilePathForRead(chartPath, f)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, safe)
+	}
+	return out, nil
+}
+
+// valuesFilePathForRead returns an absolute path to valuesFile only if it resolves under the chart directory.
+// Both sides are evaluated through filepath.EvalSymlinks so a symlink inside the chart that points outside
+// the chart tree is rejected; a lexical Rel/IsLocal check alone is unsafe because os.ReadFile follows symlinks.
+func valuesFilePathForRead(chartPath, valuesFile string) (string, error) {
+	chartAbs, err := filepath.Abs(chartPath)
+	if err != nil {
+		return "", errors.Wrap(err, "resolve chart path")
+	}
+	chartAbs = filepath.Clean(chartAbs)
+	if ev, err := filepath.EvalSymlinks(chartAbs); err == nil {
+		chartAbs = filepath.Clean(ev)
+	}
+	var p string
+	if filepath.IsAbs(valuesFile) {
+		p = filepath.Clean(valuesFile)
+	} else {
+		p = filepath.Clean(filepath.Join(chartAbs, valuesFile))
+	}
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return "", errors.Wrapf(err, "resolve values file %q", valuesFile)
+	}
+	resolved = filepath.Clean(resolved)
+	rel, err := filepath.Rel(chartAbs, resolved)
+	if err != nil || !filepath.IsLocal(rel) {
+		return "", errors.Errorf("values file %q is outside chart directory", valuesFile)
+	}
+	return resolved, nil
+}
+
+func isHelmTestTemplate(path string) bool {
+	path = filepath.ToSlash(path)
+	return strings.Contains(path, "/tests/") || strings.HasPrefix(path, "tests/")
+}
+
+func splitManifestYAML(template *release.Release) ([]splitManifest, error) {
+	var sources []*chart.File
+	sources = updateName(sources, template.Chart, template.Chart.Name())
+	var splitedManifest []splitManifest
+	splitedSource := strings.Split(template.Manifest, "---")
+	origData := toMap(sources)
+	for _, splited := range splitedSource {
+		var lineID string
+		for _, line := range strings.Split(splited, "\n") {
+			if strings.Contains(line, kicsHelmID) {
+				lineID = line
+				break
+			}
+		}
+		path := strings.Split(strings.TrimPrefix(splited, "\n# Source: "), "\n")
+		if path[0] == "" {
+			continue
+		}
+		if origData[filepath.FromSlash(path[0])] == nil {
+			continue
+		}
+		idMap, err := getIDMap(origData[filepath.FromSlash(path[0])])
+		if err != nil {
+			return nil, err
+		}
+		splitedManifest = append(splitedManifest, splitManifest{
+			path:       path[0],
+			content:    []byte(strings.ReplaceAll(splited, "\r", "")),
+			original:   origData[filepath.FromSlash(path[0])],
+			splitID:    lineID,
+			splitIDMap: idMap,
+		})
+	}
+	return splitedManifest, nil
+}
+
+func toMap(files []*chart.File) map[string][]byte {
+	mapFiles := make(map[string][]byte)
+	for _, file := range files {
+		mapFiles[file.Name] = []byte(strings.ReplaceAll(string(file.Data), "\r", ""))
+	}
+	return mapFiles
+}
+
+func updateName(template []*chart.File, charts *chart.Chart, name string) []*chart.File {
+	if name != charts.Name() {
+		name = filepath.Join(name, charts.Name())
+	}
+	for _, temp := range charts.Templates {
+		temp.Name = filepath.Join(name, temp.Name)
+	}
+	template = append(template, charts.Templates...)
+	for _, dep := range charts.Dependencies() {
+		template = updateName(template, dep, filepath.Join(name, "charts"))
+	}
+	return template
+}
+
+func getIDMap(originalData []byte) (map[int]interface{}, error) {
+	ids := make(map[int]interface{})
+	mapLines := make(map[int]int)
+	idHelm := -1
+	for line, stringLine := range strings.Split(string(originalData), "\n") {
+		if strings.Contains(stringLine, kicsHelmID) {
+			id, err := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(stringLine, kicsHelmID), ":"))
+			if err != nil {
+				return nil, err
+			}
+			if idHelm == -1 {
+				idHelm = id
+				mapLines[line] = line
+			} else {
+				ids[idHelm] = mapLines
+				mapLines = make(map[int]int)
+				idHelm = id
+				mapLines[line] = line
+			}
+		} else if idHelm != -1 {
+			mapLines[line] = line
+		}
+	}
+	ids[idHelm] = mapLines
+
+	return ids, nil
+}

--- a/pkg/resolver/helm/render_test.go
+++ b/pkg/resolver/helm/render_test.go
@@ -1,0 +1,212 @@
+package helm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/cli/values"
+)
+
+func testHelmFixtureChartDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	return filepath.Join(filepath.Dir(file), "..", "..", "..", "test", "fixtures", "test_helm")
+}
+
+func TestRenderChart_invalidChartPath(t *testing.T) {
+	ctx := context.Background()
+	_, err := RenderChart(ctx, &RenderOptions{
+		ChartPath:   "/this/path/does/not/exist/chart",
+		IncludeCRDs: true,
+	})
+	require.Error(t, err)
+}
+
+func TestRenderChart_valuesInlineAndSkipTests(t *testing.T) {
+	ctx := context.Background()
+	chartDir := testHelmFixtureChartDir(t)
+	out, err := RenderChart(ctx, &RenderOptions{
+		ChartPath:   chartDir,
+		IncludeCRDs: true,
+		SkipTests:   true,
+		ValuesInline: map[string]interface{}{
+			"service": map[string]interface{}{
+				"port": 9090,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, out.Resources)
+	var joined strings.Builder
+	for _, r := range out.Resources {
+		joined.Write(r.Content)
+	}
+	require.Contains(t, joined.String(), "9090")
+}
+
+func TestMergedValuesInlineBytes_UsesAllValuesFilesBeforeInline(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "base.yaml")
+	override := filepath.Join(dir, "override.yaml")
+	require.NoError(t, os.WriteFile(base, []byte("service:\n  port: 80\n  type: ClusterIP\n"), 0o600))
+	require.NoError(t, os.WriteFile(override, []byte("service:\n  port: 8080\n"), 0o600))
+
+	opts := &RenderOptions{
+		ChartPath:   dir,
+		ValuesFiles: []string{base, override},
+		ValuesInline: map[string]interface{}{
+			"service": map[string]interface{}{
+				"type": "LoadBalancer",
+			},
+		},
+		ValuesMerge: valuesMergeOverride,
+	}
+	normalizedFiles, err := normalizeValuesFiles(opts.ChartPath, opts.ValuesFiles)
+	require.NoError(t, err)
+	out, err := mergedValuesInlineBytes(opts, normalizedFiles)
+	require.NoError(t, err)
+	txt := string(out)
+	require.Contains(t, txt, "port: 8080")
+	require.Contains(t, txt, "type: LoadBalancer")
+}
+
+func TestApplyValuesInline_ReplacesWholeValuesFileStack(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	base := filepath.Join(dir, "base.yaml")
+	override := filepath.Join(dir, "override.yaml")
+	require.NoError(t, os.WriteFile(base, []byte("service:\n  port: 80\n"), 0o600))
+	require.NoError(t, os.WriteFile(override, []byte("service:\n  port: 8080\n"), 0o600))
+
+	valueOpts := &values.Options{ValueFiles: []string{base, override}}
+	opts := &RenderOptions{
+		ChartPath:   dir,
+		ValuesFiles: []string{base, override},
+		ValuesInline: map[string]interface{}{
+			"service": map[string]interface{}{
+				"type": "LoadBalancer",
+			},
+		},
+		ValuesMerge: valuesMergeOverride,
+	}
+	normalizedFiles, err := normalizeValuesFiles(opts.ChartPath, opts.ValuesFiles)
+	require.NoError(t, err)
+	cleanup, err := applyValuesInline(ctx, valueOpts, opts, normalizedFiles)
+	require.NoError(t, err)
+	defer cleanup()
+	require.Len(t, valueOpts.ValueFiles, 1)
+	require.NotEqual(t, base, valueOpts.ValueFiles[0])
+	require.NotEqual(t, override, valueOpts.ValueFiles[0])
+}
+
+func TestApplyValuesInline_CleanupRemovesTempFile(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	base := filepath.Join(dir, "base.yaml")
+	require.NoError(t, os.WriteFile(base, []byte("service:\n  port: 80\n"), 0o600))
+
+	valueOpts := &values.Options{ValueFiles: []string{base}}
+	opts := &RenderOptions{
+		ChartPath:   dir,
+		ValuesFiles: []string{base},
+		ValuesInline: map[string]interface{}{
+			"service": map[string]interface{}{
+				"type": "LoadBalancer",
+			},
+		},
+		ValuesMerge: valuesMergeOverride,
+	}
+	normalizedFiles, err := normalizeValuesFiles(opts.ChartPath, opts.ValuesFiles)
+	require.NoError(t, err)
+	cleanup, err := applyValuesInline(ctx, valueOpts, opts, normalizedFiles)
+	require.NoError(t, err)
+	require.Len(t, valueOpts.ValueFiles, 1)
+	tempPath := valueOpts.ValueFiles[0]
+	_, statErr := os.Stat(tempPath)
+	require.NoError(t, statErr)
+
+	cleanup()
+
+	_, statErr = os.Stat(tempPath)
+	require.Error(t, statErr)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+// Regression: a values file outside the chart tree must be rejected even when
+// no ValuesInline is provided (the inline-only normalization path is bypassed).
+func TestRenderChart_RejectsExternalValuesFileWithoutInline(t *testing.T) {
+	ctx := context.Background()
+	chartDir := testHelmFixtureChartDir(t)
+	outsideDir := t.TempDir()
+	external := filepath.Join(outsideDir, "external.yaml")
+	require.NoError(t, os.WriteFile(external, []byte("service:\n  port: 9090\n"), 0o600))
+
+	_, err := RenderChart(ctx, &RenderOptions{
+		ChartPath:   chartDir,
+		ValuesFiles: []string{external},
+		IncludeCRDs: true,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "outside chart directory")
+}
+
+// Regression: a relative values file must resolve against ChartPath, not the scanner CWD.
+func TestNormalizeValuesFiles_RelativeResolvesToChartPath(t *testing.T) {
+	chartDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte("a: 1\n"), 0o600))
+
+	out, err := normalizeValuesFiles(chartDir, []string{"values.yaml"})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.True(t, filepath.IsAbs(out[0]))
+	require.Equal(t, "values.yaml", filepath.Base(out[0]))
+}
+
+func TestValuesFilePathForRead_RejectsSymlinkEscape(t *testing.T) {
+	chartDir := t.TempDir()
+	outsideDir := t.TempDir()
+	secret := filepath.Join(outsideDir, "secret.yaml")
+	require.NoError(t, os.WriteFile(secret, []byte("password: hunter2\n"), 0o600))
+
+	link := filepath.Join(chartDir, "values.yaml")
+	require.NoError(t, os.Symlink(secret, link))
+
+	_, err := valuesFilePathForRead(chartDir, "values.yaml")
+	require.Error(t, err, "symlinked values file pointing outside the chart must be rejected")
+}
+
+func TestValuesFilePathForRead_AcceptsSymlinkInsideChart(t *testing.T) {
+	chartDir := t.TempDir()
+	real := filepath.Join(chartDir, "real-values.yaml")
+	require.NoError(t, os.WriteFile(real, []byte("service:\n  port: 80\n"), 0o600))
+	link := filepath.Join(chartDir, "values.yaml")
+	require.NoError(t, os.Symlink(real, link))
+
+	p, err := valuesFilePathForRead(chartDir, "values.yaml")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Base(real), filepath.Base(p), "symlinked values file inside chart should be accepted and resolved")
+}
+
+func TestRenderChart_PreservesExplicitReleaseName(t *testing.T) {
+	ctx := context.Background()
+	chartDir := testHelmFixtureChartDir(t)
+	out, err := RenderChart(ctx, &RenderOptions{
+		ChartPath:    chartDir,
+		ReleaseName:  "custom-release",
+		IncludeCRDs:  true,
+		ValuesInline: map[string]interface{}{},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, out.Resources)
+	var joined strings.Builder
+	for _, r := range out.Resources {
+		joined.Write(r.Content)
+	}
+	require.Contains(t, joined.String(), "custom-release")
+}

--- a/pkg/resolver/helm/resolver.go
+++ b/pkg/resolver/helm/resolver.go
@@ -2,196 +2,93 @@ package helm
 
 import (
 	"context"
+	"os"
 	"path/filepath"
-	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	masterUtils "github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/pkg/errors"
-	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/cli/values"
-	"helm.sh/helm/v3/pkg/release"
 )
 
-// Resolver is an instance of the helm resolver
+// Resolver is an instance of the helm preprocessor.
 type Resolver struct {
+	IncludeCRDs bool
 }
 
-// splitManifest keeps the information of the manifest splitted by source
-type splitManifest struct {
-	path       string
-	content    []byte
-	original   []byte
-	splitID    string
-	splitIDMap map[int]interface{}
+// NewResolver returns a Helm preprocessor with CRDs included in rendered output (recommended default).
+func NewResolver() *Resolver {
+	return &Resolver{IncludeCRDs: true}
 }
 
-const (
-	kicsHelmID = "# KICS_HELM_ID_"
-)
+// NewResolverWithIncludeCRDs returns a Helm preprocessor with explicit IncludeCRDs behavior.
+func NewResolverWithIncludeCRDs(includeCRDs bool) *Resolver {
+	return &Resolver{IncludeCRDs: includeCRDs}
+}
 
-// Resolve will render the passed helm chart and return its content ready for parsing
+// Name implements resolver.Preprocessor.
+func (r *Resolver) Name() string {
+	return "helm"
+}
+
+// Detect returns (KindHELM, true) when path is a chart directory.
+func (r *Resolver) Detect(path string) (model.FileKind, bool) {
+	_, err := os.Stat(filepath.Join(path, "Chart.yaml"))
+	if err != nil {
+		return model.KindCOMMON, false
+	}
+	return model.KindHELM, true
+}
+
+// Resolve renders the passed helm chart and returns manifests ready for parsing.
 func (r *Resolver) Resolve(ctx context.Context, filePath string) (model.ResolvedFiles, error) {
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("Resolving Helm files")
-	// handle panic during resolve process
 	defer func() {
-		if r := recover(); r != nil {
+		if rec := recover(); rec != nil {
 			errMessage := "Recovered from panic during resolve of file " + filePath
-			masterUtils.HandlePanic(ctx, r, errMessage)
+			masterUtils.HandlePanic(ctx, rec, errMessage)
 		}
 	}()
-	splits, excluded, err := renderHelm(ctx, filePath)
-	if err != nil { // return error to be logged
-		return model.ResolvedFiles{}, errors.New("failed to render helm chart")
+
+	rc, err := RenderChart(ctx, &RenderOptions{
+		ChartPath:   filePath,
+		IncludeCRDs: r.IncludeCRDs,
+	})
+	if err != nil {
+		return model.ResolvedFiles{}, errors.Wrap(err, "failed to render helm chart")
 	}
+
 	var rfiles = model.ResolvedFiles{
-		Excluded: excluded,
+		Excluded: rc.Excluded,
 	}
-	contextLogger.Debug().Msgf("Processing %d helm manifest splits from chart '%s'", len(*splits), filePath)
-	for _, split := range *splits {
+	contextLogger.Debug().Msgf("Processing %d helm manifest splits from chart '%s'", len(rc.Resources), filePath)
+	for _, res := range rc.Resources {
 		subFolder := filepath.Base(filePath)
-
-		splitPath := strings.Split(split.path, getPathSeparator(split.path))
-
+		splitPath := strings.Split(res.SourceFile, getPathSeparator(res.SourceFile))
 		splited := filepath.Join(splitPath[1:]...)
-
 		origpath := filepath.Join(filepath.Dir(filePath), subFolder, splited)
-		rfiles.File = append(rfiles.File, model.ResolvedHelm{
+		rfiles.File = append(rfiles.File, model.ResolvedVirtual{
 			FileName:     origpath,
-			Content:      split.content,
-			OriginalData: split.original,
-			SplitID:      split.splitID,
-			IDInfo:       split.splitIDMap,
+			Content:      res.Content,
+			OriginalData: res.Original,
+			SplitID:      res.SplitID,
+			IDInfo:       res.IDInfo,
 		})
 	}
-	contextLogger.Debug().Msgf("Successfully processed %d helm files from chart '%s'", len(*splits), filePath)
+	contextLogger.Debug().Msgf("Successfully processed %d helm files from chart '%s'", len(rc.Resources), filePath)
 	return rfiles, nil
 }
 
-// SupportedTypes returns the supported fileKinds for this resolver
+// SupportedTypes returns the supported file kinds for this preprocessor.
 func (r *Resolver) SupportedTypes() []model.FileKind {
 	return []model.FileKind{model.KindHELM}
 }
 
-// renderHelm will use helm library to render helm charts
-func renderHelm(ctx context.Context, path string) (*[]splitManifest, []string, error) {
-	contextLogger := logger.FromContext(ctx)
-	client := newClient(ctx)
-	contextLogger.Debug().Msg("Running helm install")
-	manifest, excluded, err := runInstall(ctx, []string{path}, client, &values.Options{})
-	if err != nil {
-		contextLogger.Error().Msgf("failed to run helm install '%s': %s", path, err)
-		return nil, []string{}, err
-	}
-	splitted, err := splitManifestYAML(manifest)
-	if err != nil {
-		contextLogger.Error().Msgf("failed to split helm manifest YAML for chart '%s': %s", path, err)
-		return nil, []string{}, err
-	}
-	return splitted, excluded, nil
-}
-
-// splitManifestYAML will split the rendered file and return its content by template as well as the template path
-func splitManifestYAML(template *release.Release) (*[]splitManifest, error) {
-	sources := make([]*chart.File, 0)
-	sources = updateName(sources, template.Chart, template.Chart.Name())
-	var splitedManifest []splitManifest
-	splitedSource := strings.Split(template.Manifest, "---") // split manifest by '---'
-	origData := toMap(sources)
-	for _, splited := range splitedSource {
-		var lineID string
-		for _, line := range strings.Split(splited, "\n") {
-			if strings.Contains(line, kicsHelmID) {
-				lineID = line // get auxiliary line id
-				break
-			}
-		}
-		path := strings.Split(strings.TrimPrefix(splited, "\n# Source: "), "\n") // get source of split yaml
-		// ignore auxiliary files used to render chart
-		if path[0] == "" {
-			continue
-		}
-		if origData[filepath.FromSlash(path[0])] == nil {
-			continue
-		}
-		idMap, err := getIDMap(origData[filepath.FromSlash(path[0])])
-		if err != nil {
-			return nil, err
-		}
-		splitedManifest = append(splitedManifest, splitManifest{
-			path:       path[0],
-			content:    []byte(strings.ReplaceAll(splited, "\r", "")),
-			original:   origData[filepath.FromSlash(path[0])], // get original data from template
-			splitID:    lineID,
-			splitIDMap: idMap,
-		})
-	}
-	return &splitedManifest, nil
-}
-
-// toMap will convert to map original data having the path as it's key
-func toMap(files []*chart.File) map[string][]byte {
-	mapFiles := make(map[string][]byte)
-	for _, file := range files {
-		mapFiles[file.Name] = []byte(strings.ReplaceAll(string(file.Data), "\r", ""))
-	}
-	return mapFiles
-}
-
-// updateName will update the templates name as well as its dependencies
-func updateName(template []*chart.File, charts *chart.Chart, name string) []*chart.File {
-	if name != charts.Name() {
-		name = filepath.Join(name, charts.Name())
-	}
-	for _, temp := range charts.Templates {
-		temp.Name = filepath.Join(name, temp.Name)
-	}
-	template = append(template, charts.Templates...)
-	for _, dep := range charts.Dependencies() {
-		template = updateName(template, dep, filepath.Join(name, "charts"))
-	}
-	return template
-}
-
-// getIdMap will construct a map with ids with the corresponding lines as keys
-// for use in detector
-func getIDMap(originalData []byte) (map[int]interface{}, error) {
-	ids := make(map[int]interface{})
-	mapLines := make(map[int]int)
-	idHelm := -1
-	for line, stringLine := range strings.Split(string(originalData), "\n") {
-		if strings.Contains(stringLine, kicsHelmID) {
-			id, err := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(stringLine, kicsHelmID), ":"))
-			if err != nil {
-				return nil, err
-			}
-			if idHelm == -1 {
-				idHelm = id
-				mapLines[line] = line
-			} else {
-				ids[idHelm] = mapLines
-				mapLines = make(map[int]int)
-				idHelm = id
-				mapLines[line] = line
-			}
-		} else if idHelm != -1 {
-			mapLines[line] = line
-		}
-	}
-	ids[idHelm] = mapLines
-
-	return ids, nil
-}
-
 func getPathSeparator(path string) string {
-	if matched, err := regexp.MatchString(`[a-zA-Z0-9_\/-]+(\[a-zA-Z0-9_\/-]+)*`, path); matched && err == nil {
-		return "/"
-	} else if matched, err := regexp.MatchString(`[a-z0-9_.$-]+(\\[a-z0-9_.$-]+)*`, path); matched && err == nil {
+	if strings.Contains(path, "\\") {
 		return "\\"
 	}
-	return ""
+	return "/"
 }

--- a/pkg/resolver/helm/resolver_test.go
+++ b/pkg/resolver/helm/resolver_test.go
@@ -22,7 +22,8 @@ func TestHelm_SupportedTypes(t *testing.T) {
 }
 
 func TestHelm_Resolve(t *testing.T) { //nolint
-	res := &Resolver{}
+	// Match legacy snapshots: CRDs were off before the refactor default flip.
+	res := NewResolverWithIncludeCRDs(false)
 	type args struct {
 		filePath string
 	}
@@ -38,7 +39,7 @@ func TestHelm_Resolve(t *testing.T) { //nolint
 				filePath: filepath.FromSlash("../../../test/fixtures/test_helm"),
 			},
 			want: model.ResolvedFiles{
-				File: []model.ResolvedHelm{
+				File: []model.ResolvedVirtual{
 					{
 						SplitID:  "# KICS_HELM_ID_0:",
 						FileName: filepath.FromSlash("../../../test/fixtures/test_helm/templates/service.yaml"),
@@ -95,7 +96,6 @@ spec:
 			args: args{
 				filePath: filepath.FromSlash("../../../test/fixtures/all_auth_users_get_read_access"),
 			},
-			want:    model.ResolvedFiles{},
 			wantErr: true,
 		},
 		{
@@ -104,7 +104,7 @@ spec:
 				filePath: filepath.FromSlash("../../../test/fixtures/test_helm_subchart"),
 			},
 			want: model.ResolvedFiles{
-				File: []model.ResolvedHelm{
+				File: []model.ResolvedVirtual{
 					{
 						FileName: filepath.FromSlash("../../../test/fixtures/test_helm_subchart/templates/serviceaccount.yaml"),
 						SplitID:  "# KICS_HELM_ID_1:",
@@ -199,12 +199,13 @@ spec:
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Resolve() = %v, wantErr = %v", err, tt.wantErr)
 			}
+			if tt.wantErr {
+				return
+			}
 			if !reflect.DeepEqual(got.File, tt.want.File) {
 				t.Errorf("Resolve() = %v, want = %v", got, tt.want)
 			}
-			if err == nil {
-				require.NotEmpty(t, got.Excluded)
-			}
+			require.NotEmpty(t, got.Excluded)
 		})
 	}
 }

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -7,81 +7,81 @@ package resolver
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 )
 
-// kindResolver is a type of resolver interface (ex: helm resolver)
-// Resolve will render file/template
-// SupportedTypes will return the file kinds that the resolver supports
-type kindResolver interface {
-	Resolve(ctx context.Context, filePath string) (model.ResolvedFiles, error)
+// Preprocessor expands composed IaC (Helm, Kustomize, …) into files for parsing.
+type Preprocessor interface {
+	Resolve(ctx context.Context, rootDir string) (model.ResolvedFiles, error)
 	SupportedTypes() []model.FileKind
+	Name() string
+	Detect(path string) (model.FileKind, bool)
 }
 
-// Resolver is a struct containing the resolvers by file kind
+// Resolver dispatches to preprocessors by file kind.
 type Resolver struct {
-	resolvers map[model.FileKind]kindResolver
+	byKind  map[model.FileKind]Preprocessor
+	ordered []Preprocessor
 }
 
-// Builder is a struct used to create a new resolver
+// Builder constructs a Resolver from preprocessors.
 type Builder struct {
-	resolvers []kindResolver
+	preprocessors []Preprocessor
 }
 
-// NewBuilder creates a new Builder's reference
+// NewBuilder creates a new Builder.
 func NewBuilder() *Builder {
 	return &Builder{}
 }
 
-// Add will add kindResolvers for building the resolver
-func (b *Builder) Add(ctx context.Context, p kindResolver) *Builder {
+// Add registers a preprocessor (call order is preserved for GetType detection).
+func (b *Builder) Add(ctx context.Context, p Preprocessor) *Builder {
 	contextLogger := logger.FromContext(ctx)
-	contextLogger.Debug().Msgf("resolver.Add()")
-	b.resolvers = append(b.resolvers, p)
+	contextLogger.Debug().Msgf("resolver.Add(%s)", p.Name())
+	b.preprocessors = append(b.preprocessors, p)
 	return b
 }
 
-// Build will create a new instance of a resolver
+// Build creates the Resolver. Later preprocessors overwrite byKind for the same FileKind.
 func (b *Builder) Build(ctx context.Context) (*Resolver, error) {
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("resolver.Build()")
 
-	resolvers := make(map[model.FileKind]kindResolver, len(b.resolvers))
-	for _, resolver := range b.resolvers {
-		for _, typeRes := range resolver.SupportedTypes() {
-			resolvers[typeRes] = resolver
+	byKind := make(map[model.FileKind]Preprocessor)
+	for _, p := range b.preprocessors {
+		for _, t := range p.SupportedTypes() {
+			byKind[t] = p
 		}
 	}
 
 	return &Resolver{
-		resolvers: resolvers,
+		byKind:  byKind,
+		ordered: append([]Preprocessor(nil), b.preprocessors...),
 	}, nil
 }
 
-// Resolve will resolve the files according to its type
+// Resolve runs the preprocessor for the given kind.
 func (r *Resolver) Resolve(ctx context.Context, filePath string, kind model.FileKind) (model.ResolvedFiles, error) {
 	contextLogger := logger.FromContext(ctx)
-	if r, ok := r.resolvers[kind]; ok {
-		obj, err := r.Resolve(ctx, filePath)
+	if p, ok := r.byKind[kind]; ok {
+		obj, err := p.Resolve(ctx, filePath)
 		if err != nil {
 			return model.ResolvedFiles{}, err
 		}
 		contextLogger.Debug().Msgf("resolver.Resolve() rendered file: %s", filePath)
 		return obj, nil
 	}
-	// need to log here
 	return model.ResolvedFiles{}, nil
 }
 
-// GetType will analyze the filepath to determine which resolver to use
+// GetType picks a preprocessor for a directory; registration order matters (Helm before Kustomize for Chart.yaml dirs).
 func (r *Resolver) GetType(filePath string) model.FileKind {
-	_, err := os.Stat(filepath.Join(filePath, "Chart.yaml"))
-	if err == nil {
-		return model.KindHELM
+	for _, p := range r.ordered {
+		if k, ok := p.Detect(filePath); ok {
+			return k
+		}
 	}
 	return model.KindCOMMON
 }

--- a/pkg/resolver/sandbox/bounded_fs.go
+++ b/pkg/resolver/sandbox/bounded_fs.go
@@ -1,0 +1,232 @@
+package sandbox
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+// BoundedFS wraps a kustomize FileSystem and rejects paths outside repoRoot.
+type BoundedFS struct {
+	inner   filesys.FileSystem
+	repoAbs string
+}
+
+// NewBoundedFS returns a disk-backed filesystem bounded to repoRoot (must exist).
+func NewBoundedFS(repoRoot string) (*BoundedFS, error) {
+	abs, err := canonicalPath(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	if st, err := os.Stat(abs); err != nil || !st.IsDir() {
+		return nil, fmt.Errorf("sandbox: repo root %q is not a directory", abs)
+	}
+	return &BoundedFS{
+		inner:   filesys.MakeFsOnDisk(),
+		repoAbs: filepath.Clean(abs),
+	}, nil
+}
+
+func (b *BoundedFS) under(abs string) bool {
+	cp, err := canonicalPath(abs)
+	if err != nil {
+		cp = filepath.Clean(abs)
+	}
+	return cp == b.repoAbs || strings.HasPrefix(cp, b.repoAbs+string(filepath.Separator))
+}
+
+func (b *BoundedFS) checkCleaned(d filesys.ConfirmedDir, f string, resolveLeaf bool) error {
+	full, err := canonicalPath(filepath.Join(string(d), f))
+	if err != nil {
+		full = filepath.Clean(filepath.Join(string(d), f))
+	}
+	if err := b.checkParents(full); err != nil {
+		return err
+	}
+	if !resolveLeaf {
+		if parent := filepath.Dir(full); parent != full {
+			if ev, err := filepath.EvalSymlinks(parent); err == nil {
+				full = filepath.Join(filepath.Clean(ev), filepath.Base(full))
+			}
+		}
+		// Writes follow leaf symlinks at the OS layer, which would let a
+		// pre-existing or dangling symlink escape the sandbox. Reject any
+		// symlink leaf so the outside target is never created or overwritten.
+		if li, lerr := os.Lstat(full); lerr == nil && li.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink leaf rejected for write: %s", full)
+		}
+	}
+	if !b.under(full) {
+		return fmt.Errorf("path outside scan root: %s", full)
+	}
+	return nil
+}
+
+func (b *BoundedFS) checkParents(path string) error {
+	cur := filepath.Clean(path)
+	if cur == b.repoAbs {
+		return nil
+	}
+	for {
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return nil
+		}
+		ev, err := canonicalPath(parent)
+		if err == nil {
+			if ev == b.repoAbs {
+				return nil
+			}
+			if !strings.HasPrefix(ev, b.repoAbs+string(filepath.Separator)) {
+				return fmt.Errorf("path outside scan root: %s", path)
+			}
+		}
+		cur = parent
+	}
+}
+
+func canonicalPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	if ev, err := filepath.EvalSymlinks(abs); err == nil {
+		return filepath.Clean(ev), nil
+	}
+	return filepath.Clean(abs), nil
+}
+
+func (b *BoundedFS) cleanedPath(path string, resolveLeaf bool) (filesys.ConfirmedDir, string, error) {
+	d, f, err := b.inner.CleanedAbs(path)
+	if err != nil {
+		return "", "", err
+	}
+	if err := b.checkCleaned(d, f, resolveLeaf); err != nil {
+		return "", "", err
+	}
+	return d, f, nil
+}
+
+// Create implements filesys.FileSystem.
+func (b *BoundedFS) Create(path string) (filesys.File, error) {
+	if _, _, err := b.cleanedPath(path, false); err != nil {
+		return nil, err
+	}
+	return b.inner.Create(path)
+}
+
+// Mkdir implements filesys.FileSystem.
+func (b *BoundedFS) Mkdir(path string) error {
+	if _, _, err := b.cleanedPath(path, false); err != nil {
+		return err
+	}
+	return b.inner.Mkdir(path)
+}
+
+// MkdirAll implements filesys.FileSystem.
+func (b *BoundedFS) MkdirAll(path string) error {
+	if _, _, err := b.cleanedPath(path, false); err != nil {
+		return err
+	}
+	return b.inner.MkdirAll(path)
+}
+
+// RemoveAll implements filesys.FileSystem.
+func (b *BoundedFS) RemoveAll(path string) error {
+	if _, _, err := b.cleanedPath(path, true); err != nil {
+		return err
+	}
+	return b.inner.RemoveAll(path)
+}
+
+// Open implements filesys.FileSystem.
+func (b *BoundedFS) Open(path string) (filesys.File, error) {
+	if _, _, err := b.cleanedPath(path, true); err != nil {
+		return nil, err
+	}
+	return b.inner.Open(path)
+}
+
+// IsDir implements filesys.FileSystem.
+func (b *BoundedFS) IsDir(path string) bool {
+	if _, _, err := b.cleanedPath(path, true); err != nil {
+		return false
+	}
+	return b.inner.IsDir(path)
+}
+
+// ReadDir implements filesys.FileSystem.
+func (b *BoundedFS) ReadDir(path string) ([]string, error) {
+	if _, _, err := b.cleanedPath(path, true); err != nil {
+		return nil, err
+	}
+	return b.inner.ReadDir(path)
+}
+
+// CleanedAbs implements filesys.FileSystem.
+func (b *BoundedFS) CleanedAbs(path string) (filesys.ConfirmedDir, string, error) {
+	return b.cleanedPath(path, true)
+}
+
+// Exists implements filesys.FileSystem.
+func (b *BoundedFS) Exists(path string) bool {
+	if _, _, err := b.cleanedPath(path, true); err != nil {
+		return false
+	}
+	return b.inner.Exists(path)
+}
+
+// Glob implements filesys.FileSystem.
+func (b *BoundedFS) Glob(pattern string) ([]string, error) {
+	matches, err := b.inner.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, m := range matches {
+		if _, _, err := b.cleanedPath(m, true); err != nil {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}
+
+// ReadFile implements filesys.FileSystem.
+func (b *BoundedFS) ReadFile(path string) ([]byte, error) {
+	if _, _, err := b.cleanedPath(path, true); err != nil {
+		return nil, err
+	}
+	return b.inner.ReadFile(path)
+}
+
+// WriteFile implements filesys.FileSystem.
+func (b *BoundedFS) WriteFile(path string, data []byte) error {
+	if _, _, err := b.cleanedPath(path, false); err != nil {
+		return err
+	}
+	return b.inner.WriteFile(path, data)
+}
+
+// Walk implements filesys.FileSystem.
+func (b *BoundedFS) Walk(path string, walkFn filepath.WalkFunc) error {
+	if _, _, err := b.cleanedPath(path, true); err != nil {
+		return err
+	}
+	return b.inner.Walk(path, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return walkFn(p, info, err)
+		}
+		cd, cf, errC := b.inner.CleanedAbs(p)
+		if errC != nil {
+			return walkFn(p, info, errC)
+		}
+		if errB := b.checkCleaned(cd, cf, true); errB != nil {
+			return filepath.SkipDir
+		}
+		return walkFn(p, info, nil)
+	})
+}

--- a/pkg/resolver/sandbox/bounded_fs_test.go
+++ b/pkg/resolver/sandbox/bounded_fs_test.go
@@ -1,0 +1,95 @@
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoundedFS_RejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.yaml")
+	require.NoError(t, os.WriteFile(outside, []byte("secret"), 0o600))
+	link := filepath.Join(root, "escape.yaml")
+	require.NoError(t, os.Symlink(outside, link))
+
+	fs, err := NewBoundedFS(root)
+	require.NoError(t, err)
+	_, err = fs.ReadFile(link)
+	require.Error(t, err, "read through symlink to outside root should be rejected")
+}
+
+func TestBoundedFS_RejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "safe")
+	require.NoError(t, os.MkdirAll(sub, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "a.yaml"), []byte("k: v\n"), 0o600))
+
+	fs, err := NewBoundedFS(root)
+	require.NoError(t, err)
+	_, err = fs.ReadFile(filepath.Join(sub, "a.yaml"))
+	require.NoError(t, err)
+
+	outside := filepath.Join(root, "..", "outside")
+	_, err = fs.ReadFile(outside)
+	require.Error(t, err)
+}
+
+func TestBoundedFS_RejectsWriteThroughSymlinkedParent(t *testing.T) {
+	root := t.TempDir()
+	outsideRoot := t.TempDir()
+	linkDir := filepath.Join(root, "linked")
+	require.NoError(t, os.Symlink(outsideRoot, linkDir))
+
+	fs, err := NewBoundedFS(root)
+	require.NoError(t, err)
+
+	target := filepath.Join(linkDir, "escape.yaml")
+	err = fs.WriteFile(target, []byte("secret"))
+	require.Error(t, err, "write through symlinked parent should be rejected")
+
+	_, statErr := os.Stat(filepath.Join(outsideRoot, "escape.yaml"))
+	require.Error(t, statErr)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestBoundedFS_RejectsWriteThroughDanglingLeafSymlink(t *testing.T) {
+	root := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideTarget := filepath.Join(outsideDir, "new.yaml")
+	link := filepath.Join(root, "link.yaml")
+	require.NoError(t, os.Symlink(outsideTarget, link))
+
+	fs, err := NewBoundedFS(root)
+	require.NoError(t, err)
+
+	require.Error(t, fs.WriteFile(link, []byte("secret")), "write through dangling leaf symlink must be rejected")
+	_, statErr := os.Stat(outsideTarget)
+	require.Error(t, statErr)
+	require.True(t, os.IsNotExist(statErr), "outside target must not have been created")
+
+	_, err = fs.Create(link)
+	require.Error(t, err, "create through dangling leaf symlink must be rejected")
+	_, statErr = os.Stat(outsideTarget)
+	require.Error(t, statErr)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestBoundedFS_RejectsWriteThroughExistingLeafSymlink(t *testing.T) {
+	root := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideTarget := filepath.Join(outsideDir, "existing.yaml")
+	require.NoError(t, os.WriteFile(outsideTarget, []byte("original"), 0o600))
+	link := filepath.Join(root, "link.yaml")
+	require.NoError(t, os.Symlink(outsideTarget, link))
+
+	fs, err := NewBoundedFS(root)
+	require.NoError(t, err)
+
+	require.Error(t, fs.WriteFile(link, []byte("clobber")), "overwrite via leaf symlink must be rejected")
+	got, readErr := os.ReadFile(outsideTarget)
+	require.NoError(t, readErr)
+	require.Equal(t, "original", string(got), "outside target must not be overwritten")
+}

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -154,7 +154,7 @@ func createContext(ctx context.Context, timeout time.Duration) testContext {
 	}
 }
 
-// TODO: fix those tests see K9VULN-8520
+// TODO: re-enable concurrent scan tests once shared scan state is race-free.
 //func TestScanner_ConcurrentScans(t *testing.T) {
 //	ctx := context.Background()
 //


### PR DESCRIPTION
> [!TIP]
> This PR is best reviewed commit by commit.

## Summary
- Refactor Helm chart rendering into a reusable preprocessor renderer with virtual file outputs and option handling.
- Add Kustomize foundation model/provenance types plus shared YAML line detection support for future resolver work.
- Add bounded filesystem safeguards for resolver file access and wire virtual files through scan preparation

Full design context and architecture details: https://github.com/DataDog/datadog-iac-scanner/issues/113

## Test plan
- `go test ./cmd/scanner ./pkg/featureflags ./pkg/kics ./pkg/resolver/helm ./pkg/resolver/sandbox ./pkg/scanner`
- `git diff --check origin/main`

## Non-goals
- No Kustomize preprocessor is registered or enabled in this PR.
- Existing Helm scan behavior is expected to remain compatible for the default scanner path.