### PR TITLE
Read and apply server-side configurations

### DIFF
--- a/cmd/scanner/list_queries.go
+++ b/cmd/scanner/list_queries.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	cli "github.com/urfave/cli/v3"
@@ -66,6 +67,7 @@ func getQuerySource(ctx context.Context, c *cli.Command) (source.QueriesSource, 
 		return fss, nil
 	}
 	return source.NewDatadogSource(
+		datadog.NewDatadogClient(),
 		source.WithWantedPlatforms(GetSupportedPlatforms()),
 		source.WithLibrarySource(fss),
 	)

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -32,6 +32,7 @@ func main() {
 			scanAction,
 			listPlatformsAction,
 			listQueriesAction,
+			showConfigAction,
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/internal/console"
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/scan"
@@ -93,6 +94,7 @@ const (
 	dirPerms  = 0755
 )
 
+// nolint:gocyclo
 func runScan(ctx context.Context, c *cli.Command) error {
 	if c.Args().Len() > 0 {
 		return fmt.Errorf("unexpected arguments: %v", c.Args().Slice())
@@ -126,7 +128,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		return fmt.Errorf("error retrieving repository commit information: %w", err)
 	}
 
-	cfg, err := config.ReadConfiguration(ctx, repoDir)
+	cfg, _, err := config.ReadConfiguration(ctx, repoDir, config.WithDatadog(datadog.NewDatadogClient(), repoInfo.RepositoryUrl))
 	if err != nil {
 		return fmt.Errorf("error reading the configuration: %w", err)
 	}

--- a/cmd/scanner/show_config.go
+++ b/cmd/scanner/show_config.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/config"
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
+	cli "github.com/urfave/cli/v3"
+)
+
+var showConfigAction = &cli.Command{
+	Name:  "show-config",
+	Usage: "Displays the Datadog IaC scanner configuration for this repository",
+	Flags: []cli.Flag{
+		&cli.StringSliceFlag{
+			Name:    "path",
+			Aliases: []string{"p"},
+			Usage:   "repository root path",
+			Value:   []string{"."},
+		},
+		&cli.BoolFlag{
+			Name:  "local",
+			Usage: "read only the local configuration",
+			Value: false,
+		},
+	},
+	Action: showConfig,
+}
+
+func showConfig(ctx context.Context, c *cli.Command) error {
+	repoInfo, repoDir, err := getRepositoryCommitInfo(c.StringSlice("path"))
+	if err != nil {
+		return fmt.Errorf("error retrieving repository commit information: %w", err)
+	}
+
+	var cfgOptions []config.ReadConfigurationOption
+	if !c.Bool("local") {
+		cfgOptions = append(cfgOptions, config.WithDatadog(datadog.NewDatadogClient(), repoInfo.RepositoryUrl))
+	}
+
+	parsed, cfgFile, err := config.ReadConfiguration(ctx, repoDir, cfgOptions...)
+	if err != nil {
+		return fmt.Errorf("error reading the configuration: %w", err)
+	}
+
+	fmt.Println("Read configuration:")
+	if len(cfgFile) == 0 {
+		fmt.Println("<default configuration>")
+		fmt.Println()
+	} else {
+		fmt.Println(string(cfgFile))
+	}
+
+	fmt.Println("Parsed configuration:")
+	if parsed == nil {
+		fmt.Println("<default configuration>")
+	} else {
+		fmt.Printf("%+v\n", *parsed)
+	}
+
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -34,7 +35,12 @@ type iacGlobalConfig struct {
 	OnlyCategories   []string `yaml:"only-categories,omitempty"`
 }
 
+// ParseConfig turns a YAML configuration file into a parsed configuration
 func ParseConfig(cfgBytes []byte) (*IacConfig, error) {
+	if len(cfgBytes) == 0 {
+		return nil, nil
+	}
+
 	var cfg *cfgFileYaml
 	decoder := yaml.NewDecoder(bytes.NewReader(cfgBytes))
 	decoder.KnownFields(true)
@@ -70,6 +76,45 @@ func ParseConfig(cfgBytes []byte) (*IacConfig, error) {
 		OnlyCategories:   cfg.Iac.GlobalConfig.OnlyCategories,
 	}
 	return out, nil
+}
+
+// UnparseConfig turns a parsed configuration into a YAML file.
+// It ignores the LegacyExcludeResults field, since it's not representable in YAML.
+// You will need to handle it externally if you need to.
+func UnparseConfig(cfg *IacConfig) ([]byte, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+
+	iac := iacConfig{
+		IgnoreRules: cfg.IgnoreRules,
+		UseRules:    cfg.OnlyRules,
+		GlobalConfig: iacGlobalConfig{
+			IgnorePaths:      cfg.IgnorePaths,
+			OnlyPaths:        cfg.OnlyPaths,
+			IgnoreSeverities: cfg.IgnoreSeverities,
+			OnlySeverities:   cfg.OnlySeverities,
+			IgnoreCategories: cfg.IgnoreCategories,
+			OnlyCategories:   cfg.OnlyCategories,
+		},
+	}
+
+	if reflect.DeepEqual(iac, iacConfig{}) {
+		return []byte{}, nil
+	}
+
+	outCfg := cfgFileYaml{
+		SchemaVersion: "v1.2",
+		Iac:           &iac,
+	}
+
+	out := bytes.Buffer{}
+	encoder := yaml.NewEncoder(&out)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(outCfg); err != nil {
+		return nil, fmt.Errorf("could not encode configuration: %w", err)
+	}
+	return out.Bytes(), nil
 }
 
 func parseSchemaVersion(schema string) (version schemaVersion, err error) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -56,3 +56,9 @@ func TestParseUnknownField(t *testing.T) {
 	_, err = ParseConfig([]byte("schema-version: v1.1\niac:\n  global-config:\n    xinvalid: abc"))
 	assert.Error(t, err, "The unknown field was expected to be rejected")
 }
+
+func TestUnparseConfig(t *testing.T) {
+	b, err := UnparseConfig(&parsedCfgFile)
+	assert.NoError(t, err)
+	assert.Equal(t, cfgFile, string(b))
+}

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -2,8 +2,12 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 )
 
 const (
@@ -11,23 +15,113 @@ const (
 	LegacyConfigFileName = "dd-iac-scan.config"
 )
 
-func ReadConfiguration(ctx context.Context, rootPath string) (*IacConfig, error) {
-	if path, found := fileExists(rootPath, ConfigFileNameBase, ".yaml", ".yml"); found {
-		b, err := os.ReadFile(path) // nolint:gosec
+// ReadConfiguration reads and parses the configuration file in the local repository.
+// It returns the parsed configuration and the YAML file (or a YAML conversion, in the case of legacy configurations).
+func ReadConfiguration(ctx context.Context, rootPath string, options ...ReadConfigurationOption) (*IacConfig, []byte, error) {
+	var cfgContent []byte
+	if cfg, cfgBytes, err := readAndParseConfiguration(ctx, rootPath, options...); cfg != nil || err != nil {
+		return cfg, cfgBytes, err
+	} else if cfgBytes != nil {
+		cfgContent = cfgBytes
+	}
+
+	if cfg, cfgBytes, err := readAndParseLegacyConfiguration(ctx, rootPath, options...); cfg != nil || err != nil {
+		return cfg, cfgBytes, err
+	} else if cfgBytes != nil {
+		cfgContent = cfgBytes
+	}
+
+	return &IacConfig{}, cfgContent, nil
+}
+
+func readAndParseConfiguration(ctx context.Context, rootPath string, options ...ReadConfigurationOption) (*IacConfig, []byte, error) {
+	path, found := fileExists(rootPath, ConfigFileNameBase, ".yaml", ".yml")
+	if !found {
+		return nil, nil, nil
+	}
+
+	cfgBytes, err := os.ReadFile(path) // nolint:gosec
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not read configuration file %s: %w", path, err)
+	}
+
+	for _, option := range options {
+		newCfg, err := option(ctx, cfgBytes)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		cfg, err := ParseConfig(b)
-		if cfg != nil || err != nil {
-			return cfg, err
-		}
+		cfgBytes = newCfg
 	}
 
-	if _, found := fileExists(rootPath, LegacyConfigFileName); found {
-		return readLegacyConfiguration(ctx, rootPath)
+	cfg, err := ParseConfig(cfgBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not parse configuration file: %w", err)
+	}
+	return cfg, cfgBytes, nil
+}
+
+func readAndParseLegacyConfiguration(ctx context.Context, rootPath string, options ...ReadConfigurationOption) (*IacConfig, []byte, error) {
+	_, found := fileExists(rootPath, LegacyConfigFileName)
+	if !found {
+		return nil, nil, nil
 	}
 
-	return &IacConfig{}, nil
+	converted, err := readLegacyConfiguration(ctx, rootPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not read legacy configuration file: %w", err)
+	}
+
+	// Try to convert the legacy configuration to the new format so we can apply the options
+	cfgBytes, err := UnparseConfig(converted)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not convert legacy configuration file: %w", err)
+	}
+
+	for _, option := range options {
+		newCfg, err := option(ctx, cfgBytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		cfgBytes = newCfg
+	}
+
+	cfg, err := ParseConfig(cfgBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not parse configuration file: %w", err)
+	}
+
+	// Restore the original file's 'exclude-results' setting on the final configuration
+	if len(converted.LegacyExcludeResults) > 0 {
+		if cfg == nil {
+			cfg = &IacConfig{}
+		}
+		cfg.LegacyExcludeResults = converted.LegacyExcludeResults
+	}
+
+	if cfg != nil && len(cfg.LegacyExcludeResults) > 0 {
+		// We are returning a converted configuration but the original had settings that are not available
+		// in the new, so add a comment.
+		var resultNames []string
+		for _, rn := range cfg.LegacyExcludeResults {
+			resultNames = append(resultNames, fmt.Sprintf("%q", rn))
+		}
+		cfgBytes = []byte(
+			string(cfgBytes) +
+				fmt.Sprintf(
+					"# These settings have been applied, but they cannot be expressed in the new configuration format:\n"+
+						"# exclude-results: [ %s ]\n", strings.Join(resultNames, ", ")),
+		)
+	}
+	return cfg, cfgBytes, nil
+}
+
+type ReadConfigurationOption func(context.Context, []byte) ([]byte, error)
+
+// WithDatadog calls the Datadog backend to append server-side customizations to the local repo config
+func WithDatadog(client datadog.Client, repoUrl string) ReadConfigurationOption {
+	return func(ctx context.Context, cfgBytes []byte) ([]byte, error) {
+		return client.GetRemoteConfig(ctx, repoUrl, cfgBytes)
+	}
 }
 
 func fileExists(rootPath, name string, exts ...string) (string, bool) {

--- a/pkg/config/reader_test.go
+++ b/pkg/config/reader_test.go
@@ -1,26 +1,43 @@
 package config
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-const cfgFile = `
-schema-version: v1.2
+const cfgFile = `schema-version: v1.2
 iac:
-  ignore-rules: [query1, query2]
-  use-rules: [query3, query4]
+  ignore-rules:
+    - query1
+    - query2
+  use-rules:
+    - query3
+    - query4
   global-config:
-    ignore-paths: [path1, path2]
-    only-paths: [path3, path4]
-    ignore-severities: [sev1, sev2]
-    only-severities: [sev3, sev4]
-    ignore-categories: [cat1, cat2]
-    only-categories: [cat3, cat4]
+    ignore-paths:
+      - path1
+      - path2
+    only-paths:
+      - path3
+      - path4
+    ignore-severities:
+      - sev1
+      - sev2
+    only-severities:
+      - sev3
+      - sev4
+    ignore-categories:
+      - cat1
+      - cat2
+    only-categories:
+      - cat3
+      - cat4
 `
 
 var parsedCfgFile = IacConfig{
@@ -34,8 +51,7 @@ var parsedCfgFile = IacConfig{
 	OnlyCategories:   []string{"cat3", "cat4"},
 }
 
-const legacyCfg = `
-exclude-categories: [cat1, cat2]
+const legacyCfg = `exclude-categories: [cat1, cat2]
 exclude-paths: [path1, path2]
 exclude-queries: [query1, query2]
 exclude-results: [res1, res2]
@@ -49,6 +65,27 @@ var parsedLegacyCfg = IacConfig{
 	IgnoreCategories:     []string{"cat1", "cat2"},
 	LegacyExcludeResults: []string{"res1", "res2"},
 }
+
+const convertedLegacyCfg = `schema-version: v1.2
+iac:
+  ignore-rules:
+    - query1
+    - query2
+  global-config:
+    ignore-paths:
+      - path1
+      - path2
+    ignore-severities:
+      - sev1
+      - sev2
+    ignore-categories:
+      - cat1
+      - cat2
+`
+
+const excludeSuffix = `# These settings have been applied, but they cannot be expressed in the new configuration format:
+# exclude-results: [ "res1", "res2" ]
+`
 
 const emptyCfgFile = `
 schema-version: v1.2
@@ -65,11 +102,10 @@ iac:
 func TestNoConfig(t *testing.T) {
 	tmp := t.TempDir()
 
-	cfg, err := ReadConfiguration(t.Context(), tmp)
+	cfg, b, err := ReadConfiguration(t.Context(), tmp)
 	assert.NoError(t, err)
-
-	expected := IacConfig{}
-	assert.Equal(t, expected, *cfg)
+	assert.Empty(t, b)
+	assert.Equal(t, IacConfig{}, *cfg)
 }
 
 func TestReadConfig(t *testing.T) {
@@ -78,9 +114,9 @@ func TestReadConfig(t *testing.T) {
 			tmp := t.TempDir()
 			require.NoError(t, os.WriteFile(filepath.Join(tmp, ConfigFileNameBase+ext), []byte(cfgFile), 0644))
 
-			cfg, err := ReadConfiguration(t.Context(), tmp)
+			cfg, b, err := ReadConfiguration(t.Context(), tmp)
 			assert.NoError(t, err)
-
+			assert.Equal(t, cfgFile, string(b))
 			assert.Equal(t, parsedCfgFile, *cfg)
 		})
 	}
@@ -103,11 +139,10 @@ func TestIgnoredConfigFile(t *testing.T) {
 			tmp := t.TempDir()
 			require.NoError(t, os.WriteFile(filepath.Join(tmp, ConfigFileNameBase+".yaml"), []byte(tc.cfg), 0644))
 
-			cfg, err := ReadConfiguration(t.Context(), tmp)
+			cfg, b, err := ReadConfiguration(t.Context(), tmp)
 			assert.NoError(t, err)
-
-			expected := IacConfig{}
-			assert.Equal(t, expected, *cfg)
+			assert.Equal(t, tc.cfg, string(b))
+			assert.Equal(t, IacConfig{}, *cfg)
 		})
 	}
 }
@@ -116,19 +151,21 @@ func TestReadLegacyOnly(t *testing.T) {
 	tmp := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(tmp, LegacyConfigFileName), []byte(legacyCfg), 0644))
 
-	cfg, err := ReadConfiguration(t.Context(), tmp)
+	cfg, b, err := ReadConfiguration(t.Context(), tmp)
 	assert.NoError(t, err)
-
+	assert.Equal(t, convertedLegacyCfg+excludeSuffix, string(b))
 	assert.Equal(t, parsedLegacyCfg, *cfg)
 }
 
 func TestReadLegacyWithIncludeRulesOnly(t *testing.T) {
 	tmp := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(tmp, LegacyConfigFileName), []byte(legacyCfg+"include-queries: [query3, query4]\n"), 0644))
+	myCfgFile := legacyCfg + "include-queries: [query3, query4]\n"
+	includeOnly := "schema-version: v1.2\niac:\n  use-rules:\n    - query3\n    - query4\n"
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, LegacyConfigFileName), []byte(myCfgFile), 0644))
 
-	cfg, err := ReadConfiguration(t.Context(), tmp)
+	cfg, b, err := ReadConfiguration(t.Context(), tmp)
 	assert.NoError(t, err)
-
+	assert.Equal(t, includeOnly, string(b))
 	assert.Equal(t, IacConfig{
 		OnlyRules: []string{"query3", "query4"},
 	}, *cfg)
@@ -139,9 +176,9 @@ func TestConfigFilePrecedence(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tmp, ConfigFileNameBase+".yaml"), []byte(cfgFile), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(tmp, LegacyConfigFileName), []byte(legacyCfg), 0644))
 
-	cfg, err := ReadConfiguration(t.Context(), tmp)
+	cfg, b, err := ReadConfiguration(t.Context(), tmp)
 	assert.NoError(t, err)
-
+	assert.Equal(t, cfgFile, string(b))
 	assert.Equal(t, parsedCfgFile, *cfg)
 }
 
@@ -163,10 +200,82 @@ func TestConfigFilePrecedenceWithIgnoredConfigFile(t *testing.T) {
 			require.NoError(t, os.WriteFile(filepath.Join(tmp, ConfigFileNameBase+".yaml"), []byte(tc.cfg), 0644))
 			require.NoError(t, os.WriteFile(filepath.Join(tmp, LegacyConfigFileName), []byte(legacyCfg), 0644))
 
-			cfg, err := ReadConfiguration(t.Context(), tmp)
+			cfg, b, err := ReadConfiguration(t.Context(), tmp)
 			assert.NoError(t, err)
-
+			assert.Equal(t, convertedLegacyCfg+excludeSuffix, string(b))
 			assert.Equal(t, parsedLegacyCfg, *cfg)
 		})
 	}
+}
+
+func TestConfigFileFromDatadog(t *testing.T) {
+	const repoUrl = "https://example.com/repo.git"
+	const cfgWithExclude = cfgFile + excludeSuffix
+	parsedCfgWithExclude := parsedCfgFile
+	parsedCfgWithExclude.LegacyExcludeResults = []string{"res1", "res2"}
+	for _, tc := range []struct {
+		name           string
+		isLegacyConfig bool
+		localConfig    string
+		sentConfig     string
+		finalConfig    string
+		expectedConfig string
+		parsedConfig   *IacConfig
+	}{
+		{
+			name:           "regular config",
+			localConfig:    "local config file",
+			sentConfig:     "local config file",
+			finalConfig:    cfgFile,
+			expectedConfig: cfgFile,
+			parsedConfig:   &parsedCfgFile,
+		},
+		{
+			name:           "legacy config",
+			isLegacyConfig: true,
+			localConfig:    legacyCfg,
+			sentConfig:     convertedLegacyCfg,
+			finalConfig:    cfgFile,
+			expectedConfig: cfgWithExclude,
+			parsedConfig:   &parsedCfgWithExclude,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeDatadogClient{
+				t:                  t,
+				expectedSentConfig: []byte(tc.sentConfig),
+				expectedRepoUrl:    repoUrl,
+				remoteConfig:       []byte(tc.finalConfig),
+			}
+
+			tmp := t.TempDir()
+			if tc.isLegacyConfig {
+				require.NoError(t, os.WriteFile(filepath.Join(tmp, LegacyConfigFileName), []byte(tc.localConfig), 0644))
+			} else {
+				require.NoError(t, os.WriteFile(filepath.Join(tmp, ConfigFileNameBase+".yaml"), []byte(tc.localConfig), 0644))
+			}
+
+			cfg, b, err := ReadConfiguration(t.Context(), tmp, WithDatadog(client, repoUrl))
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedConfig, string(b))
+			assert.Equal(t, *tc.parsedConfig, *cfg)
+		})
+	}
+}
+
+type fakeDatadogClient struct {
+	t                  *testing.T
+	expectedRepoUrl    string
+	expectedSentConfig []byte
+	remoteConfig       []byte
+}
+
+func (f *fakeDatadogClient) GetDefaultRuleset(ctx context.Context) (*datadog.Ruleset, error) {
+	panic("unimplemented")
+}
+
+func (f *fakeDatadogClient) GetRemoteConfig(_ context.Context, repoUrl string, localConfig []byte) ([]byte, error) {
+	assert.Equal(f.t, f.expectedRepoUrl, repoUrl)
+	assert.Equal(f.t, string(f.expectedSentConfig), string(localConfig))
+	return f.remoteConfig, nil
 }

--- a/pkg/datadog/client.go
+++ b/pkg/datadog/client.go
@@ -1,0 +1,272 @@
+package datadog
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/DataDog/jsonapi"
+)
+
+type Client interface {
+	// GetDefaultRuleset returns the content of the default ruleset.
+	GetDefaultRuleset(ctx context.Context) (*Ruleset, error)
+	// GetRemoteConfig applies server-side changes to the local configuration.
+	GetRemoteConfig(ctx context.Context, repoUrl string, localConfig []byte) ([]byte, error)
+}
+
+// NewDatadogClient creates a DatadogSource with the given options.
+func NewDatadogClient(options ...DatadogClientOption) Client {
+	out := &datadogClient{
+		httpClient: http.DefaultClient,
+	}
+	for _, option := range options {
+		option(out)
+	}
+	if out.hostname == "" {
+		WithSiteFromEnv()(out)
+	}
+	if out.apiKey == "" {
+		WithApiKeyFromEnv()(out)
+	}
+	if out.appKey == "" {
+		WithAppKeyFromEnv()(out)
+	}
+	return out
+}
+
+// WithSite lets you specify a Datadog site to use.
+// If unspecified, the Datadog site will be fetched from the environment using WithSiteFromEnv.
+func WithSite(site string) DatadogClientOption {
+	return WithHostname("api." + site)
+}
+
+// WithSiteFromEnv uses the Datadog site specified in the DD_SITE or DATADOG_SITE environment variable.
+// If neither variable exists, "datadoghq.com" will be used.
+func WithSiteFromEnv() DatadogClientOption {
+	site := getDdEnvvar("SITE")
+	if site == "" {
+		site = "datadoghq.com"
+	}
+	return WithSite(site)
+}
+
+// WithApiKey lets you specify a Datadog API key.
+// If unspecified, the API key will be fetched from the environment using WithApiKeyFromEnv.
+func WithApiKey(apiKey string) DatadogClientOption {
+	return func(ds *datadogClient) {
+		ds.apiKey = apiKey
+	}
+}
+
+// WithAppKey lets you specify a Datadog application key.
+// If unspecified, the application key will be fetched from the environment using WithAppKeyFromEnv.
+func WithAppKey(appKey string) DatadogClientOption {
+	return func(ds *datadogClient) {
+		ds.appKey = appKey
+	}
+}
+
+// WithApiKeyFromEnv uses the API key specified in the DD_API_KEY or DATADOG_API_KEY environment variable.
+// If neither variable exists, an empty API key will be used.
+func WithApiKeyFromEnv() DatadogClientOption {
+	return WithApiKey(getDdEnvvar("API_KEY"))
+}
+
+// WithAppKeyFromEnv uses the application key specified in the DD_APP_KEY or DATADOG_APP_KEY environment variable.
+// If neither variable exists, an empty application key will be used.
+func WithAppKeyFromEnv() DatadogClientOption {
+	return WithAppKey(getDdEnvvar("APP_KEY"))
+}
+
+// WithHttpClient lets you specify an http.Client instance to use.
+// If unspecified, the [http.DefaultClient] will be used.
+func WithHttpClient(client *http.Client) DatadogClientOption {
+	return func(ds *datadogClient) {
+		ds.httpClient = client
+	}
+}
+
+// WithHostname lets you specify the hostname to use for Datadog API requests.
+// Used in the implementation and unit tests.
+func WithHostname(hostname string) DatadogClientOption {
+	return func(ds *datadogClient) {
+		ds.hostname = hostname
+	}
+}
+
+type DatadogClientOption func(source *datadogClient)
+
+// DatadogSource is a QueriesSource that reads queries from the Datadog API.
+// Libraries are fetched via another QueriesSource.
+type datadogClient struct {
+	hostname   string
+	apiKey     string
+	appKey     string
+	httpClient *http.Client
+}
+
+// GetDefaultRuleset returns the content of the default ruleset.
+func (s *datadogClient) GetDefaultRuleset(ctx context.Context) (*Ruleset, error) {
+	path := "iac/rulesets/default-ruleset?include_tests=false&include_testing_rules=true"
+	response, err := s.sendRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close() // nolint:errcheck
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("the Datadog API returned status %d", response.StatusCode)
+	}
+
+	var ruleset *Ruleset
+	b, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := jsonapi.Unmarshal(b, &ruleset); err != nil {
+		return nil, err
+	}
+
+	return ruleset, nil
+}
+
+// GetRemoteConfig applies server-side changes to the local configuration.
+func (s *datadogClient) GetRemoteConfig(ctx context.Context, repoUrl string, localConfig []byte) ([]byte, error) {
+	if s.apiKey == "" && s.appKey == "" {
+		// Without credentials, do not send the request; echo the local configuration instead
+		return localConfig, nil
+	}
+
+	path := "config/client?schema_version=v1"
+
+	request := remoteConfigRequest{
+		ID:         "config-request",
+		Repository: repoUrl,
+		Config:     localConfig,
+	}
+	body, err := jsonapi.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	response, err := s.sendRequest(ctx, http.MethodPost, path, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	defer response.Body.Close() // nolint:errcheck
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("the Datadog API returned status %d", response.StatusCode)
+	}
+
+	b, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	var data remoteConfigResponse
+	if err := jsonapi.Unmarshal(b, &data); err != nil {
+		return nil, err
+	}
+
+	return data.Config, nil
+}
+
+// sendRequest sends a Datadog API request
+func (s *datadogClient) sendRequest(ctx context.Context, method, path string, requestBody io.Reader) (*http.Response, error) {
+	url := fmt.Sprintf("https://%s/api/v2/static-analysis/%s", s.hostname, path)
+	req, err := http.NewRequestWithContext(ctx, method, url, requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("error building %s %s request: %w", method, url, err)
+	}
+	req.Header.Add("content-type", "application/json")
+	if s.apiKey != "" {
+		req.Header.Add("dd-api-key", s.apiKey)
+	}
+	if s.appKey != "" {
+		req.Header.Add("dd-application-key", s.appKey)
+	}
+	return s.httpClient.Do(req)
+}
+
+// getDdEnvvar returns the value of the given Datadog environment variable.
+// The DD_ prefix is checked first, then the DATADOG_ prefix.
+// Returns an empty string if neither environment variable exists.
+func getDdEnvvar(name string) string {
+	if v, ok := os.LookupEnv("DD_" + name); ok {
+		return v
+	} else if v, ok = os.LookupEnv("DATADOG_" + name); ok {
+		return v
+	}
+	return ""
+}
+
+// Ruleset defines a collection of rules.
+type Ruleset struct {
+	ID               string  `jsonapi:"primary,iac_ruleset" json:"id"`
+	Name             string  `jsonapi:"attribute" json:"name"`
+	ShortDescription string  `jsonapi:"attribute" json:"short_description"`
+	Description      string  `jsonapi:"attribute" json:"description"`
+	Rules            []*Rule `jsonapi:"attribute" json:"rules"`
+}
+
+// Rule defines the structure of a rule that's stored in Datadog.
+type Rule struct {
+	ID                string         `jsonapi:"primary,iac_rule" json:"id"`
+	Name              string         `jsonapi:"attribute" json:"name"`
+	LegacyId          *string        `jsonapi:"attribute" json:"legacy_id,omitempty"`
+	ShortDescription  string         `jsonapi:"attribute" json:"short_description"`
+	Description       string         `jsonapi:"attribute" json:"description"`
+	DescriptionId     *string        `jsonapi:"attribute" json:"description_id,omitempty"`
+	Platform          string         `jsonapi:"attribute" json:"platform"`
+	Type              string         `jsonapi:"attribute" json:"type"`
+	RegoQuery         []byte         `jsonapi:"attribute" json:"rego_query"`
+	Severity          string         `jsonapi:"attribute" json:"severity"`
+	Category          string         `jsonapi:"attribute" json:"category"`
+	Provider          *string        `jsonapi:"attribute" json:"provider,omitempty"`
+	Cwe               *string        `jsonapi:"attribute" json:"cwe,omitempty"`
+	DocumentationUrl  *string        `jsonapi:"attribute" json:"documentation_url,omitempty"`
+	ProviderUrl       *string        `jsonapi:"attribute" json:"provider_url,omitempty"`
+	Aggregation       *int           `jsonapi:"attribute" json:"aggregation,omitempty"`
+	Overrides         []RuleOverride `jsonapi:"attribute" json:"overrides,omitempty"`
+	DefaultFrameworks []Framework    `jsonapi:"attribute" json:"default_frameworks,omitempty"`
+	CustomFrameworks  []Framework    `jsonapi:"attribute" json:"custom_frameworks,omitempty"`
+	IsTesting         bool           `jsonapi:"attribute" json:"is_testing"`
+	IsPublished       bool           `jsonapi:"attribute" json:"is_published"`
+}
+
+// RuleOverride contains a set of keyed changes for the rule configuration
+type RuleOverride struct {
+	Key              string  `jsonapi:"primary,iac_rule_override" json:"key"`
+	ID               *string `jsonapi:"attribute" json:"id,omitempty"`
+	ShortDescription *string `jsonapi:"attribute" json:"short_description,omitempty"`
+	Description      *string `jsonapi:"attribute" json:"description,omitempty"`
+	DescriptionId    *string `jsonapi:"attribute" json:"description_id,omitempty"`
+	Platform         *string `jsonapi:"attribute" json:"platform,omitempty"`
+	Severity         *string `jsonapi:"attribute" json:"severity,omitempty"`
+	Category         *string `jsonapi:"attribute" json:"category,omitempty"`
+	Provider         *string `jsonapi:"attribute" json:"provider,omitempty"`
+	Cwe              *string `jsonapi:"attribute" json:"cwe,omitempty"`
+	DocumentationUrl *string `jsonapi:"attribute" json:"documentation_url,omitempty"`
+	ProviderUrl      *string `jsonapi:"attribute" json:"provider_url,omitempty"`
+}
+
+// Framework defines a compliance framework
+type Framework struct {
+	Framework   string `jsonapi:"attribute" json:"framework"`
+	Version     string `jsonapi:"attribute" json:"version"`
+	Requirement string `jsonapi:"attribute" json:"requirement"`
+	Control     string `jsonapi:"attribute" json:"control"`
+}
+
+type remoteConfigRequest struct {
+	ID         string `jsonapi:"primary,config" json:"id"`
+	Repository string `jsonapi:"attribute" json:"repository"`
+	Config     []byte `jsonapi:"attribute" json:"config_base64"`
+}
+
+type remoteConfigResponse struct {
+	ID     string `jsonapi:"primary,config" json:"id"`
+	Config []byte `jsonapi:"attribute" json:"config_base64"`
+}

--- a/pkg/datadog/client_test.go
+++ b/pkg/datadog/client_test.go
@@ -1,0 +1,117 @@
+package datadog
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/jsonapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDefaultRuleset(t *testing.T) {
+	rules := []*Rule{
+		{
+			ID:               "dockerfile-gcp-rule-1",
+			Name:             "rule-1",
+			LegacyId:         nil,
+			ShortDescription: "short 1",
+			Description:      "full 1",
+			DescriptionId:    ptr("abcdef"),
+			Platform:         "Dockerfile",
+			Type:             "rego",
+			RegoQuery:        []byte("query text 1"),
+			Severity:         "HIGH",
+			Category:         "Encryption",
+			Provider:         ptr("gcp"),
+			Cwe:              ptr("123"),
+			DocumentationUrl: ptr("http://example.com/doc1"),
+			IsTesting:        false,
+			IsPublished:      true,
+		},
+		{
+			ID:               "common-rule-2",
+			Name:             "rule-2",
+			LegacyId:         ptr("rule-2"),
+			ShortDescription: "short 2",
+			Description:      "full 2",
+			Platform:         "Common",
+			Type:             "rego",
+			RegoQuery:        []byte("query text 2"),
+			Severity:         "MEDIUM",
+			Category:         "Backup",
+			IsTesting:        true,
+			IsPublished:      true,
+		},
+	}
+
+	client := getDatadogClient(t, rules, "", nil)
+	ruleset, err := client.GetDefaultRuleset(t.Context())
+	assert.NoError(t, err)
+	assert.Equal(t, rules, ruleset.Rules)
+}
+
+func TestGetRemoteConfig(t *testing.T) {
+	repoUrl := "https://example.com/repo"
+	remoteConfig := "this is the configuration"
+	client := getDatadogClient(t, nil, repoUrl, []byte(remoteConfig))
+	actual, err := client.GetRemoteConfig(t.Context(), repoUrl, []byte{})
+	assert.NoError(t, err)
+	assert.Equal(t, remoteConfig, string(actual))
+}
+
+func getDatadogClient(t *testing.T, rules []*Rule, repoUrl string, config []byte) Client {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "my-api-key", r.Header.Get("dd-api-key"))
+		assert.Equal(t, "my-app-key", r.Header.Get("dd-application-key"))
+		if r.URL.Path == "/api/v2/static-analysis/iac/rulesets/default-ruleset" {
+			assert.Equal(t, http.MethodGet, r.Method)
+			ruleset := Ruleset{
+				ID:    "default-ruleset",
+				Name:  "default-ruleset",
+				Rules: rules,
+			}
+			body, err := jsonapi.Marshal(ruleset)
+			require.NoError(t, err)
+			w.Header().Add("content-type", "application/json")
+			_, err = w.Write(body)
+			require.NoError(t, err)
+		} else if r.URL.Path == "/api/v2/static-analysis/config/client" {
+			assert.Equal(t, http.MethodPost, r.Method)
+			defer r.Body.Close()
+			var request remoteConfigRequest
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, jsonapi.Unmarshal(body, &request))
+			assert.Equal(t, repoUrl, request.Repository)
+			body, err = jsonapi.Marshal(remoteConfigResponse{
+				ID:     "cfg",
+				Config: config,
+			})
+			require.NoError(t, err)
+			w.Header().Add("content-type", "application/json")
+			_, err = w.Write(body)
+			require.NoError(t, err)
+		} else {
+			assert.Failf(t, "Unexpected request: %s %s", r.Method, r.URL)
+			http.NotFoundHandler().ServeHTTP(w, r)
+			return
+		}
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	source := NewDatadogClient(
+		WithHostname(server.Listener.Addr().String()),
+		WithHttpClient(server.Client()),
+		WithApiKey("my-api-key"),
+		WithAppKey("my-app-key"),
+	)
+	return source
+}
+
+func ptr[T any](t T) *T {
+	return &t
+}

--- a/pkg/engine/source/datadog.go
+++ b/pkg/engine/source/datadog.go
@@ -5,34 +5,22 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io"
-	"net/http"
-	"os"
 	"slices"
 	"strings"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
-	"github.com/DataDog/jsonapi"
 )
 
 // NewDatadogSource creates a DatadogSource with the given options.
-func NewDatadogSource(options ...DatadogSourceOption) (QueriesSource, error) {
+func NewDatadogSource(client datadog.Client, options ...DatadogSourceOption) (QueriesSource, error) {
 	out := &DatadogSource{
-		httpClient:           http.DefaultClient,
+		client:               client,
 		wantedPlatforms:      []string{""},
 		wantedCloudProviders: []string{""},
 	}
 	for _, option := range options {
 		option(out)
-	}
-	if out.hostname == "" {
-		WithSiteFromEnv()(out)
-	}
-	if out.apiKey == "" {
-		WithApiKeyFromEnv()(out)
-	}
-	if out.appKey == "" {
-		WithAppKeyFromEnv()(out)
 	}
 	if out.librarySource == nil {
 		librarySource := NewFilesystemSource(
@@ -72,82 +60,19 @@ func WithLibrarySource(source QueriesSource) DatadogSourceOption {
 	}
 }
 
-// WithSite lets you specify a Datadog site to use.
-// If unspecified, the Datadog site will be fetched from the environment using WithSiteFromEnv.
-func WithSite(site string) DatadogSourceOption {
-	return withHostname("api." + site)
-}
-
-// WithSiteFromEnv uses the Datadog site specified in the DD_SITE or DATADOG_SITE environment variable.
-// If neither variable exists, "datadoghq.com" will be used.
-func WithSiteFromEnv() DatadogSourceOption {
-	site := getDdEnvvar("SITE")
-	if site == "" {
-		site = "datadoghq.com"
-	}
-	return WithSite(site)
-}
-
-// WithApiKey lets you specify a Datadog API key.
-// If unspecified, the API key will be fetched from the environment using WithApiKeyFromEnv.
-func WithApiKey(apiKey string) DatadogSourceOption {
-	return func(ds *DatadogSource) {
-		ds.apiKey = apiKey
-	}
-}
-
-// WithAppKey lets you specify a Datadog application key.
-// If unspecified, the application key will be fetched from the environment using WithAppKeyFromEnv.
-func WithAppKey(appKey string) DatadogSourceOption {
-	return func(ds *DatadogSource) {
-		ds.appKey = appKey
-	}
-}
-
-// WithApiKeyFromEnv uses the API key specified in the DD_API_KEY or DATADOG_API_KEY environment variable.
-// If neither variable exists, an empty API key will be used.
-func WithApiKeyFromEnv() DatadogSourceOption {
-	return WithApiKey(getDdEnvvar("API_KEY"))
-}
-
-// WithAppKeyFromEnv uses the application key specified in the DD_APP_KEY or DATADOG_APP_KEY environment variable.
-// If neither variable exists, an empty application key will be used.
-func WithAppKeyFromEnv() DatadogSourceOption {
-	return WithAppKey(getDdEnvvar("APP_KEY"))
-}
-
-// WithHttpClient lets you specify an http.Client instance to use.
-// If unspecified, the [http.DefaultClient] will be used.
-func WithHttpClient(client *http.Client) DatadogSourceOption {
-	return func(ds *DatadogSource) {
-		ds.httpClient = client
-	}
-}
-
-// withHostname lets you specify the hostname to use for Datadog API requests.
-// Used in the implementation and unit tests.
-func withHostname(hostname string) DatadogSourceOption {
-	return func(ds *DatadogSource) {
-		ds.hostname = hostname
-	}
-}
-
 type DatadogSourceOption func(source *DatadogSource)
 
 // DatadogSource is a QueriesSource that reads queries from the Datadog API.
 // Libraries are fetched via another QueriesSource.
 type DatadogSource struct {
-	hostname             string
-	apiKey               string
-	appKey               string
-	httpClient           *http.Client
+	client               datadog.Client
 	librarySource        QueriesSource
 	wantedPlatforms      []string
 	wantedCloudProviders []string
 }
 
 func (s *DatadogSource) GetQueries(ctx context.Context, querySelection *QueryInspectorParameters) ([]model.QueryMetadata, error) {
-	defaultRuleset, err := s.getDefaultRuleset(ctx)
+	defaultRuleset, err := s.client.GetDefaultRuleset(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving rules from Datadog: %w", err)
 	}
@@ -158,32 +83,8 @@ func (s *DatadogSource) GetQueryLibrary(ctx context.Context, platform string) (R
 	return s.librarySource.GetQueryLibrary(ctx, platform)
 }
 
-// getDefaultRuleset returns the content of the default ruleset.
-func (s *DatadogSource) getDefaultRuleset(ctx context.Context) (*Ruleset, error) {
-	path := "rulesets/default-ruleset?include_tests=false&include_testing_rules=true"
-	response, err := s.sendRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer response.Body.Close() // nolint:errcheck
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("the Datadog API returned status %d", response.StatusCode)
-	}
-
-	var ruleset *Ruleset
-	bytes, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, err
-	}
-	if err := jsonapi.Unmarshal(bytes, &ruleset); err != nil {
-		return nil, err
-	}
-
-	return ruleset, nil
-}
-
 // filterRules selects the rules from the given ruleset according to the selection criteria.
-func (s *DatadogSource) filterRules(ruleset *Ruleset, selection *QueryInspectorParameters) ([]model.QueryMetadata, error) {
+func (s *DatadogSource) filterRules(ruleset *datadog.Ruleset, selection *QueryInspectorParameters) ([]model.QueryMetadata, error) {
 	var out []model.QueryMetadata
 	for _, rule := range ruleset.Rules {
 		if !rule.IsPublished {
@@ -231,7 +132,7 @@ func (s *DatadogSource) isWantedCloudProvider(provider *string) bool {
 	return isInCaseInsensitiveList(provider, s.wantedCloudProviders)
 }
 
-func checkExcluded(rule *Rule, selection *QueryInspectorParameters) bool {
+func checkExcluded(rule *datadog.Rule, selection *QueryInspectorParameters) bool {
 	return isInCaseInsensitiveList(rule.LegacyId, selection.ExcludeQueries.ByIDs) ||
 		isInCaseInsensitiveList(&rule.ID, selection.ExcludeQueries.ByIDs) ||
 		isInCaseInsensitiveList(&rule.Category, selection.ExcludeQueries.ByCategories) ||
@@ -239,7 +140,7 @@ func checkExcluded(rule *Rule, selection *QueryInspectorParameters) bool {
 		(!selection.BomQueries && strings.EqualFold(rule.Severity, model.SeverityTrace))
 }
 
-func checkIncluded(rule *Rule, selection *QueryInspectorParameters) bool {
+func checkIncluded(rule *datadog.Rule, selection *QueryInspectorParameters) bool {
 	return (isInCaseInsensitiveNotEmptyList(rule.LegacyId, selection.IncludeQueries.ByIDs) ||
 		isInCaseInsensitiveNotEmptyList(&rule.ID, selection.IncludeQueries.ByIDs)) &&
 		isInCaseInsensitiveNotEmptyList(&rule.Category, selection.IncludeQueries.ByCategories) &&
@@ -267,7 +168,7 @@ func isInCaseInsensitiveNotEmptyList(id *string, list []string) bool {
 
 // nolint:gocyclo
 // ConvertRule converts a Datadog api [Rule] to a [model.QueryMetadata]
-func ConvertRule(rule *Rule) model.QueryMetadata {
+func ConvertRule(rule *datadog.Rule) model.QueryMetadata {
 	id := rule.ID
 	if rule.LegacyId != nil {
 		id = *rule.LegacyId
@@ -351,7 +252,7 @@ func setStringPtr[T ~string](m map[string]any, key string, v *T) {
 	}
 }
 
-func frameworksToMeta(fs []Framework) []any {
+func frameworksToMeta(fs []datadog.Framework) []any {
 	result := make([]any, len(fs))
 	for i, f := range fs {
 		result[i] = map[string]any{
@@ -364,89 +265,4 @@ func frameworksToMeta(fs []Framework) []any {
 	return result
 }
 
-// sendRequest sends a Datadog API request
-func (s *DatadogSource) sendRequest(ctx context.Context, method, path string, requestBody io.Reader) (*http.Response, error) {
-	url := fmt.Sprintf("https://%s/api/v2/static-analysis/iac/%s", s.hostname, path)
-	req, err := http.NewRequestWithContext(ctx, method, url, requestBody)
-	if err != nil {
-		return nil, fmt.Errorf("error building %s %s request: %w", method, url, err)
-	}
-	req.Header.Add("content-type", "application/json")
-	if s.apiKey != "" {
-		req.Header.Add("dd-api-key", s.apiKey)
-	}
-	if s.appKey != "" {
-		req.Header.Add("dd-application-key", s.appKey)
-	}
-	return s.httpClient.Do(req)
-}
-
 var _ QueriesSource = (*DatadogSource)(nil)
-
-// getDdEnvvar returns the value of the given Datadog environment variable.
-// The DD_ prefix is checked first, then the DATADOG_ prefix.
-// Returns an empty string if neither environment variable exists.
-func getDdEnvvar(name string) string {
-	if v, ok := os.LookupEnv("DD_" + name); ok {
-		return v
-	} else if v, ok = os.LookupEnv("DATADOG_" + name); ok {
-		return v
-	}
-	return ""
-}
-
-// Ruleset defines a collection of rules.
-type Ruleset struct {
-	ID               string  `jsonapi:"primary,iac_ruleset" json:"id"`
-	Name             string  `jsonapi:"attribute" json:"name"`
-	ShortDescription string  `jsonapi:"attribute" json:"short_description"`
-	Description      string  `jsonapi:"attribute" json:"description"`
-	Rules            []*Rule `jsonapi:"attribute" json:"rules"`
-}
-
-// Rule defines the structure of a rule that's stored in Datadog.
-type Rule struct {
-	ID                string         `jsonapi:"primary,iac_rule" json:"id"`
-	Name              string         `jsonapi:"attribute" json:"name"`
-	LegacyId          *string        `jsonapi:"attribute" json:"legacy_id,omitempty"`
-	ShortDescription  string         `jsonapi:"attribute" json:"short_description"`
-	Description       string         `jsonapi:"attribute" json:"description"`
-	DescriptionId     *string        `jsonapi:"attribute" json:"description_id,omitempty"`
-	Platform          string         `jsonapi:"attribute" json:"platform"`
-	Type              string         `jsonapi:"attribute" json:"type"`
-	RegoQuery         []byte         `jsonapi:"attribute" json:"rego_query"`
-	Severity          string         `jsonapi:"attribute" json:"severity"`
-	Category          string         `jsonapi:"attribute" json:"category"`
-	Provider          *string        `jsonapi:"attribute" json:"provider,omitempty"`
-	Cwe               *string        `jsonapi:"attribute" json:"cwe,omitempty"`
-	DocumentationUrl  *string        `jsonapi:"attribute" json:"documentation_url,omitempty"`
-	ProviderUrl       *string        `jsonapi:"attribute" json:"provider_url,omitempty"`
-	Aggregation       *int           `jsonapi:"attribute" json:"aggregation,omitempty"`
-	Overrides         []RuleOverride `jsonapi:"attribute" json:"overrides,omitempty"`
-	DefaultFrameworks []Framework    `jsonapi:"attribute" json:"default_frameworks,omitempty"`
-	CustomFrameworks  []Framework    `jsonapi:"attribute" json:"custom_frameworks,omitempty"`
-	IsTesting         bool           `jsonapi:"attribute" json:"is_testing"`
-	IsPublished       bool           `jsonapi:"attribute" json:"is_published"`
-}
-
-type RuleOverride struct {
-	Key              string  `jsonapi:"primary,iac_rule_override" json:"key"`
-	ID               *string `jsonapi:"attribute" json:"id,omitempty"`
-	ShortDescription *string `jsonapi:"attribute" json:"short_description,omitempty"`
-	Description      *string `jsonapi:"attribute" json:"description,omitempty"`
-	DescriptionId    *string `jsonapi:"attribute" json:"description_id,omitempty"`
-	Platform         *string `jsonapi:"attribute" json:"platform,omitempty"`
-	Severity         *string `jsonapi:"attribute" json:"severity,omitempty"`
-	Category         *string `jsonapi:"attribute" json:"category,omitempty"`
-	Provider         *string `jsonapi:"attribute" json:"provider,omitempty"`
-	Cwe              *string `jsonapi:"attribute" json:"cwe,omitempty"`
-	DocumentationUrl *string `jsonapi:"attribute" json:"documentation_url,omitempty"`
-	ProviderUrl      *string `jsonapi:"attribute" json:"provider_url,omitempty"`
-}
-
-type Framework struct {
-	Framework   string `jsonapi:"attribute" json:"framework"`
-	Version     string `jsonapi:"attribute" json:"version"`
-	Requirement string `jsonapi:"attribute" json:"requirement"`
-	Control     string `jsonapi:"attribute" json:"control"`
-}

--- a/pkg/engine/source/datadog_test.go
+++ b/pkg/engine/source/datadog_test.go
@@ -1,12 +1,11 @@
 package source
 
 import (
-	"net/http"
-	"net/http/httptest"
+	"context"
 	"testing"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
-	"github.com/DataDog/jsonapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -341,7 +340,7 @@ func TestSourceWithWantedProviders(t *testing.T) {
 	}
 }
 
-var rules = []*Rule{
+var rules = []*datadog.Rule{
 	{
 		ID:               "dockerfile-gcp-rule-1",
 		Name:             "rule-1",
@@ -386,7 +385,7 @@ var rules = []*Rule{
 		Category:         "Supply-Chain",
 		Provider:         ptr("common"),
 		Aggregation:      ptr(2),
-		Overrides: []RuleOverride{
+		Overrides: []datadog.RuleOverride{
 			{
 				Key:              "1.0",
 				ID:               ptr("ovr-rule-3"),
@@ -480,41 +479,28 @@ var queries = []model.QueryMetadata{
 	},
 }
 
-func getDatadogSource(t *testing.T, rules []*Rule, options ...DatadogSourceOption) QueriesSource {
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		expectedPath := "/api/v2/static-analysis/iac/rulesets/default-ruleset"
-		assert.Equal(t, expectedPath, r.URL.Path)
-		if r.URL.Path != expectedPath {
-			http.NotFoundHandler().ServeHTTP(w, r)
-			return
-		}
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "my-api-key", r.Header.Get("dd-api-key"))
-		assert.Equal(t, "my-app-key", r.Header.Get("dd-application-key"))
-		ruleset := Ruleset{
-			ID:    "default-ruleset",
-			Name:  "default-ruleset",
-			Rules: rules,
-		}
-		body, err := jsonapi.Marshal(ruleset)
-		require.NoError(t, err)
-		w.Header().Add("content-type", "application/json")
-		_, err = w.Write(body)
-		require.NoError(t, err)
-	}
-	server := httptest.NewTLSServer(http.HandlerFunc(handler))
-	t.Cleanup(server.Close)
-
-	source, err := NewDatadogSource(
-		append(options,
-			withHostname(server.Listener.Addr().String()),
-			WithHttpClient(server.Client()),
-			WithApiKey("my-api-key"),
-			WithAppKey("my-app-key"),
-		)...,
-	)
+func getDatadogSource(t *testing.T, rules []*datadog.Rule, options ...DatadogSourceOption) QueriesSource {
+	client := &fakeDatadogClient{rules: rules}
+	source, err := NewDatadogSource(client, options...)
 	require.NoError(t, err)
 	return source
+}
+
+type fakeDatadogClient struct {
+	rules []*datadog.Rule
+}
+
+func (f fakeDatadogClient) GetDefaultRuleset(ctx context.Context) (*datadog.Ruleset, error) {
+	out := &datadog.Ruleset{
+		ID:    "default-ruleset",
+		Name:  "default-ruleset",
+		Rules: f.rules,
+	}
+	return out, nil
+}
+
+func (f fakeDatadogClient) GetRemoteConfig(ctx context.Context, repoUrl string, localConfig []byte) ([]byte, error) {
+	panic("unimplemented")
 }
 
 func ptr[T any](t T) *T {

--- a/pkg/scan/pre_scan.go
+++ b/pkg/scan/pre_scan.go
@@ -14,7 +14,7 @@ func initializeConfig(ctx context.Context, rootPath string) (*config.IacConfig, 
 
 	baseLogger.Debug().Msg("console.initializeConfig()")
 
-	configParams, err := config.ReadConfiguration(ctx, rootPath)
+	configParams, _, err := config.ReadConfiguration(ctx, rootPath)
 
 	return configParams, logCtx, err
 }

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -10,6 +10,7 @@ package scan
 import (
 	"context"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
@@ -125,6 +126,7 @@ func (c *Client) createQuerySource(ctx context.Context, paramsPlatforms []string
 		return fss, nil
 	}
 	return source.NewDatadogSource(
+		datadog.NewDatadogClient(),
 		source.WithWantedPlatforms(paramsPlatforms),
 		source.WithWantedCloudProviders(c.ScanParams.CloudProvider),
 		source.WithLibrarySource(fss),


### PR DESCRIPTION
## Motivation

Datadog customers can create and store tool configuration files on the Datadog backend. With this, the IaC scanner can get that server-side configuration and use it.

Legacy configurations also participate in this.

## Changes

Split out the Datadog client into its own package, with "get default rules" and "get configuration" methods.

Change configuration parsing so it will return the config file contents. This lets us send the configuration file to the backend.

Convert legacy configurations to YAML so they can be sent to the backend, and then apply any legacy-only configurations to the end result.

Add a "show-config" command that displays the effective configuration, with or without server-side changes.

## Author Checklist

- [X] I have reviewed my own PR.
- [X] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [X] All new and existing tests pass.
- [x] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Tell the reviewer how they can make sure the PR is indeed working as intended. Tell them what they should be looking for.

## Blast Radius

What services will this change impact. Is it only DataDog IaC Scanner, internal services, the documentation or anything else?

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
