### PR TITLE
Add Kustomize resolver preprocessor core

### DIFF
--- a/cmd/scanner/internal.go
+++ b/cmd/scanner/internal.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/resolver/kustomize"
+	cli "github.com/urfave/cli/v3"
+)
+
+// internalAction holds hidden subcommands the scanner re-execs (e.g. kustomize
+// render in a child the parent can kill on timeout). Hidden from --help.
+var internalAction = &cli.Command{
+	Name:   "internal",
+	Hidden: true,
+	Usage:  "internal helpers used by the scanner to re-exec itself; not for direct use",
+	Commands: []*cli.Command{
+		{
+			Name:   "kustomize-render",
+			Hidden: true,
+			Usage:  "run a single kustomize build; reads a JSON request from stdin and writes a JSON response to stdout",
+			Action: func(ctx context.Context, c *cli.Command) error {
+				return kustomize.RunHelperFromStdin()
+			},
+		},
+	},
+}

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/resolver/kustomize"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	cli "github.com/urfave/cli/v3"
@@ -22,6 +23,7 @@ const defaultFailCode = 126
 const gcPercent = 50
 
 func main() {
+	kustomize.MaybeRunAsKustomizeRenderHelper()
 	if _, ok := os.LookupEnv("GOGC"); !ok {
 		debug.SetGCPercent(gcPercent)
 	}
@@ -33,6 +35,7 @@ func main() {
 			listPlatformsAction,
 			listQueriesAction,
 			showConfigAction,
+			internalAction,
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,8 @@ require (
 	k8s.io/client-go v0.35.1
 	mvdan.cc/sh/v3 v3.12.0
 	sigs.k8s.io/controller-runtime v0.23.1
+	sigs.k8s.io/kustomize/api v0.21.1
+	sigs.k8s.io/kustomize/kyaml v0.21.1
 )
 
 require (
@@ -167,8 +169,6 @@ require (
 	k8s.io/component-base v0.35.1 // indirect
 	k8s.io/kubectl v0.35.1 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect
-	sigs.k8s.io/kustomize/api v0.21.1 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )

--- a/pkg/resolver/kustomize/attribute.go
+++ b/pkg/resolver/kustomize/attribute.go
@@ -1,0 +1,217 @@
+package kustomize
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"sigs.k8s.io/kustomize/api/konfig"
+	"sigs.k8s.io/kustomize/api/resource"
+)
+
+// TransformerAnnotationKey is the alpha transformation-chain annotation (must match upstream; see konfig_constants_test).
+const TransformerAnnotationKey = "alpha.config.kubernetes.io/transformations"
+
+func helmInflatedOrigin(res *resource.Resource, kustAbs string) *model.KustomizeOrigin {
+	ann := res.GetAnnotations()
+	if ann == nil {
+		return nil
+	}
+	if _, ok := ann[konfig.HelmGeneratedAnnotation]; !ok {
+		return nil
+	}
+	return &model.KustomizeOrigin{
+		OriginKind:          model.KustomizeOriginHelmInflated,
+		GeneratorConfigFile: kustAbs,
+		ResourceGVK:         res.GetGvk().String(),
+		ResourceName:        res.GetName(),
+	}
+}
+
+func appendTransformationFromOrigin(
+	chain []model.KustomizeTransformation,
+	t *resource.Origin,
+	kustomizationDir, origSourceRepo string,
+) []model.KustomizeTransformation {
+	if t == nil {
+		return chain
+	}
+	configuredIn := ""
+	if t.ConfiguredIn != "" {
+		configuredIn = t.ConfiguredIn
+		if origSourceRepo != "" {
+			configuredIn = joinRepoURL(origSourceRepo, configuredIn)
+		} else if !filepath.IsAbs(configuredIn) {
+			configuredIn = filepath.Join(kustomizationDir, filepath.Clean(configuredIn))
+		}
+	}
+	transformerPath := resolveOriginPath(kustomizationDir, origSourceRepo, t.Path)
+	if configuredIn != "" && t.Path != "" && !looksLikeRemotePath(configuredIn) {
+		transformerPath = filepath.Join(filepath.Dir(configuredIn), filepath.Clean(t.Path))
+	} else if configuredIn != "" && t.Path != "" && looksLikeRemotePath(configuredIn) {
+		transformerPath = joinRepoURL(dirURL(configuredIn), t.Path)
+	}
+	return append(chain, model.KustomizeTransformation{
+		TransformerPath: cleanLocalPath(transformerPath),
+		ConfiguredIn:    configuredIn,
+		FieldPath:       t.Path,
+	})
+}
+
+func transformerOrigin(res *resource.Resource, kustomizationDir, kustAbs string) *model.KustomizeOrigin {
+	trans, err := res.GetTransformations()
+	if err != nil || len(trans) == 0 {
+		return nil
+	}
+	origSourceFile, origSourceRepo, origSourceRef := "", "", ""
+	if origin, originErr := res.GetOrigin(); originErr == nil && origin != nil && origin.Path != "" {
+		origSourceFile = resolveOriginPath(kustomizationDir, origin.Repo, origin.Path)
+		origSourceRepo = origin.Repo
+		origSourceRef = origin.Ref
+	}
+	var chain []model.KustomizeTransformation
+	for _, t := range trans {
+		chain = appendTransformationFromOrigin(chain, t, kustomizationDir, origSourceRepo)
+	}
+	return &model.KustomizeOrigin{
+		OriginKind:          model.KustomizeOriginTransformer,
+		GeneratorConfigFile: kustAbs,
+		Transformations:     chain,
+		OriginalSourceFile:  origSourceFile,
+		OriginalSourceRepo:  origSourceRepo,
+		OriginalSourceRef:   origSourceRef,
+		ResourceGVK:         res.GetGvk().String(),
+		ResourceName:        res.GetName(),
+	}
+}
+
+// OriginFromResource builds KustomizeOrigin from kustomize API resource metadata.
+func OriginFromResource(res *resource.Resource, kustomizationDir string) *model.KustomizeOrigin {
+	if res == nil {
+		return nil
+	}
+	kustFile := kustomizationEntryFile(kustomizationDir)
+	kustAbs := filepath.Join(kustomizationDir, kustFile)
+
+	if o := helmInflatedOrigin(res, kustAbs); o != nil {
+		return o
+	}
+	if o := transformerOrigin(res, kustomizationDir, kustAbs); o != nil {
+		return o
+	}
+
+	origin, err := res.GetOrigin()
+	if err != nil || origin == nil {
+		return &model.KustomizeOrigin{
+			OriginKind:          model.KustomizeOriginDirect,
+			GeneratorConfigFile: kustAbs,
+			ResourceGVK:         res.GetGvk().String(),
+			ResourceName:        res.GetName(),
+		}
+	}
+
+	cbKind := origin.ConfiguredBy.GetKind()
+	cbName := origin.ConfiguredBy.GetName()
+	if origin.ConfiguredIn != "" && isGeneratorConfiguredKind(cbKind) {
+		cfg := origin.ConfiguredIn
+		if !filepath.IsAbs(cfg) {
+			cfg = filepath.Join(kustomizationDir, cfg)
+		}
+		return &model.KustomizeOrigin{
+			OriginKind:          model.KustomizeOriginGenerator,
+			GeneratorKind:       cbKind,
+			ConfiguredByKind:    cbKind,
+			ConfiguredByName:    cbName,
+			GeneratorConfigFile: cfg,
+			ResourceGVK:         res.GetGvk().String(),
+			ResourceName:        generatorResourceName(res),
+		}
+	}
+
+	if origin.Path != "" {
+		sf := resolveOriginPath(kustomizationDir, origin.Repo, origin.Path)
+		return &model.KustomizeOrigin{
+			OriginKind:          model.KustomizeOriginDirect,
+			SourceFile:          sf,
+			SourceRepo:          origin.Repo,
+			SourceRef:           origin.Ref,
+			ResourceGVK:         res.GetGvk().String(),
+			ResourceName:        res.GetName(),
+			GeneratorConfigFile: kustAbs,
+		}
+	}
+
+	return &model.KustomizeOrigin{
+		OriginKind:          model.KustomizeOriginDirect,
+		GeneratorConfigFile: kustAbs,
+		ResourceGVK:         res.GetGvk().String(),
+		ResourceName:        res.GetName(),
+	}
+}
+
+func resolveOriginPath(kustomizationDir, repo, path string) string {
+	if path == "" {
+		return ""
+	}
+	if repo != "" {
+		return joinRepoURL(repo, path)
+	}
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(kustomizationDir, path)
+}
+
+func looksLikeRemotePath(path string) bool {
+	return strings.Contains(path, "://")
+}
+
+func joinRepoURL(base, rel string) string {
+	if base == "" {
+		return rel
+	}
+	if rel == "" {
+		return base
+	}
+	if looksLikeRemotePath(rel) {
+		return rel
+	}
+	return strings.TrimRight(base, "/") + "/" + strings.TrimLeft(filepath.ToSlash(rel), "/")
+}
+
+func dirURL(path string) string {
+	if !looksLikeRemotePath(path) {
+		return filepath.Dir(path)
+	}
+	path = strings.TrimRight(path, "/")
+	idx := strings.LastIndex(path, "/")
+	if idx < 0 {
+		return path
+	}
+	return path[:idx]
+}
+
+func cleanLocalPath(path string) string {
+	if looksLikeRemotePath(path) {
+		return path
+	}
+	return filepath.Clean(path)
+}
+
+func isGeneratorConfiguredKind(kind string) bool {
+	k := strings.ToLower(kind)
+	if k == "" {
+		return false
+	}
+	return strings.Contains(k, "generator")
+}
+
+func kustomizationEntryFile(dir string) string {
+	for _, n := range kustomizationNames {
+		if _, err := os.Stat(filepath.Join(dir, n)); err == nil {
+			return n
+		}
+	}
+	return "kustomization.yaml"
+}

--- a/pkg/resolver/kustomize/buildmetadata.go
+++ b/pkg/resolver/kustomize/buildmetadata.go
@@ -1,0 +1,95 @@
+package kustomize
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/rootfile"
+	"gopkg.in/yaml.v3"
+)
+
+const buildMetadataFilePerm = 0o600
+
+func buildMetadataSupplementsNeeded(data []byte) (bool, error) {
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return false, err
+	}
+	meta, ok := doc["buildMetadata"].([]interface{})
+	if !ok || len(meta) == 0 {
+		return true, nil
+	}
+	has := func(want string) bool {
+		for _, m := range meta {
+			if s, ok := m.(string); ok && s == want {
+				return true
+			}
+		}
+		return false
+	}
+	return !has("originAnnotations") || !has("transformerAnnotations"), nil
+}
+
+func ensureBuildMetadataEntries(doc map[string]interface{}) {
+	meta, ok := doc["buildMetadata"].([]interface{})
+	if !ok || len(meta) == 0 {
+		doc["buildMetadata"] = []interface{}{"originAnnotations", "transformerAnnotations"}
+		return
+	}
+	has := func(want string) bool {
+		for _, m := range meta {
+			if s, ok := m.(string); ok && s == want {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("originAnnotations") {
+		meta = append(meta, "originAnnotations")
+	}
+	if !has("transformerAnnotations") {
+		meta = append(meta, "transformerAnnotations")
+	}
+	doc["buildMetadata"] = meta
+}
+
+// ensureBuildMetadataIfNeeded adds originAnnotations / transformerAnnotations when missing; writes only if bytes change.
+func ensureBuildMetadataIfNeeded(dir string) error {
+	kf := kustomizationEntryFile(dir)
+	cleanDir := filepath.Clean(dir)
+	p := filepath.Join(cleanDir, kf)
+	p = filepath.Clean(p)
+	if !isUnderRoot(p, cleanDir) {
+		return fmt.Errorf("invalid kustomization path under %q", cleanDir)
+	}
+	data, err := rootfile.ReadFile(p)
+	if err != nil {
+		return err
+	}
+	need, err := buildMetadataSupplementsNeeded(data)
+	if err != nil || !need {
+		return err
+	}
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return err
+	}
+	ensureBuildMetadataEntries(doc)
+	b, err := yaml.Marshal(doc)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(data, b) {
+		return nil
+	}
+	root, err := os.OpenRoot(cleanDir)
+	if err != nil {
+		return err
+	}
+	werr := root.WriteFile(filepath.ToSlash(kf), b, buildMetadataFilePerm)
+	cerr := root.Close()
+	return errors.Join(werr, cerr)
+}

--- a/pkg/resolver/kustomize/buildmetadata_test.go
+++ b/pkg/resolver/kustomize/buildmetadata_test.go
@@ -1,0 +1,60 @@
+package kustomize
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildMetadataSupplementsNeeded_trueWithoutTransformerAnnotations(t *testing.T) {
+	raw := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+buildMetadata:
+- originAnnotations
+resources: []
+`
+	need, err := buildMetadataSupplementsNeeded([]byte(raw))
+	require.NoError(t, err)
+	require.True(t, need)
+}
+
+func TestBuildMetadataSupplementsNeeded_falseWhenComplete(t *testing.T) {
+	raw := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+buildMetadata:
+- originAnnotations
+- transformerAnnotations
+resources: []
+`
+	need, err := buildMetadataSupplementsNeeded([]byte(raw))
+	require.NoError(t, err)
+	require.False(t, need)
+}
+
+func TestResolve_doesNotRewriteUserKustomizationWhenMetadataComplete(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cm.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\ndata: {}\n"), 0o600))
+	kust := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+buildMetadata:
+- originAnnotations
+- transformerAnnotations
+resources:
+- cm.yaml
+`
+	path := filepath.Join(dir, "kustomization.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(kust), 0o600))
+	before, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	r := NewResolver(Options{RepoRoot: dir, AllowHelmInflation: false})
+	_, err = r.Resolve(ctx, dir)
+	require.NoError(t, err)
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, before, after, "scanner must not rewrite the user's kustomization on disk")
+}

--- a/pkg/resolver/kustomize/copytree.go
+++ b/pkg/resolver/kustomize/copytree.go
@@ -1,0 +1,91 @@
+package kustomize
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	dirPermCopyTree  = 0o700
+	filePermCopyTree = 0o600
+	parentDirPrefix  = ".." + string(filepath.Separator)
+	relDotDot        = ".."
+)
+
+func mkdirParentInRoot(dstR *os.Root, rel string) error {
+	parent := filepath.Dir(rel)
+	if parent == "." || parent == "" {
+		return nil
+	}
+	parentSlash := filepath.ToSlash(filepath.Clean(parent))
+	if parentSlash == "." {
+		return nil
+	}
+	return dstR.MkdirAll(parentSlash, dirPermCopyTree)
+}
+
+func copyOneRelFile(dstR, srcR *os.Root, srcRoot, rel string) error {
+	rel = filepath.Clean(rel)
+	if rel == "." || !filepath.IsLocal(rel) || strings.HasPrefix(rel, parentDirPrefix) || rel == relDotDot {
+		return nil
+	}
+	joined := filepath.Join(srcRoot, rel)
+	if !isUnderRoot(joined, srcRoot) {
+		return nil
+	}
+	relSlash := filepath.ToSlash(rel)
+	fi, err := srcR.Lstat(relSlash)
+	if err != nil || fi.Mode()&os.ModeSymlink != 0 || fi.IsDir() {
+		return nil
+	}
+	data, err := srcR.ReadFile(relSlash)
+	if err != nil {
+		return err
+	}
+	if err := mkdirParentInRoot(dstR, rel); err != nil {
+		return err
+	}
+	df, err := dstR.OpenFile(relSlash, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, filePermCopyTree)
+	if err != nil {
+		return err
+	}
+	_, werr := df.Write(data)
+	cerr := df.Close()
+	return errors.Join(werr, cerr)
+}
+
+// CopyRepoRelativeFilesNoSymlinks copies relFiles from srcRoot to dstRoot by relative path; skips symlinks and out-of-root paths.
+func CopyRepoRelativeFilesNoSymlinks(dstRoot, srcRoot string, relFiles []string) (err error) {
+	srcRoot = filepath.Clean(srcRoot)
+	dstRoot = filepath.Clean(dstRoot)
+	if mkerr := os.MkdirAll(dstRoot, dirPermCopyTree); mkerr != nil {
+		return mkerr
+	}
+	srcR, err := os.OpenRoot(srcRoot)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := srcR.Close(); cerr != nil {
+			err = errors.Join(err, cerr)
+		}
+	}()
+	dstR, err := os.OpenRoot(dstRoot)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := dstR.Close(); cerr != nil {
+			err = errors.Join(err, cerr)
+		}
+	}()
+
+	for _, rel := range relFiles {
+		if cerr := copyOneRelFile(dstR, srcR, srcRoot, rel); cerr != nil {
+			return cerr
+		}
+	}
+	return err
+}

--- a/pkg/resolver/kustomize/copytree_test.go
+++ b/pkg/resolver/kustomize/copytree_test.go
@@ -1,0 +1,28 @@
+package kustomize
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyRepoRelativeFilesNoSymlinks_skipsSymlinks(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	secret := filepath.Join(t.TempDir(), "secret.txt")
+	require.NoError(t, os.WriteFile(secret, []byte("secret"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "ok.txt"), []byte("ok"), 0o600))
+	require.NoError(t, os.Symlink(secret, filepath.Join(src, "leak")))
+
+	require.NoError(t, CopyRepoRelativeFilesNoSymlinks(dst, src, []string{"ok.txt", "leak"}))
+
+	got, err := os.ReadFile(filepath.Join(dst, "ok.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "ok", string(got))
+	_, err = os.Stat(filepath.Join(dst, "leak"))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, os.ErrNotExist), "symlink must not be copied")
+}

--- a/pkg/resolver/kustomize/detect.go
+++ b/pkg/resolver/kustomize/detect.go
@@ -1,0 +1,31 @@
+package kustomize
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+var kustomizationNames = []string{"kustomization.yaml", "kustomization.yml", "Kustomization"}
+
+// IsKustomizationEntryFile reports whether path is a kustomization entry filename.
+func IsKustomizationEntryFile(path string) bool {
+	base := filepath.Base(path)
+	for _, n := range kustomizationNames {
+		if base == n {
+			return true
+		}
+	}
+	return false
+}
+
+// Detect returns KindKUSTOMIZE when the directory contains a kustomization entry file.
+func Detect(dir string) (model.FileKind, bool) {
+	for _, n := range kustomizationNames {
+		if _, err := os.Stat(filepath.Join(dir, n)); err == nil {
+			return model.KindKUSTOMIZE, true
+		}
+	}
+	return model.KindCOMMON, false
+}

--- a/pkg/resolver/kustomize/discover.go
+++ b/pkg/resolver/kustomize/discover.go
@@ -1,0 +1,402 @@
+package kustomize
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/rootfile"
+	"gopkg.in/yaml.v3"
+)
+
+// TransitiveLocalPaths returns local file paths referenced by a kustomization (best-effort for Excluded).
+func TransitiveLocalPaths(root string) ([]string, error) {
+	seen := map[string]struct{}{}
+	var out []string
+	addAbs := func(abs string) {
+		abs = filepath.Clean(abs)
+		if _, ok := seen[abs]; ok {
+			return
+		}
+		seen[abs] = struct{}{}
+		out = append(out, abs)
+	}
+	err := WalkLocalKustomizations(root, func(kustPath string, raw []byte) error {
+		addAbs(kustPath)
+		kustDir := filepath.Dir(kustPath)
+		var doc map[string]interface{}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			return err
+		}
+		add := func(p string) {
+			if p == "" || strings.Contains(p, "://") {
+				return
+			}
+			addAbs(filepath.Join(kustDir, filepath.Clean(p)))
+		}
+		appendDeclaredLocalPathStrings(doc, add)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// TransitiveRelativeLocalPaths lists relative local refs from the kustomization graph (no abs paths: keeps inference in-tree).
+func TransitiveRelativeLocalPaths(root string) ([]string, error) {
+	root = filepath.Clean(root)
+	seen := map[string]struct{}{root: {}}
+	out := []string{root}
+	err := WalkLocalKustomizations(root, func(kustPath string, raw []byte) error {
+		kustDir := filepath.Dir(kustPath)
+		if _, ok := seen[kustDir]; !ok {
+			seen[kustDir] = struct{}{}
+			out = append(out, kustDir)
+		}
+		var doc map[string]interface{}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			return err
+		}
+		add := func(p string) {
+			if p == "" || strings.Contains(p, "://") || filepath.IsAbs(p) {
+				return
+			}
+			abs := filepath.Clean(filepath.Join(kustDir, p))
+			if _, ok := seen[abs]; ok {
+				return
+			}
+			seen[abs] = struct{}{}
+			out = append(out, abs)
+		}
+		appendDeclaredLocalPathStrings(doc, add)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+const defaultHelmChartHome = "charts"
+
+func appendFromMixedStringOrPathList(v interface{}, add func(string)) {
+	t, ok := v.([]interface{})
+	if !ok {
+		return
+	}
+	for _, item := range t {
+		switch x := item.(type) {
+		case string:
+			add(x)
+		case map[string]interface{}:
+			if p, ok := x["path"].(string); ok {
+				add(p)
+			}
+		}
+	}
+}
+
+func appendHelmChartsDeclaredPaths(doc map[string]interface{}, add func(string)) {
+	list, ok := doc["helmCharts"].([]interface{})
+	if !ok {
+		return
+	}
+	chartHome := defaultHelmChartHome
+	if g, ok := doc["helmGlobals"].(map[string]interface{}); ok {
+		if ch, ok := g["chartHome"].(string); ok && ch != "" {
+			chartHome = ch
+		}
+	}
+	for _, item := range list {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := m["name"].(string); ok && name != "" {
+			add(filepath.Join(chartHome, name))
+		}
+		if vf, ok := m["valuesFile"].(string); ok {
+			add(vf)
+		}
+		if av, ok := m["additionalValuesFiles"].([]interface{}); ok {
+			for _, it := range av {
+				if s, ok := it.(string); ok {
+					add(s)
+				}
+			}
+		}
+	}
+}
+
+func appendPatchesJSON6902Paths(doc map[string]interface{}, add func(string)) {
+	list, ok := doc["patchesJson6902"].([]interface{})
+	if !ok {
+		return
+	}
+	for _, item := range list {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if p, ok := m["path"].(string); ok {
+			add(p)
+		}
+	}
+}
+
+func appendGeneratorFilePaths(doc map[string]interface{}, add func(string)) {
+	for _, k := range []string{"configMapGenerator", "secretGenerator"} {
+		v, ok := doc[k]
+		if !ok {
+			continue
+		}
+		list, ok := v.([]interface{})
+		if !ok {
+			continue
+		}
+		for _, item := range list {
+			m, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if files, ok := m["files"].([]interface{}); ok {
+				for _, f := range files {
+					if s, ok := f.(string); ok {
+						parts := strings.SplitN(s, "=", 2)
+						add(parts[len(parts)-1])
+					}
+				}
+			}
+			if envs, ok := m["envs"].([]interface{}); ok {
+				for _, f := range envs {
+					if s, ok := f.(string); ok {
+						add(s)
+					}
+				}
+			}
+		}
+	}
+}
+
+// appendDeclaredLocalPathStrings calls add for each local path in doc (resources, patches, generators, …).
+// Paths are as written in YAML, relative to the kustomization directory.
+func appendDeclaredLocalPathStrings(doc map[string]interface{}, add func(string)) {
+	for _, k := range []string{
+		"resources", "components", "bases",
+		"patchesStrategicMerge", "crds", "configurations",
+	} {
+		if v, ok := doc[k]; ok {
+			appendFromMixedStringOrPathList(v, add)
+		}
+	}
+	if v, ok := doc["replacements"]; ok {
+		collectReplacementFileRefs(v, add)
+	}
+	for _, k := range []string{"patches", "generators", "transformers", "validators"} {
+		if v, ok := doc[k]; ok {
+			appendFromMixedStringOrPathList(v, add)
+		}
+	}
+	if om, ok := doc["openapi"].(map[string]interface{}); ok {
+		if p, ok := om["path"].(string); ok {
+			add(p)
+		}
+	}
+	appendHelmChartsDeclaredPaths(doc, add)
+	appendPatchesJSON6902Paths(doc, add)
+	appendGeneratorFilePaths(doc, add)
+}
+
+// BuildMetadataStageRelPaths lists repo-relative files to copy into scratch for buildMetadata
+// (full kustom tree + declared locals under repoRoot).
+func BuildMetadataStageRelPaths(repoRoot, kustomRoot string) ([]string, error) {
+	repoRoot = filepath.Clean(repoRoot)
+	kustomRoot = filepath.Clean(kustomRoot)
+	set := make(map[string]struct{})
+	if err := WalkLocalKustomizations(kustomRoot, func(kustPath string, raw []byte) error {
+		kustDir := filepath.Dir(kustPath)
+		if err := treeFilesUnderIntoRelSet(repoRoot, kustDir, set); err != nil {
+			return err
+		}
+		var doc map[string]interface{}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			return err
+		}
+		add := func(p string) {
+			if p == "" || strings.Contains(p, "://") {
+				return
+			}
+			abs := filepath.Join(kustDir, filepath.Clean(p))
+			_ = stageAbsPathFilesIntoRelSet(repoRoot, abs, set)
+		}
+		appendDeclaredLocalPathStrings(doc, add)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	out := make([]string, 0, len(set))
+	for r := range set {
+		out = append(out, r)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// StageRelPathsForKustomRoot is repo-relative paths to stage one kustom root in scratch (delegates to BuildMetadataStageRelPaths).
+func StageRelPathsForKustomRoot(repoRoot, kustomRoot string) ([]string, error) {
+	return BuildMetadataStageRelPaths(repoRoot, kustomRoot)
+}
+
+func kustomBaseChildDirsFromDoc(doc map[string]interface{}, dir string) []string {
+	var next []string
+	addRef := func(p string) {
+		p = strings.TrimSpace(p)
+		if p == "" || isRemoteKustomizeRef(p) {
+			return
+		}
+		abs := filepath.Clean(filepath.Join(dir, p))
+		if st, err := os.Lstat(abs); err == nil && st.Mode()&fs.ModeSymlink == 0 && st.IsDir() {
+			if _, ok := Detect(abs); ok {
+				next = append(next, abs)
+			}
+		}
+	}
+	for _, key := range []string{"resources", "components", "bases"} {
+		v, ok := doc[key]
+		if !ok {
+			continue
+		}
+		list, ok := v.([]interface{})
+		if !ok {
+			continue
+		}
+		for _, item := range list {
+			switch x := item.(type) {
+			case string:
+				addRef(x)
+			case map[string]interface{}:
+				if p, ok := x["path"].(string); ok {
+					addRef(p)
+				}
+			}
+		}
+	}
+	return next
+}
+
+// WalkLocalKustomizations walks local bases/components/resources (no remote URLs).
+func WalkLocalKustomizations(root string, visit func(kustPath string, raw []byte) error) error {
+	root = filepath.Clean(root)
+	type item struct {
+		dir string
+	}
+	queue := []item{{dir: root}}
+	seen := map[string]struct{}{}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		dir := filepath.Clean(cur.dir)
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		seen[dir] = struct{}{}
+
+		kf := kustomizationEntryFile(dir)
+		kustPath := filepath.Join(dir, kf)
+		raw, err := rootfile.ReadFile(kustPath)
+		if err != nil {
+			return err
+		}
+		if err := visit(kustPath, raw); err != nil {
+			return err
+		}
+
+		var doc map[string]interface{}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			return err
+		}
+		for _, d := range kustomBaseChildDirsFromDoc(doc, dir) {
+			queue = append(queue, item{dir: d})
+		}
+	}
+	return nil
+}
+
+func treeFilesUnderIntoRelSet(repoRoot, root string, set map[string]struct{}) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			return nil
+		}
+		if rel == relDotDot || strings.HasPrefix(rel, parentDirPrefix) {
+			return nil
+		}
+		set[rel] = struct{}{}
+		return nil
+	})
+}
+
+func stageAbsPathFilesIntoRelSet(repoRoot, abs string, set map[string]struct{}) error {
+	abs = filepath.Clean(abs)
+	rel, err := filepath.Rel(filepath.Clean(repoRoot), abs)
+	if err != nil {
+		return err
+	}
+	if rel == relDotDot || strings.HasPrefix(rel, parentDirPrefix) {
+		return nil
+	}
+	fi, err := os.Lstat(abs)
+	if err != nil {
+		return nil
+	}
+	if fi.Mode()&fs.ModeSymlink != 0 {
+		return nil
+	}
+	if fi.IsDir() {
+		return treeFilesUnderIntoRelSet(repoRoot, abs, set)
+	}
+	set[rel] = struct{}{}
+	return nil
+}
+
+// collectReplacementFileRefs feeds add with replacement file paths only (top-level list strings and map `path`; ignores other scalars).
+func collectReplacementFileRefs(v interface{}, add func(string)) {
+	collectReplacementFileRefsRec(v, add, true)
+}
+
+func collectReplacementFileRefsRec(v interface{}, add func(string), topLevel bool) {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		if p, ok := t["path"].(string); ok {
+			add(p)
+		}
+	case []interface{}:
+		for _, it := range t {
+			switch x := it.(type) {
+			case string:
+				if topLevel {
+					add(x)
+				}
+			default:
+				collectReplacementFileRefsRec(x, add, false)
+			}
+		}
+	}
+}

--- a/pkg/resolver/kustomize/discover_buildmetadata_test.go
+++ b/pkg/resolver/kustomize/discover_buildmetadata_test.go
@@ -1,0 +1,80 @@
+package kustomize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildMetadataStageRelPaths_includesParentDirectoryRefs(t *testing.T) {
+	repo := t.TempDir()
+	base := filepath.Join(repo, "base")
+	overlay := filepath.Join(repo, "overlay")
+	require.NoError(t, os.MkdirAll(base, 0o700))
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "cm.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\ndata:\n  k: v\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+`), 0o600))
+
+	rels, err := BuildMetadataStageRelPaths(repo, overlay)
+	require.NoError(t, err)
+	require.Contains(t, rels, filepath.Join("overlay", "kustomization.yaml"))
+	require.Contains(t, rels, filepath.Join("base", "cm.yaml"))
+}
+
+func TestWalkLocalKustomizations_visitsNestedBases(t *testing.T) {
+	repo := t.TempDir()
+	base := filepath.Join(repo, "base")
+	overlay := filepath.Join(repo, "overlay")
+	require.NoError(t, os.MkdirAll(base, 0o700))
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+`), 0o600))
+
+	var visited []string
+	err := WalkLocalKustomizations(overlay, func(kustPath string, _ []byte) error {
+		visited = append(visited, filepath.Clean(kustPath))
+		return nil
+	})
+	require.NoError(t, err)
+	require.Contains(t, visited, filepath.Join(overlay, "kustomization.yaml"))
+	require.Contains(t, visited, filepath.Join(base, "kustomization.yaml"))
+}
+
+func TestBuildMetadataStageRelPaths_includesNestedChildParentRefs(t *testing.T) {
+	repo := t.TempDir()
+	common := filepath.Join(repo, "common")
+	base := filepath.Join(repo, "base")
+	overlay := filepath.Join(repo, "overlay")
+	require.NoError(t, os.MkdirAll(common, 0o700))
+	require.NoError(t, os.MkdirAll(base, 0o700))
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(common, "shared.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: shared\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../common/shared.yaml
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+`), 0o600))
+
+	rels, err := BuildMetadataStageRelPaths(repo, overlay)
+	require.NoError(t, err)
+	require.Contains(t, rels, filepath.Join("base", "kustomization.yaml"))
+	require.Contains(t, rels, filepath.Join("common", "shared.yaml"))
+}

--- a/pkg/resolver/kustomize/generator_origin_test.go
+++ b/pkg/resolver/kustomize/generator_origin_test.go
@@ -1,0 +1,48 @@
+package kustomize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/stretchr/testify/require"
+	krusty "sigs.k8s.io/kustomize/api/krusty"
+	kustypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+func TestOriginFromResource_GeneratorUsesOrgIdNameWithoutHashSuffix(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+- name: my-map
+  literals:
+  - k=v
+`), 0o600))
+	require.NoError(t, ensureBuildMetadataIfNeeded(dir))
+
+	opts := krusty.MakeDefaultOptions()
+	opts.LoadRestrictions = kustypes.LoadRestrictionsNone
+	opts.PluginConfig = kustypes.DisabledPluginConfig()
+	opts.PluginConfig.HelmConfig.Enabled = false
+	k := krusty.MakeKustomizer(opts)
+	rm, err := k.Run(filesys.MakeFsOnDisk(), dir)
+	require.NoError(t, err)
+
+	var found bool
+	for _, res := range rm.Resources() {
+		if res.GetGvk().Kind != "ConfigMap" {
+			continue
+		}
+		origin := OriginFromResource(res, dir)
+		if origin == nil || origin.OriginKind != model.KustomizeOriginGenerator {
+			continue
+		}
+		require.Equal(t, "my-map", origin.ResourceName)
+		require.NotEqual(t, res.GetName(), origin.ResourceName, "rendered name should include hash suffix while ResourceName stays stable")
+		found = true
+	}
+	require.True(t, found, "expected a generator-origin ConfigMap")
+}

--- a/pkg/resolver/kustomize/helmprepass.go
+++ b/pkg/resolver/kustomize/helmprepass.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
-	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/resolver/helm"
 	"github.com/DataDog/datadog-iac-scanner/pkg/rootfile"
 	"gopkg.in/yaml.v3"
@@ -164,17 +163,6 @@ func renderHelmChartEntries(
 			continue
 		}
 
-		valuesFiles, err := helmValueFilesForEntry(stagedRepo, kustDir, entry)
-		if err != nil {
-			diags = append(diags, ResolverDiagnostic{
-				FilePath: kustPath,
-				Message:  err.Error(),
-				QueryID:  "kustomize-helm-values-invalid",
-				Line:     1,
-			})
-			continue
-		}
-
 		releaseName, _ := entry["releaseName"].(string)
 		nameTemplate, _ := entry["nameTemplate"].(string)
 		namespace, _ := entry["namespace"].(string)
@@ -195,6 +183,17 @@ func renderHelmChartEntries(
 		skipTests := false
 		if v, ok := entry["skipTests"].(bool); ok && v {
 			skipTests = true
+		}
+
+		valuesFiles, err := helmValueFilesForEntry(stagedRepo, kustDir, chartPath, entry)
+		if err != nil {
+			diags = append(diags, ResolverDiagnostic{
+				FilePath: kustPath,
+				Message:  err.Error(),
+				QueryID:  "kustomize-helm-values-invalid",
+				Line:     1,
+			})
+			continue
 		}
 
 		rc, err := helm.RenderChart(ctx, &helm.RenderOptions{
@@ -314,10 +313,10 @@ func rewriteHelmChartsInKustomization(
 	return diags, nil
 }
 
-func helmValueFilesForEntry(repoRoot, staging string, entry map[string]interface{}) ([]string, error) {
+func helmValueFilesForEntry(repoRoot, staging, chartPath string, entry map[string]interface{}) ([]string, error) {
 	var files []string
 	if vf, ok := entry["valuesFile"].(string); ok && vf != "" {
-		p, err := stagedHelmValuePath(repoRoot, staging, vf)
+		p, err := stagedHelmValuePath(repoRoot, staging, chartPath, vf)
 		if err != nil {
 			return nil, err
 		}
@@ -326,7 +325,7 @@ func helmValueFilesForEntry(repoRoot, staging string, entry map[string]interface
 	if av, ok := entry["additionalValuesFiles"].([]interface{}); ok {
 		for _, x := range av {
 			if s, ok := x.(string); ok && s != "" {
-				p, err := stagedHelmValuePath(repoRoot, staging, s)
+				p, err := stagedHelmValuePath(repoRoot, staging, chartPath, s)
 				if err != nil {
 					return nil, err
 				}
@@ -338,14 +337,39 @@ func helmValueFilesForEntry(repoRoot, staging string, entry map[string]interface
 	return files, validateValuesMerge(entry)
 }
 
-func stagedHelmValuePath(stagedRepoRoot, staging, rel string) (string, error) {
+func stagedHelmValuePath(stagedRepoRoot, staging, chartPath, rel string) (string, error) {
 	stagedRepoRoot = filepath.Clean(stagedRepoRoot)
 	staging = filepath.Clean(staging)
 	p := filepath.Clean(filepath.Join(staging, rel))
 	if !isUnderRoot(p, stagedRepoRoot) {
 		return "", fmt.Errorf("helm values file %q escapes the staged repo root", rel)
 	}
+	if strings.TrimSpace(chartPath) != "" && filepath.IsAbs(chartPath) {
+		return copyHelmValueIntoChart(chartPath, p, rel)
+	}
 	return p, nil
+}
+
+func copyHelmValueIntoChart(chartPath, valuePath, rel string) (string, error) {
+	chartPath = filepath.Clean(chartPath)
+	if !isUnderRoot(valuePath, chartPath) {
+		dest := filepath.Join(chartPath, ".iac-scanner-values", filepath.Clean(rel))
+		if !isUnderRoot(dest, chartPath) {
+			return "", fmt.Errorf("helm values file %q has invalid destination", rel)
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), dirPermCopyTree); err != nil {
+			return "", err
+		}
+		raw, err := rootfile.ReadFile(valuePath)
+		if err != nil {
+			return "", err
+		}
+		if err := os.WriteFile(dest, raw, filePermCopyTree); err != nil {
+			return "", err
+		}
+		return dest, nil
+	}
+	return valuePath, nil
 }
 
 // stagedHelmChartPath resolves a local helmCharts entry to a path under

--- a/pkg/resolver/kustomize/helmprepass.go
+++ b/pkg/resolver/kustomize/helmprepass.go
@@ -1,0 +1,440 @@
+package kustomize
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/resolver/helm"
+	"github.com/DataDog/datadog-iac-scanner/pkg/rootfile"
+	"gopkg.in/yaml.v3"
+)
+
+// ErrMaxStagingBytes is returned when copied helm staging exceeds MaxFetchBytes.
+var ErrMaxStagingBytes = errors.New("kustomize staging exceeds max fetch bytes")
+
+type ResolverDiagnostic struct {
+	FilePath string
+	Message  string
+	QueryID  string
+	Line     int
+}
+
+func subtreeDeclaresHelmCharts(kustomRoot, kf string) bool {
+	var found bool
+	_ = WalkLocalKustomizations(kustomRoot, func(kustPath string, raw []byte) error {
+		if filepath.Clean(kustPath) == filepath.Join(kustomRoot, kf) {
+			return nil
+		}
+		var childDoc map[string]interface{}
+		if err := yaml.Unmarshal(raw, &childDoc); err != nil {
+			return nil
+		}
+		if childHC, _ := childDoc["helmCharts"].([]interface{}); len(childHC) > 0 {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
+// PrepareHelmChartsIfNeeded returns the kustomize build dir and fs root; rewrites nested kustomizations with helmCharts.
+// If inflation is off, strips helmCharts and emits diagnostics so the rest of the tree can still scan.
+func PrepareHelmChartsIfNeeded(
+	ctx context.Context,
+	repoRoot,
+	kustomRoot,
+	scratchDir string,
+	allowInflation,
+	helmIncludeCRDs bool,
+	maxStagingBytes int64,
+) (buildRoot, fsRoot string, diags []ResolverDiagnostic, _ error) {
+	repoRoot = filepath.Clean(repoRoot)
+	kustomRoot = filepath.Clean(kustomRoot)
+	kf := kustomizationEntryFile(kustomRoot)
+	data, err := rootfile.ReadFile(filepath.Join(kustomRoot, kf))
+	if err != nil {
+		return kustomRoot, repoRoot, nil, err
+	}
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return kustomRoot, repoRoot, nil, err
+	}
+	hc, _ := doc["helmCharts"].([]interface{})
+	if len(hc) == 0 && !subtreeDeclaresHelmCharts(kustomRoot, kf) {
+		return kustomRoot, repoRoot, nil, nil
+	}
+
+	// Isolate staging per (scratch, kustom root) so same-named overlays do not collide.
+	sum := sha256.Sum256([]byte(filepath.Clean(scratchDir) + "\x00" + filepath.Clean(kustomRoot)))
+	stagedRepo := filepath.Join(scratchDir, "helm-prepass", hex.EncodeToString(sum[:16]))
+	stageRels, err := StageRelPathsForKustomRoot(repoRoot, kustomRoot)
+	if err != nil {
+		return kustomRoot, repoRoot, []ResolverDiagnostic{{
+			FilePath: filepath.Join(kustomRoot, kf),
+			Message:  err.Error(),
+			QueryID:  "kustomize-helm-prepass-failed",
+			Line:     1,
+		}}, nil
+	}
+	if err := CopyRepoRelativeFilesNoSymlinks(stagedRepo, repoRoot, stageRels); err != nil {
+		return kustomRoot, repoRoot, []ResolverDiagnostic{{
+			FilePath: filepath.Join(kustomRoot, kf),
+			Message:  err.Error(),
+			QueryID:  "kustomize-helm-prepass-failed",
+			Line:     1,
+		}}, nil
+	}
+	relFromRepo, err := filepath.Rel(repoRoot, kustomRoot)
+	if err != nil || relFromRepo == relDotDot || strings.HasPrefix(relFromRepo, parentDirPrefix) {
+		return kustomRoot, repoRoot, []ResolverDiagnostic{{
+			FilePath: filepath.Join(kustomRoot, kf),
+			Message:  "kustomization root is outside configured repo root",
+			QueryID:  "kustomize-helm-prepass-failed",
+			Line:     1,
+		}}, nil
+	}
+	staging := filepath.Join(stagedRepo, relFromRepo)
+	if maxStagingBytes > 0 {
+		sz, err := DirTotalSize(stagedRepo)
+		if err == nil && sz > maxStagingBytes {
+			return kustomRoot, stagedRepo, []ResolverDiagnostic{{
+				FilePath: filepath.Join(kustomRoot, kf),
+				Message:  "helm prepass copy exceeds configured Kustomize max fetch bytes",
+				QueryID:  "kustomize-max-fetch-exceeded",
+				Line:     1,
+			}}, ErrMaxStagingBytes
+		}
+	}
+
+	configHome := filepath.Join(scratchDir, "helm-config")
+	repoConfig := filepath.Join(configHome, "repositories.yaml")
+	repoCache := filepath.Join(configHome, ".cache")
+	registryConfig := filepath.Join(configHome, "registry", "config.json")
+	_ = os.MkdirAll(filepath.Dir(repoConfig), dirPermCopyTree)
+	_ = os.MkdirAll(repoCache, dirPermCopyTree)
+	_ = os.MkdirAll(filepath.Dir(registryConfig), dirPermCopyTree)
+
+	if err := WalkLocalKustomizations(staging, func(kustPath string, raw []byte) error {
+		var err error
+		diags, err = rewriteHelmChartsInKustomization(
+			ctx, kustPath, raw, stagedRepo,
+			helmIncludeCRDs, allowInflation,
+			repoConfig, repoCache, registryConfig, diags,
+		)
+		return err
+	}); err != nil {
+		return kustomRoot, stagedRepo, diags, err
+	}
+	return staging, stagedRepo, diags, nil
+}
+
+func renderHelmChartEntries(
+	ctx context.Context,
+	hc []interface{},
+	kustPath, kustDir, stagedRepo, genDir, chartHome string,
+	helmIncludeCRDs bool,
+	repoConfig, repoCache, registryConfig string,
+	diags []ResolverDiagnostic,
+) ([]string, []ResolverDiagnostic) {
+	var newResources []string
+	for i, item := range hc {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := entry["name"].(string)
+		if name == "" {
+			continue
+		}
+		repo, _ := entry["repo"].(string)
+		version, _ := entry["version"].(string)
+
+		chartPath, chartDiags, ok := resolveHelmChartPath(ctx, kustPath, stagedRepo, kustDir, chartHome, name, repo)
+		diags = append(diags, chartDiags...)
+		if !ok {
+			continue
+		}
+
+		valuesFiles, err := helmValueFilesForEntry(stagedRepo, kustDir, entry)
+		if err != nil {
+			diags = append(diags, ResolverDiagnostic{
+				FilePath: kustPath,
+				Message:  err.Error(),
+				QueryID:  "kustomize-helm-values-invalid",
+				Line:     1,
+			})
+			continue
+		}
+
+		releaseName, _ := entry["releaseName"].(string)
+		nameTemplate, _ := entry["nameTemplate"].(string)
+		namespace, _ := entry["namespace"].(string)
+		valuesInline := mapStringAny(entry["valuesInline"])
+		valuesMerge, _ := entry["valuesMerge"].(string)
+		apiVersions := stringSlice(entry["apiVersions"])
+		kubeVersion, _ := entry["kubeVersion"].(string)
+		devel, _ := entry["devel"].(bool)
+
+		includeCRDs := helmIncludeCRDs
+		if v, ok := entry["includeCRDs"].(bool); ok {
+			includeCRDs = v
+		}
+		skipHooks := false
+		if v, ok := entry["skipHooks"].(bool); ok && v {
+			skipHooks = true
+		}
+		skipTests := false
+		if v, ok := entry["skipTests"].(bool); ok && v {
+			skipTests = true
+		}
+
+		rc, err := helm.RenderChart(ctx, &helm.RenderOptions{
+			ChartPath:        chartPath,
+			ChartRepo:        strings.TrimSpace(repo),
+			ReleaseName:      strings.TrimSpace(releaseName),
+			NameTemplate:     strings.TrimSpace(nameTemplate),
+			Namespace:        strings.TrimSpace(namespace),
+			ValuesFiles:      valuesFiles,
+			ValuesInline:     valuesInline,
+			ValuesMerge:      strings.TrimSpace(valuesMerge),
+			IncludeCRDs:      includeCRDs,
+			SkipHooks:        skipHooks,
+			SkipTests:        skipTests,
+			APIVersions:      apiVersions,
+			KubeVersion:      strings.TrimSpace(kubeVersion),
+			Version:          strings.TrimSpace(version),
+			Devel:            devel,
+			RepositoryConfig: repoConfig,
+			RepositoryCache:  repoCache,
+			RegistryConfig:   registryConfig,
+		})
+		if err != nil {
+			diags = append(diags, ResolverDiagnostic{
+				FilePath: kustPath,
+				Message:  err.Error(),
+				QueryID:  "kustomize-helm-render-failed",
+				Line:     1,
+			})
+			continue
+		}
+		outPath := filepath.Join(genDir, filepath.Base(name)+"-"+strconv.Itoa(i)+".yaml")
+		var blobs [][]byte
+		for _, res := range rc.Resources {
+			blobs = append(blobs, res.Content)
+		}
+		if err := os.WriteFile(outPath, joinYAML(blobs), filePermCopyTree); err != nil {
+			diags = append(diags, ResolverDiagnostic{
+				FilePath: outPath,
+				Message:  err.Error(),
+				QueryID:  "kustomize-helm-write-failed",
+				Line:     1,
+			})
+			continue
+		}
+		rel, _ := filepath.Rel(kustDir, outPath)
+		newResources = append(newResources, rel)
+	}
+	return newResources, diags
+}
+
+func rewriteHelmChartsInKustomization(
+	ctx context.Context,
+	kustPath string,
+	raw []byte,
+	stagedRepo string,
+	helmIncludeCRDs, allowInflation bool,
+	repoConfig, repoCache, registryConfig string,
+	diags []ResolverDiagnostic,
+) ([]ResolverDiagnostic, error) {
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return diags, err
+	}
+	hc, _ := doc["helmCharts"].([]interface{})
+	if len(hc) == 0 {
+		return diags, nil
+	}
+	kustDir := filepath.Dir(kustPath)
+	if !allowInflation {
+		delete(doc, "helmCharts")
+		delete(doc, "helmGlobals")
+		outK, err := yaml.Marshal(doc)
+		if err != nil {
+			return diags, err
+		}
+		if err := os.WriteFile(kustPath, outK, filePermCopyTree); err != nil {
+			return diags, err
+		}
+		return append(diags, ResolverDiagnostic{
+			FilePath: kustPath,
+			Message:  "kustomization declares helmCharts but Kustomize Helm inflation is disabled",
+			QueryID:  "kustomize-helm-inflation-disabled",
+			Line:     1,
+		}), nil
+	}
+
+	chartHome := defaultHelmChartHome
+	if g, ok := doc["helmGlobals"].(map[string]interface{}); ok {
+		if ch, ok := g["chartHome"].(string); ok && ch != "" {
+			chartHome = ch
+		}
+	}
+	genDir := filepath.Join(kustDir, ".iac-scanner-helm-out")
+	_ = os.MkdirAll(genDir, dirPermCopyTree)
+
+	newResources, diags := renderHelmChartEntries(
+		ctx, hc, kustPath, kustDir, stagedRepo, genDir, chartHome,
+		helmIncludeCRDs, repoConfig, repoCache, registryConfig, diags,
+	)
+
+	delete(doc, "helmCharts")
+	delete(doc, "helmGlobals")
+	existing, _ := doc["resources"].([]interface{})
+	resList := append([]interface{}(nil), existing...)
+	for _, r := range newResources {
+		resList = append(resList, r)
+	}
+	doc["resources"] = resList
+	outK, err := yaml.Marshal(doc)
+	if err != nil {
+		return diags, err
+	}
+	if err := os.WriteFile(kustPath, outK, filePermCopyTree); err != nil {
+		return diags, err
+	}
+	return diags, nil
+}
+
+func helmValueFilesForEntry(repoRoot, staging string, entry map[string]interface{}) ([]string, error) {
+	var files []string
+	if vf, ok := entry["valuesFile"].(string); ok && vf != "" {
+		p, err := stagedHelmValuePath(repoRoot, staging, vf)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, p)
+	}
+	if av, ok := entry["additionalValuesFiles"].([]interface{}); ok {
+		for _, x := range av {
+			if s, ok := x.(string); ok && s != "" {
+				p, err := stagedHelmValuePath(repoRoot, staging, s)
+				if err != nil {
+					return nil, err
+				}
+				files = append(files, p)
+			}
+		}
+	}
+	// Inline values go through RenderOptions.ValuesInline in helm.RenderChart, not ValueFiles here.
+	return files, validateValuesMerge(entry)
+}
+
+func stagedHelmValuePath(stagedRepoRoot, staging, rel string) (string, error) {
+	stagedRepoRoot = filepath.Clean(stagedRepoRoot)
+	staging = filepath.Clean(staging)
+	p := filepath.Clean(filepath.Join(staging, rel))
+	if !isUnderRoot(p, stagedRepoRoot) {
+		return "", fmt.Errorf("helm values file %q escapes the staged repo root", rel)
+	}
+	return p, nil
+}
+
+// stagedHelmChartPath resolves a local helmCharts entry to a path under
+// stagedRepoRoot, rejecting "../" escapes via chartHome or name.
+func stagedHelmChartPath(stagedRepoRoot, kustDir, chartHome, name string) (string, error) {
+	stagedRepoRoot = filepath.Clean(stagedRepoRoot)
+	kustDir = filepath.Clean(kustDir)
+	p := filepath.Clean(filepath.Join(kustDir, chartHome, name))
+	if !isUnderRoot(p, stagedRepoRoot) {
+		return "", fmt.Errorf("helm chart %q (chartHome %q) escapes the staged repo root", name, chartHome)
+	}
+	return p, nil
+}
+
+// resolveHelmChartPath returns the chart locator for a helmCharts entry. For
+// remote charts (repo != "") it is the chart name; for local charts it is the
+// staged path. ok is false when the entry must be skipped.
+func resolveHelmChartPath(
+	ctx context.Context,
+	kustPath, stagedRepo, kustDir, chartHome, name, repo string,
+) (string, []ResolverDiagnostic, bool) {
+	if strings.TrimSpace(repo) != "" {
+		return name, nil, true
+	}
+	contextLogger := logger.FromContext(ctx)
+	localPath, err := stagedHelmChartPath(stagedRepo, kustDir, chartHome, name)
+	if err != nil {
+		return "", []ResolverDiagnostic{{
+			FilePath: kustPath,
+			Message:  err.Error(),
+			QueryID:  "kustomize-helm-chart-escape",
+			Line:     1,
+		}}, false
+	}
+	if _, err := os.Stat(localPath); err != nil {
+		contextLogger.Warn().Msgf("kustomize helm chart not found at %s", localPath)
+		return "", []ResolverDiagnostic{{
+			FilePath: kustPath,
+			Message:  "helm chart not found: " + localPath,
+			QueryID:  "kustomize-helm-chart-missing",
+			Line:     1,
+		}}, false
+	}
+	return localPath, nil, true
+}
+
+func validateValuesMerge(entry map[string]interface{}) error {
+	mode, _ := entry["valuesMerge"].(string)
+	mode = strings.TrimSpace(mode)
+	switch mode {
+	case "", "merge", "override", "replace":
+		return nil
+	default:
+		return fmt.Errorf("invalid valuesMerge %q (expected merge, override, or replace)", mode)
+	}
+}
+
+func mapStringAny(v interface{}) map[string]interface{} {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return m
+}
+
+func stringSlice(v interface{}) []string {
+	list, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(list))
+	for _, item := range list {
+		if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+			out = append(out, strings.TrimSpace(s))
+		}
+	}
+	return out
+}
+
+func joinYAML(parts [][]byte) []byte {
+	var b []byte
+	for i, p := range parts {
+		if i > 0 {
+			b = append(b, "---\n"...)
+		}
+		b = append(b, p...)
+		if len(p) > 0 && p[len(p)-1] != '\n' {
+			b = append(b, '\n')
+		}
+	}
+	return b
+}

--- a/pkg/resolver/kustomize/helmprepass_test.go
+++ b/pkg/resolver/kustomize/helmprepass_test.go
@@ -1,0 +1,280 @@
+package kustomize
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareHelmChartsIfNeeded_ErrMaxStagingBytes(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	scratch := t.TempDir()
+	charts := filepath.Join(root, "charts", "mini")
+	require.NoError(t, os.MkdirAll(filepath.Join(charts, "templates"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "Chart.yaml"), []byte("apiVersion: v2\nname: mini\nversion: 0.1.0\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "values.yaml"), []byte("{}"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "templates", "cm.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\ndata: {}\n"), 0o600))
+
+	kust := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+- name: mini
+  releaseName: r
+`
+	require.NoError(t, os.WriteFile(filepath.Join(root, "kustomization.yaml"), []byte(kust), 0o600))
+
+	_, _, diags, err := PrepareHelmChartsIfNeeded(ctx, root, root, scratch, true, true, 1)
+	require.ErrorIs(t, err, ErrMaxStagingBytes)
+	require.NotEmpty(t, diags)
+}
+
+func TestPrepareHelmChartsIfNeeded_InvalidValuesMerge(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	scratch := t.TempDir()
+	charts := filepath.Join(root, "charts", "mini")
+	require.NoError(t, os.MkdirAll(filepath.Join(charts, "templates"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "Chart.yaml"), []byte("apiVersion: v2\nname: mini\nversion: 0.1.0\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "values.yaml"), []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "templates", "cm.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n"), 0o600))
+	kust := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+- name: mini
+  valuesMerge: banana
+`
+	require.NoError(t, os.WriteFile(filepath.Join(root, "kustomization.yaml"), []byte(kust), 0o600))
+	_, _, diags, err := PrepareHelmChartsIfNeeded(ctx, root, root, scratch, true, true, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, diags)
+	require.Equal(t, "kustomize-helm-values-invalid", diags[0].QueryID)
+}
+
+func TestPrepareHelmChartsIfNeeded_StagesSiblingBaseRefs(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	base := filepath.Join(repo, "base")
+	overlay := filepath.Join(repo, "overlay")
+	charts := filepath.Join(overlay, "charts", "mini")
+	require.NoError(t, os.MkdirAll(filepath.Join(charts, "templates"), 0o700))
+	require.NoError(t, os.MkdirAll(base, 0o700))
+
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "Chart.yaml"), []byte("apiVersion: v2\nname: mini\nversion: 0.1.0\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "values.yaml"), []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "templates", "cm.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: from-helm\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "cm.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: from-base\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cm.yaml
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+helmCharts:
+- name: mini
+  releaseName: rel
+`), 0o600))
+
+	buildRoot, fsRoot, diags, err := PrepareHelmChartsIfNeeded(ctx, repo, overlay, t.TempDir(), true, true, 0)
+	require.NoError(t, err)
+	require.Empty(t, diags)
+	require.NotEqual(t, overlay, buildRoot)
+	require.Equal(t, filepath.Dir(buildRoot), fsRoot)
+
+	raw, err := os.ReadFile(filepath.Join(buildRoot, "kustomization.yaml"))
+	require.NoError(t, err)
+	txt := string(raw)
+	require.Contains(t, txt, "../base")
+	require.NotContains(t, txt, "helmCharts:")
+
+	stagedBaseFile := filepath.Join(fsRoot, "base", "cm.yaml")
+	_, err = os.Stat(stagedBaseFile)
+	require.NoError(t, err)
+
+	stagedContent, err := os.ReadFile(filepath.Join(buildRoot, "kustomization.yaml"))
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(stagedContent), "../base") || strings.Contains(string(stagedContent), "base"))
+}
+
+func TestPrepareHelmChartsIfNeeded_StagesCustomValuesFiles(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	overlay := filepath.Join(repo, "overlay")
+	charts := filepath.Join(overlay, "charts", "mini")
+	require.NoError(t, os.MkdirAll(filepath.Join(charts, "templates"), 0o700))
+
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "Chart.yaml"), []byte("apiVersion: v2\nname: mini\nversion: 0.1.0\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "values.yaml"), []byte("service:\n  port: 80\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "templates", "svc.yaml"), []byte("apiVersion: v1\nkind: Service\nmetadata:\n  name: svc\nspec:\n  ports:\n  - port: {{ .Values.service.port }}\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "custom-values.yaml"), []byte("service:\n  port: 9090\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+- name: mini
+  releaseName: rel
+  valuesFile: custom-values.yaml
+`), 0o600))
+
+	buildRoot, fsRoot, diags, err := PrepareHelmChartsIfNeeded(ctx, repo, overlay, t.TempDir(), true, true, 0)
+	require.NoError(t, err)
+	require.Empty(t, diags)
+	require.Equal(t, filepath.Dir(buildRoot), fsRoot)
+	_, err = os.Stat(filepath.Join(buildRoot, "custom-values.yaml"))
+	require.NoError(t, err)
+}
+
+func TestPrepareHelmChartsIfNeeded_RewritesNestedBaseHelmCharts(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	base := filepath.Join(repo, "base")
+	overlay := filepath.Join(repo, "overlay")
+	charts := filepath.Join(base, "charts", "mini")
+	require.NoError(t, os.MkdirAll(filepath.Join(charts, "templates"), 0o700))
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "Chart.yaml"), []byte("apiVersion: v2\nname: mini\nversion: 0.1.0\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "values.yaml"), []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "templates", "cm.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: nested\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+- name: mini
+  releaseName: rel
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+`), 0o600))
+
+	buildRoot, _, diags, err := PrepareHelmChartsIfNeeded(ctx, repo, overlay, t.TempDir(), true, true, 0)
+	require.NoError(t, err)
+	require.Empty(t, diags)
+
+	stagedBaseKust := filepath.Join(filepath.Dir(buildRoot), "base", "kustomization.yaml")
+	raw, err := os.ReadFile(stagedBaseKust)
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), "helmCharts:")
+	require.Contains(t, string(raw), ".iac-scanner-helm-out")
+}
+
+func TestPrepareHelmChartsIfNeeded_StripsHelmChartsWhenInflationDisabled(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	charts := filepath.Join(repo, "charts", "mini")
+	require.NoError(t, os.MkdirAll(filepath.Join(charts, "templates"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "Chart.yaml"), []byte("apiVersion: v2\nname: mini\nversion: 0.1.0\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "values.yaml"), []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(charts, "templates", "cm.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: disabled\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "local.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: keep-me\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- local.yaml
+helmCharts:
+- name: mini
+  releaseName: rel
+`), 0o600))
+
+	buildRoot, _, diags, err := PrepareHelmChartsIfNeeded(ctx, repo, repo, t.TempDir(), false, true, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, diags)
+	require.Equal(t, "kustomize-helm-inflation-disabled", diags[0].QueryID)
+
+	raw, err := os.ReadFile(filepath.Join(buildRoot, "kustomization.yaml"))
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), "helmCharts:")
+	require.Contains(t, string(raw), "local.yaml")
+}
+
+func TestPrepareHelmChartsIfNeeded_DoesNotPreRejectRemoteRepoWithoutVersion(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+- name: mini
+  repo: https://example.com/charts
+  releaseName: rel
+`), 0o600))
+
+	_, _, diags, err := PrepareHelmChartsIfNeeded(ctx, repo, repo, t.TempDir(), true, true, 0)
+	require.NoError(t, err)
+	for _, d := range diags {
+		require.NotEqual(t, "kustomize-helm-remote-chart-invalid", d.QueryID)
+	}
+}
+
+func TestHelmValueFilesForEntry_RejectsEscape(t *testing.T) {
+	root := t.TempDir()
+	staging := filepath.Join(root, "overlay")
+	entry := map[string]interface{}{
+		"valuesFile": "../../secrets.yaml",
+	}
+	_, err := helmValueFilesForEntry(root, staging, entry)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "escapes the staged repo root")
+}
+
+func TestStagedHelmChartPath_RejectsEscape(t *testing.T) {
+	stagedRepo := t.TempDir()
+	kustDir := filepath.Join(stagedRepo, "overlay")
+
+	cases := []struct {
+		name      string
+		chartHome string
+		chart     string
+	}{
+		{"chartHome traversal", "../../../etc", "passwd"},
+		{"chart name traversal", "charts", "../../../etc/passwd"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := stagedHelmChartPath(stagedRepo, kustDir, tc.chartHome, tc.chart)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "escapes the staged repo root")
+		})
+	}
+}
+
+func TestStagedHelmChartPath_AcceptsInRoot(t *testing.T) {
+	stagedRepo := t.TempDir()
+	kustDir := filepath.Join(stagedRepo, "overlay")
+	require.NoError(t, os.MkdirAll(filepath.Join(kustDir, "charts", "mini"), 0o700))
+
+	got, err := stagedHelmChartPath(stagedRepo, kustDir, "charts", "mini")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(kustDir, "charts", "mini"), got)
+}
+
+func TestPrepareHelmChartsIfNeeded_RejectsLocalChartEscape(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmGlobals:
+  chartHome: ../../../etc
+helmCharts:
+- name: passwd
+  releaseName: rel
+`), 0o600))
+
+	_, _, diags, err := PrepareHelmChartsIfNeeded(ctx, repo, repo, t.TempDir(), true, true, 0)
+	require.NoError(t, err)
+	var sawEscape bool
+	for _, d := range diags {
+		if d.QueryID == "kustomize-helm-chart-escape" {
+			sawEscape = true
+			require.Contains(t, d.Message, "escapes the staged repo root")
+		}
+		require.NotEqual(t, "kustomize-helm-render-failed", d.QueryID)
+	}
+	require.True(t, sawEscape, "%+v", diags)
+}

--- a/pkg/resolver/kustomize/helmprepass_test.go
+++ b/pkg/resolver/kustomize/helmprepass_test.go
@@ -218,7 +218,7 @@ func TestHelmValueFilesForEntry_RejectsEscape(t *testing.T) {
 	entry := map[string]interface{}{
 		"valuesFile": "../../secrets.yaml",
 	}
-	_, err := helmValueFilesForEntry(root, staging, entry)
+	_, err := helmValueFilesForEntry(root, staging, filepath.Join(staging, "charts", "mini"), entry)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "escapes the staged repo root")
 }

--- a/pkg/resolver/kustomize/helper.go
+++ b/pkg/resolver/kustomize/helper.go
@@ -1,0 +1,93 @@
+package kustomize
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/resolver/sandbox"
+	krusty "sigs.k8s.io/kustomize/api/krusty"
+	kustypes "sigs.k8s.io/kustomize/api/types"
+)
+
+// helperEnvVar: set by renderWithTimeout when re-execing a test binary (no CLI
+// binary). Production uses `internal kustomize-render` instead.
+const helperEnvVar = "GO_WANT_KUSTOMIZE_RENDER_HELPER"
+
+// helperSleepEnvVar: test-only delay before stdin handling (timeout regression).
+const helperSleepEnvVar = "KUSTOMIZE_HELPER_SLEEP_MS"
+
+// MaybeRunAsKustomizeRenderHelper exits early when helperEnvVar=1 (test subprocess
+// re-exec); call from main before the CLI runs. No-op in normal/production runs.
+func MaybeRunAsKustomizeRenderHelper() {
+	if os.Getenv(helperEnvVar) != "1" {
+		return
+	}
+	if sleepMs := os.Getenv(helperSleepEnvVar); sleepMs != "" {
+		if n, err := strconv.Atoi(sleepMs); err == nil && n > 0 {
+			time.Sleep(time.Duration(n) * time.Millisecond)
+		}
+	}
+	_ = RunHelperFromStdin()
+	os.Exit(0)
+}
+
+// helperRequest is the JSON body on stdin for one kustomize build.
+type helperRequest struct {
+	BuildRoot  string `json:"build_root"`
+	RunFSRoot  string `json:"run_fs_root"`
+	StrictLoad bool   `json:"strict_load"`
+}
+
+// buildResult is JSON on stdout; render errors use Err (timeouts/crashes are parent-side).
+type buildResult struct {
+	YAML string `json:"yaml"`
+	Err  string `json:"err,omitempty"`
+}
+
+// RunHelperFromStdin is the `internal kustomize-render` entrypoint: stdin JSON
+// request, stdout JSON result; render failures are encoded in buildResult.Err.
+func RunHelperFromStdin() error {
+	body, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return writeHelperResult(buildResult{Err: fmt.Sprintf("read stdin: %v", err)})
+	}
+	var req helperRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return writeHelperResult(buildResult{Err: fmt.Sprintf("decode helper request: %v", err)})
+	}
+	return writeHelperResult(helperRender(req.BuildRoot, req.RunFSRoot, req.StrictLoad))
+}
+
+func writeHelperResult(r buildResult) error {
+	return json.NewEncoder(os.Stdout).Encode(r)
+}
+
+// helperRender runs krusty in-process (shared by CLI subcommand and test re-exec).
+func helperRender(buildRoot, runFSRoot string, strictLoad bool) buildResult {
+	opts := krusty.MakeDefaultOptions()
+	if strictLoad {
+		opts.LoadRestrictions = kustypes.LoadRestrictionsRootOnly
+	} else {
+		opts.LoadRestrictions = kustypes.LoadRestrictionsNone
+	}
+	opts.PluginConfig = kustypes.DisabledPluginConfig()
+	opts.PluginConfig.HelmConfig.Enabled = false
+	k := krusty.MakeKustomizer(opts)
+	runFS, err := sandbox.NewBoundedFS(runFSRoot)
+	if err != nil {
+		return buildResult{Err: err.Error()}
+	}
+	rm, err := k.Run(runFS, buildRoot)
+	if err != nil {
+		return buildResult{Err: err.Error()}
+	}
+	yamlOut, err := rm.AsYaml()
+	if err != nil {
+		return buildResult{Err: err.Error()}
+	}
+	return buildResult{YAML: string(yamlOut)}
+}

--- a/pkg/resolver/kustomize/helper_main_test.go
+++ b/pkg/resolver/kustomize/helper_main_test.go
@@ -1,0 +1,13 @@
+package kustomize
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain mirrors cmd/scanner main: subprocess kustomize render re-execs this test binary with
+// GO_WANT_KUSTOMIZE_RENDER_HELPER=1 and must handle stdin before tests run.
+func TestMain(m *testing.M) {
+	MaybeRunAsKustomizeRenderHelper()
+	os.Exit(m.Run())
+}

--- a/pkg/resolver/kustomize/konfig_constants_test.go
+++ b/pkg/resolver/kustomize/konfig_constants_test.go
@@ -1,0 +1,12 @@
+package kustomize
+
+import "testing"
+
+func TestTransformerAnnotationKey_AlignsWithKustomizeAPI(t *testing.T) {
+	// Must match the annotation key used by sigs.k8s.io/kustomize/api/resource.Resource.GetTransformations
+	// (sigs.k8s.io/kustomize/api/internal/utils.TransformerAnnotationKey).
+	const expected = "alpha.config.kubernetes.io/transformations"
+	if TransformerAnnotationKey != expected {
+		t.Fatalf("TransformerAnnotationKey = %q, want %q", TransformerAnnotationKey, expected)
+	}
+}

--- a/pkg/resolver/kustomize/namehash.go
+++ b/pkg/resolver/kustomize/namehash.go
@@ -1,0 +1,33 @@
+package kustomize
+
+import (
+	"regexp"
+
+	"sigs.k8s.io/kustomize/api/resource"
+)
+
+// Default kustomize content-hash suffix length is 10 alphanumeric characters.
+var kustomizeNameHashSuffix = regexp.MustCompile(`-[a-z0-9]{10}$`)
+
+func stripKustomizeNameHashSuffix(name string) string {
+	return kustomizeNameHashSuffix.ReplaceAllString(name, "")
+}
+
+// generatorResourceName returns the stable id for generator-produced resources (pre-hash-suffix).
+// OrgId().Name may still include the content hash; strip a trailing kustomize hash when present.
+func generatorResourceName(res *resource.Resource) string {
+	if res == nil {
+		return ""
+	}
+	rendered := res.GetName()
+	if s := stripKustomizeNameHashSuffix(rendered); s != "" && s != rendered {
+		return s
+	}
+	if n := res.OrgId().Name; n != "" {
+		if s := stripKustomizeNameHashSuffix(n); s != "" && s != n {
+			return s
+		}
+		return n
+	}
+	return rendered
+}

--- a/pkg/resolver/kustomize/paths.go
+++ b/pkg/resolver/kustomize/paths.go
@@ -1,0 +1,14 @@
+package kustomize
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// isUnderRoot reports whether path is root itself or strictly under root.
+// Used to confine reads/writes to the configured repo or scratch trees.
+func isUnderRoot(path, root string) bool {
+	cp := filepath.Clean(path)
+	cr := filepath.Clean(root)
+	return cp == cr || strings.HasPrefix(cp, cr+string(filepath.Separator))
+}

--- a/pkg/resolver/kustomize/precheck.go
+++ b/pkg/resolver/kustomize/precheck.go
@@ -1,0 +1,134 @@
+package kustomize
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+func appendRemoteRefsFromResourceItems(v interface{}, add func(string)) {
+	t, ok := v.([]interface{})
+	if !ok {
+		return
+	}
+	for _, item := range t {
+		switch x := item.(type) {
+		case string:
+			add(x)
+		case map[string]interface{}:
+			for _, subk := range []string{"repo", "url", "path"} {
+				if s, ok := x[subk].(string); ok {
+					add(s)
+				}
+			}
+		}
+	}
+}
+
+func appendRemoteRefsFromPatchLikeItems(v interface{}, add func(string)) {
+	t, ok := v.([]interface{})
+	if !ok {
+		return
+	}
+	for _, item := range t {
+		switch x := item.(type) {
+		case string:
+			add(x)
+		case map[string]interface{}:
+			if s, ok := x["path"].(string); ok {
+				add(s)
+			}
+			if s, ok := x["repo"].(string); ok {
+				add(s)
+			}
+			if s, ok := x["url"].(string); ok {
+				add(s)
+			}
+		}
+	}
+}
+
+func appendRemoteRefsFromOpenAPI(openapi map[string]interface{}, add func(string)) {
+	if s, ok := openapi["path"].(string); ok {
+		add(s)
+	}
+	if s, ok := openapi["repo"].(string); ok {
+		add(s)
+	}
+	if s, ok := openapi["url"].(string); ok {
+		add(s)
+	}
+}
+
+// CollectRemoteRefsFromKustomization lists remote-like refs in a kustomization
+// document. helmCharts are intentionally excluded; the Helm prepass owns
+// chart repos and gracefully handles the inflation-disabled path.
+func CollectRemoteRefsFromKustomization(data []byte) ([]string, error) {
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	var out []string
+	add := func(s string) {
+		if isRemoteKustomizeRef(s) {
+			out = append(out, s)
+		}
+	}
+	for _, key := range []string{"resources", "components", "bases"} {
+		if v, ok := doc[key]; ok {
+			appendRemoteRefsFromResourceItems(v, add)
+		}
+	}
+	for _, key := range []string{"patches", "generators", "transformers", "validators", "patchesJson6902"} {
+		if v, ok := doc[key]; ok {
+			appendRemoteRefsFromPatchLikeItems(v, add)
+		}
+	}
+	if openapi, ok := doc["openapi"].(map[string]interface{}); ok {
+		appendRemoteRefsFromOpenAPI(openapi, add)
+	}
+	return out, nil
+}
+
+// DetectKRMInlineFunctions is true when generators/transformers/validators use inline KRM objects (not executed here).
+func DetectKRMInlineFunctions(doc map[string]interface{}) bool {
+	for _, key := range []string{"generators", "transformers", "validators"} {
+		v, ok := doc[key]
+		if !ok {
+			continue
+		}
+		list, ok := v.([]interface{})
+		if !ok {
+			continue
+		}
+		for _, item := range list {
+			m, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if _, hasPath := m["path"]; hasPath {
+				continue
+			}
+			if m["apiVersion"] != nil && m["kind"] != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// DirTotalSize returns the sum of regular file sizes under root (best-effort).
+func DirTotalSize(root string) (int64, error) {
+	var n int64
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			n += info.Size()
+		}
+		return nil
+	})
+	return n, err
+}

--- a/pkg/resolver/kustomize/precheck_test.go
+++ b/pkg/resolver/kustomize/precheck_test.go
@@ -1,0 +1,204 @@
+package kustomize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCollectRemoteRefsFromKustomization(t *testing.T) {
+	raw := `resources:
+- ./local
+- https://example.com/base
+- git::https://github.com/org/repo.git//kustomize?ref=main
+- github.com/org/another-repo//deploy?ref=main
+- github.com/org/plain-repo//base
+- github.com/Liujingfang1/mysql?ref=test
+bases:
+- git@github.com:org/repo.git//deploy?ref=main
+components:
+- ssh://git@example.com/acme/comp.git
+patches:
+- path: https://example.com/patch.yaml
+transformers:
+- path: github.com/org/transformers//labeler
+generators:
+- path: git::https://github.com/org/plugin.git//gen
+helmCharts:
+- name: foo
+  repo: oci://registry.example.com/charts/foo
+`
+	got, err := CollectRemoteRefsFromKustomization([]byte(raw))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		"https://example.com/base",
+		"git::https://github.com/org/repo.git//kustomize?ref=main",
+		"github.com/org/another-repo//deploy?ref=main",
+		"github.com/org/plain-repo//base",
+		"github.com/Liujingfang1/mysql?ref=test",
+		"git@github.com:org/repo.git//deploy?ref=main",
+		"ssh://git@example.com/acme/comp.git",
+		"https://example.com/patch.yaml",
+		"github.com/org/transformers//labeler",
+		"git::https://github.com/org/plugin.git//gen",
+	}, got)
+}
+
+func TestIsRemoteKustomizeRef(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{".", false},
+		{"./local", false},
+		{"../base", false},
+		{"base", false},
+		{"my.dir/file.yaml", false},
+		{"/abs/path", false},
+		{"server/foo/bar", false},
+		{"my-base?ref=foo", false},
+
+		{"https://example.com/base", true},
+		{"HTTPS://EXAMPLE.com/base", true},
+		{"http://example.com/base", true},
+		{"ssh://git@example.com/acme/comp.git", true},
+		{"oci://registry.example.com/charts/foo", true},
+		{"file:///etc/passwd", true},
+		{"git::https://github.com/org/plugin.git//gen", true},
+		{"git@github.com:org/repo.git//deploy?ref=main", true},
+		{"git@gitlab2.example.com:infra/repo.git?ref=v1", true},
+		{"org-12345@github.com:foo/bar", true},
+		{"github.com/Liujingfang1/mysql?ref=test", true},
+		{"GitHub.com/foo/bar", true},
+		{"github.com/foo/bar//sub?ref=v1", true},
+		{"example.org/path/to/repo//examples/multibases/dev", true},
+		{"https://example.com/path/to/repo.git/sub", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			require.Equal(t, tc.want, isRemoteKustomizeRef(tc.in), "input: %q", tc.in)
+		})
+	}
+}
+
+func TestCollectRemoteRefsFromKustomization_HelmChartsAreOwnedByPrepass(t *testing.T) {
+	raw := `helmCharts:
+- name: chart-a
+  repo: oci://registry.example.com/charts/foo
+- name: chart-b
+  repo: https://charts.example.com
+`
+	got, err := CollectRemoteRefsFromKustomization([]byte(raw))
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestDetectKRMInlineFunctions(t *testing.T) {
+	var doc map[string]interface{}
+	require.NoError(t, yaml.Unmarshal([]byte(`generators:
+- apiVersion: builtin
+  kind: ConfigMapGenerator
+  name: x
+`), &doc))
+	require.True(t, DetectKRMInlineFunctions(doc))
+
+	require.NoError(t, yaml.Unmarshal([]byte(`generators:
+- path: ./plugin.yaml
+`), &doc))
+	require.False(t, DetectKRMInlineFunctions(doc))
+}
+
+func TestTransitiveLocalPaths_ReplacementsOnlyCollectsPathFields(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+replacements:
+- source:
+    kind: ConfigMap
+    name: app-config
+    fieldPath: data.message
+  targets:
+  - select:
+      kind: Deployment
+      name: app
+    options:
+      delimiter: "."
+      index: 1
+    fieldPaths:
+    - spec.template.spec.containers.0.image
+- path: repl.yaml
+`), 0o600))
+	got, err := TransitiveLocalPaths(dir)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		filepath.Join(dir, "kustomization.yaml"),
+		filepath.Join(dir, "repl.yaml"),
+	}, got)
+}
+
+func TestTransitiveLocalPaths_IncludesUpwardLocalRefsAndEntryFile(t *testing.T) {
+	repo := t.TempDir()
+	base := filepath.Join(repo, "base")
+	overlay := filepath.Join(repo, "overlay")
+	require.NoError(t, os.MkdirAll(base, 0o700))
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patches:
+- path: ../base/patch.yaml
+`), 0o600))
+
+	got, err := TransitiveLocalPaths(overlay)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		filepath.Join(overlay, "kustomization.yaml"),
+		filepath.Join(base),
+		filepath.Join(base, "patch.yaml"),
+	}, got)
+}
+
+func TestTransitiveLocalPaths_RecursesIntoNestedLocalKustomizations(t *testing.T) {
+	repo := t.TempDir()
+	common := filepath.Join(repo, "common")
+	base := filepath.Join(repo, "base")
+	overlay := filepath.Join(repo, "overlay")
+	require.NoError(t, os.MkdirAll(common, 0o700))
+	require.NoError(t, os.MkdirAll(base, 0o700))
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "Kustomization"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../common/shared.yaml
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+`), 0o600))
+
+	got, err := TransitiveLocalPaths(overlay)
+	require.NoError(t, err)
+	require.Contains(t, got, filepath.Join(overlay, "kustomization.yml"))
+	require.Contains(t, got, filepath.Join(base, "Kustomization"))
+	require.Contains(t, got, filepath.Join(common, "shared.yaml"))
+}
+
+func TestTransitiveRelativeLocalPaths_IgnoresAbsoluteRefs(t *testing.T) {
+	repo := t.TempDir()
+	external := t.TempDir()
+	overlay := filepath.Join(repo, "overlay")
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), []byte("apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n- ../shared\n- "+filepath.Join(external, "base")+"\n"), 0o600))
+
+	got, err := TransitiveRelativeLocalPaths(overlay)
+	require.NoError(t, err)
+	require.Contains(t, got, overlay)
+	require.Contains(t, got, filepath.Join(repo, "shared"))
+	require.NotContains(t, got, filepath.Join(external, "base"))
+}

--- a/pkg/resolver/kustomize/remote_ref.go
+++ b/pkg/resolver/kustomize/remote_ref.go
@@ -1,0 +1,69 @@
+package kustomize
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var remoteURLSchemes = []string{
+	"http://",
+	"https://",
+	"ssh://",
+	"oci://",
+	"file://",
+}
+
+// scpStyleRE matches "user@host:path" (kustomize SCP-style git remote).
+var scpStyleRE = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]*@[^/:]+:`)
+
+// isRemoteKustomizeRef reports whether s would be treated as a remote
+// reference by kustomize at render time (sigs.k8s.io/kustomize/api/internal/git,
+// v0.21.1) or by go-getter, plus oci:// from #113.
+func isRemoteKustomizeRef(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" || isLocalKustomizePath(s) {
+		return false
+	}
+	return hasRemoteURLScheme(s) ||
+		hasPrefixCaseInsensitive(s, "git::") ||
+		scpStyleRE.MatchString(s) ||
+		isSchemelessGithubHost(s) ||
+		hasGoGetterDoubleSlash(s) ||
+		hasGitSuffixOverDelimiter(s)
+}
+
+func isLocalKustomizePath(s string) bool {
+	return filepath.IsAbs(s) ||
+		strings.HasPrefix(s, "./") ||
+		strings.HasPrefix(s, "../") ||
+		s == "." ||
+		s == ".."
+}
+
+func hasRemoteURLScheme(s string) bool {
+	for _, scheme := range remoteURLSchemes {
+		if hasPrefixCaseInsensitive(s, scheme) {
+			return true
+		}
+	}
+	return false
+}
+
+// isSchemelessGithubHost mirrors kustomize's isStandardGithubHost.
+func isSchemelessGithubHost(s string) bool {
+	lower := strings.ToLower(s)
+	return strings.HasPrefix(lower, "github.com/") || strings.HasPrefix(lower, "github.com:")
+}
+
+func hasGoGetterDoubleSlash(s string) bool {
+	return strings.Contains(s, "//") && strings.Contains(s, ".")
+}
+
+func hasGitSuffixOverDelimiter(s string) bool {
+	return strings.Contains(s, ".git") && (strings.Contains(s, "://") || strings.Contains(s, "@"))
+}
+
+func hasPrefixCaseInsensitive(s, prefix string) bool {
+	return len(prefix) <= len(s) && strings.EqualFold(s[:len(prefix)], prefix)
+}

--- a/pkg/resolver/kustomize/resolver.go
+++ b/pkg/resolver/kustomize/resolver.go
@@ -1,0 +1,408 @@
+package kustomize
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"sigs.k8s.io/kustomize/api/provider"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
+)
+
+// Options configures the Kustomize preprocessor.
+type Options struct {
+	RepoRoot           string
+	AllowHelmInflation bool
+	RenderTimeout      time.Duration
+	HelmIncludeCRDs    bool
+	// MaxFetchBytes: cap bytes under the resolve scratch dir (0 = unlimited).
+	MaxFetchBytes int64
+	// StrictLoad: RootOnly (stricter) vs None (overlay-friendly, wider reads).
+	StrictLoad bool
+}
+
+// Resolver renders kustomization directories to concrete manifests.
+type Resolver struct {
+	opts Options
+}
+
+// NewResolver constructs a Kustomize preprocessor.
+func NewResolver(opts Options) *Resolver {
+	if opts.RenderTimeout <= 0 {
+		opts.RenderTimeout = 60 * time.Second
+	}
+	return &Resolver{opts: opts}
+}
+
+// Name implements resolver.Preprocessor.
+func (r *Resolver) Name() string {
+	return "kustomize"
+}
+
+// Detect implements resolver.Preprocessor.
+func (r *Resolver) Detect(path string) (model.FileKind, bool) {
+	return Detect(path)
+}
+
+// SupportedTypes implements resolver.Preprocessor.
+func (r *Resolver) SupportedTypes() []model.FileKind {
+	return []model.FileKind{model.KindKUSTOMIZE}
+}
+
+// Resolve runs kustomize build for the given root directory.
+func (r *Resolver) Resolve(ctx context.Context, rootDir string) (model.ResolvedFiles, error) {
+	contextLogger := logger.FromContext(ctx)
+	rootAbs, err := normalizeKustomRoot(rootDir)
+	if err != nil {
+		logResolverDiagnostics(ctx, []ResolverDiagnostic{renderFailure(rootDir, err.Error())})
+		return model.ResolvedFiles{}, nil
+	}
+	repoRoot := r.effectiveRepoRoot(rootAbs)
+	if repoRoot == "" {
+		repoRoot = rootAbs
+	}
+	repoAbs, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return model.ResolvedFiles{}, err
+	}
+	if !isUnderRoot(rootAbs, repoAbs) {
+		logResolverDiagnostics(ctx, []ResolverDiagnostic{
+			renderFailure(rootDir, "kustomization root is outside configured repo root"),
+		})
+		return model.ResolvedFiles{}, nil
+	}
+
+	scratchDir, err := os.MkdirTemp("", "datadog-iac-kustomize-*")
+	if err != nil {
+		return model.ResolvedFiles{}, err
+	}
+	defer func() { _ = os.RemoveAll(scratchDir) }()
+
+	kf := kustomizationEntryFile(rootAbs)
+	kustPath := filepath.Join(rootAbs, kf)
+	excluded, _ := TransitiveLocalPaths(rootAbs)
+	var diags []ResolverDiagnostic
+	remoteDiags, earlyRemote, stopRemote := remotePolicyResult(rootAbs, kustPath, excluded)
+	diags = append(diags, remoteDiags...)
+	if stopRemote {
+		logResolverDiagnostics(ctx, diags)
+		return earlyRemote, nil
+	}
+
+	br, fsRoot, d, err := PrepareHelmChartsIfNeeded(
+		ctx, repoAbs, rootAbs, scratchDir,
+		r.opts.AllowHelmInflation, r.opts.HelmIncludeCRDs, r.opts.MaxFetchBytes,
+	)
+	if errors.Is(err, ErrMaxStagingBytes) {
+		diags = append(diags, d...)
+		logResolverDiagnostics(ctx, diags)
+		return model.ResolvedFiles{Excluded: stringSliceUnique(excluded)}, nil
+	}
+	if err != nil {
+		contextLogger.Warn().Msgf("kustomize helm prepass: %v", err)
+	}
+	buildRoot := br
+	runFSRoot := fsRoot
+	diags = append(diags, d...)
+
+	scratchAbs := filepath.Clean(scratchDir)
+	brMeta, fsMeta, diags, earlyMeta, stopMeta := maybeStageBuildMetadata(
+		ctx, repoAbs, rootDir, scratchAbs, excluded, buildRoot, runFSRoot, diags,
+	)
+	if stopMeta {
+		logResolverDiagnostics(ctx, diags)
+		return earlyMeta, nil
+	}
+	buildRoot, runFSRoot = brMeta, fsMeta
+
+	runCtx, cancel := context.WithTimeout(ctx, r.opts.RenderTimeout)
+	defer cancel()
+
+	yamlOut, err := renderWithTimeout(runCtx, buildRoot, runFSRoot, r.opts.StrictLoad)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			diags = append(diags, renderFailure(rootDir, "kustomize render timed out"))
+			logResolverDiagnostics(ctx, diags)
+			return model.ResolvedFiles{Excluded: stringSliceUnique(excluded)}, nil
+		}
+		diags = append(diags, renderFailure(rootDir, err.Error()))
+		logResolverDiagnostics(ctx, diags)
+		return model.ResolvedFiles{Excluded: stringSliceUnique(excluded)}, nil
+	}
+
+	rm, err := parseRenderedResMap(yamlOut)
+	if err != nil {
+		diags = append(diags, renderFailure(rootDir, err.Error()))
+		logResolverDiagnostics(ctx, diags)
+		return model.ResolvedFiles{Excluded: stringSliceUnique(excluded)}, nil
+	}
+
+	if rf, stop := rejectIfScratchExceedsLimit(r.opts.MaxFetchBytes, scratchDir, excluded); stop {
+		if r.opts.MaxFetchBytes > 0 {
+			if sz, err := DirTotalSize(scratchDir); err == nil {
+				diags = append(diags, scratchLimitWarning(rootDir, sz, r.opts.MaxFetchBytes))
+			}
+		}
+		logResolverDiagnostics(ctx, diags)
+		return rf, nil
+	}
+
+	out := resolvedVirtualsFromResMap(rm, rootAbs, repoAbs, scratchAbs, diags, excluded)
+	logResolverDiagnostics(ctx, diags)
+	return out, nil
+}
+
+func (r *Resolver) repoRootLimit(rootAbs string) string {
+	limit := ""
+	if r.opts.RepoRoot != "" {
+		if abs, err := filepath.Abs(r.opts.RepoRoot); err == nil {
+			limit = filepath.Clean(abs)
+		} else {
+			limit = filepath.Clean(r.opts.RepoRoot)
+		}
+	}
+	if gitRoot := nearestGitRoot(rootAbs); gitRoot != "" {
+		if limit == "" || isUnderRoot(gitRoot, limit) {
+			limit = gitRoot
+		}
+	}
+	return limit
+}
+
+func (r *Resolver) effectiveRepoRoot(rootDir string) string {
+	rootAbs, err := filepath.Abs(rootDir)
+	if err != nil {
+		rootAbs = filepath.Clean(rootDir)
+	}
+	limit := r.repoRootLimit(rootAbs)
+	cur := rootAbs
+	best := rootAbs
+	for {
+		rels, err := TransitiveRelativeLocalPaths(cur)
+		if err != nil || len(rels) == 0 {
+			break
+		}
+		candidate := commonAncestorPathForRoots(rels)
+		if candidate == "" || filepath.Clean(candidate) == filepath.Clean(best) {
+			break
+		}
+		if limit != "" && !isUnderRoot(candidate, limit) {
+			break
+		}
+		best = candidate
+		cur = candidate
+	}
+	if limit != "" && isUnderRoot(best, limit) {
+		return best
+	}
+	if limit != "" {
+		return limit
+	}
+	return best
+}
+
+func sourcePathForOutput(origin *model.KustomizeOrigin, kustomRoot string, res *resource.Resource) string {
+	if origin != nil && origin.SourceFile != "" && filepath.IsAbs(origin.SourceFile) {
+		return origin.SourceFile
+	}
+	if origin != nil && origin.SourceFile != "" && origin.SourceRepo != "" {
+		return origin.SourceFile
+	}
+	if origin != nil && origin.SourceFile != "" {
+		return filepath.Clean(filepath.Join(kustomRoot, origin.SourceFile))
+	}
+	return filepath.Join(kustomRoot, "generated-"+res.GetGvk().Kind+"-"+res.GetName()+".yaml")
+}
+
+func metadataPathForResolvedResource(origin *model.KustomizeOrigin, fallback string) string {
+	if origin == nil {
+		return fallback
+	}
+	if origin.OriginKind == model.KustomizeOriginTransformer {
+		for i := len(origin.Transformations) - 1; i >= 0; i-- {
+			if path := origin.Transformations[i].TransformerPath; path != "" && !looksLikeRemotePath(path) {
+				return cleanLocalPath(path)
+			}
+		}
+	}
+	return fallback
+}
+
+// renderWithTimeout runs kustomize in a subprocess so CommandContext can kill
+// it on deadline. Prod: same binary as `internal kustomize-render`; tests: same
+// test binary with helperEnvVar + MaybeRunAsKustomizeRenderHelper. JSON over stdin/stdout.
+func renderWithTimeout(ctx context.Context, buildRoot, runFSRoot string, strictLoad bool) (string, error) {
+	argv, extraEnv := helperInvocation()
+	bin, binErr := os.Executable()
+	if binErr != nil {
+		return "", fmt.Errorf("kustomize render helper binary: %w", binErr)
+	}
+	var cmd *exec.Cmd
+	if len(argv) == 0 {
+		//nolint:gosec // G204: bin is this process's own executable (os.Executable); no user input.
+		cmd = exec.CommandContext(ctx, bin)
+	} else {
+		//nolint:gosec // G204: bin is os.Executable(); argv is allowlisted in helperInvocation.
+		cmd = exec.CommandContext(ctx, bin, argv...)
+	}
+	cmd.Env = append(os.Environ(), extraEnv...)
+
+	reqBytes, err := json.Marshal(helperRequest{
+		BuildRoot:  buildRoot,
+		RunFSRoot:  runFSRoot,
+		StrictLoad: strictLoad,
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode kustomize render request: %w", err)
+	}
+	cmd.Stdin = bytes.NewReader(reqBytes)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	out, err := cmd.Output()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", ctxErr
+		}
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return "", fmt.Errorf("kustomize render helper: %s", msg)
+		}
+		return "", fmt.Errorf("kustomize render helper: %w", err)
+	}
+
+	var result buildResult
+	if err := json.Unmarshal(bytes.TrimSpace(out), &result); err != nil {
+		return "", fmt.Errorf("decode kustomize render result: %w", err)
+	}
+	if result.Err != "" {
+		return "", errors.New(result.Err)
+	}
+	return result.YAML, nil
+}
+
+// helperInvocation: prod uses `internal kustomize-render`; tests set helperEnvVar only (main calls MaybeRunAsKustomizeRenderHelper).
+func helperInvocation() (argv, env []string) {
+	if isTestBinary() {
+		return nil, []string{helperEnvVar + "=1"}
+	}
+	return []string{"internal", "kustomize-render"}, nil
+}
+
+func isTestBinary() bool {
+	base := filepath.Base(os.Args[0])
+	return strings.HasSuffix(base, ".test") || strings.HasSuffix(base, ".test.exe")
+}
+
+func parseRenderedResMap(yamlOut string) (resmap.ResMap, error) {
+	return resmap.NewFactory(provider.NewDepProvider().GetResourceFactory()).NewResMapFromBytes([]byte(yamlOut))
+}
+
+func skipLocalConfig(res *resource.Resource) bool {
+	ann := res.GetAnnotations()
+	if ann == nil {
+		return false
+	}
+	return ann["config.kubernetes.io/local-config"] == "true"
+}
+
+func commonAncestorPathForRoots(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	common := filepath.Clean(paths[0])
+	for _, p := range paths[1:] {
+		cur := filepath.Clean(p)
+		for common != cur && !strings.HasPrefix(cur, common+string(filepath.Separator)) {
+			parent := filepath.Dir(common)
+			if parent == common {
+				return common
+			}
+			common = parent
+		}
+	}
+	return common
+}
+
+func nearestGitRoot(path string) string {
+	cur := filepath.Clean(path)
+	for {
+		if _, err := os.Stat(filepath.Join(cur, ".git")); err == nil {
+			return cur
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return ""
+		}
+		cur = parent
+	}
+}
+
+func normalizeKustomRoot(rootDir string) (string, error) {
+	rootAbs, err := filepath.Abs(rootDir)
+	if err != nil {
+		return "", err
+	}
+	st, err := os.Stat(rootAbs)
+	if err != nil {
+		return "", err
+	}
+	if st.IsDir() {
+		return rootAbs, nil
+	}
+	if IsKustomizationEntryFile(rootAbs) {
+		return filepath.Dir(rootAbs), nil
+	}
+	return "", fmt.Errorf("kustomize root %q is neither a directory nor a kustomization entry file", rootDir)
+}
+
+func stringSliceUnique(in []string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// originalDataForResolvedResource returns the bytes to expose as the source
+// for a rendered resource. Local origin paths are read only when they sit
+// under repoAbs or scratchAbs to avoid leaking arbitrary host files via
+// attacker-controlled kustomize origin annotations.
+func originalDataForResolvedResource(
+	origin *model.KustomizeOrigin,
+	renderedYAML string,
+	repoAbs, scratchAbs string,
+) []byte {
+	if origin == nil {
+		return []byte(renderedYAML)
+	}
+	if origin.SourceFile != "" && origin.SourceRepo == "" && filepath.IsAbs(origin.SourceFile) {
+		if raw, ok := safeReadResolvedFile(origin.SourceFile, repoAbs, scratchAbs); ok {
+			return raw
+		}
+	}
+	if origin.OriginalSourceFile != "" && origin.OriginalSourceRepo == "" && filepath.IsAbs(origin.OriginalSourceFile) {
+		if raw, ok := safeReadResolvedFile(origin.OriginalSourceFile, repoAbs, scratchAbs); ok {
+			return raw
+		}
+	}
+	return []byte(renderedYAML)
+}

--- a/pkg/resolver/kustomize/resolver_phases.go
+++ b/pkg/resolver/kustomize/resolver_phases.go
@@ -1,0 +1,286 @@
+package kustomize
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/rootfile"
+	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/kustomize/api/resmap"
+)
+
+func rejectIfScratchExceedsLimit(
+	maxBytes int64,
+	scratchDir string,
+	excluded []string,
+) (model.ResolvedFiles, bool) {
+	if maxBytes <= 0 {
+		return model.ResolvedFiles{}, false
+	}
+	sz, szErr := DirTotalSize(scratchDir)
+	if szErr != nil || sz <= maxBytes {
+		return model.ResolvedFiles{}, false
+	}
+	return model.ResolvedFiles{Excluded: stringSliceUnique(excluded)}, true
+}
+
+// remotePolicyWalk scans the kustomization tree for remote refs and inline KRM diagnostics.
+func remotePolicyWalk(rootAbs string) (
+	firstRemotePath string,
+	firstRemoteRefs []string,
+	krmDiags []ResolverDiagnostic,
+	walkErr error,
+) {
+	walkErr = WalkLocalKustomizations(rootAbs, func(kustPath string, raw []byte) error {
+		if rem, err := CollectRemoteRefsFromKustomization(raw); err == nil && len(rem) > 0 && firstRemotePath == "" {
+			firstRemotePath = kustPath
+			firstRemoteRefs = append([]string(nil), rem...)
+		}
+		var doc map[string]interface{}
+		if err := yaml.Unmarshal(raw, &doc); err == nil && DetectKRMInlineFunctions(doc) {
+			krmDiags = append(krmDiags, ResolverDiagnostic{
+				FilePath: kustPath,
+				Message:  "inline KRM generators/transformers/validators are not executed in this scanner",
+				QueryID:  "kustomize-exec-plugin-disabled",
+				Line:     1,
+			})
+		}
+		return nil
+	})
+	return firstRemotePath, firstRemoteRefs, krmDiags, walkErr
+}
+
+func remotePolicyResult(rootAbs, kustPath string, excluded []string) ([]ResolverDiagnostic, model.ResolvedFiles, bool) {
+	firstRemotePath, firstRemoteRefs, krmDiags, remotePolicyErr := remotePolicyWalk(rootAbs)
+	if remotePolicyErr == nil && len(firstRemoteRefs) > 0 {
+		return []ResolverDiagnostic{remoteRefWarning(firstRemotePath, firstRemoteRefs)}, model.ResolvedFiles{
+			Excluded: stringSliceUnique(append(excluded, firstRemotePath)),
+		}, true
+	}
+	return appendKRMIfWalkFailed(kustPath, remotePolicyErr, krmDiags), model.ResolvedFiles{}, false
+}
+
+func appendKRMIfWalkFailed(kustPath string, remotePolicyErr error, diags []ResolverDiagnostic) []ResolverDiagnostic {
+	if remotePolicyErr == nil {
+		return diags
+	}
+	if raw, err := rootfile.ReadFile(kustPath); err == nil {
+		var doc map[string]interface{}
+		if err := yaml.Unmarshal(raw, &doc); err == nil && DetectKRMInlineFunctions(doc) {
+			diags = append(diags, ResolverDiagnostic{
+				FilePath: kustPath,
+				Message:  "inline KRM generators/transformers/validators are not executed in this scanner",
+				QueryID:  "kustomize-exec-plugin-disabled",
+				Line:     1,
+			})
+		}
+	}
+	return diags
+}
+
+func logResolverDiagnostics(ctx context.Context, diags []ResolverDiagnostic) {
+	if len(diags) == 0 {
+		return
+	}
+	contextLogger := logger.FromContext(ctx)
+	for _, d := range diags {
+		contextLogger.Warn().Msgf("%s: %s (%s)", d.FilePath, d.Message, d.QueryID)
+	}
+}
+
+func resolverWarning(filePath, message, queryID string) ResolverDiagnostic {
+	return ResolverDiagnostic{
+		FilePath: filePath,
+		Message:  message,
+		QueryID:  queryID,
+		Line:     1,
+	}
+}
+
+func renderFailure(filePath, message string) ResolverDiagnostic {
+	return resolverWarning(filePath, message, "kustomize-render-failed")
+}
+
+func scratchLimitWarning(rootDir string, sz, maxBytes int64) ResolverDiagnostic {
+	return resolverWarning(
+		rootDir,
+		fmt.Sprintf("kustomize scratch dir size exceeds configured maximum (%d > %d bytes)", sz, maxBytes),
+		"kustomize-max-fetch-exceeded",
+	)
+}
+
+func remoteRefWarning(filePath string, refs []string) ResolverDiagnostic {
+	return ResolverDiagnostic{
+		FilePath: filePath,
+		Message:  fmt.Sprintf("kustomization references remote resources which are not supported: %v", refs),
+		QueryID:  "kustomize-remote-disallowed",
+		Line:     1,
+	}
+}
+
+// maybeStageBuildMetadata returns done=true and rf when Resolve should return rf immediately.
+func maybeStageBuildMetadata(
+	ctx context.Context,
+	repoAbs, rootDir, scratchAbs string,
+	excluded []string,
+	buildRoot, runFSRoot string,
+	diags []ResolverDiagnostic,
+) (brOut, fsOut string, diagsOut []ResolverDiagnostic, rf model.ResolvedFiles, done bool) {
+	contextLogger := logger.FromContext(ctx)
+	buildAbs := filepath.Clean(buildRoot)
+	kustRel := kustomizationEntryFile(buildAbs)
+	metaPath := filepath.Join(buildAbs, kustRel)
+	metaBytes, err := rootfile.ReadFile(metaPath)
+	if err != nil {
+		return buildRoot, runFSRoot, diags, model.ResolvedFiles{}, false
+	}
+	need, err := buildMetadataSupplementsNeeded(metaBytes)
+	if err != nil {
+		contextLogger.Warn().Msgf("kustomize buildMetadata read: %v", err)
+		return buildRoot, runFSRoot, diags, model.ResolvedFiles{}, false
+	}
+	if !need {
+		return buildRoot, runFSRoot, diags, model.ResolvedFiles{}, false
+	}
+	if isUnderRoot(buildAbs, scratchAbs) {
+		if err := ensureBuildMetadataIfNeeded(buildRoot); err != nil {
+			contextLogger.Warn().Msgf("kustomize buildMetadata: %v", err)
+		}
+		return buildRoot, runFSRoot, diags, model.ResolvedFiles{}, false
+	}
+	relFromRepo, relErr := filepath.Rel(repoAbs, buildAbs)
+	if relErr != nil || relFromRepo == relDotDot || strings.HasPrefix(relFromRepo, parentDirPrefix) {
+		return "", "", nil, model.ResolvedFiles{Excluded: stringSliceUnique(excluded)}, true
+	}
+	sum := sha256.Sum256([]byte(repoAbs + "\x00" + buildAbs))
+	stagedRepo := filepath.Join(scratchAbs, "kustomize-build", hex.EncodeToString(sum[:]))
+	_ = os.RemoveAll(stagedRepo)
+	stageRels, stageErr := BuildMetadataStageRelPaths(repoAbs, buildAbs)
+	if stageErr != nil {
+		return "", "", nil, model.ResolvedFiles{Excluded: stringSliceUnique(excluded)}, true
+	}
+	if err := CopyRepoRelativeFilesNoSymlinks(stagedRepo, repoAbs, stageRels); err != nil {
+		return "", "", nil, model.ResolvedFiles{Excluded: stringSliceUnique(excluded)}, true
+	}
+	stagedKustom := filepath.Join(stagedRepo, relFromRepo)
+	if err := ensureBuildMetadataIfNeeded(stagedKustom); err != nil {
+		contextLogger.Warn().Msgf("kustomize buildMetadata: %v", err)
+	}
+	return stagedKustom, stagedRepo, diags, model.ResolvedFiles{}, false
+}
+
+func appendMissingTransformerPathDiags(
+	origin *model.KustomizeOrigin,
+	repoAbs, scratchAbs string,
+	seen map[string]struct{},
+	diags []ResolverDiagnostic,
+) []ResolverDiagnostic {
+	if origin == nil || len(origin.Transformations) == 0 {
+		return diags
+	}
+	for _, tr := range origin.Transformations {
+		if tr.TransformerPath == "" || strings.Contains(tr.TransformerPath, "://") {
+			continue
+		}
+		// Skip paths outside the repo/scratch sandbox so attacker-controlled
+		// origin annotations don't probe host files or leak into diagnostics.
+		if !isResolvedFileSafe(tr.TransformerPath, repoAbs, scratchAbs) {
+			continue
+		}
+		if _, err := rootfile.Lstat(tr.TransformerPath); err != nil {
+			key := origin.GeneratorConfigFile + "\x00" + tr.FieldPath + "\x00" + tr.TransformerPath
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			diags = append(diags, ResolverDiagnostic{
+				FilePath: origin.GeneratorConfigFile,
+				Message: fmt.Sprintf(
+					"transformer patch not found at %q (declared path %q)",
+					tr.TransformerPath, tr.FieldPath,
+				),
+				QueryID: "kustomize-transformer-path-missing",
+				Line:    1,
+			})
+		}
+	}
+	return diags
+}
+
+// isResolvedFileSafe reports whether a kustomize-supplied path may be read as
+// scan source bytes. It rejects empty/remote/relative paths and any path that
+// is not under one of the configured roots (repo or scratch).
+func isResolvedFileSafe(path string, roots ...string) bool {
+	if path == "" || strings.Contains(path, "://") || !filepath.IsAbs(path) {
+		return false
+	}
+	clean := filepath.Clean(path)
+	for _, r := range roots {
+		if r != "" && isUnderRoot(clean, r) {
+			return true
+		}
+	}
+	return false
+}
+
+// safeReadResolvedFile reads path through rootfile only when it satisfies
+// isResolvedFileSafe. Returns ok=false on any rejection or read error.
+func safeReadResolvedFile(path string, roots ...string) ([]byte, bool) {
+	if !isResolvedFileSafe(path, roots...) {
+		return nil, false
+	}
+	raw, err := rootfile.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, false
+	}
+	return raw, true
+}
+
+func resolvedVirtualsFromResMap(
+	rm resmap.ResMap,
+	rootAbs, repoAbs, scratchAbs string,
+	diags []ResolverDiagnostic,
+	excluded []string,
+) model.ResolvedFiles {
+	var out model.ResolvedFiles
+	out.Excluded = stringSliceUnique(excluded)
+	missingTransformerDiag := map[string]struct{}{}
+	for _, res := range rm.Resources() {
+		if skipLocalConfig(res) {
+			continue
+		}
+		yml := res.MustYaml()
+		origin := OriginFromResource(res, rootAbs)
+		diags = appendMissingTransformerPathDiags(origin, repoAbs, scratchAbs, missingTransformerDiag, diags)
+		if origin != nil && origin.SourceFile != "" && origin.SourceRepo == "" && !filepath.IsAbs(origin.SourceFile) {
+			origin.SourceFile = filepath.Join(rootAbs, origin.SourceFile)
+		}
+		srcPath := sourcePathForOutput(origin, rootAbs, res)
+		metadataPath := metadataPathForResolvedResource(origin, srcPath)
+		orig := originalDataForResolvedResource(origin, yml, repoAbs, scratchAbs)
+		if metadataPath != "" {
+			if raw, ok := safeReadResolvedFile(metadataPath, repoAbs, scratchAbs); ok {
+				orig = raw
+			} else if metadataPath != srcPath {
+				// Untrusted transformer path: don't surface it to downstream
+				// parsers/sinks; fall back to the rendered source path.
+				metadataPath = srcPath
+			}
+		}
+		out.File = append(out.File, model.ResolvedVirtual{
+			FileName:     srcPath,
+			MetadataPath: metadataPath,
+			Content:      []byte(yml),
+			OriginalData: orig,
+			Origin:       origin,
+		})
+	}
+	return out
+}

--- a/pkg/resolver/kustomize/resolver_test.go
+++ b/pkg/resolver/kustomize/resolver_test.go
@@ -1,0 +1,583 @@
+package kustomize
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolver_KRMInlineDoesNotFailScanPrep(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	require.NoError(t, writeFile(filepath.Join(dir, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+- apiVersion: builtin
+  kind: ConfigMapGenerator
+  name: gen
+resources: []
+`))
+	r := NewResolver(Options{RepoRoot: dir})
+	out, err := r.Resolve(ctx, dir)
+	require.NoError(t, err)
+	require.Empty(t, out.File)
+}
+
+func TestResolver_RemoteRefsDisallowed(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	require.NoError(t, writeFile(filepath.Join(dir, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://example.com/some/base
+`))
+	r := NewResolver(Options{RepoRoot: dir})
+	out, err := r.Resolve(ctx, dir)
+	require.NoError(t, err)
+	require.Empty(t, out.File)
+	require.Contains(t, out.Excluded, filepath.Join(dir, "kustomization.yaml"))
+}
+
+func TestResolver_LegacyHostStyleRemoteRefDisallowed(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	require.NoError(t, writeFile(filepath.Join(dir, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- github.com/Liujingfang1/mysql?ref=test
+`))
+	r := NewResolver(Options{RepoRoot: dir})
+	out, err := r.Resolve(ctx, dir)
+	require.NoError(t, err)
+	require.Empty(t, out.File)
+	require.Contains(t, out.Excluded, filepath.Join(dir, "kustomization.yaml"))
+}
+
+func TestResolver_HelmChartsRemoteRepoNotPreRejectedWhenInflationDisabled(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	require.NoError(t, writeFile(filepath.Join(repo, "local.yaml"), `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keep-me
+data:
+  k: v
+`))
+	require.NoError(t, writeFile(filepath.Join(repo, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- local.yaml
+helmCharts:
+- name: mini
+  repo: https://charts.example.com
+  releaseName: rel
+`))
+
+	r := NewResolver(Options{RepoRoot: repo, AllowHelmInflation: false})
+	out, err := r.Resolve(ctx, repo)
+	require.NoError(t, err)
+
+	var sawLocal bool
+	for _, f := range out.File {
+		if strings.Contains(f.FileName, "local.yaml") {
+			sawLocal = true
+		}
+	}
+	require.True(t, sawLocal, "%+v", out.File)
+}
+
+func TestResolver_RejectsLocalPathsOutsideRepoRoot(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(t, writeFile(filepath.Join(repo, "kustomization.yaml"), "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n- "+filepath.Join(outside, "deployment.yaml")+"\n"))
+
+	r := NewResolver(Options{RepoRoot: repo})
+	out, err := r.Resolve(ctx, repo)
+	require.NoError(t, err)
+	require.Empty(t, out.File)
+}
+
+func TestResolver_RemoteRefsDisallowedInNestedLocalBase(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	base := filepath.Join(repo, "base")
+	root := filepath.Join(repo, "root")
+	require.NoError(t, os.MkdirAll(base, 0o700))
+	require.NoError(t, os.MkdirAll(root, 0o700))
+	require.NoError(t, writeFile(filepath.Join(base, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://example.com/nested/remote
+`))
+	require.NoError(t, writeFile(filepath.Join(root, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+`))
+
+	r := NewResolver(Options{RepoRoot: repo})
+	out, err := r.Resolve(ctx, root)
+	require.NoError(t, err)
+	require.Empty(t, out.File)
+	require.Contains(t, out.Excluded, filepath.Join(base, "kustomization.yaml"))
+}
+
+func TestResolver_NamespaceFromOverlay(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	base := filepath.Join(repo, "base")
+	overlay := filepath.Join(repo, "overlay")
+	require.NoError(t, os.MkdirAll(base, 0o700))
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+
+	require.NoError(t, writeFile(filepath.Join(base, "deployment.yaml"), `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: app
+        image: nginx
+`))
+	require.NoError(t, writeFile(filepath.Join(base, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+`))
+	require.NoError(t, writeFile(filepath.Join(overlay, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+namespace: production
+`))
+
+	r := NewResolver(Options{
+		RepoRoot:           repo,
+		AllowHelmInflation: false,
+		RenderTimeout:      0,
+		HelmIncludeCRDs:    true,
+	})
+	out, err := r.Resolve(ctx, overlay)
+	require.NoError(t, err)
+	require.NotEmpty(t, out.File)
+
+	var joined strings.Builder
+	for _, f := range out.File {
+		joined.Write(f.Content)
+	}
+	combined := joined.String()
+	require.Contains(t, combined, "namespace: production")
+}
+
+func TestResolver_NamespaceFromOverlay_FileInputPath(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	base := filepath.Join(repo, "base")
+	overlay := filepath.Join(repo, "overlay")
+	require.NoError(t, os.MkdirAll(base, 0o700))
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+
+	require.NoError(t, writeFile(filepath.Join(base, "deployment.yaml"), `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: app
+        image: nginx
+`))
+	require.NoError(t, writeFile(filepath.Join(base, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+`))
+	require.NoError(t, writeFile(filepath.Join(overlay, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+namespace: production
+`))
+
+	r := NewResolver(Options{
+		RepoRoot:           repo,
+		AllowHelmInflation: false,
+		RenderTimeout:      0,
+		HelmIncludeCRDs:    true,
+	})
+	out, err := r.Resolve(ctx, filepath.Join(overlay, "kustomization.yaml"))
+	require.NoError(t, err)
+	require.NotEmpty(t, out.File)
+
+	var joined strings.Builder
+	for _, f := range out.File {
+		joined.Write(f.Content)
+	}
+	combined := joined.String()
+	require.Contains(t, combined, "namespace: production")
+}
+
+func TestResolver_TransformerConfiguredInTracksBaseKustomization(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	base := filepath.Join(repo, "base")
+	overlay := filepath.Join(repo, "overlay")
+	require.NoError(t, os.MkdirAll(base, 0o700))
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+
+	require.NoError(t, writeFile(filepath.Join(base, "deployment.yaml"), `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: app
+        image: nginx
+`))
+	require.NoError(t, writeFile(filepath.Join(base, "patch.yaml"), `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  replicas: 5
+`))
+	require.NoError(t, writeFile(filepath.Join(base, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+patches:
+- path: patch.yaml
+`))
+	require.NoError(t, writeFile(filepath.Join(overlay, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+`))
+
+	r := NewResolver(Options{
+		RepoRoot:           repo,
+		AllowHelmInflation: false,
+		HelmIncludeCRDs:    true,
+	})
+	out, err := r.Resolve(ctx, overlay)
+	require.NoError(t, err)
+	require.NotEmpty(t, out.File)
+
+	found := false
+	for _, f := range out.File {
+		if f.Origin == nil || f.Origin.OriginKind != model.KustomizeOriginTransformer {
+			continue
+		}
+		require.NotEmpty(t, f.Origin.Transformations)
+		require.Equal(t, filepath.Join(base, "kustomization.yaml"), f.Origin.Transformations[0].ConfiguredIn)
+		found = true
+	}
+	require.True(t, found, "expected transformed resource with base-owned configuredIn path")
+}
+
+func TestResolver_DirectOriginPreservesSourceBytes(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	root := filepath.Join(repo, "root")
+	require.NoError(t, os.MkdirAll(root, 0o700))
+	sourcePath := filepath.Join(root, "deployment.yaml")
+	source := `# dd-iac-scan ignore-block
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  replicas: 1
+`
+	require.NoError(t, writeFile(sourcePath, source))
+	require.NoError(t, writeFile(filepath.Join(root, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+`))
+
+	r := NewResolver(Options{RepoRoot: repo})
+	out, err := r.Resolve(ctx, root)
+	require.NoError(t, err)
+	require.NotEmpty(t, out.File)
+	require.Equal(t, sourcePath, out.File[0].FileName)
+	require.Equal(t, source, string(out.File[0].OriginalData))
+}
+
+func TestResolver_TransformerOriginPreservesOriginalSourceBytes(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	base := filepath.Join(repo, "base")
+	overlay := filepath.Join(repo, "overlay")
+	require.NoError(t, os.MkdirAll(base, 0o700))
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+	source := `# dd-iac-scan ignore-block
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  replicas: 1
+`
+	require.NoError(t, writeFile(filepath.Join(base, "deployment.yaml"), source))
+	require.NoError(t, writeFile(filepath.Join(overlay, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base/deployment.yaml
+namespace: prod
+`))
+
+	r := NewResolver(Options{RepoRoot: repo})
+	out, err := r.Resolve(ctx, overlay)
+	require.NoError(t, err)
+	require.NotEmpty(t, out.File)
+	require.Equal(t, source, string(out.File[0].OriginalData))
+	require.NotNil(t, out.File[0].Origin)
+	require.Equal(t, model.KustomizeOriginTransformer, out.File[0].Origin.OriginKind)
+}
+
+func TestRenderWithTimeout_KillsHelperProcess(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	t.Setenv("KUSTOMIZE_HELPER_SLEEP_MS", "200")
+	_, err := renderWithTimeout(ctx, t.TempDir(), t.TempDir(), false)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestResolver_ExcludedIncludesKustomizationAndUpwardBaseRefs(t *testing.T) {
+	ctx := context.Background()
+	repo := t.TempDir()
+	base := filepath.Join(repo, "base")
+	overlay := filepath.Join(repo, "overlay")
+	require.NoError(t, os.MkdirAll(base, 0o700))
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+	require.NoError(t, writeFile(filepath.Join(base, "deployment.yaml"), `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  replicas: 1
+`))
+	require.NoError(t, writeFile(filepath.Join(base, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+`))
+	require.NoError(t, writeFile(filepath.Join(overlay, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+`))
+
+	r := NewResolver(Options{RepoRoot: repo})
+	out, err := r.Resolve(ctx, overlay)
+	require.NoError(t, err)
+	require.Contains(t, out.Excluded, filepath.Join(overlay, "kustomization.yaml"))
+	require.Contains(t, out.Excluded, filepath.Join(base))
+}
+
+func TestSourcePathForOutput_PreservesRemoteOriginPath(t *testing.T) {
+	origin := &model.KustomizeOrigin{
+		OriginKind: model.KustomizeOriginDirect,
+		SourceFile: "https://github.com/org/repo/base/deployment.yaml",
+		SourceRepo: "https://github.com/org/repo",
+	}
+	got := sourcePathForOutput(origin, "/tmp/local-root", nil)
+	require.Equal(t, "https://github.com/org/repo/base/deployment.yaml", got)
+}
+
+func TestCleanLocalPath_PreservesRemoteTransformerURL(t *testing.T) {
+	got := cleanLocalPath("https://github.com/org/repo/base/patch.yaml")
+	require.Equal(t, "https://github.com/org/repo/base/patch.yaml", got)
+}
+
+func TestResolver_EffectiveRepoRoot_StaysWithinNeededSubtreeInsideGitRepo(t *testing.T) {
+	repo := t.TempDir()
+	overlay := filepath.Join(repo, "services", "app", "overlay")
+	base := filepath.Join(repo, "services", "base")
+	other := filepath.Join(repo, "other")
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o700))
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+	require.NoError(t, os.MkdirAll(base, 0o700))
+	require.NoError(t, os.MkdirAll(other, 0o700))
+	require.NoError(t, writeFile(filepath.Join(overlay, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+`))
+
+	r := NewResolver(Options{RepoRoot: repo})
+	got := r.effectiveRepoRoot(overlay)
+	require.Equal(t, filepath.Join(repo, "services"), got)
+}
+
+func TestResolver_EffectiveRepoRoot_DoesNotBroadenAcrossDistinctGitRepos(t *testing.T) {
+	parent := t.TempDir()
+	repoA := filepath.Join(parent, "repo-a")
+	repoB := filepath.Join(parent, "repo-b")
+	overlayA := filepath.Join(repoA, "overlay")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoA, ".git"), 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoB, ".git"), 0o700))
+	require.NoError(t, os.MkdirAll(overlayA, 0o700))
+	require.NoError(t, writeFile(filepath.Join(overlayA, "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []
+`))
+
+	r := NewResolver(Options{RepoRoot: parent})
+	got := r.effectiveRepoRoot(overlayA)
+	require.Equal(t, overlayA, got)
+	require.NotEqual(t, parent, got)
+}
+
+func TestDetect(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, writeFile(filepath.Join(dir, "kustomization.yaml"), "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n"))
+	k, ok := Detect(dir)
+	require.True(t, ok)
+	require.Equal(t, string(model.KindKUSTOMIZE), string(k))
+}
+
+func TestIsResolvedFileSafe(t *testing.T) {
+	repo := t.TempDir()
+	scratch := t.TempDir()
+	other := t.TempDir()
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"empty", "", false},
+		{"relative", "patch.yaml", false},
+		{"remote URL", "https://example.com/patch.yaml", false},
+		{"absolute outside roots", filepath.Join(other, "patch.yaml"), false},
+		{"absolute under repo", filepath.Join(repo, "base", "patch.yaml"), true},
+		{"absolute under scratch", filepath.Join(scratch, "kustomize-build", "x.yaml"), true},
+		{"escapes via dotdot back into repo", filepath.Join(repo, "..", filepath.Base(repo), "x.yaml"), true},
+		{"escapes via dotdot to host", filepath.Join(repo, "..", "..", "..", "etc", "passwd"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isResolvedFileSafe(tc.path, repo, scratch)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSafeReadResolvedFile_RejectsOutOfRoot(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "secret")
+	require.NoError(t, os.WriteFile(target, []byte("topsecret"), 0o600))
+
+	_, ok := safeReadResolvedFile(target, repo)
+	require.False(t, ok, "must not read host files outside configured roots")
+}
+
+func TestSafeReadResolvedFile_AllowsInRoot(t *testing.T) {
+	repo := t.TempDir()
+	target := filepath.Join(repo, "patch.yaml")
+	require.NoError(t, os.WriteFile(target, []byte("payload"), 0o600))
+
+	raw, ok := safeReadResolvedFile(target, repo, "")
+	require.True(t, ok)
+	require.Equal(t, "payload", string(raw))
+}
+
+func TestOriginalDataForResolvedResource_DropsOutOfRootSourceFile(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	hostFile := filepath.Join(outside, "passwd")
+	require.NoError(t, os.WriteFile(hostFile, []byte("root:x:0:0:root:/root:/bin/sh\n"), 0o600))
+
+	origin := &model.KustomizeOrigin{
+		OriginKind: model.KustomizeOriginDirect,
+		SourceFile: hostFile,
+	}
+	rendered := "kind: ConfigMap\n"
+	got := originalDataForResolvedResource(origin, rendered, repo, "")
+	require.Equal(t, rendered, string(got), "must not surface host file bytes as OriginalData")
+}
+
+func TestOriginalDataForResolvedResource_DropsOutOfRootOriginalSourceFile(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	hostFile := filepath.Join(outside, "shadow")
+	require.NoError(t, os.WriteFile(hostFile, []byte("hash"), 0o600))
+
+	origin := &model.KustomizeOrigin{
+		OriginKind:         model.KustomizeOriginTransformer,
+		OriginalSourceFile: hostFile,
+	}
+	rendered := "kind: Deployment\n"
+	got := originalDataForResolvedResource(origin, rendered, repo, "")
+	require.Equal(t, rendered, string(got))
+}
+
+func TestAppendMissingTransformerPathDiags_SkipsOutOfRoot(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	missingHostPath := filepath.Join(outside, "does-not-exist", "patch.yaml")
+
+	origin := &model.KustomizeOrigin{
+		OriginKind:          model.KustomizeOriginTransformer,
+		GeneratorConfigFile: filepath.Join(repo, "kustomization.yaml"),
+		Transformations: []model.KustomizeTransformation{
+			{TransformerPath: missingHostPath, FieldPath: "patches[0].path"},
+		},
+	}
+	got := appendMissingTransformerPathDiags(origin, repo, "", map[string]struct{}{}, nil)
+	require.Empty(t, got, "must not emit diagnostics that surface attacker-controlled host paths")
+}
+
+func TestOriginalDataForResolvedResource_ReadsInRootSourceFile(t *testing.T) {
+	repo := t.TempDir()
+	srcPath := filepath.Join(repo, "deployment.yaml")
+	src := "kind: Deployment\nmetadata:\n  name: app\n"
+	require.NoError(t, os.WriteFile(srcPath, []byte(src), 0o600))
+
+	origin := &model.KustomizeOrigin{
+		OriginKind: model.KustomizeOriginDirect,
+		SourceFile: srcPath,
+	}
+	got := originalDataForResolvedResource(origin, "rendered", repo, "")
+	require.Equal(t, src, string(got))
+}
+
+func writeFile(p, content string) error {
+	return os.WriteFile(p, []byte(content), 0o600)
+}

--- a/pkg/resolver/kustomize/transformations_test.go
+++ b/pkg/resolver/kustomize/transformations_test.go
@@ -1,0 +1,80 @@
+package kustomize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	krusty "sigs.k8s.io/kustomize/api/krusty"
+	kustypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+func TestBuildMetadataIncludesTransformerAnnotations_GetTransformationsPopulated(t *testing.T) {
+	repo := t.TempDir()
+	base := filepath.Join(repo, "base")
+	overlay := filepath.Join(repo, "overlay")
+	require.NoError(t, os.MkdirAll(base, 0o700))
+	require.NoError(t, os.MkdirAll(overlay, 0o700))
+
+	require.NoError(t, os.WriteFile(filepath.Join(base, "deployment.yaml"), []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+`), 0o600))
+
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "patch.yaml"), []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  replicas: 3
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patchesStrategicMerge:
+- patch.yaml
+`), 0o600))
+
+	require.NoError(t, ensureBuildMetadataIfNeeded(overlay))
+
+	opts := krusty.MakeDefaultOptions()
+	opts.LoadRestrictions = kustypes.LoadRestrictionsNone
+	opts.PluginConfig = kustypes.DisabledPluginConfig()
+	opts.PluginConfig.HelmConfig.Enabled = false
+	k := krusty.MakeKustomizer(opts)
+	rm, err := k.Run(filesys.MakeFsOnDisk(), overlay)
+	require.NoError(t, err)
+
+	var anyTrans bool
+	for _, res := range rm.Resources() {
+		trans, err := res.GetTransformations()
+		require.NoError(t, err)
+		if len(trans) > 0 {
+			anyTrans = true
+			break
+		}
+	}
+	require.True(t, anyTrans, "with transformerAnnotations in buildMetadata, GetTransformations should be non-empty for patched resources")
+}

--- a/pkg/rootfile/rootfile.go
+++ b/pkg/rootfile/rootfile.go
@@ -1,0 +1,59 @@
+// Package rootfile provides filesystem reads scoped with os.OpenRoot for safer path handling.
+package rootfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func openParentRoot(absPath string) (*os.Root, string, error) {
+	absPath = filepath.Clean(absPath)
+	dir := filepath.Dir(absPath)
+	rel, err := filepath.Rel(dir, absPath)
+	if err != nil {
+		return nil, "", err
+	}
+	if !filepath.IsLocal(rel) {
+		return nil, "", fmt.Errorf("path %q is not local under %q", absPath, dir)
+	}
+	r, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, "", err
+	}
+	return r, filepath.ToSlash(rel), nil
+}
+
+// ReadFile reads absPath by opening filepath.Dir(absPath) with os.OpenRoot and reading the relative path.
+func ReadFile(absPath string) ([]byte, error) {
+	r, rel, err := openParentRoot(absPath)
+	if err != nil {
+		return nil, err
+	}
+	data, rerr := r.ReadFile(rel)
+	cerr := r.Close()
+	if rerr != nil {
+		return nil, rerr
+	}
+	if cerr != nil {
+		return nil, cerr
+	}
+	return data, nil
+}
+
+// Lstat returns file info for absPath using os.OpenRoot on the parent directory.
+func Lstat(absPath string) (os.FileInfo, error) {
+	r, rel, err := openParentRoot(absPath)
+	if err != nil {
+		return nil, err
+	}
+	fi, rerr := r.Lstat(rel)
+	cerr := r.Close()
+	if rerr != nil {
+		return nil, rerr
+	}
+	if cerr != nil {
+		return nil, cerr
+	}
+	return fi, nil
+}

--- a/pkg/rootfile/rootfile_test.go
+++ b/pkg/rootfile/rootfile_test.go
@@ -1,0 +1,24 @@
+package rootfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadFile_roundTrip(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a", "b.txt")
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o700))
+	require.NoError(t, os.WriteFile(p, []byte("hello"), 0o600))
+
+	got, err := ReadFile(p)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(got))
+
+	fi, err := Lstat(p)
+	require.NoError(t, err)
+	require.False(t, fi.IsDir())
+}


### PR DESCRIPTION
> [!TIP]
> This PR is best reviewed commit by commit.

## Summary
- add the Kustomize resolver core, including local-tree discovery, precheck diagnostics, helm prepass, and render orchestration
- add internal helper subprocess wiring (`internal kustomize-render`) and startup hook so kustomize builds run with timeout control
- add root-scoped file utilities and apply them in resolver paths to keep file access bounded while satisfying lint checks

Full design context and architecture details: https://github.com/DataDog/datadog-iac-scanner/issues/113

## Test plan
- [x] `go test ./pkg/resolver/kustomize/... ./pkg/rootfile/... -count=1`
- [x] `$(go env GOPATH)/bin/golangci-lint run ./pkg/resolver/kustomize/... ./pkg/rootfile/...`

## Notes
- this PR only includes preprocessor/resolver core changes
- detector mapping, scan activation, and fixtures are split into follow-up PRs