### PR TITLE
Overprovisioned secrets root env is not checked

### DIFF
--- a/assets/queries/cicd/github/overprovisioned_secrets/query.rego
+++ b/assets/queries/cicd/github/overprovisioned_secrets/query.rego
@@ -283,6 +283,46 @@ CxPolicy[result] {
 	}
 }
 
+# Detect toJSON(secrets) or dynamic secret access in root env block
+CxPolicy[result] {
+	doc := input.document[i]
+	cicd_lib.check_provider(doc) == "github"
+	env := doc.env
+
+	# Get the env block
+	env_value := env[e]
+
+	# Check if it's a string with parsed expressions
+	is_string(env_value)
+
+	# Build the parsed expressions key
+	parsed_key := concat("", ["_parsed_expressions_", e])
+	parsed_exprs := env[parsed_key][_]
+
+	# Verify parsing succeeded
+	parsed_exprs.parse_ok == true
+
+	# Check for either secrets expansion or dynamic secret key
+	any([parsed_exprs.has_secrets_expansion, parsed_exprs.has_dynamic_secret_key])
+
+	# Build appropriate message
+	message := sprintf("Expression '%s' %s", [
+		parsed_exprs.raw,
+		get_submessage(parsed_exprs.has_secrets_expansion)
+	])
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("env.%s", [e]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets should be referenced individually with literal keys",
+		"keyActualValue": message,
+		"searchLine": common_lib.build_search_line(["env", e], []),
+		"resourceType": "github_action",
+		"resourceName": "env"
+	}
+}
+
 get_submessage(has_secrets_expansion) = "injects the entire secrets context" {
 	has_secrets_expansion
 } else = "uses dynamic indexing to access secrets" {

--- a/assets/queries/cicd/github/overprovisioned_secrets/test/.github/positive1.yaml
+++ b/assets/queries/cicd/github/overprovisioned_secrets/test/.github/positive1.yaml
@@ -1,0 +1,13 @@
+name: dogfood-overprovisioned-secrets-noncompliant-workflow-env
+on:
+  workflow_dispatch: {}
+
+env:
+  ALL_SECRETS: ${{ toJSON(secrets) }}
+  DYNAMIC_SECRET: ${{ secrets[matrix.secret_key] }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "inherits env; entire secrets JSON is available to the job"

--- a/assets/queries/cicd/github/overprovisioned_secrets/test/.github/positive_expected_result.json
+++ b/assets/queries/cicd/github/overprovisioned_secrets/test/.github/positive_expected_result.json
@@ -70,5 +70,17 @@
     "severity": "MEDIUM",
     "line": 63,
     "fileName": "positive.yaml"
+  },
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 6,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "Overprovisioned secrets",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive1.yaml"
   }
 ]

--- a/documentation/rules/cicd/github/overprovisioned_secrets.md
+++ b/documentation/rules/cicd/github/overprovisioned_secrets.md
@@ -165,3 +165,20 @@ jobs:
       - run: echo "Running"
 
 ```
+
+```yaml
+name: dogfood-overprovisioned-secrets-noncompliant-workflow-env
+on:
+  workflow_dispatch: {}
+
+env:
+  ALL_SECRETS: ${{ toJSON(secrets) }}
+  DYNAMIC_SECRET: ${{ secrets[matrix.secret_key] }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "inherits env; entire secrets JSON is available to the job"
+
+```


### PR DESCRIPTION
## Motivation

The env at the root level of the github action is not checked, leaving room for mistake for users without any alerts raised by the product

## Changes

- Added rego check for the root env
- Added test case
- Regenerated documentation

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [x] I have updated any relevant documentation (if applicable).

## QA Instruction

Check that the added logic matches the above description

## Blast Radius

New Overprovisioned secrets findings should be opened

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
