### PR TITLE
Exit with code 127 for invalid IaC configuration files

### DIFF
--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	cli "github.com/urfave/cli/v3"
@@ -58,6 +59,9 @@ func main() {
 	if err := cmd.Run(context.Background(), os.Args); err != nil {
 		var exitCode *normalExitCode
 		if errors.As(err, &exitCode) {
+			if exitCode.code == constants.InvalidConfigErrorCode {
+				log.Error().Err(err).Msg("invalid IaC configuration")
+			}
 			os.Exit(exitCode.code)
 		}
 

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/console"
+	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
@@ -130,16 +131,20 @@ func runScan(ctx context.Context, c *cli.Command) error {
 
 	cfg, _, err := config.ReadConfiguration(ctx, repoDir, config.WithDatadog(datadog.NewDatadogClient(), repoInfo.RepositoryUrl))
 	if err != nil {
+		var localCfgErr *config.InvalidLocalConfigError
+		if errors.As(err, &localCfgErr) {
+			return fmt.Errorf("error reading the configuration (%w): %w", exitCode(constants.InvalidConfigErrorCode), err)
+		}
 		return fmt.Errorf("error reading the configuration: %w", err)
 	}
 	excludePaths, err := getRepoRelativePaths(repoDir, cfg.IgnorePaths)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid path in IaC configuration (%w): %w", exitCode(constants.InvalidConfigErrorCode), err)
 	}
 	cfg.IgnorePaths = excludePaths
 	onlyPaths, err := getRepoRelativePaths(repoDir, cfg.OnlyPaths)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid path in IaC configuration (%w): %w", exitCode(constants.InvalidConfigErrorCode), err)
 	}
 	cfg.OnlyPaths = onlyPaths
 	cfg.IgnoreRules = append(c.StringSlice("exclude-queries"), cfg.IgnoreRules...)

--- a/e2e/config_test.go
+++ b/e2e/config_test.go
@@ -1,0 +1,182 @@
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/e2e/utils"
+	git "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_E2E_Config - Verifies that only local IaC configuration parse errors cause
+// the scanner to exit with InvalidConfigErrorCode (127). Remote API errors (e.g.,
+// unreachable Datadog backend) must not be misclassified as config errors and must
+// exit with the generic engine error code (126).
+func Test_E2E_Config(t *testing.T) {
+	localBin := utils.GetScannerLocalBin()
+	// Make sure that the scanner binary is available.
+	if _, err := os.Stat(localBin); os.IsNotExist(err) {
+		t.Skip("E2E local execution must have a scanner binary in the 'bin' folder.\nPath not found: " + localBin)
+	}
+
+	if testing.Short() {
+		t.Skip("skipping E2E tests in short mode.")
+	}
+
+	tests := []struct {
+		name       string
+		configFile string // empty = no config written
+		content    string
+		wantStatus int
+	}{
+		// Local parse errors → 127
+		{
+			name:       "invalid new format - unknown field",
+			configFile: "code-security.datadog.yaml",
+			content:    "schema-version: v1.2\niac:\n  xinvalid: abc",
+			wantStatus: 127,
+		},
+		{
+			name:       "invalid new format - future major schema version",
+			configFile: "code-security.datadog.yaml",
+			content:    "schema-version: v2.1\niac:",
+			wantStatus: 127,
+		},
+		{
+			name:       "invalid new format - malformed YAML",
+			configFile: "code-security.datadog.yaml",
+			content:    "schema-version: [invalid",
+			wantStatus: 127,
+		},
+		{
+			name:       "invalid legacy format - malformed YAML",
+			configFile: "dd-iac-scan.config",
+			content:    "bad: [yaml:",
+			wantStatus: 127,
+		},
+		{
+			name:       "invalid new format - path escaping repo root",
+			configFile: "code-security.datadog.yaml",
+			content:    "schema-version: v1.2\niac:\n  global-config:\n    ignore-paths:\n      - ../../outside",
+			wantStatus: 127,
+		},
+		// Valid / absent configs → 0
+		{
+			name:       "valid new format",
+			configFile: "code-security.datadog.yaml",
+			content:    "schema-version: v1.2\niac:\n  ignore-rules: []",
+			wantStatus: 0,
+		},
+		{
+			name:       "valid legacy format",
+			configFile: "dd-iac-scan.config",
+			content:    "exclude-categories: []",
+			wantStatus: 0,
+		},
+		{
+			name:       "no config file",
+			configFile: "",
+			content:    "",
+			wantStatus: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repoDir := createTempRepo(t)
+
+			if tt.configFile != "" {
+				cfgPath := filepath.Join(repoDir, tt.configFile)
+				require.NoError(t, os.WriteFile(cfgPath, []byte(tt.content), 0600))
+			}
+
+			out, err := utils.RunCommand([]string{"scan", "-p", repoDir, "-o", repoDir})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantStatus, out.Status)
+		})
+	}
+}
+
+// Test_E2E_Config_RemoteError - Verifies that a Datadog API failure (network error
+// when credentials are present) does NOT produce InvalidConfigErrorCode (127). It
+// must exit with the generic engine error code (126) instead.
+func Test_E2E_Config_RemoteError(t *testing.T) {
+	localBin := utils.GetScannerLocalBin()
+	// Make sure that the scanner binary is available.
+	if _, err := os.Stat(localBin); os.IsNotExist(err) {
+		t.Skip("E2E local execution must have a scanner binary in the 'bin' folder.\nPath not found: " + localBin)
+	}
+
+	if testing.Short() {
+		t.Skip("skipping E2E tests in short mode.")
+	}
+
+	repoDir := createTempRepo(t)
+	// A syntactically valid config so the local parse step succeeds.
+	cfgPath := filepath.Join(repoDir, "code-security.datadog.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("schema-version: v1.2\niac:\n  ignore-rules: []\n"), 0600))
+
+	// Pass credentials so GetRemoteConfig fires, pointed at a port that refuses
+	// connections so it errors immediately without touching any real Datadog endpoint.
+	cmd := exec.Command(localBin, "scan", "-p", repoDir, "-o", repoDir)
+	cmd.Env = append(os.Environ(),
+		"DD_API_KEY=test-key",
+		"DD_APP_KEY=test-app-key",
+		"DD_SITE=127.0.0.1:1", // nothing listens on port 1 → instant connection refused
+	)
+	_, err := cmd.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		} else {
+			require.NoError(t, err)
+		}
+	}
+
+	assert.Equal(t, 126, exitCode, "Datadog API network error must not be misclassified as an invalid config error")
+}
+
+// createTempRepo initialises an isolated git repository in a temp directory.
+// The repo has one commit and a fake origin remote, satisfying the scanner's
+// requirement for HEAD, branch, and remote URL.
+func createTempRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	repo, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+
+	_, err = repo.CreateRemote(&gitconfig.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"https://example.com/test-repo.git"},
+	})
+	require.NoError(t, err)
+
+	// A comment-only Terraform file produces no violations, so valid-config
+	// tests reliably exit 0.
+	tfPath := filepath.Join(dir, "main.tf")
+	require.NoError(t, os.WriteFile(tfPath, []byte("# no resources\n"), 0600))
+
+	w, err := repo.Worktree()
+	require.NoError(t, err)
+
+	_, err = w.Add("main.tf")
+	require.NoError(t, err)
+
+	_, err = w.Commit("initial commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@example.com"},
+	})
+	require.NoError(t, err)
+
+	return dir
+}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -111,6 +111,9 @@ const (
 	// EngineErrorCode - Exit Status code for error in engine
 	EngineErrorCode = 126
 
+	// InvalidConfigErrorCode - Exit status code for an invalid IaC configuration file
+	InvalidConfigErrorCode = 127
+
 	// SignalInterruptCode - Exit Status code for a signal interrupt
 	SignalInterruptCode = 130
 

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -1,0 +1,15 @@
+package config
+
+// InvalidLocalConfigError is returned when the local IaC configuration file
+// cannot be read or parsed. It does NOT cover errors from remote config sources
+// such as Datadog API calls via WithDatadog.
+type InvalidLocalConfigError struct {
+	err error
+}
+
+func newInvalidLocalConfigError(err error) error {
+	return &InvalidLocalConfigError{err: err}
+}
+
+func (e *InvalidLocalConfigError) Error() string { return e.err.Error() }
+func (e *InvalidLocalConfigError) Unwrap() error { return e.err }

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -42,7 +42,7 @@ func readAndParseConfiguration(ctx context.Context, rootPath string, options ...
 
 	cfgBytes, err := os.ReadFile(path) // nolint:gosec
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not read configuration file %s: %w", path, err)
+		return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not read configuration file %s: %w", path, err))
 	}
 
 	for _, option := range options {
@@ -55,7 +55,7 @@ func readAndParseConfiguration(ctx context.Context, rootPath string, options ...
 
 	cfg, err := ParseConfig(cfgBytes)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not parse configuration file: %w", err)
+		return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not parse configuration file: %w", err))
 	}
 	return cfg, cfgBytes, nil
 }
@@ -68,13 +68,13 @@ func readAndParseLegacyConfiguration(ctx context.Context, rootPath string, optio
 
 	converted, err := readLegacyConfiguration(ctx, rootPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not read legacy configuration file: %w", err)
+		return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not read legacy configuration file: %w", err))
 	}
 
 	// Try to convert the legacy configuration to the new format so we can apply the options
 	cfgBytes, err := UnparseConfig(converted)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not convert legacy configuration file: %w", err)
+		return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not convert legacy configuration file: %w", err))
 	}
 
 	for _, option := range options {
@@ -87,7 +87,7 @@ func readAndParseLegacyConfiguration(ctx context.Context, rootPath string, optio
 
 	cfg, err := ParseConfig(cfgBytes)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not parse configuration file: %w", err)
+		return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not parse configuration file: %w", err))
 	}
 
 	// Restore the original file's 'exclude-results' setting on the final configuration


### PR DESCRIPTION
## What

Add `InvalidConfigErrorCode = 127` to distinguish configuration parse errors from generic engine failures (exit code 126).

When `ReadConfiguration` fails due to:
- Malformed YAML in `code-security.datadog.yaml` or `dd-iac-scan.config`
- An invalid or unsupported schema version
- Unknown fields in the `iac:` block
- Paths in `ignore-paths`/`only-paths` that escape the repository root

...the scanner now exits with 127 instead of 126.

## Why

Callers need to distinguish user-facing configuration errors from transient infrastructure failures. A dedicated exit code allows them to surface a meaningful status to the user and skip retries, rather than treating the failure as a generic scan error.

## Test

E2E tests added in `e2e/config_test.go` covering all error paths for both new-format (`code-security.datadog.yaml`) and legacy (`dd-iac-scan.config`) configs, as well as valid configs confirming exit 0.