### PR TITLE
Fix: Apply remote config even when no local config file is present

### DIFF
--- a/cmd/scanner/show_config.go
+++ b/cmd/scanner/show_config.go
@@ -14,10 +14,10 @@ var showConfigAction = &cli.Command{
 	Usage: "Displays the Datadog IaC scanner configuration for this repository",
 	Flags: []cli.Flag{
 		&cli.StringSliceFlag{
-			Name:    "path",
-			Aliases: []string{"p"},
-			Usage:   "repository root path",
-			Value:   []string{"."},
+			Name:        "path",
+			Aliases:     []string{"p"},
+			Usage:       "repository root path",
+			DefaultText: ".",
 		},
 		&cli.BoolFlag{
 			Name:  "local",
@@ -29,7 +29,11 @@ var showConfigAction = &cli.Command{
 }
 
 func showConfig(ctx context.Context, c *cli.Command) error {
-	repoInfo, repoDir, err := getRepositoryCommitInfo(c.StringSlice("path"))
+	paths := c.StringSlice("path")
+	if len(paths) == 0 {
+		paths = []string{"."}
+	}
+	repoInfo, repoDir, err := getRepositoryCommitInfo(paths)
 	if err != nil {
 		return fmt.Errorf("error retrieving repository commit information: %w", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,11 +52,9 @@ func ParseConfig(cfgBytes []byte) (*IacConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Versions older than v1.2 can't have an IaC configuration
 	if version.compare(minIacVersion) < 0 {
 		return nil, nil
 	}
-	// Versions v2.0 and higher are not supported
 	if version.compare(minUnsupportedVersion) >= 0 {
 		return nil, fmt.Errorf("configuration schema version %s is not supported", version)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,11 +53,11 @@ func ParseConfig(cfgBytes []byte) (*IacConfig, error) {
 		return nil, err
 	}
 	// Versions older than v1.2 can't have an IaC configuration
-	if version.compare(schemaVersion{1, 2}) < 0 {
+	if version.compare(minIacVersion) < 0 {
 		return nil, nil
 	}
 	// Versions v2.0 and higher are not supported
-	if version.compare(schemaVersion{2, 0}) >= 0 {
+	if version.compare(minUnsupportedVersion) >= 0 {
 		return nil, fmt.Errorf("configuration schema version %s is not supported", version)
 	}
 
@@ -142,6 +142,13 @@ func parseSchemaVersion(schema string) (version schemaVersion, err error) {
 type schemaVersion struct {
 	major, minor int
 }
+
+var (
+	// minIacVersion is the minimum schema version supporting the iac: configuration section.
+	minIacVersion = schemaVersion{1, 2}
+	// minUnsupportedVersion is the minimum schema version not supported by this scanner.
+	minUnsupportedVersion = schemaVersion{2, 0}
+)
 
 // compare returns a positive number if this schema version is higher than the other schema version,
 // a negative number if it's smaller, or zero if they are equal

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -52,19 +53,25 @@ func ReadConfiguration(ctx context.Context, rootPath string, options ...ReadConf
 	return &IacConfig{}, cfgBytes, nil
 }
 
-// minimalCfgFile is a minimal view of the config file used for fall-through detection only.
-// It does not use KnownFields, so unknown properties (future minor-version additions) are accepted.
-type minimalCfgFile struct {
+// knownRootsCfgFile is the exhaustive set of valid root-level product keys. Used with
+// KnownFields to reject unrecognized root properties per the RFC requirement.
+type knownRootsCfgFile struct {
 	SchemaVersion string `yaml:"schema-version"`
 	Iac           any    `yaml:"iac"`
+	Sast          any    `yaml:"sast"`
+	Secrets       any    `yaml:"secrets"`
+	Sca           any    `yaml:"sca"`
+	Iast          any    `yaml:"iast"`
 }
 
 // hasIacSectionForSupportedVersion reports whether b contains an iac: section for a supported
-// schema version, using lenient YAML parsing. Unknown root or iac fields are ignored so that
-// files from future minor versions are not incorrectly treated as "no iac section".
+// schema version. Unknown root keys are rejected (all products fail per the RFC). Unknown
+// fields within known sections are accepted because each product key is typed as any.
 func hasIacSectionForSupportedVersion(b []byte) (bool, error) {
-	var doc minimalCfgFile
-	if err := yaml.Unmarshal(b, &doc); err != nil {
+	var doc knownRootsCfgFile
+	decoder := yaml.NewDecoder(bytes.NewReader(b))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&doc); err != nil {
 		return false, newInvalidLocalConfigError(fmt.Errorf("could not parse configuration file: %w", err))
 	}
 	version, err := parseSchemaVersion(doc.SchemaVersion)

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -15,54 +15,71 @@ const (
 	LegacyConfigFileName = "dd-iac-scan.config"
 )
 
-// ReadConfiguration reads and parses the configuration file in the local repository.
-// It returns the parsed configuration and the YAML file (or a YAML conversion, in the case of legacy configurations).
+// ReadConfiguration reads the local config file (if any), applies all options
+// (e.g. WithDatadog), and returns the parsed result.
+// Options are always applied even when no local file exists, so server-side
+// customizations are fetched regardless of local file presence.
 func ReadConfiguration(ctx context.Context, rootPath string, options ...ReadConfigurationOption) (*IacConfig, []byte, error) {
-	var cfgContent []byte
-	if cfg, cfgBytes, err := readAndParseConfiguration(ctx, rootPath, options...); cfg != nil || err != nil {
-		return cfg, cfgBytes, err
-	} else if cfgBytes != nil {
-		cfgContent = cfgBytes
-	}
-
-	if cfg, cfgBytes, err := readAndParseLegacyConfiguration(ctx, rootPath, options...); cfg != nil || err != nil {
-		return cfg, cfgBytes, err
-	} else if cfgBytes != nil {
-		cfgContent = cfgBytes
-	}
-
-	return &IacConfig{}, cfgContent, nil
-}
-
-func readAndParseConfiguration(ctx context.Context, rootPath string, options ...ReadConfigurationOption) (*IacConfig, []byte, error) {
-	path, found := fileExists(rootPath, ConfigFileNameBase, ".yaml", ".yml")
-	if !found {
-		return nil, nil, nil
-	}
-
-	cfgBytes, err := os.ReadFile(path) // nolint:gosec
+	cfgBytes, legacyExcludeResults, err := findLocalConfig(ctx, rootPath)
 	if err != nil {
-		return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not read configuration file %s: %w", path, err))
+		return nil, nil, err
 	}
 
 	for _, option := range options {
-		newCfg, err := option(ctx, cfgBytes)
+		cfgBytes, err = option(ctx, cfgBytes)
 		if err != nil {
 			return nil, nil, err
 		}
-		cfgBytes = newCfg
 	}
 
 	cfg, err := ParseConfig(cfgBytes)
 	if err != nil {
 		return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not parse configuration file: %w", err))
 	}
-	return cfg, cfgBytes, nil
+
+	if len(legacyExcludeResults) > 0 {
+		if cfg == nil {
+			cfg = &IacConfig{}
+		}
+		cfg.LegacyExcludeResults = legacyExcludeResults
+		cfgBytes = appendLegacyExcludeResultsComment(cfgBytes, legacyExcludeResults)
+	}
+
+	if cfg != nil {
+		return cfg, cfgBytes, nil
+	}
+	return &IacConfig{}, cfgBytes, nil
 }
 
-func readAndParseLegacyConfiguration(ctx context.Context, rootPath string, options ...ReadConfigurationOption) (*IacConfig, []byte, error) {
-	_, found := fileExists(rootPath, LegacyConfigFileName)
-	if !found {
+// findLocalConfig returns the local configuration as YAML bytes.
+// The new config format (code-security.datadog.yaml) takes priority over the legacy
+// format only when it contains an iac section. If the new file exists but has no iac
+// section, the legacy format is used as a fallback. Returns (nil, nil, nil) when no
+// config file is found. legacyExcludeResults is populated only for legacy configs.
+func findLocalConfig(ctx context.Context, rootPath string) (cfgBytes []byte, legacyExcludeResults []string, err error) {
+	if path, found := fileExists(rootPath, ConfigFileNameBase, ".yaml", ".yml"); found {
+		b, err := os.ReadFile(path) // nolint:gosec
+		if err != nil {
+			return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not read configuration file %s: %w", path, err))
+		}
+		cfg, err := ParseConfig(b)
+		if err != nil {
+			return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not parse configuration file: %w", err))
+		}
+		if cfg != nil {
+			// New file has an iac section: use it exclusively.
+			return b, nil, nil
+		}
+		// New file has no iac section: fall through to legacy.
+	}
+
+	return readLegacyConfigBytes(ctx, rootPath)
+}
+
+// readLegacyConfigBytes reads and converts the legacy config file to YAML bytes.
+// Returns (nil, nil, nil) if no legacy config file is found.
+func readLegacyConfigBytes(ctx context.Context, rootPath string) (cfgBytes []byte, legacyExcludeResults []string, err error) {
+	if _, found := fileExists(rootPath, LegacyConfigFileName); !found {
 		return nil, nil, nil
 	}
 
@@ -71,53 +88,27 @@ func readAndParseLegacyConfiguration(ctx context.Context, rootPath string, optio
 		return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not read legacy configuration file: %w", err))
 	}
 
-	// Try to convert the legacy configuration to the new format so we can apply the options
-	cfgBytes, err := UnparseConfig(converted)
+	b, err := UnparseConfig(converted)
 	if err != nil {
 		return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not convert legacy configuration file: %w", err))
 	}
 
-	for _, option := range options {
-		newCfg, err := option(ctx, cfgBytes)
-		if err != nil {
-			return nil, nil, err
-		}
-		cfgBytes = newCfg
-	}
+	return b, converted.LegacyExcludeResults, nil
+}
 
-	cfg, err := ParseConfig(cfgBytes)
-	if err != nil {
-		return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not parse configuration file: %w", err))
+func appendLegacyExcludeResultsComment(cfgBytes []byte, excludeResults []string) []byte {
+	var names []string
+	for _, rn := range excludeResults {
+		names = append(names, fmt.Sprintf("%q", rn))
 	}
-
-	// Restore the original file's 'exclude-results' setting on the final configuration
-	if len(converted.LegacyExcludeResults) > 0 {
-		if cfg == nil {
-			cfg = &IacConfig{}
-		}
-		cfg.LegacyExcludeResults = converted.LegacyExcludeResults
-	}
-
-	if cfg != nil && len(cfg.LegacyExcludeResults) > 0 {
-		// We are returning a converted configuration but the original had settings that are not available
-		// in the new, so add a comment.
-		var resultNames []string
-		for _, rn := range cfg.LegacyExcludeResults {
-			resultNames = append(resultNames, fmt.Sprintf("%q", rn))
-		}
-		cfgBytes = []byte(
-			string(cfgBytes) +
-				fmt.Sprintf(
-					"# These settings have been applied, but they cannot be expressed in the new configuration format:\n"+
-						"# exclude-results: [ %s ]\n", strings.Join(resultNames, ", ")),
-		)
-	}
-	return cfg, cfgBytes, nil
+	return []byte(string(cfgBytes) + fmt.Sprintf(
+		"# These settings have been applied, but they cannot be expressed in the new configuration format:\n"+
+			"# exclude-results: [ %s ]\n", strings.Join(names, ", ")))
 }
 
 type ReadConfigurationOption func(context.Context, []byte) ([]byte, error)
 
-// WithDatadog calls the Datadog backend to append server-side customizations to the local repo config
+// WithDatadog calls the Datadog backend to append server-side customizations to the local repo config.
 func WithDatadog(client datadog.Client, repoUrl string) ReadConfigurationOption {
 	return func(ctx context.Context, cfgBytes []byte) ([]byte, error) {
 		return client.GetRemoteConfig(ctx, repoUrl, cfgBytes)

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -51,6 +52,34 @@ func ReadConfiguration(ctx context.Context, rootPath string, options ...ReadConf
 	return &IacConfig{}, cfgBytes, nil
 }
 
+// minimalCfgFile is a minimal view of the config file used for fall-through detection only.
+// It does not use KnownFields, so unknown properties (future minor-version additions) are accepted.
+type minimalCfgFile struct {
+	SchemaVersion string `yaml:"schema-version"`
+	Iac           any    `yaml:"iac"`
+}
+
+// hasIacSectionForSupportedVersion reports whether b contains an iac: section for a supported
+// schema version, using lenient YAML parsing. Unknown root or iac fields are ignored so that
+// files from future minor versions are not incorrectly treated as "no iac section".
+func hasIacSectionForSupportedVersion(b []byte) (bool, error) {
+	var doc minimalCfgFile
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		return false, newInvalidLocalConfigError(fmt.Errorf("could not parse configuration file: %w", err))
+	}
+	version, err := parseSchemaVersion(doc.SchemaVersion)
+	if err != nil {
+		return false, newInvalidLocalConfigError(fmt.Errorf("invalid schema version: %w", err))
+	}
+	if version.compare(minUnsupportedVersion) >= 0 {
+		return false, newInvalidLocalConfigError(fmt.Errorf("configuration schema version %s is not supported", version))
+	}
+	if version.compare(minIacVersion) < 0 {
+		return false, nil
+	}
+	return doc.Iac != nil, nil
+}
+
 // findLocalConfig returns the local configuration as YAML bytes.
 // The new config format (code-security.datadog.yaml) takes priority over the legacy
 // format only when it contains an iac section. If the new file exists but has no iac
@@ -62,15 +91,14 @@ func findLocalConfig(ctx context.Context, rootPath string) (cfgBytes []byte, leg
 		if err != nil {
 			return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not read configuration file %s: %w", path, err))
 		}
-		cfg, err := ParseConfig(b)
+		hasIac, err := hasIacSectionForSupportedVersion(b)
 		if err != nil {
-			return nil, nil, newInvalidLocalConfigError(fmt.Errorf("could not parse configuration file: %w", err))
+			return nil, nil, err
 		}
-		if cfg != nil {
-			// New file has an iac section: use it exclusively.
+		if hasIac {
 			return b, nil, nil
 		}
-		// New file has no iac section: fall through to legacy.
+		// No iac section or schema too old: fall through to legacy.
 	}
 
 	return readLegacyConfigBytes(ctx, rootPath)

--- a/pkg/config/reader_test.go
+++ b/pkg/config/reader_test.go
@@ -122,6 +122,40 @@ func TestReadConfig(t *testing.T) {
 	}
 }
 
+// Unknown root properties cause all products to fail.
+func TestUnknownRootKey(t *testing.T) {
+	for _, tc := range []struct {
+		name, cfg string
+	}{
+		{
+			name: "unknown root key only",
+			cfg:  "schema-version: v1.2\nfuture-product:\n  config: foo\n",
+		},
+		{
+			name: "unknown root key alongside iac section",
+			cfg:  "schema-version: v1.2\niac:\n  ignore-rules:\n    - r1\nfuture-product:\n  config: foo\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(tmp, ConfigFileNameBase+".yaml"), []byte(tc.cfg), 0644))
+
+			_, _, err := ReadConfiguration(t.Context(), tmp)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// When the new config file has an unknown root key, the legacy config is NOT used as fallback.
+func TestUnknownRootKeyIgnoresLegacy(t *testing.T) {
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, ConfigFileNameBase+".yaml"), []byte("schema-version: v1.2\nfuture-product:\n  config: foo\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, LegacyConfigFileName), []byte(legacyCfg), 0644))
+
+	_, _, err := ReadConfiguration(t.Context(), tmp)
+	assert.Error(t, err)
+}
+
 // Parsers MUST reject schema major versions >= 2.
 func TestUnsupportedSchemaVersion(t *testing.T) {
 	for _, tc := range []struct {
@@ -286,10 +320,10 @@ func TestConfigFileFromDatadog(t *testing.T) {
 			parsedConfig:   &parsedCfgFile,
 		},
 		{
-			// v1.5 file with an unknown root key and no iac section: lenient check sees no iac key,
-			// falls through, sends nil to the API (same as no local file).
+			// v1.5 file with only known root keys and no iac section: falls through,
+			// sending nil to the API (same as no local file).
 			name:           "future minor version without iac section",
-			localConfig:    "schema-version: v1.5\nfuture-product:\n  config: foo\n",
+			localConfig:    "schema-version: v1.5\nsast:\n  use-rulesets: [foo]\n",
 			sentConfig:     "",
 			finalConfig:    cfgFile,
 			expectedConfig: cfgFile,

--- a/pkg/config/reader_test.go
+++ b/pkg/config/reader_test.go
@@ -122,6 +122,34 @@ func TestReadConfig(t *testing.T) {
 	}
 }
 
+// Parsers MUST reject schema major versions >= 2.
+func TestUnsupportedSchemaVersion(t *testing.T) {
+	for _, tc := range []struct {
+		name, cfg string
+	}{
+		{name: "v2.0", cfg: "schema-version: v2.0\niac:\n  ignore-rules:\n    - r1\n"},
+		{name: "v3.0", cfg: "schema-version: v3.0\niac:\n  ignore-rules:\n    - r1\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(tmp, ConfigFileNameBase+".yaml"), []byte(tc.cfg), 0644))
+
+			_, _, err := ReadConfiguration(t.Context(), tmp)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// When the new config file has an unsupported major version, the legacy config is NOT used as fallback.
+func TestUnsupportedSchemaVersionIgnoresLegacy(t *testing.T) {
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, ConfigFileNameBase+".yaml"), []byte("schema-version: v2.0\niac:\n  ignore-rules:\n    - r1\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, LegacyConfigFileName), []byte(legacyCfg), 0644))
+
+	_, _, err := ReadConfiguration(t.Context(), tmp)
+	assert.Error(t, err)
+}
+
 func TestIgnoredConfigFile(t *testing.T) {
 	for _, tc := range []struct {
 		name, cfg string
@@ -240,8 +268,7 @@ func TestConfigFileFromDatadog(t *testing.T) {
 		parsedConfig   *IacConfig
 	}{
 		{
-			// New config file has no iac section: falls through to legacy path (none here),
-			// so nil is sent to the API which returns a merged config.
+			// New config file has no iac section: falls through, sending nil to the API.
 			name:           "regular config without iac section",
 			localConfig:    emptyCfgFile,
 			sentConfig:     "",
@@ -250,10 +277,20 @@ func TestConfigFileFromDatadog(t *testing.T) {
 			parsedConfig:   &parsedCfgFile,
 		},
 		{
-			// New config file has an iac section: sent directly to the API.
+			// New config file has an iac section: bytes sent directly to the API.
 			name:           "regular config with iac section",
 			localConfig:    cfgFile,
 			sentConfig:     cfgFile,
+			finalConfig:    cfgFile,
+			expectedConfig: cfgFile,
+			parsedConfig:   &parsedCfgFile,
+		},
+		{
+			// v1.5 file with an unknown root key and no iac section: lenient check sees no iac key,
+			// falls through, sends nil to the API (same as no local file).
+			name:           "future minor version without iac section",
+			localConfig:    "schema-version: v1.5\nfuture-product:\n  config: foo\n",
+			sentConfig:     "",
 			finalConfig:    cfgFile,
 			expectedConfig: cfgFile,
 			parsedConfig:   &parsedCfgFile,

--- a/pkg/config/reader_test.go
+++ b/pkg/config/reader_test.go
@@ -141,7 +141,7 @@ func TestIgnoredConfigFile(t *testing.T) {
 
 			cfg, b, err := ReadConfiguration(t.Context(), tmp)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.cfg, string(b))
+			assert.Empty(t, b)
 			assert.Equal(t, IacConfig{}, *cfg)
 		})
 	}
@@ -200,12 +200,29 @@ func TestConfigFilePrecedenceWithIgnoredConfigFile(t *testing.T) {
 			require.NoError(t, os.WriteFile(filepath.Join(tmp, ConfigFileNameBase+".yaml"), []byte(tc.cfg), 0644))
 			require.NoError(t, os.WriteFile(filepath.Join(tmp, LegacyConfigFileName), []byte(legacyCfg), 0644))
 
+			// New config file has no iac section, so legacy takes over.
 			cfg, b, err := ReadConfiguration(t.Context(), tmp)
 			assert.NoError(t, err)
 			assert.Equal(t, convertedLegacyCfg+excludeSuffix, string(b))
 			assert.Equal(t, parsedLegacyCfg, *cfg)
 		})
 	}
+}
+
+func TestNoConfigWithDatadog(t *testing.T) {
+	const repoUrl = "https://example.com/repo.git"
+	client := &fakeDatadogClient{
+		t:                  t,
+		expectedSentConfig: nil,
+		expectedRepoUrl:    repoUrl,
+		remoteConfig:       []byte(cfgFile),
+	}
+
+	// No local config file — options must still be applied so server-side config is fetched.
+	cfg, b, err := ReadConfiguration(t.Context(), t.TempDir(), WithDatadog(client, repoUrl))
+	assert.NoError(t, err)
+	assert.Equal(t, cfgFile, string(b))
+	assert.Equal(t, parsedCfgFile, *cfg)
 }
 
 func TestConfigFileFromDatadog(t *testing.T) {
@@ -223,9 +240,20 @@ func TestConfigFileFromDatadog(t *testing.T) {
 		parsedConfig   *IacConfig
 	}{
 		{
-			name:           "regular config",
-			localConfig:    "local config file",
-			sentConfig:     "local config file",
+			// New config file has no iac section: falls through to legacy path (none here),
+			// so nil is sent to the API which returns a merged config.
+			name:           "regular config without iac section",
+			localConfig:    emptyCfgFile,
+			sentConfig:     "",
+			finalConfig:    cfgFile,
+			expectedConfig: cfgFile,
+			parsedConfig:   &parsedCfgFile,
+		},
+		{
+			// New config file has an iac section: sent directly to the API.
+			name:           "regular config with iac section",
+			localConfig:    cfgFile,
+			sentConfig:     cfgFile,
 			finalConfig:    cfgFile,
 			expectedConfig: cfgFile,
 			parsedConfig:   &parsedCfgFile,


### PR DESCRIPTION
## What

Refactors `pkg/config` to always apply server-side options (e.g. `WithDatadog`) regardless of whether a local config file exists, and aligns the config file reading logic with the RFC requirements for schema version handling and unknown root properties.

## Why

`WithDatadog`, which fetches the merged org/repo-level config from the Datadog settings API, was only invoked when a local `code-security.datadog.yaml` or `dd-iac-scan.config` was found. Repositories with no local config file never had server-side customizations applied, making org-level and repo-level IaC config settings in the Datadog UI completely ineffective.

A review of the RFC also identified two additional gaps in the local config reading logic:

- A config file with a future minor-version product section (no `iac:` key) was incorrectly passed to the API instead of falling through to the legacy config, causing a server-side error.
- Config files with unknown root properties were silently accepted instead of being rejected as the RFC requires.

## Changes

Four atomic commits:

1. `ReadConfiguration` simplified to: **find local bytes → apply options → parse**. Options are now called even when no local file exists, so the API is always consulted for server-side config.

2. `findLocalConfig` reworked to use a new `hasIacSectionForSupportedVersion` helper that uses lenient YAML parsing to check for the `iac:` key without strict field validation. Schema version boundary constants (`minIacVersion`, `minUnsupportedVersion`) extracted and shared with `ParseConfig`.

3. `hasIacSectionForSupportedVersion` updated to use `KnownFields(true)` on a struct listing all valid root keys (`sast`, `iac`, `sca`, `secrets`, `iast`), so unknown root properties produce an error per the RFC.

4. `show-config`: fix `--path` flag default causing the provided path to be appended to `"."` instead of replacing it (urfave/cli v3 `StringSliceFlag` behavior).

## Behavior matrix

| Scenario | Behavior | RFC requirement | Test |
|---|---|---|---|
| No local file, no remote | empty config | default empty | `TestNoConfig` |
| No local file, remote success | config from remote | use server-side | `TestNoConfigWithDatadog` |
| Unsupported version (>= v2.0) | error, legacy ignored | reject major >= 2 | `TestUnsupportedSchemaVersion` |
| Unknown root key | error, legacy ignored | unknown root props fail | `TestUnknownRootKey` |
| No `iac:` section (v1.2+) | fall through to legacy or nil | use legacy or server-side | `TestIgnoredConfigFile`, `TestConfigFilePrecedenceWithIgnoredConfigFile` |
| Old schema (v1.1) | fall through | accept all v1.x minor versions | `TestIgnoredConfigFile/old_schema_version` |
| Valid config, no remote | config from new file | new file with `iac:` | `TestReadConfig` |
| Valid config + remote success | merged config from remote | merge local with server-side | `TestConfigFileFromDatadog/regular_config_with_iac_section` |
| No `iac:` section + remote success | nil sent, config from remote | use server-side only | `TestConfigFileFromDatadog/regular_config_without_iac_section` |
| Legacy only, no remote | config from legacy | legacy: convert, use result | `TestReadLegacyOnly` |
| Legacy + remote success | merged config from remote | legacy: convert, merge | `TestConfigFileFromDatadog/legacy_config` |

## End-to-end test results

Tested locally using the PR binary with live Datadog API credentials across 15 scenarios covering local config, remote org/repo config, and combinations.

| Scenario | Config source | Expected | Result |
|---|---|---|---|
| S01 baseline | none | 16 findings | 16 ✅ |
| S02 ignore-rules | local | 12 (Rule A excluded) | 12 ✅ |
| S03 use-rules | local | 4 (only Rule A) | 4 ✅ |
| S04 ignore-paths | local | 12 (no `configs/ignored/`) | 12 ✅ |
| S05 only-paths | local | 4 (only `configs/included/`) | 4 ✅ |
| S06a ignore LOW severity | local | 12 (Rule A excluded) | 12 ✅ |
| S06b only HIGH+CRIT | local | 8 (Rules C+D only) | 8 ✅ |
| S07a ignore Best Practices | local | 12 (Rule A excluded) | 12 ✅ |
| S07b only Encryption | local | 4 (Rule C only) | 4 ✅ |
| S08 repo-level UI config | remote (repo) | 12 (Rule A excluded) | 12 ✅ |
| S09 org-level UI config | remote (org) | 12 (no `configs/ignored/`) | 12 ✅ |
| S10 org+repo UI config merged | remote (org+repo) | 9 (Rule A excluded + no `configs/ignored/`) | 9 ✅ |
| S11 local overrides org+repo | local + remote | 3 (only Rule B, no `configs/ignored/`) | 3 ✅ |
| S13 new config wins over legacy | local (both files) | 4 (only Rule B) | 4 ✅ |
| S14 inline suppression | local (inline comments) | 14 (Rule A suppressed in 2 files) | 14 ✅ |