### PR TITLE
Add legacy IaC config reference and refresh README configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,34 +60,47 @@ Run `datadog-iac-scanner scan --help` to see all available flags.
 
 ### Configuring the scan
 
-Create a file named `dd-iac-scan.config` in your repository to customize scanner behavior. Use this file to exclude specific categories, paths, severities, or queries. The file can be written in YAML, JSON, TOML, or HCL.
+Create a file named `code-security.datadog.yaml` at the root of your repository to customize scanner behavior. Use this file to choose which rules run, restrict scanning to specific paths, or filter findings by severity and category.
 
 ```yaml
-exclude-severities:
-  - "info"
-  - "low"
-exclude-paths:
-  - "./shouldNotScan/*"
-  - "dir/somefile.txt"
-exclude-queries:
-  - "e69890e6-fce5-461d-98ad-cb98318dfc96"
-  - "4728cd65-a20c-49da-8b31-9c08b423e4db"
-exclude-categories:
-  - "Access Control"
-  - "Best Practices"
+schema-version: v1.2
+iac:
+  # Do not run these rules.
+  ignore-rules:
+    - A
+    - B
+  # Run only these rules. If set, all other rules are ignored.
+  use-rules:
+    - A
+  global-config:
+    # Only analyze the following paths/files.
+    only-paths:
+      - "infra/"
+    # Do not analyze the following paths/files.
+    ignore-paths:
+      - "**/*.tfvars"
+    # Do not report findings with these severities.
+    ignore-severities:
+      - info
+      - low
+    # Do not report findings in these categories.
+    ignore-categories:
+      - "Best Practices"
 ```
 
-You can also use inline comments to exclude files, blocks, and individual lines from scan results. Add a comment starting with `# dd-iac-scan` followed by a command.
+Replace placeholders such as `A` and `B` with Code Security rule IDs. For the full schema, see the [IaC Security configuration documentation](https://docs.datadoghq.com/security/code_security/iac_security/configuration/).
+
+> The legacy `dd-iac-scan.config` file is still supported for backwards compatibility, but its schema is deprecated and does not receive new updates. See [`legacy_config.md`](legacy_config.md) for its reference.
+
+You can also use inline comments to exclude files, blocks, and individual lines from scan results. Add a comment containing `dd-iac-scan` followed by a command (prefixed with the comment syntax for the file format).
 
 | Comment | Description |
 |---------|-------------|
 | `# dd-iac-scan ignore-line` | Ignores findings on the next line. |
 | `# dd-iac-scan ignore-block` | Ignores findings in the following block. |
 | `# dd-iac-scan ignore` | Ignores findings in the entire file. Must appear at the beginning of the file. |
-| `# dd-iac-scan disable=queryId` | Ignores results for the specified query ID. Must appear at the beginning of the file; applies to the whole file. |
-| `# dd-iac-scan enable=queryId` | Ignores results for all queries _except_ the specified query ID. Must appear at the beginning of the file; applies to the whole file. |
-
-See the [exclusions documentation](https://docs.datadoghq.com/security/code_security/iac_security/exclusions/) for more information.
+| `# dd-iac-scan disable=<rule_id>` | Ignores findings for the specified rule. Must appear at the beginning of the file; applies to the whole file. |
+| `# dd-iac-scan enable=<rule_id>` | Ignores findings for all rules _except_ the specified rule. Must appear at the beginning of the file; applies to the whole file. |
 
 ## License
 

--- a/legacy_config.md
+++ b/legacy_config.md
@@ -1,0 +1,154 @@
+# Legacy Configuration File
+
+Datadog IaC Scanner has backwards-compatible support for the legacy `dd-iac-scan.config`
+configuration file, which has a different schema and semantics than the current
+`code-security.datadog.yaml` configuration schema (see the
+[IaC Security configuration documentation](https://docs.datadoghq.com/security/code_security/iac_security/configuration/)).
+
+Users may continue to use a `dd-iac-scan.config` file with no disruptions or behavior
+changes. The legacy schema is deprecated and does not receive new updates: prefer
+configuring the scanner with `code-security.datadog.yaml` and `schema-version` `v1.2` or
+higher for new repositories.
+
+When both files are present, a `code-security.datadog.yaml` file with an `iac` section
+takes precedence over `dd-iac-scan.config`. If the `code-security.datadog.yaml` file has
+no `iac` section (for example, only `sast`), the scanner falls back to
+`dd-iac-scan.config`.
+
+Documentation for the legacy format has been saved below for reference:
+
+---
+
+## Legacy Schema Reference
+
+The scanner can be configured using a `dd-iac-scan.config` file at the root directory of
+the repository. The file can be written in YAML, JSON, TOML, or HCL; the format is
+detected from the file extension.
+
+The following top-level entries are supported:
+
+- `exclude-severities`: (optional) a list of severities to ignore. Findings whose
+  severity matches an entry in this list are dropped from scan results.
+- `exclude-paths`: (optional) a list of paths or glob patterns to exclude from scanning.
+  Files matching any entry are not analyzed.
+- `exclude-queries`: (optional) a list of query (rule) IDs to ignore. Findings produced
+  by these queries are dropped from scan results. Both legacy UUID rule IDs and the new
+  Code Security rule IDs are accepted.
+- `exclude-categories`: (optional) a list of categories to ignore. Findings whose
+  category matches an entry in this list are dropped from scan results.
+- `include-queries`: (optional) a list of query (rule) IDs to run. If `include-queries`
+  is set, every `exclude-*` field in the same file is ignored and only the listed
+  queries are evaluated.
+- `exclude-results`: (optional) a list of result similarity IDs to drop from scan
+  results. This option only exists in the legacy schema; it has no equivalent in
+  `code-security.datadog.yaml`.
+
+### Possible values
+
+`exclude-severities` accepts the following values:
+
+- `critical`
+- `high`
+- `medium`
+- `low`
+- `info`
+
+`exclude-categories` accepts the following values:
+
+- `Access Control`
+- `Availability`
+- `Backup`
+- `Best Practices`
+- `Bill Of Materials`
+- `Build Process`
+- `Encryption`
+- `Insecure Configurations`
+- `Insecure Defaults`
+- `Networking and Firewall`
+- `Observability`
+- `Resource Management`
+- `Secret Management`
+- `Structure and Semantics`
+- `Supply-Chain`
+
+## Examples
+
+### YAML
+
+```yaml
+exclude-severities:
+  - "info"
+  - "low"
+exclude-paths:
+  - "./shouldNotScan/*"
+  - "dir/somefile.txt"
+exclude-queries:
+  - "e69890e6-fce5-461d-98ad-cb98318dfc96"
+  - "4728cd65-a20c-49da-8b31-9c08b423e4db"
+exclude-categories:
+  - "Access Control"
+  - "Best Practices"
+exclude-results:
+  - "result-similarity-id"
+```
+
+### JSON
+
+```json
+{
+  "exclude-severities": ["info", "low"],
+  "exclude-paths": ["./shouldNotScan/*", "dir/somefile.txt"],
+  "exclude-queries": [
+    "e69890e6-fce5-461d-98ad-cb98318dfc96",
+    "4728cd65-a20c-49da-8b31-9c08b423e4db"
+  ],
+  "exclude-categories": ["Access Control", "Best Practices"]
+}
+```
+
+### TOML
+
+```toml
+exclude-severities = ["info", "low"]
+exclude-paths = ["./shouldNotScan/*", "dir/somefile.txt"]
+exclude-queries = [
+  "e69890e6-fce5-461d-98ad-cb98318dfc96",
+  "4728cd65-a20c-49da-8b31-9c08b423e4db",
+]
+exclude-categories = ["Access Control", "Best Practices"]
+```
+
+### HCL
+
+```hcl
+"exclude-severities" = ["info", "low"]
+"exclude-paths" = ["./shouldNotScan/*", "dir/somefile.txt"]
+"exclude-queries" = [
+  "e69890e6-fce5-461d-98ad-cb98318dfc96",
+  "4728cd65-a20c-49da-8b31-9c08b423e4db",
+]
+"exclude-categories" = ["Access Control", "Best Practices"]
+```
+
+## Run only specific queries
+
+Use `include-queries` to run only specific queries in a repository:
+
+```yaml
+include-queries:
+  - "e69890e6-fce5-461d-98ad-cb98318dfc96"
+  - "4728cd65-a20c-49da-8b31-9c08b423e4db"
+```
+
+When `include-queries` is set, the scanner evaluates only the listed queries and ignores
+every `exclude-*` field in the same `dd-iac-scan.config` file.
+
+## Inline comments
+
+Inline comments (`dd-iac-scan ignore`, `dd-iac-scan disable=<rule_id>`,
+`dd-iac-scan enable=<rule_id>`, `dd-iac-scan ignore-line`, `dd-iac-scan ignore-block`)
+are part of the scanner itself rather than the legacy configuration file, so they
+continue to work the same way with both `code-security.datadog.yaml` and
+`dd-iac-scan.config`. See the
+[IaC Security configuration documentation](https://docs.datadoghq.com/security/code_security/iac_security/configuration/)
+for the full list of supported inline commands.


### PR DESCRIPTION
## Motivation

Datadog IaC Security documentation links to this repository for the [deprecated `dd-iac-scan.config` schema](https://github.com/DataDog/documentation/pull/36468/changes#diff-a59bf77f70ae31342bf11e1dd11732da49acb572bdd9a634d509f3ed766e5d80R284). The README still presented legacy config as the primary path. This PR adds an in-repo reference document and aligns the README with `code-security.datadog.yaml` as the supported configuration model.

## Changes

> [!NOTE]
> This PR is not ready to be merged as the feature is not released yet, but it is to be ready once the feature is released

- Add `doc/legacy_config.md` documenting the legacy `dd-iac-scan.config` format (supported fields, precedence vs `code-security.datadog.yaml`, `include-queries` behavior, `exclude-results`, and multi-format examples).
- Update README **Configuring the scan**: lead with `code-security.datadog.yaml` / `schema-version: v1.2`, link to the IaC Security configuration docs, defer legacy details to `doc/legacy_config.md`, and refresh inline `dd-iac-scan` command wording.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [x] I have tested my changes on staging (if applicable).
- [x] I have updated any relevant documentation (if applicable).

## QA Instruction

Review `README.md` and `doc/legacy_config.md`.

## Blast Radius

Documentation only: README and new `doc/` markdown.

## Additional Notes

I submit this contribution under the Apache-2.0 license.
