### PR TITLE
Apply Datadog remote config when scanning via pkg/scan

### DIFF
--- a/pkg/scan/pre_scan.go
+++ b/pkg/scan/pre_scan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -14,7 +15,36 @@ func initializeConfig(ctx context.Context, rootPath string) (*config.IacConfig, 
 
 	baseLogger.Debug().Msg("console.initializeConfig()")
 
-	configParams, _, err := config.ReadConfiguration(ctx, rootPath)
+	configParams, _, err := config.ReadConfiguration(ctx, rootPath, configurationOptions(rootPath)...)
 
 	return configParams, logCtx, err
+}
+
+// configurationOptions returns the ReadConfigurationOptions applied to every scan
+// performed via the library entrypoint. Remote configuration is fetched when a git
+// `origin` remote is resolvable for rootPath; otherwise only the local
+// configuration is used.
+func configurationOptions(rootPath string) []config.ReadConfigurationOption {
+	repoURL := lookupRepositoryURL(rootPath)
+	if repoURL == "" {
+		return nil
+	}
+	return []config.ReadConfigurationOption{
+		bestEffortDatadog(datadog.NewDatadogClient(), repoURL),
+	}
+}
+
+// bestEffortDatadog wraps config.WithDatadog so that a failure to fetch the
+// remote configuration is logged and the local configuration is preserved.
+// Transient Datadog API issues must not break the scan for library callers.
+func bestEffortDatadog(client datadog.Client, repoURL string) config.ReadConfigurationOption {
+	inner := config.WithDatadog(client, repoURL)
+	return func(ctx context.Context, cfgBytes []byte) ([]byte, error) {
+		out, err := inner(ctx, cfgBytes)
+		if err != nil {
+			log.Ctx(ctx).Warn().Err(err).Msg("could not fetch remote configuration from Datadog; using local configuration only")
+			return cfgBytes, nil
+		}
+		return out, nil
+	}
 }

--- a/pkg/scan/pre_scan_test.go
+++ b/pkg/scan/pre_scan_test.go
@@ -1,0 +1,107 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package scan
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
+	git "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRemoteConfigClient struct {
+	remote []byte
+	err    error
+}
+
+func (f fakeRemoteConfigClient) GetDefaultRuleset(_ context.Context) (*datadog.Ruleset, error) {
+	panic("unimplemented")
+}
+
+func (f fakeRemoteConfigClient) GetRemoteConfig(_ context.Context, _ string, localConfig []byte) ([]byte, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.remote != nil {
+		return f.remote, nil
+	}
+	return localConfig, nil
+}
+
+func TestBestEffortDatadog_Success(t *testing.T) {
+	client := fakeRemoteConfigClient{remote: []byte("remote-config")}
+
+	opt := bestEffortDatadog(client, "https://example.com/repo.git")
+	out, err := opt(t.Context(), []byte("local-config"))
+
+	assert.NoError(t, err)
+	assert.Equal(t, "remote-config", string(out))
+}
+
+func TestBestEffortDatadog_ErrorFallsBackToLocal(t *testing.T) {
+	client := fakeRemoteConfigClient{err: errors.New("network down")}
+
+	opt := bestEffortDatadog(client, "https://example.com/repo.git")
+	out, err := opt(t.Context(), []byte("local-config"))
+
+	assert.NoError(t, err, "remote-config errors must not fail the scan")
+	assert.Equal(t, "local-config", string(out))
+}
+
+func TestConfigurationOptions_NoGitRemoteReturnsNil(t *testing.T) {
+	opts := configurationOptions(t.TempDir())
+	assert.Nil(t, opts)
+}
+
+func TestConfigurationOptions_GitRemoteReturnsDatadogOption(t *testing.T) {
+	const remoteURL = "https://example.com/test-repo.git"
+	repoDir := initRepoWithOrigin(t, remoteURL)
+
+	t.Run("repository root", func(t *testing.T) {
+		assert.Equal(t, remoteURL, lookupRepositoryURL(repoDir))
+
+		opts := configurationOptions(repoDir)
+		require.Len(t, opts, 1, "expected a single WithDatadog-backed option")
+		assert.NotNil(t, opts[0])
+	})
+
+	t.Run("nested subdirectory walks up to repo root", func(t *testing.T) {
+		nested := filepath.Join(repoDir, "a", "b", "c")
+		require.NoError(t, os.MkdirAll(nested, 0o755))
+
+		assert.Equal(t, remoteURL, lookupRepositoryURL(nested))
+
+		opts := configurationOptions(nested)
+		require.Len(t, opts, 1)
+		assert.NotNil(t, opts[0])
+	})
+}
+
+// initRepoWithOrigin creates a temporary git repository configured with a single
+// `origin` remote pointing at remoteURL, and returns its path.
+func initRepoWithOrigin(t *testing.T, remoteURL string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+
+	_, err = repo.CreateRemote(&gitconfig.RemoteConfig{
+		Name: "origin",
+		URLs: []string{remoteURL},
+	})
+	require.NoError(t, err)
+
+	return dir
+}

--- a/pkg/scan/repo_url.go
+++ b/pkg/scan/repo_url.go
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package scan
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	git "github.com/go-git/go-git/v5"
+)
+
+// lookupRepositoryURL returns the URL of the `origin` remote of the git repository
+// containing rootPath, or the empty string when no enclosing repository or remote
+// is found.
+func lookupRepositoryURL(rootPath string) string {
+	repo, err := openRepoFrom(rootPath)
+	if err != nil {
+		return ""
+	}
+	remote, err := repo.Remote("origin")
+	if err != nil {
+		return ""
+	}
+	urls := remote.Config().URLs
+	if len(urls) == 0 {
+		return ""
+	}
+	return urls[0]
+}
+
+// openRepoFrom opens the git repository containing rootPath, walking up parent
+// directories until one is found.
+func openRepoFrom(rootPath string) (*git.Repository, error) {
+	dir, err := filepath.Abs(rootPath)
+	if err != nil {
+		return nil, err
+	}
+	for {
+		if stat, statErr := os.Stat(dir); statErr == nil && stat.IsDir() {
+			if repo, openErr := git.PlainOpen(dir); openErr == nil {
+				return repo, nil
+			} else if !errors.Is(openErr, git.ErrRepositoryNotExists) {
+				return nil, openErr
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir || parent == "" || parent == "." {
+			return nil, git.ErrRepositoryNotExists
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Motivation

PR [#141](https://github.com/DataDog/datadog-iac-scanner/pull/141) fixes `config.ReadConfiguration` so server-side options (for example `WithDatadog`) run even when there is no local `code-security.datadog.yaml`. That is necessary but not sufficient for every caller: the **library** path used by downstream integrations still called `ReadConfiguration` **without** `WithDatadog`, so the Datadog settings API was never consulted and org or repository settings in the product had no effect.

This change wires the same remote-configuration behavior into the shared entrypoint (`initializeConfig` → `GetDefaultParameters`) by resolving the repository URL from the enclosing git repository’s `origin` remote and passing `config.WithDatadog` when that URL is available. Remote fetch failures are logged and the scan continues with the local configuration only, so library callers are not broken by transient API issues; the CLI path is unchanged and still surfaces hard errors when the API fails while credentials are set (existing behavior).

## Changes

- Resolve `origin` URL from the git repo containing the scan root (`pkg/scan/repo_url.go`).
- Pass `WithDatadog` from `initializeConfig` when a remote URL exists; wrap the option so API errors fall back to local config for library scans (`pkg/scan/pre_scan.go`).
- Add unit tests for the wrapper, the no-git case, and the happy path for repo URL discovery and `configurationOptions` (`pkg/scan/pre_scan_test.go`).

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

From the repository root:

```bash
go test ./pkg/scan/... ./pkg/config/... -count=1
```

Optional: in a temp git repo with `origin` set and `DD_API_KEY` / `DD_APP_KEY` / `DD_SITE` configured, call `scan.GetDefaultParameters` (or run a scan through the library) and confirm the merged configuration reflects Datadog UI settings when no local IaC config file exists.

## Blast Radius

Affects **library** consumers of `github.com/DataDog/datadog-iac-scanner/pkg/scan` (for example embedded scanners): they will now attempt the same remote config merge as the `scanner` CLI when a git `origin` is present. The `cmd/scanner` binary behavior is unchanged. No change to SARIF schema or query assets.

## Additional Notes

I submit this contribution under the Apache-2.0 license.
