### PR TITLE
Add DD_JWT_TOKEN and DD_HOSTNAME support to the Datadog API client

### DIFF
--- a/pkg/datadog/client.go
+++ b/pkg/datadog/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/DataDog/jsonapi"
 )
@@ -25,6 +26,9 @@ func NewDatadogClient(options ...DatadogClientOption) Client {
 	}
 	for _, option := range options {
 		option(out)
+	}
+	if out.hostname == "" {
+		WithHostnameFromEnv()(out)
 	}
 	if out.hostname == "" {
 		WithSiteFromEnv()(out)
@@ -109,11 +113,19 @@ func WithHttpClient(client *http.Client) DatadogClientOption {
 }
 
 // WithHostname lets you specify the hostname to use for Datadog API requests.
-// Used in the implementation and unit tests.
+// The value may include an http:// or https:// scheme; when omitted, https:// is used.
 func WithHostname(hostname string) DatadogClientOption {
 	return func(ds *datadogClient) {
 		ds.hostname = hostname
 	}
+}
+
+// WithHostnameFromEnv uses the hostname specified in the DD_HOSTNAME or DATADOG_HOSTNAME environment variable.
+// When set, it takes precedence over DD_SITE so that internal Datadog runners can point the scanner at a
+// private static-analysis-api address (e.g. an internal fabric.dog host). Matches the behavior of
+// datadog-static-analyzer's get_datadog_basename.
+func WithHostnameFromEnv() DatadogClientOption {
+	return WithHostname(getDdEnvvar("HOSTNAME"))
 }
 
 type DatadogClientOption func(source *datadogClient)
@@ -194,7 +206,7 @@ func (s *datadogClient) GetRemoteConfig(ctx context.Context, repoUrl string, loc
 
 // sendRequest sends a Datadog API request
 func (s *datadogClient) sendRequest(ctx context.Context, method, path string, requestBody io.Reader) (*http.Response, error) {
-	url := fmt.Sprintf("https://%s/api/v2/static-analysis/%s", s.hostname, path)
+	url := fmt.Sprintf("%s/api/v2/static-analysis/%s", s.baseURL(), path)
 	req, err := http.NewRequestWithContext(ctx, method, url, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("error building %s %s request: %w", method, url, err)
@@ -210,6 +222,15 @@ func (s *datadogClient) sendRequest(ctx context.Context, method, path string, re
 		req.Header.Add("dd-auth-jwt", s.jwtToken)
 	}
 	return s.httpClient.Do(req)
+}
+
+// baseURL returns the API base URL, preserving an explicit http:// or https:// scheme
+// when present in the hostname and defaulting to https:// otherwise.
+func (s *datadogClient) baseURL() string {
+	if strings.HasPrefix(s.hostname, "http://") || strings.HasPrefix(s.hostname, "https://") {
+		return s.hostname
+	}
+	return "https://" + s.hostname
 }
 
 // getDdEnvvar returns the value of the given Datadog environment variable.

--- a/pkg/datadog/client.go
+++ b/pkg/datadog/client.go
@@ -89,7 +89,7 @@ func WithAppKeyFromEnv() DatadogClientOption {
 	return WithAppKey(getDdEnvvar("APP_KEY"))
 }
 
-// WithJwtToken lets you specify a Datadog auth JWT for service-to-service authentication.
+// WithJwtToken lets you specify a Datadog auth JWT, sent as the `dd-auth-jwt` request header.
 // If unspecified, the JWT will be fetched from the environment using WithJwtTokenFromEnv.
 func WithJwtToken(jwtToken string) DatadogClientOption {
 	return func(ds *datadogClient) {
@@ -98,8 +98,7 @@ func WithJwtToken(jwtToken string) DatadogClientOption {
 }
 
 // WithJwtTokenFromEnv uses the JWT specified in the DD_JWT_TOKEN or DATADOG_JWT_TOKEN environment variable.
-// If neither variable exists, an empty JWT will be used. The JWT is sent as the `dd-auth-jwt`
-// header and is the auth mechanism used by Datadog code-workload-runner environments.
+// If neither variable exists, an empty JWT will be used.
 func WithJwtTokenFromEnv() DatadogClientOption {
 	return WithJwtToken(getDdEnvvar("JWT_TOKEN"))
 }
@@ -121,9 +120,7 @@ func WithHostname(hostname string) DatadogClientOption {
 }
 
 // WithHostnameFromEnv uses the hostname specified in the DD_HOSTNAME or DATADOG_HOSTNAME environment variable.
-// When set, it takes precedence over DD_SITE so that internal Datadog runners can point the scanner at a
-// private static-analysis-api address (e.g. an internal fabric.dog host). Matches the behavior of
-// datadog-static-analyzer's get_datadog_basename.
+// When set, it takes precedence over DD_SITE. If neither variable exists, an empty hostname will be used.
 func WithHostnameFromEnv() DatadogClientOption {
 	return WithHostname(getDdEnvvar("HOSTNAME"))
 }
@@ -224,8 +221,7 @@ func (s *datadogClient) sendRequest(ctx context.Context, method, path string, re
 	return s.httpClient.Do(req)
 }
 
-// baseURL returns the API base URL, preserving an explicit http:// or https:// scheme
-// when present in the hostname and defaulting to https:// otherwise.
+// baseURL returns the API base URL, defaulting to https:// when the hostname has no scheme.
 func (s *datadogClient) baseURL() string {
 	if strings.HasPrefix(s.hostname, "http://") || strings.HasPrefix(s.hostname, "https://") {
 		return s.hostname
@@ -233,11 +229,8 @@ func (s *datadogClient) baseURL() string {
 	return "https://" + s.hostname
 }
 
-// getDdEnvvar returns the value of the given Datadog environment variable.
-// The DD_ prefix is checked first, then the DATADOG_ prefix. An explicitly empty
-// value is treated as absent so that callers fall through to the next candidate,
-// matching the behavior of datadog-static-analyzer's get_datadog_variable_value.
-// Returns an empty string if neither environment variable provides a value.
+// getDdEnvvar returns the value of the DD_<name> environment variable, falling back to DATADOG_<name>.
+// An explicitly empty value is treated as absent so callers fall through to the next candidate.
 func getDdEnvvar(name string) string {
 	for _, prefix := range []string{"DD_", "DATADOG_"} {
 		if v, ok := os.LookupEnv(prefix + name); ok && v != "" {

--- a/pkg/datadog/client.go
+++ b/pkg/datadog/client.go
@@ -35,6 +35,9 @@ func NewDatadogClient(options ...DatadogClientOption) Client {
 	if out.appKey == "" {
 		WithAppKeyFromEnv()(out)
 	}
+	if out.jwtToken == "" {
+		WithJwtTokenFromEnv()(out)
+	}
 	return out
 }
 
@@ -82,6 +85,21 @@ func WithAppKeyFromEnv() DatadogClientOption {
 	return WithAppKey(getDdEnvvar("APP_KEY"))
 }
 
+// WithJwtToken lets you specify a Datadog auth JWT for service-to-service authentication.
+// If unspecified, the JWT will be fetched from the environment using WithJwtTokenFromEnv.
+func WithJwtToken(jwtToken string) DatadogClientOption {
+	return func(ds *datadogClient) {
+		ds.jwtToken = jwtToken
+	}
+}
+
+// WithJwtTokenFromEnv uses the JWT specified in the DD_JWT_TOKEN or DATADOG_JWT_TOKEN environment variable.
+// If neither variable exists, an empty JWT will be used. The JWT is sent as the `dd-auth-jwt`
+// header and is the auth mechanism used by Datadog code-workload-runner environments.
+func WithJwtTokenFromEnv() DatadogClientOption {
+	return WithJwtToken(getDdEnvvar("JWT_TOKEN"))
+}
+
 // WithHttpClient lets you specify an http.Client instance to use.
 // If unspecified, the [http.DefaultClient] will be used.
 func WithHttpClient(client *http.Client) DatadogClientOption {
@@ -106,6 +124,7 @@ type datadogClient struct {
 	hostname   string
 	apiKey     string
 	appKey     string
+	jwtToken   string
 	httpClient *http.Client
 }
 
@@ -135,7 +154,7 @@ func (s *datadogClient) GetDefaultRuleset(ctx context.Context) (*Ruleset, error)
 
 // GetRemoteConfig applies server-side changes to the local configuration.
 func (s *datadogClient) GetRemoteConfig(ctx context.Context, repoUrl string, localConfig []byte) ([]byte, error) {
-	if s.apiKey == "" && s.appKey == "" {
+	if s.apiKey == "" && s.appKey == "" && s.jwtToken == "" {
 		// Without credentials, do not send the request; echo the local configuration instead
 		return localConfig, nil
 	}
@@ -186,6 +205,9 @@ func (s *datadogClient) sendRequest(ctx context.Context, method, path string, re
 	}
 	if s.appKey != "" {
 		req.Header.Add("dd-application-key", s.appKey)
+	}
+	if s.jwtToken != "" {
+		req.Header.Add("dd-auth-jwt", s.jwtToken)
 	}
 	return s.httpClient.Do(req)
 }

--- a/pkg/datadog/client.go
+++ b/pkg/datadog/client.go
@@ -213,13 +213,15 @@ func (s *datadogClient) sendRequest(ctx context.Context, method, path string, re
 }
 
 // getDdEnvvar returns the value of the given Datadog environment variable.
-// The DD_ prefix is checked first, then the DATADOG_ prefix.
-// Returns an empty string if neither environment variable exists.
+// The DD_ prefix is checked first, then the DATADOG_ prefix. An explicitly empty
+// value is treated as absent so that callers fall through to the next candidate,
+// matching the behavior of datadog-static-analyzer's get_datadog_variable_value.
+// Returns an empty string if neither environment variable provides a value.
 func getDdEnvvar(name string) string {
-	if v, ok := os.LookupEnv("DD_" + name); ok {
-		return v
-	} else if v, ok = os.LookupEnv("DATADOG_" + name); ok {
-		return v
+	for _, prefix := range []string{"DD_", "DATADOG_"} {
+		if v, ok := os.LookupEnv(prefix + name); ok && v != "" {
+			return v
+		}
 	}
 	return ""
 }

--- a/pkg/datadog/client_test.go
+++ b/pkg/datadog/client_test.go
@@ -62,6 +62,84 @@ func TestGetRemoteConfig(t *testing.T) {
 	assert.Equal(t, remoteConfig, string(actual))
 }
 
+// TestGetRemoteConfig_WithJwtToken exercises the JWT auth path used by
+// internal Datadog code-workload runners (no API/app keys, only `dd-auth-jwt`).
+func TestGetRemoteConfig_WithJwtToken(t *testing.T) {
+	clearDatadogEnv(t)
+
+	repoUrl := "https://example.com/repo"
+	remoteConfig := "remote configuration"
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "", r.Header.Get("dd-api-key"))
+		assert.Equal(t, "", r.Header.Get("dd-application-key"))
+		assert.Equal(t, "my-jwt-token", r.Header.Get("dd-auth-jwt"))
+
+		require.Equal(t, "/api/v2/static-analysis/config/client", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		defer r.Body.Close()
+		var request remoteConfigRequest
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, jsonapi.Unmarshal(body, &request))
+		assert.Equal(t, repoUrl, request.Repository)
+
+		body, err = jsonapi.Marshal(remoteConfigResponse{ID: "cfg", Config: []byte(remoteConfig)})
+		require.NoError(t, err)
+		w.Header().Add("content-type", "application/json")
+		_, err = w.Write(body)
+		require.NoError(t, err)
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	client := NewDatadogClient(
+		WithHostname(server.Listener.Addr().String()),
+		WithHttpClient(server.Client()),
+		WithJwtToken("my-jwt-token"),
+	)
+	actual, err := client.GetRemoteConfig(t.Context(), repoUrl, []byte{})
+	assert.NoError(t, err)
+	assert.Equal(t, remoteConfig, string(actual))
+}
+
+// TestGetRemoteConfig_NoCredentials documents that with no API key, no application
+// key, and no JWT token, the client echoes the local configuration without making
+// any HTTP request. The provided HTTP client would fail the test if called.
+func TestGetRemoteConfig_NoCredentials(t *testing.T) {
+	clearDatadogEnv(t)
+
+	failingHandler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Failf(t, "unexpected request", "the client must not contact the API without credentials: %s %s", r.Method, r.URL)
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(failingHandler))
+	t.Cleanup(server.Close)
+
+	client := NewDatadogClient(
+		WithHostname(server.Listener.Addr().String()),
+		WithHttpClient(server.Client()),
+	)
+	local := []byte("local config")
+	actual, err := client.GetRemoteConfig(t.Context(), "https://example.com/repo", local)
+	assert.NoError(t, err)
+	assert.Equal(t, string(local), string(actual))
+}
+
+// clearDatadogEnv ensures that no DD_* / DATADOG_* credential env vars leak into
+// the constructor's env fallbacks, which would otherwise make these tests
+// dependent on the developer's local environment.
+func clearDatadogEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"DD_API_KEY", "DATADOG_API_KEY",
+		"DD_APP_KEY", "DATADOG_APP_KEY",
+		"DD_JWT_TOKEN", "DATADOG_JWT_TOKEN",
+	} {
+		t.Setenv(name, "")
+	}
+}
+
 func getDatadogClient(t *testing.T, rules []*Rule, repoUrl string, config []byte) Client {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "my-api-key", r.Header.Get("dd-api-key"))

--- a/pkg/datadog/client_test.go
+++ b/pkg/datadog/client_test.go
@@ -103,6 +103,40 @@ func TestGetRemoteConfig_WithJwtToken(t *testing.T) {
 	assert.Equal(t, remoteConfig, string(actual))
 }
 
+// TestGetRemoteConfig_EmptyDdJwtTokenFallsBackToDatadogJwtToken covers the case
+// where DD_JWT_TOKEN is exported but empty (a common shell or runner pattern) and
+// the real token is provided via DATADOG_JWT_TOKEN. An explicitly empty DD_ value
+// must not shadow a populated DATADOG_ value.
+func TestGetRemoteConfig_EmptyDdJwtTokenFallsBackToDatadogJwtToken(t *testing.T) {
+	clearDatadogEnv(t)
+	t.Setenv("DD_JWT_TOKEN", "")
+	t.Setenv("DATADOG_JWT_TOKEN", "real-jwt-token")
+
+	repoUrl := "https://example.com/repo"
+	remoteConfig := "remote configuration"
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "real-jwt-token", r.Header.Get("dd-auth-jwt"))
+		require.Equal(t, "/api/v2/static-analysis/config/client", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		body, err := jsonapi.Marshal(remoteConfigResponse{ID: "cfg", Config: []byte(remoteConfig)})
+		require.NoError(t, err)
+		w.Header().Add("content-type", "application/json")
+		_, err = w.Write(body)
+		require.NoError(t, err)
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	client := NewDatadogClient(
+		WithHostname(server.Listener.Addr().String()),
+		WithHttpClient(server.Client()),
+	)
+	actual, err := client.GetRemoteConfig(t.Context(), repoUrl, []byte{})
+	assert.NoError(t, err)
+	assert.Equal(t, remoteConfig, string(actual))
+}
+
 // TestGetRemoteConfig_NoCredentials documents that with no API key, no application
 // key, and no JWT token, the client echoes the local configuration without making
 // any HTTP request. The provided HTTP client would fail the test if called.

--- a/pkg/datadog/client_test.go
+++ b/pkg/datadog/client_test.go
@@ -62,8 +62,8 @@ func TestGetRemoteConfig(t *testing.T) {
 	assert.Equal(t, remoteConfig, string(actual))
 }
 
-// TestGetRemoteConfig_WithJwtToken exercises the JWT auth path used by
-// internal Datadog code-workload runners (no API/app keys, only `dd-auth-jwt`).
+// TestGetRemoteConfig_WithJwtToken verifies that the client authenticates with
+// only a JWT (no API or application key) by sending the `dd-auth-jwt` header.
 func TestGetRemoteConfig_WithJwtToken(t *testing.T) {
 	clearDatadogEnv(t)
 
@@ -103,10 +103,8 @@ func TestGetRemoteConfig_WithJwtToken(t *testing.T) {
 	assert.Equal(t, remoteConfig, string(actual))
 }
 
-// TestGetRemoteConfig_EmptyDdJwtTokenFallsBackToDatadogJwtToken covers the case
-// where DD_JWT_TOKEN is exported but empty (a common shell or runner pattern) and
-// the real token is provided via DATADOG_JWT_TOKEN. An explicitly empty DD_ value
-// must not shadow a populated DATADOG_ value.
+// TestGetRemoteConfig_EmptyDdJwtTokenFallsBackToDatadogJwtToken verifies that
+// an explicitly empty DD_JWT_TOKEN does not shadow a populated DATADOG_JWT_TOKEN.
 func TestGetRemoteConfig_EmptyDdJwtTokenFallsBackToDatadogJwtToken(t *testing.T) {
 	clearDatadogEnv(t)
 	t.Setenv("DD_JWT_TOKEN", "")
@@ -137,9 +135,9 @@ func TestGetRemoteConfig_EmptyDdJwtTokenFallsBackToDatadogJwtToken(t *testing.T)
 	assert.Equal(t, remoteConfig, string(actual))
 }
 
-// TestGetRemoteConfig_NoCredentials documents that with no API key, no application
-// key, and no JWT token, the client echoes the local configuration without making
-// any HTTP request. The provided HTTP client would fail the test if called.
+// TestGetRemoteConfig_NoCredentials verifies that, with no API key, no application
+// key, and no JWT, the client echoes the local configuration without making any
+// HTTP request. The handler fails the test if called.
 func TestGetRemoteConfig_NoCredentials(t *testing.T) {
 	clearDatadogEnv(t)
 
@@ -160,9 +158,9 @@ func TestGetRemoteConfig_NoCredentials(t *testing.T) {
 	assert.Equal(t, string(local), string(actual))
 }
 
-// clearDatadogEnv ensures that no DD_* / DATADOG_* credential or endpoint env vars
-// leak into the constructor's env fallbacks, which would otherwise make these tests
-// dependent on the developer's local environment.
+// clearDatadogEnv prevents DD_* / DATADOG_* credential and endpoint env vars from
+// leaking into the constructor's env fallbacks and making the tests depend on the
+// developer's local environment.
 func clearDatadogEnv(t *testing.T) {
 	t.Helper()
 	for _, name := range []string{
@@ -177,9 +175,7 @@ func clearDatadogEnv(t *testing.T) {
 }
 
 // TestGetRemoteConfig_DdHostnameTakesPrecedenceOverDdSite verifies that the
-// internal endpoint passed via DD_HOSTNAME wins over DD_SITE so that internal
-// Datadog runners (which point the scanner at a private static-analysis-api host)
-// don't accidentally fall through to the public api.datadoghq.com endpoint.
+// hostname passed via DD_HOSTNAME wins over DD_SITE when both are set.
 func TestGetRemoteConfig_DdHostnameTakesPrecedenceOverDdSite(t *testing.T) {
 	clearDatadogEnv(t)
 
@@ -209,10 +205,9 @@ func TestGetRemoteConfig_DdHostnameTakesPrecedenceOverDdSite(t *testing.T) {
 	assert.Equal(t, remoteConfig, string(actual))
 }
 
-// TestGetRemoteConfig_HostnameWithHttpScheme verifies that DD_HOSTNAME values that
-// already include an http:// scheme are used as-is, matching the behavior of
-// datadog-static-analyzer. This is what dd-in-a-can needs to redirect the scanner
-// at a local mock server.
+// TestGetRemoteConfig_HostnameWithHttpScheme verifies that a hostname that
+// already includes an http:// scheme is used as-is, instead of being prefixed
+// with https://.
 func TestGetRemoteConfig_HostnameWithHttpScheme(t *testing.T) {
 	clearDatadogEnv(t)
 

--- a/pkg/datadog/client_test.go
+++ b/pkg/datadog/client_test.go
@@ -160,8 +160,8 @@ func TestGetRemoteConfig_NoCredentials(t *testing.T) {
 	assert.Equal(t, string(local), string(actual))
 }
 
-// clearDatadogEnv ensures that no DD_* / DATADOG_* credential env vars leak into
-// the constructor's env fallbacks, which would otherwise make these tests
+// clearDatadogEnv ensures that no DD_* / DATADOG_* credential or endpoint env vars
+// leak into the constructor's env fallbacks, which would otherwise make these tests
 // dependent on the developer's local environment.
 func clearDatadogEnv(t *testing.T) {
 	t.Helper()
@@ -169,9 +169,74 @@ func clearDatadogEnv(t *testing.T) {
 		"DD_API_KEY", "DATADOG_API_KEY",
 		"DD_APP_KEY", "DATADOG_APP_KEY",
 		"DD_JWT_TOKEN", "DATADOG_JWT_TOKEN",
+		"DD_SITE", "DATADOG_SITE",
+		"DD_HOSTNAME", "DATADOG_HOSTNAME",
 	} {
 		t.Setenv(name, "")
 	}
+}
+
+// TestGetRemoteConfig_DdHostnameTakesPrecedenceOverDdSite verifies that the
+// internal endpoint passed via DD_HOSTNAME wins over DD_SITE so that internal
+// Datadog runners (which point the scanner at a private static-analysis-api host)
+// don't accidentally fall through to the public api.datadoghq.com endpoint.
+func TestGetRemoteConfig_DdHostnameTakesPrecedenceOverDdSite(t *testing.T) {
+	clearDatadogEnv(t)
+
+	repoUrl := "https://example.com/repo"
+	remoteConfig := "remote configuration"
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v2/static-analysis/config/client", r.URL.Path)
+		body, err := jsonapi.Marshal(remoteConfigResponse{ID: "cfg", Config: []byte(remoteConfig)})
+		require.NoError(t, err)
+		w.Header().Add("content-type", "application/json")
+		_, err = w.Write(body)
+		require.NoError(t, err)
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	t.Setenv("DD_HOSTNAME", server.Listener.Addr().String())
+	t.Setenv("DD_SITE", "should-be-ignored.invalid")
+
+	client := NewDatadogClient(
+		WithHttpClient(server.Client()),
+		WithJwtToken("jwt"),
+	)
+	actual, err := client.GetRemoteConfig(t.Context(), repoUrl, []byte{})
+	assert.NoError(t, err)
+	assert.Equal(t, remoteConfig, string(actual))
+}
+
+// TestGetRemoteConfig_HostnameWithHttpScheme verifies that DD_HOSTNAME values that
+// already include an http:// scheme are used as-is, matching the behavior of
+// datadog-static-analyzer. This is what dd-in-a-can needs to redirect the scanner
+// at a local mock server.
+func TestGetRemoteConfig_HostnameWithHttpScheme(t *testing.T) {
+	clearDatadogEnv(t)
+
+	repoUrl := "https://example.com/repo"
+	remoteConfig := "remote configuration"
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v2/static-analysis/config/client", r.URL.Path)
+		body, err := jsonapi.Marshal(remoteConfigResponse{ID: "cfg", Config: []byte(remoteConfig)})
+		require.NoError(t, err)
+		w.Header().Add("content-type", "application/json")
+		_, err = w.Write(body)
+		require.NoError(t, err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	client := NewDatadogClient(
+		WithHostname(server.URL),
+		WithJwtToken("jwt"),
+	)
+	actual, err := client.GetRemoteConfig(t.Context(), repoUrl, []byte{})
+	assert.NoError(t, err)
+	assert.Equal(t, remoteConfig, string(actual))
 }
 
 func getDatadogClient(t *testing.T, rules []*Rule, repoUrl string, config []byte) Client {


### PR DESCRIPTION
## Motivation

[#141](https://github.com/DataDog/datadog-iac-scanner/pull/141) fixed the local-file gate so `WithDatadog` always runs. The scanner can still miss remote configuration in two scenarios that the current client cannot express:

1. **JWT-based authentication.** `pkg/datadog/client.go` only honored `DD_API_KEY` / `DD_APP_KEY`; with neither set, `GetRemoteConfig` silently echoed the local configuration with no HTTP request, no log, and no error. Callers that authenticate via a `dd-auth-jwt` header had no way to opt in.
2. **Endpoints that are not `api.<DD_SITE>`.** The host was always built from `DD_SITE`, so there was no way to point the client at a different hostname (for example a custom mock or a non-public host) without also changing the rest of the API contract.

[datadog-static-analyzer](https://github.com/DataDog/datadog-static-analyzer) already exposes both knobs (`DD_JWT_TOKEN` for the `dd-auth-jwt` header, and `DD_HOSTNAME` taking precedence over `DD_SITE`). This PR brings the IaC scanner client to the same contract.

## Changes

- Add `WithJwtToken` / `WithJwtTokenFromEnv` reading `DD_JWT_TOKEN` (or `DATADOG_JWT_TOKEN`); when set, send `dd-auth-jwt: <token>` on outgoing requests.
- Extend the silent "no credentials" bailout in `GetRemoteConfig` to also check the JWT, so the request is only skipped when no API key, no application key, **and** no JWT are configured.
- Add `WithHostnameFromEnv` reading `DD_HOSTNAME` (or `DATADOG_HOSTNAME`), taking precedence over `DD_SITE`. The value may include an `http://` or `https://` scheme; when omitted, `https://` is used.
- Treat an explicitly empty `DD_*` env var as absent so the `DATADOG_*` form is honored when the `DD_` alias is exported empty.
- Tests in `pkg/datadog/client_test.go` cover each path: JWT auth, no-credentials no-op, empty-`DD_*` fallback, `DD_HOSTNAME`-over-`DD_SITE` precedence, and the `http://` scheme passthrough.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [x] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

From the repository root:

```bash
go test ./pkg/datadog/... -count=1 -v
```

The new tests assert the exact request shape (path, method, headers) on every new path; a regression on credential precedence or hostname handling will fail one of them.

## Blast Radius

Strictly additive. Existing usage with `DD_API_KEY` + `DD_APP_KEY` and `DD_SITE` is unchanged: when `DD_HOSTNAME` is unset and credentials are present, the client still issues the same request to `api.<DD_SITE>` it did before. Callers with no credentials at all still hit the same silent no-op. No change to SARIF output, query assets, rule evaluation, or scan exit codes.

## Additional Notes

I submit this contribution under the Apache-2.0 license.