### PR TITLE
Remove noise when rules don't have legacyIds

### DIFF
--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -176,7 +176,7 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 	}
 
 	queryID := getStringFromMap(ctx, "id", DefaultQueryID, overrideKey, vObj, &logWithFields)
-	legacyQueryID := getStringFromMap(ctx, "legacyId", DefaultQueryID, overrideKey, vObj, &logWithFields)
+	legacyQueryID := getOptionalStringKey(ctx, "legacyId", DefaultQueryID, overrideKey, vObj, &logWithFields)
 
 	severity := getResolvedSeverity(ctx, vObj, &logWithFields, overrideKey, useOldSeverities)
 
@@ -226,7 +226,7 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 		KeyActualValue:        PtrStringToString(mustMapKeyToString(ctx, vObj, "keyActualValue")),
 		Value:                 mustMapKeyToString(ctx, vObj, "value"),
 		Output:                string(output),
-		CloudProvider:         getCloudProvider(ctx, overrideKey, vObj, &logWithFields),
+		CloudProvider:         getOptionalStringKey(ctx, "cloudProvider", "", overrideKey, vObj, &logWithFields),
 		Remediation:           PtrStringToString(mustMapKeyToString(ctx, vObj, "remediation")),
 		RemediationType:       PtrStringToString(mustMapKeyToString(ctx, vObj, "remediationType")),
 		QueryDuration:         queryDuration,
@@ -376,14 +376,6 @@ func checkMinified(ctx *QueryContext, resolvedFile string) bool {
 
 // </editor-fold>
 // </editor-fold>
-
-func getCloudProvider(ctx context.Context, overrideKey string, vObj map[string]interface{}, logWithFields *zerolog.Logger) string {
-	cloudProvider := ""
-	if _, ok := vObj["cloudProvider"]; ok {
-		cloudProvider = getStringFromMap(ctx, "cloudProvider", "", overrideKey, vObj, logWithFields)
-	}
-	return cloudProvider
-}
 
 // calculate search Line if possible (default uses values of search key)
 func calculeSearchLine(ctx context.Context, searchLineCalc *searchLineCalculator) (lineNumber int,

--- a/pkg/engine/vulnerability_utils.go
+++ b/pkg/engine/vulnerability_utils.go
@@ -177,7 +177,8 @@ func getSeverity(severity string) model.Severity {
 	return ""
 }
 
-func getOptionalStringKey(ctx context.Context, key, defaultValue, overrideKey string, vObj map[string]interface{}, logWithFields *zerolog.Logger) string {
+func getOptionalStringKey(ctx context.Context, key, defaultValue, overrideKey string,
+	vObj map[string]interface{}, logWithFields *zerolog.Logger) string {
 	optionalKey := defaultValue
 	if _, ok := vObj[key]; ok {
 		optionalKey = getStringFromMap(ctx, key, defaultValue, overrideKey, vObj, logWithFields)

--- a/pkg/engine/vulnerability_utils.go
+++ b/pkg/engine/vulnerability_utils.go
@@ -176,3 +176,11 @@ func getSeverity(severity string) model.Severity {
 	}
 	return ""
 }
+
+func getOptionalStringKey(ctx context.Context, key, defaultValue, overrideKey string, vObj map[string]interface{}, logWithFields *zerolog.Logger) string {
+	optionalKey := defaultValue
+	if _, ok := vObj[key]; ok {
+		optionalKey = getStringFromMap(ctx, key, defaultValue, overrideKey, vObj, logWithFields)
+	}
+	return optionalKey
+}

--- a/pkg/engine/vulnerability_utils_test.go
+++ b/pkg/engine/vulnerability_utils_test.go
@@ -8,9 +8,11 @@ package engine
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -179,4 +181,33 @@ func Test_PtrStringToString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetOptionalStringKey(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.New(os.Stdout)
+
+	t.Run("returns value when key is present", func(t *testing.T) {
+		vObj := map[string]interface{}{"legacyId": "test-legacy-id"}
+		result := getOptionalStringKey(ctx, "legacyId", DefaultQueryID, "", vObj, &logger)
+		require.Equal(t, "test-legacy-id", result)
+	})
+
+	t.Run("returns default when key is absent", func(t *testing.T) {
+		vObj := map[string]interface{}{}
+		result := getOptionalStringKey(ctx, "legacyId", DefaultQueryID, "", vObj, &logger)
+		require.Equal(t, DefaultQueryID, result)
+	})
+
+	t.Run("handles empty string value", func(t *testing.T) {
+		vObj := map[string]interface{}{"legacyId": ""}
+		result := getOptionalStringKey(ctx, "legacyId", DefaultQueryID, "", vObj, &logger)
+		require.Equal(t, "", result)
+	})
+
+	t.Run("applies cloudProvider with empty default", func(t *testing.T) {
+		vObj := map[string]interface{}{"cloudProvider": "aws"}
+		result := getOptionalStringKey(ctx, "cloudProvider", "", "", vObj, &logger)
+		require.Equal(t, "aws", result)
+	})
 }


### PR DESCRIPTION
## Motivation

When rules do not have a `legacyId`, an error is logged. This is noisy as not having a `legacyId` should be an expected behavior for the rules.

## Changes

- Created a function similar to the `cloudProvider` one to retrieve the `legacyId` without logging errors: both merged into a `getOptionalStringKey` helper function.
- Added testing for the helper function

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- User may either either by removing a `legacyId` and launching a scan locally

## Blast Radius

Does not change the logic applied

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
