### PR TITLE
Preserve id and legacyId on backend rule conversion

### DIFF
--- a/pkg/engine/source/datadog.go
+++ b/pkg/engine/source/datadog.go
@@ -169,16 +169,12 @@ func isInCaseInsensitiveNotEmptyList(id *string, list []string) bool {
 // nolint:gocyclo
 // ConvertRule converts a Datadog api [Rule] to a [model.QueryMetadata]
 func ConvertRule(rule *datadog.Rule) model.QueryMetadata {
-	id := rule.ID
-	if rule.LegacyId != nil {
-		id = *rule.LegacyId
-	}
 	out := model.QueryMetadata{
 		InputData: "{}",
 		Query:     rule.Name,
 		Content:   string(rule.RegoQuery),
 		Metadata: map[string]any{
-			"id":              id,
+			"id":              rule.ID,
 			"queryName":       rule.ShortDescription,
 			"descriptionText": rule.Description,
 			"platform":        rule.Platform,
@@ -189,6 +185,7 @@ func ConvertRule(rule *datadog.Rule) model.QueryMetadata {
 		Aggregation:  1,
 		Experimental: rule.IsTesting,
 	}
+	setStringPtr(out.Metadata, "legacyId", rule.LegacyId)
 	setStringPtr(out.Metadata, "providerUrl", rule.ProviderUrl)
 	setStringPtr(out.Metadata, "descriptionID", rule.DescriptionId)
 	setStringPtr(out.Metadata, "cloudProvider", rule.Provider)

--- a/pkg/engine/source/datadog_test.go
+++ b/pkg/engine/source/datadog_test.go
@@ -429,7 +429,8 @@ var queries = []model.QueryMetadata{
 		Query:     "rule-2",
 		Content:   "query text 2",
 		Metadata: map[string]any{
-			"id":              "rule-2",
+			"id":              "common-rule-2",
+			"legacyId":        "rule-2",
 			"queryName":       "short 2",
 			"descriptionText": "full 2",
 			"platform":        "Common",


### PR DESCRIPTION
## Motivation

When the scanner pulls rules from the Datadog backend via `DatadogSource`, `ConvertRule` was producing a `model.QueryMetadata` shape that differed from what `FilesystemSource` produces for the same rule on disk.

For backend-served rules, `ConvertRule` was writing the rule's optional legacy UUID into `metadata["id"]` (and falling back to the slug if no legacy id was set), and never writing `metadata["legacyId"]`.

For filesystem-served rules, the contract is the opposite and is asserted by the scanner's own tests:

- `metadata["id"]` holds the rule slug (e.g. `terraform-aws-alb-deletion-protection-disabled`)
- `metadata["legacyId"]` holds the legacy UUID when present (e.g. `afecd1f1-6378-4f7e-bb3b-60c35801fdd4`)

See `pkg/engine/source/filesystem_test.go` (around the `terraform-aws-alb-deletion-protection-disabled` assertions) and `FilesystemSource.checkQueryInclude/Exclude`, which already filters on both `metadata["id"]` and `metadata["legacyId"]`.

This PR aligns `ConvertRule` with that contract so backend-served rules carry the same metadata shape as filesystem-served rules.

JIRA Ticket: N/A

## Changes

- In `ConvertRule`, set `metadata["id"]` directly from `rule.ID` (the rule slug) instead of preferring `rule.LegacyId`.
- Also set `metadata["legacyId"]` from `rule.LegacyId` when it is non-nil.
- Update the corresponding test fixture (`queries[1]`) so that both `id` (slug) and `legacyId` (UUID) are present, matching the `rules[1]` input.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [x] I have updated any relevant documentation (if applicable).

## QA Instruction

- Run `go test ./pkg/engine/source/...` — `DatadogSource` tests should still pass.
- `--include-queries`/`--exclude-queries` continue to work for both the slug and the legacy UUID (the existing `IncludeQueriesById works with legacy id` / `with regular id` test cases remain green).
- After this lands, the round-trip in `datadog-iac-scanner-default-rules` `./tool.sh verify` no longer reports `Metadata["legacyId"]: has "..." in original, missing in roundtrip`.

## Blast Radius

Affects the scanner only, and only when reading rules from the Datadog backend via `DatadogSource` (`--use-datadog-rules` / `x-downloadqueriesfromdatadog`). Filesystem scans are unaffected.

## Additional Notes

Paired with a companion PR in the rules repository (`QueryMetadataToRule` will read `id` and `legacyId` straight from `metadata.json` instead of recomputing the rule id from platform + provider + slug).

I submit this contribution under the Apache-2.0 license.
