### PR TITLE
Convert four inspector tests, executeScan smoke, cyclonedx, and jsonencode helper to local testdata

### DIFF
--- a/pkg/detector/terraform/terraform_helper_test.go
+++ b/pkg/detector/terraform/terraform_helper_test.go
@@ -380,7 +380,7 @@ func TestGetArrayElementLine(t *testing.T) {
 }
 
 func TestResolveListIndexStatementInJsonencodeThirdElement(t *testing.T) {
-	data, err := os.ReadFile(filepath.Join("..", "..", "..", "assets", "queries", "terraform", "aws", "s3_bucket_access_to_any_principal", "test", "positive3.tf"))
+	data, err := os.ReadFile(filepath.Join("test", "jsonencode_third_element.tf"))
 	require.NoError(t, err)
 	linesPtr := utils.SplitLines(string(data))
 	lines := *linesPtr

--- a/pkg/detector/terraform/test/jsonencode_third_element.tf
+++ b/pkg/detector/terraform/test/jsonencode_third_element.tf
@@ -1,0 +1,61 @@
+resource "aws_s3_bucket" "this" {
+  bucket = "my_tf_test_bucket"
+  tags = {
+    Name = "My bucket"
+  }
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      # When used directly as a Cloudfront origin.
+      Effect = "Allow"
+      Action = "s3:GetObject"
+      Principal = {
+        Service = "cloudfront.amazonaws.com"
+      }
+      Resource = [
+        "${aws_s3_bucket.this.arn}/*",
+      ]
+      Condition = {
+        StringEquals = {
+          "AWS:SourceArn" = aws_cloudfront_distribution.this.arn
+        }
+      }
+      },
+      {
+        # Admin access for policy updates, etc.
+        Effect = "Allow"
+        Action = "s3:*"
+        Principal = {
+          AWS = [
+            data.aws_caller_identity.current.id,
+          ]
+        }
+        Resource = [
+          "${aws_s3_bucket.this.arn}/*",
+        ]
+      },
+      {
+        # Delegate access to the access point.
+        Effect = "Allow"
+        Action = "*"
+        Principal = {
+          AWS = [
+            "*"
+          ]
+        }
+        Resource = [
+          aws_s3_bucket.this.arn,
+          "${aws_s3_bucket.this.arn}/*",
+        ]
+        Condition = {
+          "StringEquals" = {
+            "s3:DataAccessPointAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+    }]
+  })
+}

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -9,31 +9,114 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-iac-scanner/assets"
 	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
 	"github.com/DataDog/datadog-iac-scanner/pkg/detector"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
+	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
-	"github.com/DataDog/datadog-iac-scanner/test"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-policy-agent/opa/cover"
 )
+
+// stubQueriesSource is an in-memory [source.QueriesSource] that returns a
+// fixed slice of query metadata and a trivial rego library for any platform.
+type stubQueriesSource struct {
+	queries []model.QueryMetadata
+}
+
+func (s *stubQueriesSource) GetQueries(_ context.Context, _ *source.QueryInspectorParameters) ([]model.QueryMetadata, error) {
+	return s.queries, nil
+}
+
+func (s *stubQueriesSource) GetQueryLibrary(_ context.Context, platform string) (source.RegoLibraries, error) {
+	return source.RegoLibraries{
+		LibraryCode:      "package generic." + platform + "\n",
+		LibraryInputData: "{}",
+	}, nil
+}
+
+// inspectorOpts configures [newTestInspector]; zero values yield an inspector
+// with no rules. Set `querySource` to plug in a custom QueriesSource (e.g. a
+// gomock) instead of the default in-memory stub backed by `queries`.
+type inspectorOpts struct {
+	queries             []model.QueryMetadata
+	querySource         source.QueriesSource
+	queryParameters     *source.QueryInspectorParameters
+	excludeResults      map[string]bool
+	repoPath            string
+	queryTimeout        int
+	useOldSeverities    bool
+	needsLog            bool
+	numWorkers          int
+	kicsComputeNewSimID bool
+	vb                  VulnerabilityBuilder
+	tracker             Tracker
+}
+
+// newTestInspector runs the real [NewInspector] against a configurable
+// [source.QueriesSource] so callers get the production constructor wiring
+// without loading any rules from disk.
+func newTestInspector(t *testing.T, opts inspectorOpts) *Inspector {
+	t.Helper()
+
+	if opts.querySource == nil {
+		opts.querySource = &stubQueriesSource{queries: opts.queries}
+	}
+	if opts.queryParameters == nil {
+		opts.queryParameters = &source.QueryInspectorParameters{}
+	}
+	if opts.excludeResults == nil {
+		opts.excludeResults = map[string]bool{}
+	}
+	if opts.repoPath == "" {
+		opts.repoPath = "."
+	}
+	if opts.queryTimeout == 0 {
+		opts.queryTimeout = 60
+	}
+	if opts.numWorkers == 0 {
+		opts.numWorkers = 1
+	}
+	if opts.vb == nil {
+		opts.vb = func(_ context.Context, _ *QueryContext, _ Tracker, _ interface{},
+			_ *detector.DetectLine, _ bool, _ bool, _ time.Duration) (*model.Vulnerability, error) {
+			return &model.Vulnerability{}, nil
+		}
+	}
+	if opts.tracker == nil {
+		opts.tracker = &tracker.CITracker{}
+	}
+
+	ins, err := NewInspector(
+		context.Background(),
+		opts.querySource,
+		opts.vb,
+		opts.tracker,
+		opts.queryParameters,
+		opts.excludeResults,
+		opts.repoPath,
+		opts.queryTimeout,
+		opts.useOldSeverities,
+		opts.needsLog,
+		opts.numWorkers,
+		opts.kicsComputeNewSimID,
+		featureflags.NewLocalEvaluator(),
+	)
+	require.NoError(t, err)
+	return ins
+}
 
 // TestInspector_EnableCoverageReport tests the functions [EnableCoverageReport()] and all the methods called by them
 func TestInspector_EnableCoverageReport(t *testing.T) {
@@ -127,139 +210,42 @@ func TestInspector_GetCoverageReport(t *testing.T) {
 	}
 }
 
-// TestNewInspector tests the functions [NewInspector()] and all the methods called by them
-func TestNewInspector(t *testing.T) { //nolint
-	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
-		t.Fatal(err)
-	}
-	contentByte, err := os.ReadFile(filepath.FromSlash("./test/fixtures/get_queries_test/content_get_queries.rego"))
-	require.NoError(t, err)
-	contentByte2, err2 := os.ReadFile(filepath.FromSlash("./test/fixtures/get_queries_test/common_query.rego"))
-	require.NoError(t, err2)
-
+// TestNewInspector smoke-tests the [NewInspector] wiring: vb, tracker, and
+// the queries returned by the source must flow through to the resulting
+// inspector unchanged.
+func TestNewInspector(t *testing.T) {
 	track := &tracker.CITracker{}
-	sources := &mockSource{
-		Source: []string{
-			filepath.FromSlash("./test/fixtures/all_auth_users_get_read_access"),
-			filepath.FromSlash("./test/fixtures/common_query_test"),
-		},
-		Types: []string{""},
-	}
-	vbs := DefaultVulnerabilityBuilder
-	opaQueries := make([]model.QueryMetadata, 0, 1)
-	opaQueries = append(opaQueries, model.QueryMetadata{
-		Query:     "all_auth_users_get_read_access",
-		Content:   string(contentByte),
-		InputData: "{}",
-		Platform:  "terraform",
-		Metadata: map[string]interface{}{
-			"id":              "57b9893d-33b1-4419-bcea-b828fb87e318",
-			"queryName":       "All Auth Users Get Read Access",
-			"severity":        model.SeverityHigh,
-			"category":        "Access Control",
-			"descriptionText": "Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion", //nolint
-			"descriptionUrl":  "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#acl",
-			"platform":        "Terraform",
-		},
-		Aggregation: 1,
-	})
-
-	opaQueries = append(opaQueries, model.QueryMetadata{
-		Query:     "common_query_test",
-		Content:   string(contentByte2),
-		InputData: "{}",
-		Platform:  "common",
-		Metadata: map[string]interface{}{
-			"id":              "4a3aa2b5-9c87-452c-a3ea-f3e9e3573874",
-			"queryName":       "Common Query Test",
-			"severity":        model.SeverityHigh,
-			"category":        "Best Practices",
-			"descriptionText": "",
-			"descriptionUrl":  "",
-			"platform":        "Common",
-		},
-		Aggregation: 1,
-	})
-	type args struct {
-		ctx                 context.Context
-		source              source.QueriesSource
-		vb                  VulnerabilityBuilder
-		tracker             Tracker
-		queryFilter         source.QueryInspectorParameters
-		excludeResults      map[string]bool
-		queryExecTimeout    int
-		needsLog            bool
-		useOldSeverities    bool
-		numWorkers          int
-		kicsComputeNewSimID bool
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    *Inspector
-		wantErr bool
-	}{
+	queries := []model.QueryMetadata{
 		{
-			name: "test_new_inspector",
-			args: args{
-				ctx:                 context.Background(),
-				vb:                  vbs,
-				tracker:             track,
-				source:              sources,
-				queryFilter:         source.QueryInspectorParameters{},
-				excludeResults:      map[string]bool{},
-				queryExecTimeout:    60,
-				needsLog:            true,
-				numWorkers:          1,
-				kicsComputeNewSimID: true,
-			},
-			want: &Inspector{
-				vb:      vbs,
-				tracker: track,
-				QueryLoader: &QueryLoader{
-					QueriesMetadata: opaQueries,
-				},
-			},
-			wantErr: false,
+			Query:       "stub_terraform_rule",
+			Content:     "package stub_terraform_rule\n",
+			InputData:   "{}",
+			Platform:    "terraform",
+			Metadata:    map[string]interface{}{"id": "stub-terraform"},
+			Aggregation: 1,
+		},
+		{
+			Query:       "stub_common_rule",
+			Content:     "package stub_common_rule\n",
+			InputData:   "{}",
+			Platform:    "common",
+			Metadata:    map[string]interface{}{"id": "stub-common"},
+			Aggregation: 1,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewInspector(tt.args.ctx,
-				tt.args.source,
-				tt.args.vb,
-				tt.args.tracker,
-				&tt.args.queryFilter,
-				tt.args.excludeResults,
-				".",
-				tt.args.queryExecTimeout,
-				tt.args.useOldSeverities,
-				tt.args.needsLog,
-				tt.args.numWorkers,
-				tt.args.kicsComputeNewSimID,
-				featureflags.NewLocalEvaluator(),
-			)
 
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewInspector() error: got = %v,\n wantErr = %v", err, tt.wantErr)
-				return
-			}
+	ins := newTestInspector(t, inspectorOpts{
+		queries:             queries,
+		tracker:             track,
+		needsLog:            true,
+		kicsComputeNewSimID: true,
+	})
 
-			// Note: The test fixture defines dummy queries for setting up test expectations,
-			// but the actual implementation loads all 800+ embedded queries
-			// Here we verify that queries were loaded, not those specific test queries exist.
-			require.Greater(t, len(got.QueryLoader.QueriesMetadata), 0, "Expected queries to be loaded")
-
-			gotStrTracker, err := test.StringifyStruct(got.tracker)
-			require.Nil(t, err)
-			wantStrTracker, err := test.StringifyStruct(tt.want.tracker)
-			require.Nil(t, err)
-			if !reflect.DeepEqual(got.tracker, tt.want.tracker) {
-				t.Errorf("NewInspector() tracker: got = %v,\n want = %v", gotStrTracker, wantStrTracker)
-			}
-			require.NotNil(t, got.vb)
-		})
-	}
+	require.NotNil(t, ins.vb, "vulnerability builder should be wired")
+	require.Same(t, track, ins.tracker, "tracker should be the one we passed in")
+	require.NotNil(t, ins.QueryLoader, "query loader should be initialized")
+	require.Equal(t, queries, ins.QueryLoader.QueriesMetadata,
+		"queries supplied by the source should flow through to QueryLoader")
 }
 
 func TestEngine_contains(t *testing.T) {
@@ -315,86 +301,26 @@ func TestEngine_contains(t *testing.T) {
 }
 
 func TestEngine_LenQueriesByPlat(t *testing.T) {
-	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
-		t.Fatal(err)
+	queries := []model.QueryMetadata{
+		{Query: "tf_rule_a", Content: "package tf_rule_a\n", InputData: "{}", Platform: "terraform", Aggregation: 1},
+		{Query: "tf_rule_b", Content: "package tf_rule_b\n", InputData: "{}", Platform: "terraform", Aggregation: 1},
+		{Query: "k8s_rule", Content: "package k8s_rule\n", InputData: "{}", Platform: "kubernetes", Aggregation: 1},
 	}
+	ins := newTestInspector(t, inspectorOpts{queries: queries, kicsComputeNewSimID: true})
 
-	type args struct {
-		queriesPath         []string
-		platform            []string
-		kicsComputeNewSimID bool
-	}
-	tests := []struct {
-		name string
-		args args
-		min  int
-	}{
-		{
-			name: "test_len_queries_plat",
-			args: args{
-				queriesPath:         []string{filepath.FromSlash("./test/fixtures")},
-				platform:            []string{"terraform"},
-				kicsComputeNewSimID: true,
-			},
-			min: 1,
-		},
-		{
-			name: "test_len_queries_plat_with_multiple_queries_path",
-			args: args{
-				queriesPath: []string{
-					filepath.FromSlash("./assets/queries/terraform/aws/alb_deletion_protection_disabled"),
-					filepath.FromSlash("./assets/queries/terraform/aws/alb_is_not_integrated_with_waf"),
-				},
-				platform:            []string{"terraform"},
-				kicsComputeNewSimID: true,
-			},
-			min: 2,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ins := newInspectorInstance(t, tt.args.queriesPath, tt.args.kicsComputeNewSimID)
-			got := ins.LenQueriesByPlat(tt.args.platform)
-			require.True(t, got >= tt.min)
-		})
-	}
+	require.Equal(t, 2, ins.LenQueriesByPlat([]string{"terraform"}))
+	require.Equal(t, 1, ins.LenQueriesByPlat([]string{"kubernetes"}))
+	require.Equal(t, 3, ins.LenQueriesByPlat([]string{"terraform", "kubernetes"}))
+	require.Equal(t, 0, ins.LenQueriesByPlat([]string{"cloudformation"}))
 }
 
 func TestEngine_GetFailedQueries(t *testing.T) {
-	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
-		t.Fatal(err)
+	ins := newTestInspector(t, inspectorOpts{kicsComputeNewSimID: true})
+	const nrFailedQueries = 5
+	for idx := 0; idx < nrFailedQueries; idx++ {
+		ins.failedQueries[fmt.Sprint(idx)] = nil
 	}
-	type args struct {
-		queriesPath         []string
-		nrFailedQueries     int
-		kicsComputeNewSimID bool
-	}
-	tests := []struct {
-		name string
-		args args
-	}{
-		{
-			name: "test_get_failed_queries",
-			args: args{
-				queriesPath:         []string{filepath.FromSlash("./test/fixtures")},
-				nrFailedQueries:     5,
-				kicsComputeNewSimID: true,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ins := newInspectorInstance(t, tt.args.queriesPath, tt.args.kicsComputeNewSimID)
-			fail := make([]string, tt.args.nrFailedQueries)
-			for idx := range fail {
-				ins.failedQueries[fmt.Sprint(idx)] = nil
-			}
-			got := ins.GetFailedQueries()
-			require.Equal(t, tt.args.nrFailedQueries, len(got))
-		})
-	}
+	require.Equal(t, nrFailedQueries, len(ins.GetFailedQueries()))
 }
 
 func TestShouldSkipFile(t *testing.T) {
@@ -493,46 +419,18 @@ func TestShouldSkipFile(t *testing.T) {
 }
 
 func TestInspector_DecodeQueryResults(t *testing.T) {
-
-	//context
-	contextToUse := context.Background()
-
-	//build inspector
-	c := newInspectorInstance(t, []string{}, true)
-
-	type args struct {
-		queryContext QueryContext
-		regoResult   rego.ResultSet
-		timeDuration string
-	}
-	tests := []struct {
-		name     string
-		args     args
-		expected int
-	}{
-		{
-			name: "should_not_fail_when_timeout",
-			args: args{
-				queryContext: newQueryContext(contextToUse),
-				regoResult:   newResultset(),
-				timeDuration: "0s",
-			},
-			expected: 0,
-		},
-	}
-
 	ctx := context.Background()
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			//create a context with 0 second to timeout
-			timeoutDuration, _ := time.ParseDuration(tt.args.timeDuration)
-			myCtxTimeOut, cancel := context.WithTimeout(contextToUse, timeoutDuration)
-			defer cancel()
-			result, err := c.DecodeQueryResults(ctx, &tt.args.queryContext, myCtxTimeOut, tt.args.regoResult, 57)
-			assert.Nil(t, err, "Error not as expected")
-			assert.Equal(t, 0, len(result), "Array size is not as expected")
-		})
-	}
+	c := newTestInspector(t, inspectorOpts{kicsComputeNewSimID: true})
+
+	queryContext := newQueryContext(ctx)
+
+	// Pass a context that is already expired so DecodeQueryResults must short-circuit
+	// on its cancellation branch and return no results.
+	expiredCtx, cancel := context.WithTimeout(ctx, 0)
+	defer cancel()
+	result, err := c.DecodeQueryResults(ctx, &queryContext, expiredCtx, newResultset(), 57)
+	assert.Nil(t, err, "Error not as expected")
+	assert.Equal(t, 0, len(result), "Array size is not as expected")
 }
 
 func newResultset() rego.ResultSet {
@@ -567,61 +465,6 @@ func newQueryContext(ctx context.Context) QueryContext {
 		Query: &myQuery,
 	}
 	return queryContext
-}
-
-func newInspectorInstance(t *testing.T, queryPath []string, kicsComputeNewSimID bool) *Inspector {
-	ctx := context.Background()
-	querySource := source.NewFilesystemSource(ctx, queryPath, []string{""}, []string{""}, filepath.FromSlash("./assets/libraries"), true)
-	var vb = func(ctx context.Context, qCtx *QueryContext, tracker Tracker, v interface{},
-		detector *detector.DetectLine, useOldSeverity bool, kicsComputeNewSimID bool, queryDuration time.Duration) (*model.Vulnerability, error) {
-		return &model.Vulnerability{}, nil
-	}
-	ins, err := NewInspector(
-		context.Background(),
-		querySource,
-		vb,
-		&tracker.CITracker{},
-		&source.QueryInspectorParameters{},
-		map[string]bool{}, ".", 60,
-		false, true, 1,
-		kicsComputeNewSimID,
-		featureflags.NewLocalEvaluator(),
-	)
-	require.NoError(t, err)
-	return ins
-}
-
-type mockSource struct {
-	Source []string
-	Types  []string
-}
-
-func (m *mockSource) GetQueries(ctx context.Context, queryFilter *source.QueryInspectorParameters) ([]model.QueryMetadata, error) {
-	sources := source.NewFilesystemSource(ctx, m.Source, []string{""}, []string{""}, filepath.FromSlash("./assets/libraries"), true)
-
-	return sources.GetQueries(ctx, queryFilter)
-}
-
-func (m *mockSource) GetQueryLibrary(ctx context.Context, platform string) (source.RegoLibraries, error) {
-	library := source.GetPathToCustomLibrary(ctx, platform, "./assets/libraries")
-
-	if library != "default" {
-		content, err := os.ReadFile(library)
-		return source.RegoLibraries{
-			LibraryCode:      string(content),
-			LibraryInputData: "{}",
-		}, err
-	}
-
-	log.Debug().Msgf("Custom library not provided. Loading embedded library instead")
-
-	// getting embedded library
-	embeddedLibrary, errGettingEmbeddedLibrary := assets.GetEmbeddedLibrary(strings.ToLower(platform))
-
-	return source.RegoLibraries{
-		LibraryCode:      embeddedLibrary,
-		LibraryInputData: "{}",
-	}, errGettingEmbeddedLibrary
 }
 
 func TestExpressionToAST_RelativeTraversalExpr(t *testing.T) {

--- a/pkg/report/model/cyclonedx_test.go
+++ b/pkg/report/model/cyclonedx_test.go
@@ -2,10 +2,12 @@ package model
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var metadata Metadata = Metadata{
@@ -58,228 +61,147 @@ func TestInitCycloneDxReport(t *testing.T) {
 	}
 }
 
-// TestBuildCycloneDxReport tests the BuildCycloneDxReport function
+// fileSHA256 returns the hex-encoded SHA-256 of the file at path.
+func fileSHA256(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Clean(path))
+	require.NoError(t, err, "could not read fixture %s", path)
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+// retargetSummaryFiles deep-copies summary and rewrites every VulnerableFile
+// name according to mapping. Deep-copying matters: the inputs are shared
+// package-level mocks, and mutating them in place leaks across tests.
+//
+// Fails the test on any FileName absent from mapping. This guards against
+// silent drift if the shared mocks in `test/helpers.go` change their fixture
+// paths: instead of cyclonedx assertions failing with confusing path
+// mismatches, we fail loudly here naming the unmapped key.
+func retargetSummaryFiles(t *testing.T, in model.Summary, mapping map[string]string) model.Summary {
+	t.Helper()
+	out := in
+	out.Queries = make([]model.QueryResult, len(in.Queries))
+	for qi, q := range in.Queries {
+		nq := q
+		nq.Files = make([]model.VulnerableFile, len(q.Files))
+		for fi, f := range q.Files {
+			nf := f
+			key := filepath.ToSlash(f.FileName)
+			target, ok := mapping[key]
+			if !ok {
+				t.Fatalf("retargetSummaryFiles: mock FileName %q has no mapping entry; "+
+					"shared mocks in test/helpers.go likely changed and this test needs an updated mapping", key)
+			}
+			nf.FileName = target
+			nq.Files[fi] = nf
+		}
+		out.Queries[qi] = nq
+	}
+	return out
+}
+
 func TestBuildCycloneDxReport(t *testing.T) {
-	var cycloneDx CycloneDxReport = initCycloneDxReport
-	var cycloneDxCritical CycloneDxReport = initCycloneDxReport
-	var cycloneDxCWE CycloneDxReport = initCycloneDxReport
-	var vulnsC1, vulnsC2, vulnsC3, vulnsC4 []Vulnerability
-	var positiveSha, negativeSha, criticalSha string
+	// Use forward slashes deliberately: `BuildCycloneDxReport` normalizes
+	// FileName via `strings.ReplaceAll(_, "\\", "/")` before building BomRef
+	// / Purl, so the test must compare against slash form on every OS, and
+	// Go's `os.ReadFile` accepts forward slashes on Windows.
+	const (
+		positivePath = "test/positive.tf"
+		negativePath = "test/negative.tf"
+		criticalPath = "test/critical_positive.yaml"
+	)
 
-	var sha256TestMap = map[string]map[string]string{
-		"positive": {
-			"Unix":            "487d5879d7ec205b4dcd037d5ce0075ed4fedb9dd5b8e45390ffdfa3442f15f7",
-			"Windows":         "bd4ac2f61e7c623477b5d200b3662fd7caac5e89e042960fd1adb008e0962635",
-			"CriticalWindows": "1c624a2f982858ee0b747f26c0e0019bc7fbb130c7719e90a5d5c1f552608a4f",
-			"CriticalUnix":    "04174a2b45ae406d5432590304b1773c9a46a95a2327b3cc164cb464dc57cef5",
-		},
-		"negative": {
-			"Unix":    "cd10cef2b154363f32ca4018426982509efbc9e1a8ea6bca587e68ffaef09c37",
-			"Windows": "68b4caecf5d5130426a8b8f0222cdd7f31232b5c99a5bf0daf19099e26e2ec29",
-		},
+	positiveSha := fileSHA256(t, positivePath)
+	negativeSha := fileSHA256(t, negativePath)
+	criticalSha := fileSHA256(t, criticalPath)
+
+	purlFor := func(p, sha string) string {
+		return fmt.Sprintf("pkg:generic/%s@0.0.0-%s", p, sha[0:12])
+	}
+	refFor := func(p, sha, id string) string {
+		return fmt.Sprintf("pkg:generic/%s@0.0.0-%s%s", p, sha[0:12], id)
 	}
 
-	if runtime.GOOS == "windows" {
-		positiveSha = sha256TestMap["positive"]["Windows"]
-		negativeSha = sha256TestMap["negative"]["Windows"]
-		criticalSha = sha256TestMap["positive"]["CriticalWindows"]
-	} else {
-		positiveSha = sha256TestMap["positive"]["Unix"]
-		negativeSha = sha256TestMap["negative"]["Unix"]
-		criticalSha = sha256TestMap["positive"]["CriticalUnix"]
+	const (
+		idInfo     = "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10"
+		idMedium   = "704dadd3-54fc-48ac-b6a0-02f170011473"
+		idCritical = "316278b3-87ac-444c-8f8f-a733a28da609"
+	)
+
+	// vulnFor builds the subset of fields the assertions below actually compare
+	// (Ref, ID, Source, Ratings, Description, Recommendations). Pass `cwe`
+	// non-empty to set the optional CWE field.
+	vulnFor := func(path, sha, id, severity, cwe, description, recommendation string) Vulnerability {
+		return Vulnerability{
+			Ref:             refFor(path, sha, id),
+			ID:              id,
+			CWE:             cwe,
+			Source:          Source{Name: "DataDog IaC Scanner", URL: "https://www.datadoghq.com/"},
+			Ratings:         []Rating{{Severity: severity, Method: "Other"}},
+			Description:     description,
+			Recommendations: []Recommendation{{Recommendation: recommendation}},
+		}
 	}
 
-	v1 := Vulnerability{
-		Ref: fmt.Sprintf("pkg:generic/../../../assets/queries/terraform/aws/guardduty_detector_disabled/test/positive.tf@0.0.0-%se38a8e0a-b88b-4902-b3fe-b0fcb17d5c10", positiveSha[0:12]),
-		ID:  "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
-		CWE: "",
-		Source: Source{
-			Name: "DataDog IaC Scanner",
-			URL:  "https://www.datadoghq.com/",
-		},
-		Ratings: []Rating{
-			{
-				Severity: "None",
-				Method:   "Other",
-			},
-		},
-		Description: "[Terraform].[Resource Not Using Tags]: AWS services resource tags are an essential part of managing components",
-		Recommendations: []Recommendation{
-			{
-				Recommendation: "Problem found in line 1. Expected value: aws_guardduty_detector[{{positive1}}].tags is defined and not null. Actual value: aws_guardduty_detector[{{positive1}}].tags is undefined or null.",
-			},
-		},
+	const (
+		descTags  = "[Terraform].[Resource Not Using Tags]: AWS services resource tags are an essential part of managing components"
+		descGD    = "[Terraform].[GuardDuty Detector Disabled]: Make sure that Amazon GuardDuty is Enabled"
+		descAMQ   = "[].[AmazonMQ Broker Encryption Disabled]: testCISDescription"
+		recGDOn   = "Problem found in line 2. Expected value: GuardDuty Detector should be Enabled. Actual value: GuardDuty Detector is not Enabled."
+		recAMQTLS = "Problem found in line 6. Expected value: 'default_action.redirect.protocol' is equal 'HTTPS'. Actual value: 'default_action.redirect.protocol' is missing."
+	)
+	recTagsFor := func(resource string) string {
+		return fmt.Sprintf(
+			"Problem found in line 1. Expected value: aws_guardduty_detector[{{%s}}].tags is defined and not null. Actual value: aws_guardduty_detector[{{%s}}].tags is undefined or null.",
+			resource, resource,
+		)
 	}
 
-	v2 := Vulnerability{
-		Ref: fmt.Sprintf("pkg:generic/../../../assets/queries/terraform/aws/guardduty_detector_disabled/test/positive.tf@0.0.0-%s704dadd3-54fc-48ac-b6a0-02f170011473", positiveSha[0:12]),
-		ID:  "704dadd3-54fc-48ac-b6a0-02f170011473",
-		CWE: "",
-		Source: Source{
-			Name: "DataDog IaC Scanner",
-			URL:  "https://www.datadoghq.com/",
-		},
-		Ratings: []Rating{
-			{
-				Severity: "Medium",
-				Method:   "Other",
+	v1 := vulnFor(positivePath, positiveSha, idInfo, "None", "", descTags, recTagsFor("positive1"))
+	v2 := vulnFor(positivePath, positiveSha, idMedium, "Medium", "", descGD, recGDOn)
+	v3 := vulnFor(negativePath, negativeSha, idInfo, "None", "", descTags, recTagsFor("negative1"))
+	v4 := vulnFor(negativePath, negativeSha, idMedium, "Medium", "22", descGD, recGDOn)
+	v5 := vulnFor(criticalPath, criticalSha, idCritical, "Critical", "", descAMQ, recAMQTLS)
+
+	componentFor := func(path, sha string, vulns []Vulnerability) Component {
+		return Component{
+			Type:    "file",
+			BomRef:  purlFor(path, sha),
+			Name:    path,
+			Version: fmt.Sprintf("0.0.0-%s", sha[0:12]),
+			Purl:    purlFor(path, sha),
+			Hashes: []Hash{
+				{Alg: "SHA-256", Content: sha},
 			},
-		},
-		Description: "[Terraform].[GuardDuty Detector Disabled]: Make sure that Amazon GuardDuty is Enabled",
-		Recommendations: []Recommendation{
-			{
-				Recommendation: "Problem found in line 2. Expected value: GuardDuty Detector should be Enabled. Actual value: GuardDuty Detector is not Enabled.",
-			},
-		},
+			Vulnerabilities: vulns,
+		}
 	}
 
-	v3 := Vulnerability{
-		Ref: fmt.Sprintf("pkg:generic/../../../assets/queries/terraform/aws/guardduty_detector_disabled/test/negative.tf@0.0.0-%se38a8e0a-b88b-4902-b3fe-b0fcb17d5c10", negativeSha[0:12]),
-		ID:  "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
-		CWE: "",
-		Source: Source{
-			Name: "DataDog IaC Scanner",
-			URL:  "https://www.datadoghq.com/",
-		},
-		Ratings: []Rating{
-			{
-				Severity: "None",
-				Method:   "Other",
-			},
-		},
-		Description: "[Terraform].[Resource Not Using Tags]: AWS services resource tags are an essential part of managing components",
-		Recommendations: []Recommendation{
-			{
-				Recommendation: "Problem found in line 1. Expected value: aws_guardduty_detector[{{negative1}}].tags is defined and not null. Actual value: aws_guardduty_detector[{{negative1}}].tags is undefined or null.",
-			},
-		},
+	cyclonePositive := componentFor(positivePath, positiveSha, []Vulnerability{v1, v2})
+	cycloneNegative := componentFor(negativePath, negativeSha, []Vulnerability{v3})
+	cycloneCWENegative := componentFor(negativePath, negativeSha, []Vulnerability{v4})
+	cycloneCritical := componentFor(criticalPath, criticalSha, []Vulnerability{v5})
+
+	cycloneDx := initCycloneDxReport
+	cycloneDx.Components.Components = append(cycloneDx.Components.Components, cycloneNegative, cyclonePositive)
+	cycloneDxCWE := initCycloneDxReport
+	cycloneDxCWE.Components.Components = append(cycloneDxCWE.Components.Components, cycloneCWENegative)
+	cycloneDxCritical := initCycloneDxReport
+	cycloneDxCritical.Components.Components = append(cycloneDxCritical.Components.Components, cycloneCritical)
+
+	// Map the file names baked into the shared mocks to the local test
+	// paths. Keyed on slash form because that's what filepath.ToSlash returns
+	// on both Windows and Unix.
+	mapping := map[string]string{
+		filepath.ToSlash(filepath.Join("assets", "queries", "terraform", "aws", "guardduty_detector_disabled", "test", "positive.tf")): positivePath,
+		filepath.ToSlash(filepath.Join("assets", "queries", "terraform", "aws", "guardduty_detector_disabled", "test", "negative.tf")): negativePath,
+		filepath.ToSlash(filepath.Join("test", "fixtures", "test_critical_custom_queries", "amazon_mq_broker_encryption_disabled", "test", "positive1.yaml")): criticalPath,
 	}
 
-	v4 := Vulnerability{
-		Ref: fmt.Sprintf("pkg:generic/../../../assets/queries/terraform/aws/guardduty_detector_disabled/test/negative.tf@0.0.0-%s704dadd3-54fc-48ac-b6a0-02f170011473", negativeSha[0:12]),
-		ID:  "704dadd3-54fc-48ac-b6a0-02f170011473",
-		CWE: "22",
-		Source: Source{
-			Name: "DataDog IaC Scanner",
-			URL:  "https://www.datadoghq.com/",
-		},
-		Ratings: []Rating{
-			{
-				Severity: "Medium",
-				Method:   "Other",
-			},
-		},
-		Description: "[Terraform].[GuardDuty Detector Disabled]: Make sure that Amazon GuardDuty is Enabled",
-		Recommendations: []Recommendation{
-			{
-				Recommendation: "Problem found in line 2. Expected value: GuardDuty Detector should be Enabled. Actual value: GuardDuty Detector is not Enabled.",
-			},
-		},
-	}
-
-	vulnsC3 = append(vulnsC3, v4)
-
-	v5 := Vulnerability{
-		Ref: fmt.Sprintf("pkg:generic/../../../test/fixtures/test_critical_custom_queries/amazon_mq_broker_encryption_disabled/test/positive1.yaml@0.0.0-%v316278b3-87ac-444c-8f8f-a733a28da609", criticalSha[0:12]),
-		ID:  "316278b3-87ac-444c-8f8f-a733a28da609",
-		Source: Source{
-			Name: "DataDog IaC Scanner",
-			URL:  "https://www.datadoghq.com/",
-		},
-		Ratings: []Rating{
-			{
-				Severity: "Critical",
-				Method:   "Other",
-			},
-		},
-		Description: "[].[AmazonMQ Broker Encryption Disabled]: testCISDescription",
-		Recommendations: []Recommendation{
-			{
-				Recommendation: "Problem found in line 6. Expected value: 'default_action.redirect.protocol' is equal 'HTTPS'. Actual value: 'default_action.redirect.protocol' is missing.",
-			},
-		},
-	}
-
-	vulnsC1 = append(vulnsC1, v1)
-	vulnsC1 = append(vulnsC1, v2)
-
-	c1 := Component{
-		Type:    "file",
-		BomRef:  fmt.Sprintf("pkg:generic/../../../assets/queries/terraform/aws/guardduty_detector_disabled/test/positive.tf@0.0.0-%s", positiveSha[0:12]),
-		Name:    "../../../assets/queries/terraform/aws/guardduty_detector_disabled/test/positive.tf",
-		Version: fmt.Sprintf("0.0.0-%s", positiveSha[0:12]),
-		Purl:    fmt.Sprintf("pkg:generic/../../../assets/queries/terraform/aws/guardduty_detector_disabled/test/positive.tf@0.0.0-%s", positiveSha[0:12]),
-		Hashes: []Hash{
-			{
-				Alg:     "SHA-256",
-				Content: positiveSha,
-			},
-		},
-		Vulnerabilities: vulnsC1,
-	}
-
-	vulnsC2 = append(vulnsC2, v3)
-
-	c2 := Component{
-		Type:    "file",
-		BomRef:  fmt.Sprintf("pkg:generic/../../../assets/queries/terraform/aws/guardduty_detector_disabled/test/negative.tf@0.0.0-%s", negativeSha[0:12]),
-		Name:    "../../../assets/queries/terraform/aws/guardduty_detector_disabled/test/negative.tf",
-		Version: fmt.Sprintf("0.0.0-%s", negativeSha[0:12]),
-		Purl:    fmt.Sprintf("pkg:generic/../../../assets/queries/terraform/aws/guardduty_detector_disabled/test/negative.tf@0.0.0-%s", negativeSha[0:12]),
-		Hashes: []Hash{
-			{
-				Alg:     "SHA-256",
-				Content: negativeSha,
-			},
-		},
-		Vulnerabilities: vulnsC2,
-	}
-
-	c3 := Component{
-		Type:    "file",
-		BomRef:  fmt.Sprintf("pkg:generic/../../../assets/queries/terraform/aws/guardduty_detector_disabled/test/negative.tf@0.0.0-%s", negativeSha[0:12]),
-		Name:    "../../../assets/queries/terraform/aws/guardduty_detector_disabled/test/negative.tf",
-		Version: fmt.Sprintf("0.0.0-%s", negativeSha[0:12]),
-		Purl:    fmt.Sprintf("pkg:generic/../../../assets/queries/terraform/aws/guardduty_detector_disabled/test/negative.tf@0.0.0-%s", negativeSha[0:12]),
-		Hashes: []Hash{
-			{
-				Alg:     "SHA-256",
-				Content: negativeSha,
-			},
-		},
-		Vulnerabilities: vulnsC3,
-	}
-
-	vulnsC4 = append(vulnsC4, v5)
-
-	c4 := Component{
-		Type:    "file",
-		BomRef:  fmt.Sprintf("pkg:generic/../../../test/fixtures/test_critical_custom_queries/amazon_mq_broker_encryption_disabled/test/positive1.yaml@0.0.0-%v", criticalSha[0:12]),
-		Name:    "../../../test/fixtures/test_critical_custom_queries/amazon_mq_broker_encryption_disabled/test/positive1.yaml",
-		Version: fmt.Sprintf("0.0.0-%v", criticalSha[0:12]),
-		Purl:    fmt.Sprintf("pkg:generic/../../../test/fixtures/test_critical_custom_queries/amazon_mq_broker_encryption_disabled/test/positive1.yaml@0.0.0-%v", criticalSha[0:12]),
-		Hashes: []Hash{
-			{
-				Alg:     "SHA-256",
-				Content: criticalSha,
-			},
-		},
-		Vulnerabilities: vulnsC4,
-	}
-
-	cycloneDx.Components.Components = append(cycloneDx.Components.Components, c2)
-	cycloneDx.Components.Components = append(cycloneDx.Components.Components, c1)
-	cycloneDxCWE.Components.Components = append(cycloneDxCWE.Components.Components, c3)
-	cycloneDxCritical.Components.Components = append(cycloneDxCritical.Components.Components, c4)
-
-	filePaths := make(map[string]string)
-
-	file1 := filepath.Join("..", "..", "..", "assets", "queries", "terraform", "aws", "guardduty_detector_disabled", "test", "positive.tf")
-	file2 := filepath.Join("..", "..", "..", "assets", "queries", "terraform", "aws", "guardduty_detector_disabled", "test", "negative.tf")
-	file3 := filepath.Join("..", "..", "..", "test", "fixtures", "test_critical_custom_queries", "amazon_mq_broker_encryption_disabled", "test", "positive1.yaml")
-	filePaths[file1] = file1
-	filePaths[file2] = file2
-	filePaths[file3] = file3
+	summaryGuardduty := retargetSummaryFiles(t, test.ExampleSummaryMock, mapping)
+	summaryCritical := retargetSummaryFiles(t, test.SummaryMockCritical, mapping)
+	summaryCWE := retargetSummaryFiles(t, test.ExampleSummaryMockCWE, mapping)
 
 	type args struct {
 		summary   *model.Summary
@@ -293,24 +215,24 @@ func TestBuildCycloneDxReport(t *testing.T) {
 		{
 			name: "Build CycloneDX report",
 			args: args{
-				summary:   &test.ExampleSummaryMock,
-				filePaths: map[string]string{file1: file1, file2: file2},
+				summary:   &summaryGuardduty,
+				filePaths: map[string]string{positivePath: positivePath, negativePath: negativePath},
 			},
 			want: &cycloneDx,
 		},
 		{
 			name: "Build CycloneDX report with critical severity",
 			args: args{
-				summary:   &test.SummaryMockCritical,
-				filePaths: map[string]string{file3: file3},
+				summary:   &summaryCritical,
+				filePaths: map[string]string{criticalPath: criticalPath},
 			},
 			want: &cycloneDxCritical,
 		},
 		{
 			name: "Build CycloneDX report with cwe field complete",
 			args: args{
-				summary:   &test.ExampleSummaryMockCWE,
-				filePaths: map[string]string{file2: file2},
+				summary:   &summaryCWE,
+				filePaths: map[string]string{negativePath: negativePath},
 			},
 			want: &cycloneDxCWE,
 		},
@@ -319,27 +241,22 @@ func TestBuildCycloneDxReport(t *testing.T) {
 	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			queries := tt.args.summary.Queries
-			for idx := range queries {
-				for i := range queries[idx].Files {
-					queries[idx].Files[i].FileName = filepath.Join("..", "..", "..", queries[idx].Files[i].FileName)
-				}
-			}
 			got := BuildCycloneDxReport(ctx, tt.args.summary, tt.args.filePaths)
 			got.SerialNumber = "urn:uuid:" // set to "urn:uuid:" because it will be different for every report
-			assert.Equal(t, len(got.Components.Components), len(tt.want.Components.Components), "Comparing number of components")
+			assert.Equal(t, len(tt.want.Components.Components), len(got.Components.Components), "Comparing number of components")
 			for idx := range got.Components.Components {
-				assert.Equal(t, got.Components.Components[idx].BomRef, tt.want.Components.Components[idx].BomRef, "Comparing BomRef of components")
-				assert.Equal(t, got.Components.Components[idx].Version, tt.want.Components.Components[idx].Version, "Comparing Version of components")
-				assert.Equal(t, got.Components.Components[idx].Purl, tt.want.Components.Components[idx].Purl, "Comparing Purl of components")
-				assert.Equal(t, got.Components.Components[idx].Hashes, tt.want.Components.Components[idx].Hashes, "Comparing Hashes of components")
+				assert.Equal(t, tt.want.Components.Components[idx].BomRef, got.Components.Components[idx].BomRef, "Comparing BomRef of components")
+				assert.Equal(t, tt.want.Components.Components[idx].Version, got.Components.Components[idx].Version, "Comparing Version of components")
+				assert.Equal(t, tt.want.Components.Components[idx].Purl, got.Components.Components[idx].Purl, "Comparing Purl of components")
+				assert.Equal(t, tt.want.Components.Components[idx].Hashes, got.Components.Components[idx].Hashes, "Comparing Hashes of components")
 				for idx2 := range got.Components.Components[idx].Vulnerabilities {
-					assert.Equal(t, got.Components.Components[idx].Vulnerabilities[idx2].Ref, tt.want.Components.Components[idx].Vulnerabilities[idx2].Ref, "Comparing Vulnerabilities Ref of components")
-					assert.Equal(t, got.Components.Components[idx].Vulnerabilities[idx2].Description, tt.want.Components.Components[idx].Vulnerabilities[idx2].Description, "Comparing Vulnerabilities Description of components")
-					assert.Equal(t, got.Components.Components[idx].Vulnerabilities[idx2].Ratings, tt.want.Components.Components[idx].Vulnerabilities[idx2].Ratings, "Comparing Vulnerabilities Ratings of components")
-					assert.Equal(t, got.Components.Components[idx].Vulnerabilities[idx2].Recommendations, tt.want.Components.Components[idx].Vulnerabilities[idx2].Recommendations, "Comparing Vulnerabilities Recommendations of components")
+					assert.Equal(t, tt.want.Components.Components[idx].Vulnerabilities[idx2].Ref, got.Components.Components[idx].Vulnerabilities[idx2].Ref, "Comparing Vulnerabilities Ref of components")
+					assert.Equal(t, tt.want.Components.Components[idx].Vulnerabilities[idx2].Description, got.Components.Components[idx].Vulnerabilities[idx2].Description, "Comparing Vulnerabilities Description of components")
+					assert.Equal(t, tt.want.Components.Components[idx].Vulnerabilities[idx2].Ratings, got.Components.Components[idx].Vulnerabilities[idx2].Ratings, "Comparing Vulnerabilities Ratings of components")
+					assert.Equal(t, tt.want.Components.Components[idx].Vulnerabilities[idx2].Recommendations, got.Components.Components[idx].Vulnerabilities[idx2].Recommendations, "Comparing Vulnerabilities Recommendations of components")
 				}
 			}
 		})
 	}
 }
+

--- a/pkg/report/model/test/critical_positive.yaml
+++ b/pkg/report/model/test/critical_positive.yaml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Create a basic ActiveMQ broker"
+Resources:
+  BasicBroker:
+    Type: "AWS::AmazonMQ::Broker"
+    Properties:
+      AutoMinorVersionUpgrade: "false"
+      BrokerName: MyBasicBroker
+      DeploymentMode: SINGLE_INSTANCE
+      EngineType: ActiveMQ
+      EngineVersion: "5.15.0"
+      HostInstanceType: mq.t2.micro
+      PubliclyAccessible: "true"
+      Users:
+        -
+          ConsoleAccess: "true"
+          Groups:
+            - MyGroup
+          Password:
+            Ref: "BrokerPassword"
+          Username:
+            Ref: "BrokerUsername"

--- a/pkg/report/model/test/negative.tf
+++ b/pkg/report/model/test/negative.tf
@@ -1,0 +1,3 @@
+resource "aws_guardduty_detector" "negative1" {
+  enable = true
+}

--- a/pkg/report/model/test/positive.tf
+++ b/pkg/report/model/test/positive.tf
@@ -1,0 +1,4 @@
+resource "aws_guardduty_detector" "positive1" {
+  enable = false
+}
+

--- a/pkg/scan/scan_test.go
+++ b/pkg/scan/scan_test.go
@@ -2,7 +2,7 @@ package scan
 
 import (
 	"context"
-	"sort"
+	"path/filepath"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
@@ -13,72 +13,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Test_ExecuteScan smoke-tests the live scan path end-to-end and asserts the
+// result is well-shaped. It does NOT pin a specific result count: that count
+// is a function of the rule corpus, not of executeScan itself, and a true
+// rule-independent rewrite needs a `createQuerySource` injection point that
+// `FilesystemSource.GetQueries` does not currently expose.
 func Test_ExecuteScan(t *testing.T) {
-	// Updated test (different from Checkmarx/kics) to use a terraform file example
-	tests := []struct {
-		name                 string
-		scanParams           Parameters
-		ctx                  context.Context
-		expectedResultsCount int
-		expectedSeverity     model.Severity
-		expectedLine         int
-	}{
-		{
-			name: "test exec scan",
-			scanParams: Parameters{
-				Path:                    []string{"./../../test/e2e/fixtures/no-exclusions.tf"},
-				QueriesPath:             []string{"assets/queries"},
-				LibrariesPath:           "assets/libraries",
-				PreviewLines:            3,
-				CloudProvider:           []string{"aws"},
-				Platform:                []string{"Terraform"},
-				ChangedDefaultQueryPath: false,
-				MaxFileSizeFlag:         100,
-				QueryExecTimeout:        60,
-				ScanID:                  "console",
-				MaxResolverDepth:        15,
-				FlagEvaluator:           featureflags.NewLocalEvaluator(),
-			},
-			ctx:                  context.Background(),
-			expectedResultsCount: 5,
-			expectedSeverity:     "MEDIUM",
-			expectedLine:         5,
-		},
+	scanParams := Parameters{
+		Path:                    []string{filepath.Join("test", "sample.tf")},
+		QueriesPath:             []string{"assets/queries"},
+		LibrariesPath:           "assets/libraries",
+		PreviewLines:            3,
+		CloudProvider:           []string{"aws"},
+		Platform:                []string{"Terraform"},
+		ChangedDefaultQueryPath: false,
+		MaxFileSizeFlag:         100,
+		QueryExecTimeout:        60,
+		ScanID:                  "console",
+		MaxResolverDepth:        15,
+		FlagEvaluator:           featureflags.NewLocalEvaluator(),
 	}
 
 	ctx := context.Background()
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewClient(ctx, &tt.scanParams, &consolePrinter.Printer{})
+	c, err := NewClient(ctx, &scanParams, &consolePrinter.Printer{})
+	require.NoError(t, err, "NewClient failed for %s", scanParams.Path[0])
 
-			if err != nil {
-				t.Fatalf(`NewClient failed for path %s with error: %v`, tt.scanParams.Path[0], err)
-			}
+	r, err := c.executeScan(ctx)
+	require.NoError(t, err, "executeScan failed for %s", scanParams.Path[0])
+	require.NotNil(t, r, "executeScan should return a non-nil result")
 
-			r, err := c.executeScan(tt.ctx)
-
-			if err != nil {
-				t.Fatalf(`ExecuteScan failed for path %s with error: %v`, tt.scanParams.Path[0], err)
-			}
-
-			resultsCount := len(r.Results)
-			require.Equal(t, tt.expectedResultsCount, resultsCount)
-
-			// Sort results by severity to ensure deterministic ordering
-			// Severity order: HIGH > MEDIUM > LOW > INFO
-			severityOrder := map[model.Severity]int{
-				model.SeverityHigh:   0,
-				model.SeverityMedium: 1,
-				model.SeverityLow:    2,
-				model.SeverityInfo:   3,
-			}
-			sort.Slice(r.Results, func(i, j int) bool {
-				return severityOrder[r.Results[i].Severity] < severityOrder[r.Results[j].Severity]
-			})
-
-			firstResult := &r.Results[0]
-			require.Equal(t, tt.expectedSeverity, firstResult.Severity)
-		})
+	validSeverities := map[model.Severity]struct{}{
+		model.SeverityCritical: {},
+		model.SeverityHigh:     {},
+		model.SeverityMedium:   {},
+		model.SeverityLow:      {},
+		model.SeverityInfo:     {},
+	}
+	for i, result := range r.Results {
+		_, ok := validSeverities[result.Severity]
+		require.Truef(t, ok, "result[%d] has unexpected severity %q", i, result.Severity)
 	}
 }
 

--- a/pkg/scan/test/sample.tf
+++ b/pkg/scan/test/sample.tf
@@ -1,0 +1,4 @@
+resource "aws_s3_bucket" "scan_smoke" {
+  bucket = "scan-smoke-bucket"
+  acl    = "authenticated-read"
+}


### PR DESCRIPTION
## Summary

Phase 2 of the scanner test triage plan (follow-up to #148). Several tests only needed `assets/queries/` as **setup**, not as the thing under test. That made them brittle (hardcoded SHAs, rule-specific paths, corpus size) and blocked removing the embedded rules later.

This PR decouples those tests from the rule corpus where we can do it in test-only code. No production changes.

## Changes

### `pkg/engine`

- **`newTestInspector(t, opts)`** runs real `NewInspector` against a stub `QueriesSource` (small `[]model.QueryMetadata`, optional `querySource` override). **Replaces** walking `assets/queries/` via `NewFilesystemSource` just to build an inspector. **Unblocks** unit tests for wiring and inspector methods without loading ~1400 rules.
- **`TestNewInspector`**, **`TestEngine_LenQueriesByPlat`**, **`TestEngine_GetFailedQueries`**, **`TestInspector_DecodeQueryResults`** use that helper with synthetic data. **Replaces** corpus/fixture setup the assertions never used (including the `alb_*` “≥ 2” subtest and `len(queries) > 0` smoke). **Unblocks** these tests staying green when the embed is removed. Removed **`newInspectorInstance`** / **`mockSource`**.

### `pkg/scan`

- **`Test_ExecuteScan`** now scans `pkg/scan/testdata/sample.tf` and only asserts: no error, non-nil result, every severity is valid. No pinned finding count (that would change whenever the rule corpus changes). **Replaces** a test that asserted an exact result count tied to the live rule set. **Unblocks** a stable smoke signal for `NewClient` → `executeScan` without re-bumping counts on every rule add/remove.
- **Why it still touches the embedded corpus:** `executeScan` → `Client.createQuerySource()` → `FilesystemSource`, and `FilesystemSource.GetQueries` reads from `assets.GetEmbeddedQueryDirs()` (the embed), not from `ScanParams.QueriesPath`. Unlike the engine tests above, we cannot pass a stub source without a small production hook (e.g. injectable `createQuerySource` on `Client`). That hook is intentionally out of scope here; this PR documents the limit in the test comment and keeps a useful smoke signal for the scan path until a follow-up can inject a one-rule source.

### `pkg/report/model`

- **`TestBuildCycloneDxReport`** uses local **`testdata/`** fixtures and runtime SHA-256 for expected `BomRef` / `Purl` / `Hashes`. **Replaces** hardcoded Unix/Windows hash tables and paths under `assets/queries/.../guardduty_detector_disabled/`. **Unblocks** CycloneDX tests when those rule files leave this repo.
- **`retargetSummaryFiles`** deep-copies shared summary mocks and rewrites paths to local testdata; fails if a mock `FileName` has no mapping. **Replaces** in-place mock mutation and silent drift when `test/helpers.go` paths change.

### `pkg/detector/terraform`

- **`TestResolveListIndexStatementInJsonencodeThirdElement`** reads **`testdata/jsonencode_third_element.tf`**. **Replaces** `assets/queries/.../s3_bucket_access_to_any_principal/test/positive3.tf`. **Unblocks** the `resolveListIndex` / `jsonencode` regression after that rule moves out of the embed.

### Not in this PR

- **`TestInspectorSimilarityID`** — still on `test/helpers.go` (~1.2k lines). **Deferred** until we split rule-agnostic mocks; then move to `pkg/engine/similarity/` with synthetic rules.

## How to test

```bash
go test -count=1 ./pkg/engine ./pkg/scan ./pkg/report/model ./pkg/detector/terraform
```

To confirm corpus-independence for the engine/report/detector tests (and that `Test_ExecuteScan` still runs as a smoke test): temporarily move `assets/queries/` aside and blank the queries embed in `assets/assets.go`, then re-run the command above with `-run` for the converted test names. That's what I am doing to verify what would break without the rules, once we move them to the new repo.

## Checklist

- [x] Reviewed my own PR
- [x] Added or updated unit tests
- [x] Tests pass locally
- [ ] Documentation (N/A)

I submit this contribution under the Apache-2.0 license.