### PR TITLE
Default --x-downloadqueriesfromdatadog to true

### DIFF
--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -50,7 +50,7 @@ func main() {
 				Name:   "x-downloadqueriesfromdatadog",
 				Hidden: true,
 				Usage:  "(experimental, will be removed soon) download query data from Datadog",
-				Value:  false,
+				Value:  true,
 			},
 		},
 		Before: applyGlobalOptions,


### PR DESCRIPTION
## Motivation

The scanner has a hidden `--x-downloadqueriesfromdatadog` flag that fetches the default IaC ruleset from the Datadog API (`DatadogSource`) instead of using the rules embedded in the binary. Until now it defaulted to `false`, so every invocation ran against the embedded copy of `assets/queries/` and the API source was only exercised by callers that opted in explicitly.

We're moving the canonical authoring surface for IaC default rules out of this repo and into a separate publishing pipeline that serves them from the Datadog backend. Flipping this default to `true` is the one of the steps in that rollout: existing callers keep working (the embedded rules are still shipped and can be forced back on with `--x-downloadqueriesfromdatadog=false`), but the default scan path now matches the target architecture. Either way, it is destined to be merged once we enable the FF everywhere, and removed completely once we have enough time passed on with the flag enabled.

## Changes

`cmd/scanner/main.go`: change the `--x-downloadqueriesfromdatadog` `BoolFlag` `Value` from `false` to `true`. The flag stays `Hidden: true` and the usage string is unchanged, so the CLI surface is identical; only the implicit default behavior changes.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why. *(No new tests: the change is a single-line default flip on an existing, already-tested flag, and both code paths — `DatadogSource` and `FilesystemSource` — are already covered.)*
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [x] I have updated any relevant documentation (if applicable).

## QA Instruction

Build the scanner and run it against any sample fixture without the flag:

```bash
make build
./bin/datadog-iac-scanner scan -p assets/queries/terraform/aws/<some_rule>/test -t Terraform
```

The scan should now go through `DatadogSource` (a `GET https://api.<DD_SITE>/api/v2/static-analysis/iac/rulesets/default-ruleset` is issued during query loading). Re-running with `--x-downloadqueriesfromdatadog=false` should fall back to the embedded `assets/queries/` rules and produce the same shape of findings as before this PR.

## Blast Radius

Only `datadog-iac-scanner`. The flag was already wired through `cmd/scanner/scan.go`, `cmd/scanner/list_queries.go`, `pkg/scan/scan.go`, and `pkg/scan/client.go`; nothing else changes. Callers that need to keep the previous behavior can pass `--x-downloadqueriesfromdatadog=false` until the flag is removed for good.

## Additional Notes

When the backend rollout is complete and the embedded `assets/queries/` are removed, this whole flag block (and the `DownloadQueriesFromDatadog`/`FilesystemSource` plumbing it gates) will be deleted together.

I submit this contribution under the Apache-2.0 license.
