### PR TITLE
Emit SARIF suppressions for in-source ignored IaC findings

### DIFF
--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -73,15 +73,28 @@ func FileAnalyzer(path string) (string, error) {
 	return "", errors.New("invalid configuration file format")
 }
 
-// GenerateReport execute each report function to generate report
+// GenerateReport execute each report function to generate report.
+//
+// Suppressed findings are kept in the Summary so SARIF can emit them under
+// `suppressions[]`; every other report format gets a filtered copy that drops
+// them, matching the CLI counters and avoiding leaks into json/csv/gitlab/etc.
 func GenerateReport(ctx context.Context, path, filename string, body interface{}, formats []string, sciInfo *model.SCIInfo) error {
 	log.Debug().Msgf("helpers.GenerateReport()")
+
+	nonSarifBody := body
+	if summary, ok := body.(*model.Summary); ok {
+		nonSarifBody = summary.WithoutSuppressed()
+	}
 
 	var err error = nil
 
 	for _, format := range formats {
 		format = strings.ToLower(format)
-		if err = reportGenerators[format](ctx, path, filename, body, sciInfo); err != nil {
+		target := nonSarifBody
+		if format == "sarif" {
+			target = body
+		}
+		if err = reportGenerators[format](ctx, path, filename, target, sciInfo); err != nil {
 			log.Error().Msgf("Failed to generate %s report", format)
 			break
 		}

--- a/internal/console/helpers/helpers_test.go
+++ b/internal/console/helpers/helpers_test.go
@@ -7,9 +7,11 @@ package helpers
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -187,6 +189,77 @@ func TestHelpers_GenerateReport(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHelpers_GenerateReport_FiltersSuppressedForNonSarif ensures that
+// suppressed VulnerableFile entries do not leak into non-SARIF report formats
+// (json, csv, gitlab_sast, etc.), while SARIF still receives them so it can
+// emit the `suppressions[]` array expected by the downstream pipeline.
+func TestHelpers_GenerateReport_FiltersSuppressedForNonSarif(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	loc := model.ResourceLocation{
+		Start: model.ResourceLine{Line: 1, Col: 1},
+		End:   model.ResourceLine{Line: 1, Col: 1},
+	}
+	summary := &model.Summary{
+		Queries: model.QueryResultSlice{
+			{
+				QueryID:   "active-rule",
+				QueryName: "active-rule",
+				Severity:  model.SeverityMedium,
+				Files: []model.VulnerableFile{
+					{FileName: "active.tf", Line: 10, ResourceLocation: loc},
+				},
+			},
+			{
+				QueryID:   "suppressed-rule",
+				QueryName: "suppressed-rule",
+				Severity:  model.SeverityHigh,
+				Files: []model.VulnerableFile{
+					{
+						FileName:                 "suppressed.tf",
+						Line:                     20,
+						ResourceLocation:         loc,
+						IsSuppressed:             true,
+						SuppressionKind:          model.SuppressionKindInSource,
+						SuppressionJustification: model.SuppressionJustificationIgnoreComment,
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	require.NoError(t, GenerateReport(ctx, tmpDir, "result", summary, []string{"json", "sarif"}, &model.SCIInfo{}))
+
+	jsonBytes, err := os.ReadFile(filepath.Join(tmpDir, "result.json"))
+	require.NoError(t, err)
+
+	var parsed model.Summary
+	require.NoError(t, json.Unmarshal(jsonBytes, &parsed))
+
+	for _, q := range parsed.Queries {
+		require.NotEqual(t, "suppressed-rule", q.QueryID,
+			"non-SARIF reports must not contain suppressed rules; got query: %+v", q)
+		for _, f := range q.Files {
+			require.False(t, f.IsSuppressed,
+				"non-SARIF reports must not contain suppressed files; got file: %+v", f)
+		}
+	}
+
+	sarifBytes, err := os.ReadFile(filepath.Join(tmpDir, "result.sarif"))
+	require.NoError(t, err)
+	require.Contains(t, string(sarifBytes), "suppressions",
+		"SARIF must still emit the suppressions array for ignored findings")
+	require.Contains(t, strings.ToLower(string(sarifBytes)), "suppressed-rule",
+		"SARIF must still include the suppressed rule's result")
+
+	// Caller's Summary must not be mutated by GenerateReport so downstream code
+	// (e.g. exit codes, additional sinks) keeps seeing the suppressed entry.
+	require.Len(t, summary.Queries, 2)
+	require.Len(t, summary.Queries[1].Files, 1)
+	require.True(t, summary.Queries[1].Files[0].IsSuppressed)
 }
 
 func TestHelpers_GetDefaultQueryPath(t *testing.T) {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -591,9 +591,9 @@ func getVulnerabilitiesFromQuery(ctx context.Context, qCtx *QueryContext, c *Ins
 		return nil, false
 	}
 	if ShouldSkipVulnerability(file.Commands, vulnerability.QueryID, vulnerability.LegacyQueryID) {
-		contextLogger.Debug().Msgf("Skipping vulnerability in file %s for query '%s':%s",
+		contextLogger.Debug().Msgf("Suppressing vulnerability in file %s for query '%s':%s",
 			file.FilePath, vulnerability.QueryName, vulnerability.QueryID)
-		return nil, false
+		markSuppressed(vulnerability, model.SuppressionJustificationDisableInFile)
 	}
 
 	if vulnerability.Line == UndetectedVulnerabilityLine {
@@ -602,15 +602,28 @@ func getVulnerabilitiesFromQuery(ctx context.Context, qCtx *QueryContext, c *Ins
 
 	if _, ok := c.excludeResults[vulnerability.SimilarityID]; ok {
 		contextLogger.Debug().
-			Msgf("Excluding result SimilarityID: %s", vulnerability.SimilarityID)
-		return nil, false
+			Msgf("Suppressing result by SimilarityID: %s", vulnerability.SimilarityID)
+		markSuppressed(vulnerability, model.SuppressionJustificationExcludeResults)
 	} else if checkComment(vulnerability.Line, file.LinesIgnore) {
 		contextLogger.Debug().
-			Msgf("Excluding result Comment: %s", vulnerability.SimilarityID)
-		return nil, false
+			Msgf("Suppressing result by Comment: %s", vulnerability.SimilarityID)
+		markSuppressed(vulnerability, model.SuppressionJustificationIgnoreLine)
 	}
 
 	return vulnerability, false
+}
+
+// markSuppressed tags a vulnerability as suppressed without losing the
+// originating justification. Findings that hit multiple suppression gates
+// keep the first justification recorded; later gates are ignored so the
+// SARIF output remains stable for a given input.
+func markSuppressed(vulnerability *model.Vulnerability, justification string) {
+	if vulnerability.IsSuppressed {
+		return
+	}
+	vulnerability.IsSuppressed = true
+	vulnerability.SuppressionKind = model.SuppressionKindInSource
+	vulnerability.SuppressionJustification = justification
 }
 
 // checkComment checks if the vulnerability should be skipped from comment

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -593,36 +593,37 @@ func getVulnerabilitiesFromQuery(ctx context.Context, qCtx *QueryContext, c *Ins
 	if ShouldSkipVulnerability(file.Commands, vulnerability.QueryID, vulnerability.LegacyQueryID) {
 		contextLogger.Debug().Msgf("Suppressing vulnerability in file %s for query '%s':%s",
 			file.FilePath, vulnerability.QueryName, vulnerability.QueryID)
-		markSuppressed(vulnerability, model.SuppressionJustificationDisableInFile)
+		markSuppressed(vulnerability, model.SuppressionKindInSource, model.SuppressionJustificationDisableInFile)
 	}
 
-	if vulnerability.Line == UndetectedVulnerabilityLine {
+	// Detect-line failures should not be reported (or drop the finding) once
+	// a suppression decision has already been taken; the SARIF entry is
+	// still useful even without an exact line.
+	if vulnerability.Line == UndetectedVulnerabilityLine && !vulnerability.IsSuppressed {
 		return nil, true
 	}
 
 	if _, ok := c.excludeResults[vulnerability.SimilarityID]; ok {
 		contextLogger.Debug().
 			Msgf("Suppressing result by SimilarityID: %s", vulnerability.SimilarityID)
-		markSuppressed(vulnerability, model.SuppressionJustificationExcludeResults)
+		markSuppressed(vulnerability, model.SuppressionKindExternal, model.SuppressionJustificationExcludeResults)
 	} else if checkComment(vulnerability.Line, file.LinesIgnore) {
 		contextLogger.Debug().
 			Msgf("Suppressing result by Comment: %s", vulnerability.SimilarityID)
-		markSuppressed(vulnerability, model.SuppressionJustificationIgnoreLine)
+		markSuppressed(vulnerability, model.SuppressionKindInSource, model.SuppressionJustificationIgnoreComment)
 	}
 
 	return vulnerability, false
 }
 
-// markSuppressed tags a vulnerability as suppressed without losing the
-// originating justification. Findings that hit multiple suppression gates
-// keep the first justification recorded; later gates are ignored so the
-// SARIF output remains stable for a given input.
-func markSuppressed(vulnerability *model.Vulnerability, justification string) {
+// markSuppressed records the first suppression decision; later gates are
+// no-ops so SARIF output stays stable.
+func markSuppressed(vulnerability *model.Vulnerability, kind, justification string) {
 	if vulnerability.IsSuppressed {
 		return
 	}
 	vulnerability.IsSuppressed = true
-	vulnerability.SuppressionKind = model.SuppressionKindInSource
+	vulnerability.SuppressionKind = kind
 	vulnerability.SuppressionJustification = justification
 }
 

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -418,6 +418,159 @@ func TestShouldSkipFile(t *testing.T) {
 	}
 }
 
+// TestGetVulnerabilitiesFromQuery_SuppressionPaths verifies that the three
+// in-source suppression gates (`disable:<queryID>`, `ignore-line`, and the
+// explicit similarity-id exclusion) tag the vulnerability with the matching
+// suppression metadata instead of dropping it. The non-suppressed baseline
+// is also covered so regressions show up immediately.
+func TestGetVulnerabilitiesFromQuery_SuppressionPaths(t *testing.T) {
+	const (
+		fileID        = "file-1"
+		queryID       = "platform-provider-rule"
+		legacyQueryID = "legacy-id"
+		similarityID  = "sim-1"
+		matchingLine  = 7
+	)
+
+	baseFile := func() *model.FileMetadata {
+		return &model.FileMetadata{
+			ID:       fileID,
+			FilePath: "main.tf",
+			Commands: model.CommentsCommands{},
+		}
+	}
+
+	buildVulnerability := func() *model.Vulnerability {
+		return &model.Vulnerability{
+			FileID:        fileID,
+			QueryID:       queryID,
+			LegacyQueryID: legacyQueryID,
+			QueryName:     "rule",
+			SimilarityID:  similarityID,
+			Line:          matchingLine,
+		}
+	}
+
+	cases := []struct {
+		name                  string
+		file                  *model.FileMetadata
+		excludeResults        map[string]bool
+		expectSuppressed      bool
+		expectSuppressionKind string
+		expectJustification   string
+	}{
+		{
+			name:             "not_suppressed",
+			file:             baseFile(),
+			expectSuppressed: false,
+		},
+		{
+			name: "disable_directive_in_file",
+			file: func() *model.FileMetadata {
+				file := baseFile()
+				file.Commands = model.CommentsCommands{"disable": queryID}
+				return file
+			}(),
+			expectSuppressed:      true,
+			expectSuppressionKind: model.SuppressionKindInSource,
+			expectJustification:   model.SuppressionJustificationDisableInFile,
+		},
+		{
+			name: "ignore_line_directive",
+			file: func() *model.FileMetadata {
+				file := baseFile()
+				file.LinesIgnore = []int{matchingLine}
+				return file
+			}(),
+			expectSuppressed:      true,
+			expectSuppressionKind: model.SuppressionKindInSource,
+			expectJustification:   model.SuppressionJustificationIgnoreLine,
+		},
+		{
+			name:                  "excluded_by_similarity_id",
+			file:                  baseFile(),
+			excludeResults:        map[string]bool{similarityID: true},
+			expectSuppressed:      true,
+			expectSuppressionKind: model.SuppressionKindInSource,
+			expectJustification:   model.SuppressionJustificationExcludeResults,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			built := buildVulnerability()
+			ins := newTestInspector(t, inspectorOpts{
+				excludeResults: tc.excludeResults,
+				vb: func(_ context.Context, _ *QueryContext, _ Tracker, _ interface{},
+					_ *detector.DetectLine, _ bool, _ bool, _ time.Duration) (*model.Vulnerability, error) {
+					return built, nil
+				},
+			})
+
+			queryCtx := &QueryContext{
+				Ctx:   context.Background(),
+				Files: map[string]*model.FileMetadata{fileID: tc.file},
+				Query: &PreparedQuery{Metadata: model.QueryMetadata{Query: "q"}},
+			}
+
+			got, retry := getVulnerabilitiesFromQuery(context.Background(), queryCtx, ins, nil, 0)
+			require.NotNil(t, got, "suppressed vulnerabilities must still flow through; got nil")
+			require.False(t, retry, "retry flag should never be set for suppression paths")
+			require.Equal(t, tc.expectSuppressed, got.IsSuppressed)
+			require.Equal(t, tc.expectSuppressionKind, got.SuppressionKind)
+			require.Equal(t, tc.expectJustification, got.SuppressionJustification)
+		})
+	}
+}
+
+// TestGetVulnerabilitiesFromQuery_FirstJustificationWins covers the edge case
+// where multiple suppression gates match the same vulnerability. The first
+// gate to fire must own the justification so the SARIF output stays stable
+// for a given input.
+func TestGetVulnerabilitiesFromQuery_FirstJustificationWins(t *testing.T) {
+	const (
+		fileID       = "file-1"
+		queryID      = "platform-provider-rule"
+		similarityID = "sim-1"
+		matchingLine = 11
+	)
+
+	file := &model.FileMetadata{
+		ID:          fileID,
+		FilePath:    "main.tf",
+		Commands:    model.CommentsCommands{"disable": queryID},
+		LinesIgnore: []int{matchingLine},
+	}
+
+	built := &model.Vulnerability{
+		FileID:       fileID,
+		QueryID:      queryID,
+		QueryName:    "rule",
+		SimilarityID: similarityID,
+		Line:         matchingLine,
+	}
+
+	ins := newTestInspector(t, inspectorOpts{
+		excludeResults: map[string]bool{similarityID: true},
+		vb: func(_ context.Context, _ *QueryContext, _ Tracker, _ interface{},
+			_ *detector.DetectLine, _ bool, _ bool, _ time.Duration) (*model.Vulnerability, error) {
+			return built, nil
+		},
+	})
+
+	queryCtx := &QueryContext{
+		Ctx:   context.Background(),
+		Files: map[string]*model.FileMetadata{fileID: file},
+		Query: &PreparedQuery{Metadata: model.QueryMetadata{Query: "q"}},
+	}
+
+	got, _ := getVulnerabilitiesFromQuery(context.Background(), queryCtx, ins, nil, 0)
+	require.NotNil(t, got)
+	require.True(t, got.IsSuppressed)
+	require.Equal(t, model.SuppressionJustificationDisableInFile, got.SuppressionJustification,
+		"the disable-in-file gate runs first and must own the SARIF justification")
+}
+
 func TestInspector_DecodeQueryResults(t *testing.T) {
 	ctx := context.Background()
 	c := newTestInspector(t, inspectorOpts{kicsComputeNewSimID: true})

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -418,11 +418,9 @@ func TestShouldSkipFile(t *testing.T) {
 	}
 }
 
-// TestGetVulnerabilitiesFromQuery_SuppressionPaths verifies that the three
-// in-source suppression gates (`disable:<queryID>`, `ignore-line`, and the
-// explicit similarity-id exclusion) tag the vulnerability with the matching
-// suppression metadata instead of dropping it. The non-suppressed baseline
-// is also covered so regressions show up immediately.
+// TestGetVulnerabilitiesFromQuery_SuppressionPaths covers the three
+// suppression gates (`disable:<queryID>`, `ignore-line`, similarity-id
+// exclusion) plus the non-suppressed baseline.
 func TestGetVulnerabilitiesFromQuery_SuppressionPaths(t *testing.T) {
 	const (
 		fileID        = "file-1"
@@ -476,7 +474,7 @@ func TestGetVulnerabilitiesFromQuery_SuppressionPaths(t *testing.T) {
 			expectJustification:   model.SuppressionJustificationDisableInFile,
 		},
 		{
-			name: "ignore_line_directive",
+			name: "ignore_comment_directive",
 			file: func() *model.FileMetadata {
 				file := baseFile()
 				file.LinesIgnore = []int{matchingLine}
@@ -484,14 +482,14 @@ func TestGetVulnerabilitiesFromQuery_SuppressionPaths(t *testing.T) {
 			}(),
 			expectSuppressed:      true,
 			expectSuppressionKind: model.SuppressionKindInSource,
-			expectJustification:   model.SuppressionJustificationIgnoreLine,
+			expectJustification:   model.SuppressionJustificationIgnoreComment,
 		},
 		{
 			name:                  "excluded_by_similarity_id",
 			file:                  baseFile(),
 			excludeResults:        map[string]bool{similarityID: true},
 			expectSuppressed:      true,
-			expectSuppressionKind: model.SuppressionKindInSource,
+			expectSuppressionKind: model.SuppressionKindExternal,
 			expectJustification:   model.SuppressionJustificationExcludeResults,
 		},
 	}
@@ -521,6 +519,48 @@ func TestGetVulnerabilitiesFromQuery_SuppressionPaths(t *testing.T) {
 			require.Equal(t, tc.expectJustification, got.SuppressionJustification)
 		})
 	}
+}
+
+// TestGetVulnerabilitiesFromQuery_SuppressedSurvivesUndetectedLine guards
+// against a regression where the detect-line failure branch would drop a
+// vulnerability already marked as suppressed.
+func TestGetVulnerabilitiesFromQuery_SuppressedSurvivesUndetectedLine(t *testing.T) {
+	const (
+		fileID  = "file-1"
+		queryID = "platform-provider-rule"
+	)
+
+	file := &model.FileMetadata{
+		ID:       fileID,
+		FilePath: "main.tf",
+		Commands: model.CommentsCommands{"disable": queryID},
+	}
+
+	built := &model.Vulnerability{
+		FileID:    fileID,
+		QueryID:   queryID,
+		QueryName: "rule",
+		Line:      UndetectedVulnerabilityLine,
+	}
+
+	ins := newTestInspector(t, inspectorOpts{
+		vb: func(_ context.Context, _ *QueryContext, _ Tracker, _ interface{},
+			_ *detector.DetectLine, _ bool, _ bool, _ time.Duration) (*model.Vulnerability, error) {
+			return built, nil
+		},
+	})
+
+	queryCtx := &QueryContext{
+		Ctx:   context.Background(),
+		Files: map[string]*model.FileMetadata{fileID: file},
+		Query: &PreparedQuery{Metadata: model.QueryMetadata{Query: "q"}},
+	}
+
+	got, failedDetect := getVulnerabilitiesFromQuery(context.Background(), queryCtx, ins, nil, 0)
+	require.NotNil(t, got, "suppressed vulnerability must not be dropped when the line is undetected")
+	require.False(t, failedDetect, "detect-line failure should not be reported for suppressed findings")
+	require.True(t, got.IsSuppressed)
+	require.Equal(t, model.SuppressionJustificationDisableInFile, got.SuppressionJustification)
 }
 
 // TestGetVulnerabilitiesFromQuery_FirstJustificationWins covers the edge case

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -38,19 +38,18 @@ const (
 	IgnoreComment CommentCommand = "ignore-comment"
 )
 
-// SuppressionKind values describe where a finding suppression originates from.
-// They match the kind values defined by SARIF 2.1.0 for the `suppressions` array.
+// Suppression kinds map to SARIF 2.1.0 `suppressions[].kind`.
 const (
 	SuppressionKindInSource = "inSource"
 	SuppressionKindExternal = "external"
 )
 
-// SuppressionJustification* values describe the in-source directive (or external
-// configuration) that suppressed a finding. They are surfaced verbatim in SARIF
-// suppression entries so downstream consumers can attribute the decision.
+// Suppression justifications surfaced in SARIF `suppressions[].justification`.
+// `IgnoreComment` covers both `ignore-line` and `ignore-block` because
+// `LinesIgnore` flattens block directives to individual line numbers, so the
+// originating directive is no longer recoverable at suppression time.
 const (
-	SuppressionJustificationIgnoreLine     = "dd-iac-scan ignore-line"
-	SuppressionJustificationIgnoreBlock    = "dd-iac-scan ignore-block"
+	SuppressionJustificationIgnoreComment  = "dd-iac-scan ignore"
 	SuppressionJustificationDisableInFile  = "dd-iac-scan disable"
 	SuppressionJustificationExcludeResults = "excluded by similarity id"
 )
@@ -227,18 +226,11 @@ type Vulnerability struct {
 	FileSource            []string         `json:"fileSource"`
 	BlockLocation         ResourceLocation `json:"blockLocation"`
 	Frameworks            []Framework      `json:"frameworks,omitempty"`
-	// IsSuppressed reports whether the finding was matched by an in-source
-	// suppression directive or by an explicit exclusion. Suppressed findings
-	// are still emitted in SARIF (with a `suppressions` entry) so downstream
-	// consumers can preserve an audit trail, but they are excluded from
-	// severity counters so CLI exit codes are unchanged.
-	IsSuppressed bool `json:"isSuppressed,omitempty"`
-	// SuppressionKind mirrors the SARIF `suppressions[].kind` value. It is
-	// only meaningful when IsSuppressed is true.
-	SuppressionKind string `json:"suppressionKind,omitempty"`
-	// SuppressionJustification records which directive suppressed the
-	// finding (for example "dd-iac-scan ignore-line"). It is surfaced in the
-	// SARIF `suppressions[].justification` field.
+	// IsSuppressed marks a finding as kept-for-SARIF but excluded from
+	// severity counters; the kind/justification map directly to SARIF
+	// `suppressions[]`.
+	IsSuppressed             bool   `json:"isSuppressed,omitempty"`
+	SuppressionKind          string `json:"suppressionKind,omitempty"`
 	SuppressionJustification string `json:"suppressionJustification,omitempty"`
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -38,6 +38,23 @@ const (
 	IgnoreComment CommentCommand = "ignore-comment"
 )
 
+// SuppressionKind values describe where a finding suppression originates from.
+// They match the kind values defined by SARIF 2.1.0 for the `suppressions` array.
+const (
+	SuppressionKindInSource = "inSource"
+	SuppressionKindExternal = "external"
+)
+
+// SuppressionJustification* values describe the in-source directive (or external
+// configuration) that suppressed a finding. They are surfaced verbatim in SARIF
+// suppression entries so downstream consumers can attribute the decision.
+const (
+	SuppressionJustificationIgnoreLine     = "dd-iac-scan ignore-line"
+	SuppressionJustificationIgnoreBlock    = "dd-iac-scan ignore-block"
+	SuppressionJustificationDisableInFile  = "dd-iac-scan disable"
+	SuppressionJustificationExcludeResults = "excluded by similarity id"
+)
+
 // Constants to describe vulnerability's severity
 const (
 	SeverityCritical = "CRITICAL"
@@ -210,6 +227,19 @@ type Vulnerability struct {
 	FileSource            []string         `json:"fileSource"`
 	BlockLocation         ResourceLocation `json:"blockLocation"`
 	Frameworks            []Framework      `json:"frameworks,omitempty"`
+	// IsSuppressed reports whether the finding was matched by an in-source
+	// suppression directive or by an explicit exclusion. Suppressed findings
+	// are still emitted in SARIF (with a `suppressions` entry) so downstream
+	// consumers can preserve an audit trail, but they are excluded from
+	// severity counters so CLI exit codes are unchanged.
+	IsSuppressed bool `json:"isSuppressed,omitempty"`
+	// SuppressionKind mirrors the SARIF `suppressions[].kind` value. It is
+	// only meaningful when IsSuppressed is true.
+	SuppressionKind string `json:"suppressionKind,omitempty"`
+	// SuppressionJustification records which directive suppressed the
+	// finding (for example "dd-iac-scan ignore-line"). It is surfaced in the
+	// SARIF `suppressions[].justification` field.
+	SuppressionJustification string `json:"suppressionJustification,omitempty"`
 }
 
 // Framework represents a framework mapping for a query

--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -48,15 +48,9 @@ type VulnerableFile struct {
 	ResourceSource        string           `json:"resource_source,omitempty"`
 	FileSource            []string         `json:"file_source,omitempty"`
 	BlockLocation         ResourceLocation `json:"block_location,omitempty"`
-	// IsSuppressed mirrors Vulnerability.IsSuppressed. Suppressed entries are
-	// still listed so the SARIF report can attach a `suppressions` entry, but
-	// they are excluded from the severity counters in SeveritySummary.
-	IsSuppressed bool `json:"is_suppressed,omitempty"`
-	// SuppressionKind mirrors the SARIF `suppressions[].kind` value when
-	// IsSuppressed is true.
-	SuppressionKind string `json:"suppression_kind,omitempty"`
-	// SuppressionJustification records which directive suppressed the
-	// finding (for example "dd-iac-scan ignore-line").
+	// Suppression metadata; see Vulnerability.IsSuppressed.
+	IsSuppressed             bool   `json:"is_suppressed,omitempty"`
+	SuppressionKind          string `json:"suppression_kind,omitempty"`
 	SuppressionJustification string `json:"suppression_justification,omitempty"`
 }
 
@@ -135,8 +129,7 @@ var (
 
 const authGroupPosition = 3
 
-// countNotSuppressed returns how many files in the slice were not suppressed
-// by an in-source directive or by an explicit exclusion.
+// countNotSuppressed returns the number of non-suppressed files.
 func countNotSuppressed(files []VulnerableFile) int {
 	count := 0
 	for i := range files {
@@ -145,6 +138,45 @@ func countNotSuppressed(files []VulnerableFile) int {
 		}
 	}
 	return count
+}
+
+// WithoutSuppressed returns a shallow copy of the Summary with suppressed
+// VulnerableFile entries removed from Queries and Bom; QueryResult entries
+// whose Files become empty after filtering are dropped entirely.
+//
+// SARIF reporting must continue to use the original Summary so suppressed
+// findings can be emitted under the SARIF `suppressions` array. Every other
+// report format (json, csv, gitlab_sast, sonarqube, asff, junit, pdf, html,
+// cyclonedx, code_climate) has no notion of suppressions and would otherwise
+// expose ignored findings that the CLI counters already filtered out.
+func (s *Summary) WithoutSuppressed() *Summary {
+	out := *s
+	out.Queries = filterSuppressedQueries(s.Queries)
+	out.Bom = filterSuppressedQueries(s.Bom)
+	return &out
+}
+
+func filterSuppressedQueries(qs QueryResultSlice) QueryResultSlice {
+	if len(qs) == 0 {
+		return qs
+	}
+	out := make(QueryResultSlice, 0, len(qs))
+	for i := range qs {
+		active := make([]VulnerableFile, 0, len(qs[i].Files))
+		for j := range qs[i].Files {
+			if qs[i].Files[j].IsSuppressed {
+				continue
+			}
+			active = append(active, qs[i].Files[j])
+		}
+		if len(active) == 0 {
+			continue
+		}
+		q := qs[i]
+		q.Files = active
+		out = append(out, q)
+	}
+	return out
 }
 
 func getRelativePath(basePath, filePath string) string {
@@ -280,11 +312,8 @@ func CreateSummary(ctx context.Context, counters Counters, vulnerabilities []Vul
 	queries := make([]QueryResult, 0, len(q))
 	sevs := map[Severity]int{SeverityTrace: 0, SeverityInfo: 0, SeverityLow: 0, SeverityMedium: 0, SeverityHigh: 0, SeverityCritical: 0}
 	for idx := range q {
-		// Suppressed files are intentionally kept in the QueryResult slice so
-		// they can be emitted as SARIF `suppressions` entries, but they must
-		// not contribute to severity counters or the global total. This
-		// mirrors the SAST behavior introduced when suppressed findings
-		// started flowing through the pipeline.
+		// Suppressed files stay in the query result for SARIF, but they
+		// must not inflate severity counters or CLI exit-code thresholds.
 		activeCount := countNotSuppressed(q[idx].Files)
 		sevs[q[idx].Severity] += activeCount
 

--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -48,6 +48,16 @@ type VulnerableFile struct {
 	ResourceSource        string           `json:"resource_source,omitempty"`
 	FileSource            []string         `json:"file_source,omitempty"`
 	BlockLocation         ResourceLocation `json:"block_location,omitempty"`
+	// IsSuppressed mirrors Vulnerability.IsSuppressed. Suppressed entries are
+	// still listed so the SARIF report can attach a `suppressions` entry, but
+	// they are excluded from the severity counters in SeveritySummary.
+	IsSuppressed bool `json:"is_suppressed,omitempty"`
+	// SuppressionKind mirrors the SARIF `suppressions[].kind` value when
+	// IsSuppressed is true.
+	SuppressionKind string `json:"suppression_kind,omitempty"`
+	// SuppressionJustification records which directive suppressed the
+	// finding (for example "dd-iac-scan ignore-line").
+	SuppressionJustification string `json:"suppression_justification,omitempty"`
 }
 
 // QueryResult contains a query that tested positive ID, name, severity and a list of files that tested vulnerable
@@ -124,6 +134,18 @@ var (
 )
 
 const authGroupPosition = 3
+
+// countNotSuppressed returns how many files in the slice were not suppressed
+// by an in-source directive or by an explicit exclusion.
+func countNotSuppressed(files []VulnerableFile) int {
+	count := 0
+	for i := range files {
+		if !files[i].IsSuppressed {
+			count++
+		}
+	}
+	return count
+}
 
 func getRelativePath(basePath, filePath string) string {
 	var returnPath string
@@ -223,28 +245,31 @@ func CreateSummary(ctx context.Context, counters Counters, vulnerabilities []Vul
 
 		qItem := q[item.QueryID]
 		qItem.Files = append(qItem.Files, VulnerableFile{
-			FileName:              resolvedPath,
-			SimilarityID:          item.SimilarityID,
-			OldSimilarityID:       item.OldSimilarityID,
-			Line:                  item.Line,
-			VulnLines:             item.VulnLines,
-			ResourceType:          item.ResourceType,
-			ResourceName:          item.ResourceName,
-			IssueType:             item.IssueType,
-			SearchKey:             item.SearchKey,
-			SearchValue:           item.SearchValue,
-			SearchLine:            item.SearchLine,
-			KeyExpectedValue:      item.KeyExpectedValue,
-			KeyActualValue:        item.KeyActualValue,
-			Value:                 item.Value,
-			Remediation:           item.Remediation,
-			RemediationType:       item.RemediationType,
-			ResourceLocation:      item.VulnerabilityLocation,
-			LineWithVulnerability: item.LineWithVulnerability,
-			RemediationLocation:   item.RemediationLocation,
-			ResourceSource:        item.ResourceSource,
-			FileSource:            item.FileSource,
-			BlockLocation:         item.BlockLocation,
+			FileName:                 resolvedPath,
+			SimilarityID:             item.SimilarityID,
+			OldSimilarityID:          item.OldSimilarityID,
+			Line:                     item.Line,
+			VulnLines:                item.VulnLines,
+			ResourceType:             item.ResourceType,
+			ResourceName:             item.ResourceName,
+			IssueType:                item.IssueType,
+			SearchKey:                item.SearchKey,
+			SearchValue:              item.SearchValue,
+			SearchLine:               item.SearchLine,
+			KeyExpectedValue:         item.KeyExpectedValue,
+			KeyActualValue:           item.KeyActualValue,
+			Value:                    item.Value,
+			Remediation:              item.Remediation,
+			RemediationType:          item.RemediationType,
+			ResourceLocation:         item.VulnerabilityLocation,
+			LineWithVulnerability:    item.LineWithVulnerability,
+			RemediationLocation:      item.RemediationLocation,
+			ResourceSource:           item.ResourceSource,
+			FileSource:               item.FileSource,
+			BlockLocation:            item.BlockLocation,
+			IsSuppressed:             item.IsSuppressed,
+			SuppressionKind:          item.SuppressionKind,
+			SuppressionJustification: item.SuppressionJustification,
 		})
 
 		filePaths[resolvedPath] = item.FileName
@@ -255,14 +280,20 @@ func CreateSummary(ctx context.Context, counters Counters, vulnerabilities []Vul
 	queries := make([]QueryResult, 0, len(q))
 	sevs := map[Severity]int{SeverityTrace: 0, SeverityInfo: 0, SeverityLow: 0, SeverityMedium: 0, SeverityHigh: 0, SeverityCritical: 0}
 	for idx := range q {
-		sevs[q[idx].Severity] += len(q[idx].Files)
+		// Suppressed files are intentionally kept in the QueryResult slice so
+		// they can be emitted as SARIF `suppressions` entries, but they must
+		// not contribute to severity counters or the global total. This
+		// mirrors the SAST behavior introduced when suppressed findings
+		// started flowing through the pipeline.
+		activeCount := countNotSuppressed(q[idx].Files)
+		sevs[q[idx].Severity] += activeCount
 
 		if q[idx].Severity == SeverityTrace {
 			continue
 		}
 		queries = append(queries, q[idx])
 
-		severitySummary.TotalCounter += len(q[idx].Files)
+		severitySummary.TotalCounter += activeCount
 	}
 
 	severityOrder := map[Severity]int{
@@ -284,7 +315,7 @@ func CreateSummary(ctx context.Context, counters Counters, vulnerabilities []Vul
 	for idx := range q {
 		if q[idx].Severity == SeverityTrace {
 			materials = append(materials, q[idx])
-			severitySummary.TotalBOMResources += len(q[idx].Files)
+			severitySummary.TotalBOMResources += countNotSuppressed(q[idx].Files)
 		}
 	}
 

--- a/pkg/model/summary_test.go
+++ b/pkg/model/summary_test.go
@@ -223,6 +223,63 @@ func TestRemoveURLCredentials(t *testing.T) {
 	}
 }
 
+// TestSummary_WithoutSuppressed verifies that the filtered copy used by
+// non-SARIF reports drops every suppressed VulnerableFile, prunes queries that
+// become empty, and leaves the original Summary untouched so SARIF reporting
+// can still surface them under `suppressions[]`.
+func TestSummary_WithoutSuppressed(t *testing.T) {
+	original := &Summary{
+		Queries: QueryResultSlice{
+			{
+				QueryID: "mixed",
+				Files: []VulnerableFile{
+					{FileName: "active.tf", Line: 10},
+					{FileName: "suppressed.tf", Line: 20, IsSuppressed: true},
+				},
+			},
+			{
+				QueryID: "all-suppressed",
+				Files: []VulnerableFile{
+					{FileName: "suppressed.tf", Line: 30, IsSuppressed: true},
+				},
+			},
+			{
+				QueryID: "all-active",
+				Files: []VulnerableFile{
+					{FileName: "active.tf", Line: 40},
+				},
+			},
+		},
+		Bom: QueryResultSlice{
+			{
+				QueryID: "bom",
+				Files: []VulnerableFile{
+					{FileName: "bom-active.tf", Line: 1},
+					{FileName: "bom-suppressed.tf", Line: 2, IsSuppressed: true},
+				},
+			},
+		},
+	}
+
+	filtered := original.WithoutSuppressed()
+
+	require.Len(t, filtered.Queries, 2)
+	require.Equal(t, "mixed", filtered.Queries[0].QueryID)
+	require.Len(t, filtered.Queries[0].Files, 1)
+	require.Equal(t, "active.tf", filtered.Queries[0].Files[0].FileName)
+	require.Equal(t, "all-active", filtered.Queries[1].QueryID)
+
+	require.Len(t, filtered.Bom, 1)
+	require.Len(t, filtered.Bom[0].Files, 1)
+	require.Equal(t, "bom-active.tf", filtered.Bom[0].Files[0].FileName)
+
+	// Original is untouched so SARIF can still emit suppressions.
+	require.Len(t, original.Queries, 3)
+	require.Len(t, original.Queries[0].Files, 2)
+	require.True(t, original.Queries[0].Files[1].IsSuppressed)
+	require.Len(t, original.Bom[0].Files, 2)
+}
+
 func TestRemoveAllURLCredentials(t *testing.T) {
 	input := []struct {
 		pathExtractionMap map[string]ExtractedPathObject

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -49,18 +49,26 @@ func PrintResult(ctx context.Context, summary *model.Summary, printer *Printer, 
 			continue
 		}
 
+		// Hide suppressed findings from the CLI output: they are still emitted
+		// in SARIF via `suppressions`, but the printed list and counts should
+		// reflect only the violations that survive after suppression.
+		active := activeFiles(summary.Queries[idx].Files)
+		if len(active) == 0 {
+			continue
+		}
+
 		contextLogger.Info().Msgf(
 			"%s, Severity: %s, Results: %d\n",
 			printer.PrintBySev(summary.Queries[idx].QueryName, string(summary.Queries[idx].Severity)),
 			printer.PrintBySev(string(summary.Queries[idx].Severity), string(summary.Queries[idx].Severity)),
-			len(summary.Queries[idx].Files),
+			len(active),
 		)
 
 		if summary.Queries[idx].Experimental {
 			contextLogger.Info().Msgf("Note: this is an experimental query")
 		}
 
-		printFiles(ctx, &summary.Queries[idx], printer)
+		printFiles(ctx, summary.Queries[idx].Severity, active, printer)
 	}
 	contextLogger.Info().Msgf("\nResults Summary:\n")
 	printSeverityCounter(ctx, model.SeverityCritical, summary.SeverityCounters[model.SeverityCritical])
@@ -105,12 +113,25 @@ func printSeverityCounter(ctx context.Context, severity string, counter int) {
 	contextLogger.Info().Msgf("%s: %d\n", severity, counter)
 }
 
-func printFiles(ctx context.Context, query *model.QueryResult, printer *Printer) {
+func printFiles(ctx context.Context, severity model.Severity, files []model.VulnerableFile, printer *Printer) {
 	contextLogger := logger.FromContext(ctx)
-	for fileIdx := range query.Files {
-		contextLogger.Info().Msgf("\t%s %s:%s\n", printer.PrintBySev(fmt.Sprintf("[%d]:", fileIdx+1), string(query.Severity)),
-			query.Files[fileIdx].FileName, printer.Success.Sprint(query.Files[fileIdx].Line))
+	for fileIdx := range files {
+		contextLogger.Info().Msgf("\t%s %s:%s\n", printer.PrintBySev(fmt.Sprintf("[%d]:", fileIdx+1), string(severity)),
+			files[fileIdx].FileName, printer.Success.Sprint(files[fileIdx].Line))
 	}
+}
+
+// activeFiles returns files for findings that are not suppressed.
+func activeFiles(files []model.VulnerableFile) []model.VulnerableFile {
+	out := make([]model.VulnerableFile, 0, len(files))
+	// nolint:gocritic
+	for _, f := range files {
+		if f.IsSuppressed {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
 }
 
 // NewPrinter initializes a new Printer

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -140,7 +140,30 @@ type sarifResult struct {
 	ResultLevel         string                   `json:"level"`
 	ResultProperties    sarifProperties          `json:"properties,omitempty"`
 	ResultFixes         []model.SarifFix         `json:"fixes,omitempty"`
+	// Suppressions follows the SARIF 2.1.0 result.suppressions shape so
+	// downstream consumers (for example ci-sarif-processor) can mark the
+	// finding as suppressed instead of dropping it. The slice is omitted
+	// from JSON when empty to keep non-suppressed results byte-for-byte
+	// identical to the previous output.
+	Suppressions []sarifSuppression `json:"suppressions,omitempty"`
 }
+
+// sarifSuppression mirrors the SARIF 2.1.0 suppression object. Only the
+// fields that the scanner populates are declared; optional fields like
+// `guid` and `location` are left out so the encoder never emits `null`
+// values for them.
+type sarifSuppression struct {
+	Kind          string `json:"kind"`
+	Status        string `json:"status,omitempty"`
+	Justification string `json:"justification,omitempty"`
+}
+
+const (
+	// sarifSuppressionStatusAccepted is the only suppression status this
+	// scanner emits today. Suppression directives are user-authored and
+	// therefore always accepted by definition.
+	sarifSuppressionStatusAccepted = "accepted"
+)
 
 type SarifPartialFingerprints struct {
 	Sha                string `json:"SHA,omitempty"`
@@ -579,6 +602,7 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 						vulnerability.LineWithVulnerability,
 					),
 				},
+				Suppressions: buildSarifSuppressions(&vulnerability),
 			}
 			if vulnerability.Remediation != "" && vulnerability.RemediationType != "" {
 				sarifFix, err := remediationsHelper.TransformToSarifFix(
@@ -600,6 +624,27 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 		return issue.CWE, nil
 	}
 	return "", nil
+}
+
+// buildSarifSuppressions returns the SARIF `suppressions` array for a single
+// vulnerable file, or nil when the file was not suppressed. The function
+// defaults missing metadata to in-source / accepted because every existing
+// suppression path in this scanner originates from a user-authored directive.
+func buildSarifSuppressions(file *model.VulnerableFile) []sarifSuppression {
+	if file == nil || !file.IsSuppressed {
+		return nil
+	}
+	kind := file.SuppressionKind
+	if kind == "" {
+		kind = model.SuppressionKindInSource
+	}
+	return []sarifSuppression{
+		{
+			Kind:          kind,
+			Status:        sarifSuppressionStatusAccepted,
+			Justification: file.SuppressionJustification,
+		},
+	}
 }
 
 func (sr *sarifReport) AddTags(ctx context.Context, summary *model.Summary, diffAware *model.DiffAware) error {

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -140,30 +140,20 @@ type sarifResult struct {
 	ResultLevel         string                   `json:"level"`
 	ResultProperties    sarifProperties          `json:"properties,omitempty"`
 	ResultFixes         []model.SarifFix         `json:"fixes,omitempty"`
-	// Suppressions follows the SARIF 2.1.0 result.suppressions shape so
-	// downstream consumers (for example ci-sarif-processor) can mark the
-	// finding as suppressed instead of dropping it. The slice is omitted
-	// from JSON when empty to keep non-suppressed results byte-for-byte
-	// identical to the previous output.
+	// Suppressions follows SARIF 2.1.0 `result.suppressions`; omitted when empty.
 	Suppressions []sarifSuppression `json:"suppressions,omitempty"`
 }
 
-// sarifSuppression mirrors the SARIF 2.1.0 suppression object. Only the
-// fields that the scanner populates are declared; optional fields like
-// `guid` and `location` are left out so the encoder never emits `null`
-// values for them.
+// sarifSuppression is the SARIF 2.1.0 suppression object trimmed to the
+// fields this scanner sets; optional `guid` and `location` are skipped
+// to avoid emitting JSON `null` values.
 type sarifSuppression struct {
 	Kind          string `json:"kind"`
 	Status        string `json:"status,omitempty"`
 	Justification string `json:"justification,omitempty"`
 }
 
-const (
-	// sarifSuppressionStatusAccepted is the only suppression status this
-	// scanner emits today. Suppression directives are user-authored and
-	// therefore always accepted by definition.
-	sarifSuppressionStatusAccepted = "accepted"
-)
+const sarifSuppressionStatusAccepted = "accepted"
 
 type SarifPartialFingerprints struct {
 	Sha                string `json:"SHA,omitempty"`
@@ -626,10 +616,10 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 	return "", nil
 }
 
-// buildSarifSuppressions returns the SARIF `suppressions` array for a single
-// vulnerable file, or nil when the file was not suppressed. The function
-// defaults missing metadata to in-source / accepted because every existing
-// suppression path in this scanner originates from a user-authored directive.
+// buildSarifSuppressions returns the SARIF `suppressions` array for a
+// suppressed file, or nil otherwise. Missing kind defaults to `inSource`
+// because every current suppression path either matches that exactly or
+// sets the kind explicitly.
 func buildSarifSuppressions(file *model.VulnerableFile) []sarifSuppression {
 	if file == nil || !file.IsSuppressed {
 		return nil

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -592,7 +592,7 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 						vulnerability.LineWithVulnerability,
 					),
 				},
-				Suppressions: buildSarifSuppressions(&vulnerability),
+				Suppressions: buildSarifSuppressions(ctx, &vulnerability),
 			}
 			if vulnerability.Remediation != "" && vulnerability.RemediationType != "" {
 				sarifFix, err := remediationsHelper.TransformToSarifFix(
@@ -617,15 +617,21 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 }
 
 // buildSarifSuppressions returns the SARIF `suppressions` array for a
-// suppressed file, or nil otherwise. Missing kind defaults to `inSource`
-// because every current suppression path either matches that exactly or
-// sets the kind explicitly.
-func buildSarifSuppressions(file *model.VulnerableFile) []sarifSuppression {
+// suppressed file, or nil otherwise. The SARIF 2.1.0 spec only allows
+// `inSource` or `external` for `suppression.kind`, so if a caller ever
+// forgets to set it we keep emitting valid SARIF by defaulting to
+// `inSource` and log a warning to make the regression visible.
+func buildSarifSuppressions(ctx context.Context, file *model.VulnerableFile) []sarifSuppression {
 	if file == nil || !file.IsSuppressed {
 		return nil
 	}
 	kind := file.SuppressionKind
 	if kind == "" {
+		contextLogger := logger.FromContext(ctx)
+		contextLogger.Warn().
+			Str("file", file.FileName).
+			Int("line", file.Line).
+			Msg("suppressed VulnerableFile has empty SuppressionKind; defaulting to inSource")
 		kind = model.SuppressionKindInSource
 	}
 	return []sarifSuppression{

--- a/pkg/report/model/sarif_baseline_test.go
+++ b/pkg/report/model/sarif_baseline_test.go
@@ -461,6 +461,43 @@ func TestBuildSarifIssue_Suppressions(t *testing.T) {
 	require.Equal(t, model.SuppressionJustificationIgnoreComment, suppressedResult.Suppressions[0].Justification)
 }
 
+// TestBuildSarifSuppressions_EmptyKindDefaultsToInSource locks in the
+// defensive fallback: if a suppressed VulnerableFile ever reaches the SARIF
+// builder without a SuppressionKind set, we still emit valid SARIF
+// (`inSource`) instead of a schema-invalid empty string. The runtime warning
+// log makes the regression visible without breaking downstream consumers.
+func TestBuildSarifSuppressions_EmptyKindDefaultsToInSource(t *testing.T) {
+	file := &model.VulnerableFile{
+		FileName:                 "no-kind.tf",
+		Line:                     4,
+		IsSuppressed:             true,
+		SuppressionJustification: model.SuppressionJustificationIgnoreComment,
+	}
+
+	suppressions := buildSarifSuppressions(context.Background(), file)
+
+	require.Len(t, suppressions, 1)
+	require.Equal(t, model.SuppressionKindInSource, suppressions[0].Kind)
+	require.Equal(t, sarifSuppressionStatusAccepted, suppressions[0].Status)
+	require.Equal(t, model.SuppressionJustificationIgnoreComment, suppressions[0].Justification)
+}
+
+// TestBuildSarifSuppressions_NonSuppressedReturnsNil ensures that we never
+// attach a `suppressions[]` array to an active finding, regardless of whether
+// stale suppression metadata is set on the VulnerableFile.
+func TestBuildSarifSuppressions_NonSuppressedReturnsNil(t *testing.T) {
+	file := &model.VulnerableFile{
+		FileName:                 "active.tf",
+		Line:                     2,
+		IsSuppressed:             false,
+		SuppressionKind:          model.SuppressionKindInSource,
+		SuppressionJustification: model.SuppressionJustificationIgnoreComment,
+	}
+
+	require.Nil(t, buildSarifSuppressions(context.Background(), file))
+	require.Nil(t, buildSarifSuppressions(context.Background(), nil))
+}
+
 // TestCreateSummary_SuppressedExcludedFromCounters verifies that suppressed
 // files are still listed in the query result but do not inflate severity
 // counters, keeping CLI exit-code semantics unchanged.

--- a/pkg/report/model/sarif_baseline_test.go
+++ b/pkg/report/model/sarif_baseline_test.go
@@ -395,3 +395,118 @@ func TestSarifOutputWithNoFindings(t *testing.T) {
 		require.NotEmpty(t, driver.Properties.Tags)
 	})
 }
+
+// TestBuildSarifIssue_Suppressions verifies that suppressed vulnerable files
+// produce a SARIF `suppressions` entry with kind `inSource` and status
+// `accepted`, while non-suppressed files omit the field entirely.
+func TestBuildSarifIssue_Suppressions(t *testing.T) {
+	ctx := context.Background()
+
+	activeFile := model.VulnerableFile{
+		FileName: "active.tf",
+		Line:     3,
+		ResourceLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 3, Col: 1},
+			End:   model.ResourceLine{Line: 5, Col: 1},
+		},
+	}
+	suppressedFile := model.VulnerableFile{
+		FileName: "suppressed.tf",
+		Line:     7,
+		ResourceLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 7, Col: 1},
+			End:   model.ResourceLine{Line: 9, Col: 1},
+		},
+		IsSuppressed:             true,
+		SuppressionKind:          model.SuppressionKindInSource,
+		SuppressionJustification: model.SuppressionJustificationIgnoreLine,
+	}
+
+	issue := model.QueryResult{
+		QueryName:     "Test Suppression Rule",
+		QueryID:       "test-suppression-rule",
+		Description:   "Rule used to validate SARIF suppressions output",
+		Severity:      model.SeverityHigh,
+		Category:      "Security",
+		Platform:      "Terraform",
+		CloudProvider: "AWS",
+		Files:         []model.VulnerableFile{activeFile, suppressedFile},
+	}
+
+	report := NewSarifReport()
+	_, err := report.BuildSarifIssue(ctx, &issue, model.SCIInfo{})
+	require.NoError(t, err)
+
+	sarif := report.(*sarifReport)
+	require.Len(t, sarif.Runs[0].Results, 2)
+
+	var activeResult, suppressedResult *sarifResult
+	for i := range sarif.Runs[0].Results {
+		result := &sarif.Runs[0].Results[i]
+		switch result.ResultLocations[0].PhysicalLocation.ArtifactLocation.ArtifactURI {
+		case "active.tf":
+			activeResult = result
+		case "suppressed.tf":
+			suppressedResult = result
+		}
+	}
+
+	require.NotNil(t, activeResult, "active finding must be present in SARIF results")
+	require.NotNil(t, suppressedResult, "suppressed finding must be present in SARIF results")
+	require.Empty(t, activeResult.Suppressions,
+		"non-suppressed results must not carry a suppressions array")
+	require.Len(t, suppressedResult.Suppressions, 1)
+	require.Equal(t, model.SuppressionKindInSource, suppressedResult.Suppressions[0].Kind)
+	require.Equal(t, sarifSuppressionStatusAccepted, suppressedResult.Suppressions[0].Status)
+	require.Equal(t, model.SuppressionJustificationIgnoreLine, suppressedResult.Suppressions[0].Justification)
+}
+
+// TestCreateSummary_SuppressedExcludedFromCounters verifies that suppressed
+// files are still listed in the query result but do not inflate severity
+// counters, keeping CLI exit-code semantics unchanged.
+func TestCreateSummary_SuppressedExcludedFromCounters(t *testing.T) {
+	ctx := context.Background()
+
+	vulnerabilities := []model.Vulnerability{
+		{
+			QueryID:       "rule-a",
+			QueryName:     "Rule A",
+			Severity:      model.SeverityHigh,
+			FileName:      "active.tf",
+			SimilarityID:  "sim-active",
+			Line:          1,
+			IsSuppressed:  false,
+			ResourceType:  "aws_s3_bucket",
+			ResourceName:  "active-bucket",
+			VulnerabilityLocation: model.ResourceLocation{
+				Start: model.ResourceLine{Line: 1, Col: 1},
+				End:   model.ResourceLine{Line: 3, Col: 1},
+			},
+		},
+		{
+			QueryID:                  "rule-a",
+			QueryName:                "Rule A",
+			Severity:                 model.SeverityHigh,
+			FileName:                 "suppressed.tf",
+			SimilarityID:             "sim-suppressed",
+			Line:                     5,
+			IsSuppressed:             true,
+			SuppressionKind:          model.SuppressionKindInSource,
+			SuppressionJustification: model.SuppressionJustificationIgnoreLine,
+			ResourceType:             "aws_s3_bucket",
+			ResourceName:             "suppressed-bucket",
+			VulnerabilityLocation: model.ResourceLocation{
+				Start: model.ResourceLine{Line: 5, Col: 1},
+				End:   model.ResourceLine{Line: 7, Col: 1},
+			},
+		},
+	}
+
+	summary := model.CreateSummary(ctx, model.Counters{}, vulnerabilities, "scan-1", nil, ".")
+	require.Len(t, summary.Queries, 1)
+	require.Len(t, summary.Queries[0].Files, 2,
+		"both active and suppressed files must remain in the query result for SARIF emission")
+	require.Equal(t, 1, summary.SeveritySummary.TotalCounter,
+		"only the non-suppressed file must count toward the total")
+	require.Equal(t, 1, summary.SeveritySummary.SeverityCounters[model.SeverityHigh])
+}

--- a/pkg/report/model/sarif_baseline_test.go
+++ b/pkg/report/model/sarif_baseline_test.go
@@ -419,7 +419,7 @@ func TestBuildSarifIssue_Suppressions(t *testing.T) {
 		},
 		IsSuppressed:             true,
 		SuppressionKind:          model.SuppressionKindInSource,
-		SuppressionJustification: model.SuppressionJustificationIgnoreLine,
+		SuppressionJustification: model.SuppressionJustificationIgnoreComment,
 	}
 
 	issue := model.QueryResult{
@@ -458,7 +458,7 @@ func TestBuildSarifIssue_Suppressions(t *testing.T) {
 	require.Len(t, suppressedResult.Suppressions, 1)
 	require.Equal(t, model.SuppressionKindInSource, suppressedResult.Suppressions[0].Kind)
 	require.Equal(t, sarifSuppressionStatusAccepted, suppressedResult.Suppressions[0].Status)
-	require.Equal(t, model.SuppressionJustificationIgnoreLine, suppressedResult.Suppressions[0].Justification)
+	require.Equal(t, model.SuppressionJustificationIgnoreComment, suppressedResult.Suppressions[0].Justification)
 }
 
 // TestCreateSummary_SuppressedExcludedFromCounters verifies that suppressed
@@ -492,7 +492,7 @@ func TestCreateSummary_SuppressedExcludedFromCounters(t *testing.T) {
 			Line:                     5,
 			IsSuppressed:             true,
 			SuppressionKind:          model.SuppressionKindInSource,
-			SuppressionJustification: model.SuppressionJustificationIgnoreLine,
+			SuppressionJustification: model.SuppressionJustificationIgnoreComment,
 			ResourceType:             "aws_s3_bucket",
 			ResourceName:             "suppressed-bucket",
 			VulnerabilityLocation: model.ResourceLocation{

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -163,15 +163,21 @@ func (c *Client) generateMetadata(scanResults *Results, startTime, endTime time.
 }
 
 func (c *Client) generateStats(scanResults *Results, scanDuration time.Duration) ScanStats {
-	// iterate through scanResults and create a map of severity to count
 	violationBreakdowns := make(map[string]map[string]int)
 	severitySet := make(map[model.Severity]bool)
 	for _, sev := range model.AllSeverities {
 		severitySet[sev] = true
 	}
 
+	violations := 0
 	// nolint:gocritic
 	for _, vuln := range scanResults.Results {
+		// Suppressed vulnerabilities are kept in scanResults so they can be
+		// emitted as SARIF `suppressions`, but they must not count toward
+		// metadata stats or per-rule breakdowns that feed CLI exit codes.
+		if vuln.IsSuppressed {
+			continue
+		}
 		if !severitySet[vuln.Severity] {
 			continue
 		}
@@ -181,10 +187,11 @@ func (c *Client) generateStats(scanResults *Results, scanDuration time.Duration)
 		}
 
 		violationBreakdowns[string(vuln.Severity)][vuln.QueryID]++
+		violations++
 	}
 
 	return ScanStats{
-		Violations:          len(scanResults.Results),
+		Violations:          violations,
 		Files:               c.Tracker.FoundFiles,
 		Rules:               c.Tracker.ExecutedQueries,
 		Duration:            scanDuration,

--- a/pkg/scan/post_scan_test.go
+++ b/pkg/scan/post_scan_test.go
@@ -382,6 +382,63 @@ func Test_GetScanMetadata(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Suppressed findings must be carried in the SARIF output but must
+			// not inflate Violations or ViolationBreakdowns (those drive CLI
+			// exit codes and downstream metadata).
+			name: "suppressed vulnerabilities are excluded from stats",
+			tracker: tracker.CITracker{
+				FoundFiles:       1,
+				ExecutedQueries:  1,
+				ExecutingQueries: 1,
+				LoadedQueries:    1,
+			},
+			results: &Results{
+				Files: model.FileMetadatas{
+					&model.FileMetadata{
+						ScanID:            "test",
+						ID:                "test",
+						Kind:              model.KindTerraform,
+						OriginalData:      "",
+						LinesOriginalData: utils.SplitLines(""),
+					},
+				},
+				Results: []model.Vulnerability{
+					{
+						ScanID:    "console",
+						QueryID:   "q-active",
+						QueryName: "Active",
+						Severity:  model.SeverityMedium,
+					},
+					{
+						ScanID:                   "console",
+						QueryID:                  "q-suppressed",
+						QueryName:                "Suppressed",
+						Severity:                 model.SeverityHigh,
+						IsSuppressed:             true,
+						SuppressionKind:          model.SuppressionKindInSource,
+						SuppressionJustification: model.SuppressionJustificationIgnoreComment,
+					},
+				},
+			},
+			scanStartTime: time.Time{},
+			endTime:       time.Time{}.Add(time.Minute),
+			expectedMetadata: ScanMetadata{
+				StartTime:      time.Time{},
+				EndTime:        time.Time{}.Add(time.Minute),
+				CoresAvailable: 1,
+				DiffAware:      false,
+				Stats: ScanStats{
+					Violations: 1,
+					Files:      1,
+					Rules:      1,
+					Duration:   time.Minute,
+					ViolationBreakdowns: map[string]map[string]int{
+						string(model.SeverityMedium): {"q-active": 1},
+					},
+				},
+			},
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
## Motivation

Findings suppressed via `# dd-iac-scan` directives (`disable`, `ignore-line`, `ignore-block`) were dropped before SARIF generation, so downstream consumers could not record them as suppressed-in-code. Static analysis already emits SARIF `suppressions[]` for the same pattern; this change aligns IaC scanner behavior so the existing pipeline can surface the suppressed badge without further scanner-side changes.

## Changes

- Tag suppressed vulnerabilities in the engine instead of dropping them (`IsSuppressed`, `SuppressionKind`, `SuppressionJustification`).
- Propagate suppression metadata through `VulnerableFile` / `CreateSummary`.
- Exclude suppressed files from severity counters (CLI exit codes unchanged).
- Emit SARIF `result.suppressions[]` with `kind: inSource` and `status: accepted` for suppressed findings.
- Add unit tests for engine suppression paths, SARIF emission, and summary counting.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run `go test ./pkg/engine/... ./pkg/report/model/... -count=1`, then scan a fixture that uses `# dd-iac-scan ignore-line` and inspect the SARIF output: the matching `result` should include a `suppressions` array with `kind: "inSource"` and `status: "accepted"`, while non-suppressed results must omit `suppressions`.

## Blast Radius

This PR only changes `datadog-iac-scanner` output. SARIF reports gain `suppressions` entries for previously dropped findings Severity counters and CLI failure semantics stay the same for non-suppressed findings.

## Additional Notes

Downstream consumers already handles `suppressions[]` for IaC tool results.

I submit this contribution under the Apache-2.0 license.


[K9VULN-15194]: https://datadoghq.atlassian.net/browse/K9VULN-15194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ