### PR TITLE
Decouple scanner tests from the deleted rule corpus

### DIFF
--- a/internal/console/helpers/helpers_test.go
+++ b/internal/console/helpers/helpers_test.go
@@ -273,14 +273,11 @@ func TestHelpers_GetDefaultQueryPath(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name:        "test_get_default_query_path",
-			queriesPath: filepath.FromSlash("assets/queries"),
+			name:        "test_get_default_query_path_existing_dir",
+			queriesPath: filepath.FromSlash("assets/libraries"),
 			wantErr:     false,
 		},
 		{
-			// GetDefaultQueryPath should NOT fail for non-existent paths because
-			// queries are embedded in the binary and loaded via assets.GetEmbeddedQueryDirs().
-			// The path is only used for logging/display purposes.
 			name:        "test_get_default_query_path_nonexistent",
 			queriesPath: filepath.FromSlash("nonexistent/path"),
 			wantErr:     false,

--- a/pkg/engine/source/filesystem_test.go
+++ b/pkg/engine/source/filesystem_test.go
@@ -18,48 +18,6 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/test"
 )
 
-// BenchmarkFilesystemSource_GetQueries benchmarks getQueries to see improvements
-func BenchmarkFilesystemSource_GetQueries(b *testing.B) {
-	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
-		b.Fatal(err)
-	}
-	type fields struct {
-		Source              []string
-		Types               []string
-		CloudProviders      []string
-		Library             string
-		ExperimentalQueries bool
-	}
-	tests := []struct {
-		name   string
-		fields fields
-	}{
-		{
-			name: "testing_all_paths",
-			fields: fields{
-				Source:              []string{""},
-				Types:               []string{""},
-				CloudProviders:      []string{""},
-				Library:             "./assets/libraries",
-				ExperimentalQueries: true,
-			},
-		},
-	}
-
-	ctx := context.Background()
-	for _, tt := range tests {
-		b.Run(tt.name, func(b *testing.B) {
-			s := NewFilesystemSource(ctx, tt.fields.Source, tt.fields.Types, tt.fields.CloudProviders, tt.fields.Library, tt.fields.ExperimentalQueries)
-			for n := 0; n < b.N; n++ {
-				filter := QueryInspectorParameters{}
-				if _, err := s.GetQueries(ctx, &filter); err != nil {
-					b.Errorf("Error: %s", err)
-				}
-			}
-		})
-	}
-}
-
 // TestFilesystemSource_GetQueryLibrary tests the functions [GetQueryLibrary()] and all the methods called by them
 func TestFilesystemSource_GetQueryLibrary(t *testing.T) { //nolint
 	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
@@ -382,7 +340,6 @@ func TestFilesystemSource_ReadLocalFile(t *testing.T) {
 	assert.Equal(t, query.Metadata["id"], "wonderful-query")
 }
 
-// Should be uncommented when UUID are moved to LegacyId
 // TestCheckQueryExcludeWithLegacyId tests the checkQueryExclude function with both new ID and legacy ID
 func TestCheckQueryExcludeWithLegacyId(t *testing.T) {
 	ctx := context.Background()
@@ -493,7 +450,6 @@ func TestCheckQueryExcludeWithLegacyId(t *testing.T) {
 	}
 }
 
-// Should be uncommented when UUID are moved to LegacyId
 // TestCheckQueryIncludeWithLegacyId tests the checkQueryInclude function with both new ID and legacy ID
 func TestCheckQueryIncludeWithLegacyId(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/report/model/cyclonedx_test.go
+++ b/pkg/report/model/cyclonedx_test.go
@@ -194,8 +194,8 @@ func TestBuildCycloneDxReport(t *testing.T) {
 	// paths. Keyed on slash form because that's what filepath.ToSlash returns
 	// on both Windows and Unix.
 	mapping := map[string]string{
-		filepath.ToSlash(filepath.Join("assets", "queries", "terraform", "aws", "guardduty_detector_disabled", "test", "positive.tf")): positivePath,
-		filepath.ToSlash(filepath.Join("assets", "queries", "terraform", "aws", "guardduty_detector_disabled", "test", "negative.tf")): negativePath,
+		filepath.ToSlash(filepath.Join("testdata", "guardduty_detector_disabled", "positive.tf")): positivePath,
+		filepath.ToSlash(filepath.Join("testdata", "guardduty_detector_disabled", "negative.tf")): negativePath,
 		filepath.ToSlash(filepath.Join("test", "fixtures", "test_critical_custom_queries", "amazon_mq_broker_encryption_disabled", "test", "positive1.yaml")): criticalPath,
 	}
 

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/internal/storage"
 	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -67,6 +68,8 @@ type Client struct {
 	ExcludeResultsMap map[string]bool
 	Printer           *consolePrinter.Printer
 	FlagEvaluator     featureflags.FlagEvaluator
+	// querySourceFactory overrides createQuerySource; set in tests only.
+	querySourceFactory func(ctx context.Context, platforms []string) (source.QueriesSource, error)
 }
 
 func GetDefaultParameters(ctx context.Context, rootPath string) (*Parameters, context.Context) {

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -115,6 +115,9 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 }
 
 func (c *Client) createQuerySource(ctx context.Context, paramsPlatforms []string) (source.QueriesSource, error) {
+	if c.querySourceFactory != nil {
+		return c.querySourceFactory(ctx, paramsPlatforms)
+	}
 	fss := source.NewFilesystemSource(
 		ctx,
 		c.ScanParams.QueriesPath,

--- a/pkg/scan/scan_test.go
+++ b/pkg/scan/scan_test.go
@@ -13,15 +13,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test_ExecuteScan smoke-tests the live scan path end-to-end and asserts the
-// result is well-shaped. It does NOT pin a specific result count: that count
-// is a function of the rule corpus, not of executeScan itself, and a true
-// rule-independent rewrite needs a `createQuerySource` injection point that
-// `FilesystemSource.GetQueries` does not currently expose.
+// stubQuerySource serves a fixed query slice and a trivial Rego library.
+type stubQuerySource struct {
+	queries []model.QueryMetadata
+}
+
+func (s *stubQuerySource) GetQueries(_ context.Context, _ *source.QueryInspectorParameters) ([]model.QueryMetadata, error) {
+	return s.queries, nil
+}
+
+func (s *stubQuerySource) GetQueryLibrary(_ context.Context, platform string) (source.RegoLibraries, error) {
+	return source.RegoLibraries{
+		LibraryCode:      "package generic." + platform + "\n",
+		LibraryInputData: "{}",
+	}, nil
+}
+
+// Test_ExecuteScan runs the scan pipeline against a synthetic in-memory rule
+// so the assertions are decoupled from the rule corpus.
 func Test_ExecuteScan(t *testing.T) {
+	const ruleID = "test-execute-scan-rule"
+	rego := `package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_s3_bucket[name]
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_s3_bucket",
+		"resourceName": name,
+		"searchKey": sprintf("aws_s3_bucket[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_s3_bucket should be encrypted",
+		"keyActualValue": "aws_s3_bucket is not encrypted",
+	}
+}
+`
+	query := model.QueryMetadata{
+		Query:     ruleID,
+		Content:   rego,
+		InputData: "{}",
+		Platform:  "terraform",
+		Metadata: map[string]interface{}{
+			"id":        ruleID,
+			"legacyId":  ruleID,
+			"queryName": "Synthetic Execute-Scan Rule",
+			"severity":  "HIGH",
+			"platform":  "Terraform",
+			"category":  "Encryption",
+		},
+	}
+
 	scanParams := Parameters{
 		Path:                    []string{filepath.Join("test", "sample.tf")},
-		QueriesPath:             []string{"assets/queries"},
+		QueriesPath:             []string{"."},
 		LibrariesPath:           "assets/libraries",
 		PreviewLines:            3,
 		CloudProvider:           []string{"aws"},
@@ -36,72 +80,21 @@ func Test_ExecuteScan(t *testing.T) {
 
 	ctx := context.Background()
 	c, err := NewClient(ctx, &scanParams, &consolePrinter.Printer{})
-	require.NoError(t, err, "NewClient failed for %s", scanParams.Path[0])
+	require.NoError(t, err)
+	c.querySourceFactory = func(_ context.Context, _ []string) (source.QueriesSource, error) {
+		return &stubQuerySource{queries: []model.QueryMetadata{query}}, nil
+	}
 
 	r, err := c.executeScan(ctx)
-	require.NoError(t, err, "executeScan failed for %s", scanParams.Path[0])
-	require.NotNil(t, r, "executeScan should return a non-nil result")
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	require.NotEmpty(t, r.Results, "expected at least one synthetic violation")
 
-	validSeverities := map[model.Severity]struct{}{
-		model.SeverityCritical: {},
-		model.SeverityHigh:     {},
-		model.SeverityMedium:   {},
-		model.SeverityLow:      {},
-		model.SeverityInfo:     {},
-	}
 	for i, result := range r.Results {
-		_, ok := validSeverities[result.Severity]
-		require.Truef(t, ok, "result[%d] has unexpected severity %q", i, result.Severity)
+		require.Equalf(t, model.Severity("HIGH"), model.Severity(result.Severity), "result[%d] severity", i)
+		require.Equalf(t, ruleID, result.QueryID, "result[%d] query id", i)
 	}
 }
-
-// func Test_GetSecretsRegexRules(t *testing.T) {
-// 	tests := []struct {
-// 		name           string
-// 		scanParams     Parameters
-// 		expectedError  bool
-// 		expectedOutput string
-// 	}{
-// 		{
-// 			name: "default value",
-// 			scanParams: Parameters{
-// 				SecretsRegexesPath: "",
-// 			},
-// 			expectedOutput: assets.SecretsQueryRegexRulesJSON,
-// 			expectedError:  false,
-// 		},
-// 		{
-// 			name: "custom value",
-// 			scanParams: Parameters{
-// 				SecretsRegexesPath: filepath.Join("..", "..", "assets", "queries", "common", "passwords_and_secrets", "regex_rules.json"),
-// 			},
-// 			expectedOutput: assets.SecretsQueryRegexRulesJSON,
-// 			expectedError:  false,
-// 		},
-// 		{
-// 			name: "invalid path value",
-// 			scanParams: Parameters{
-// 				SecretsRegexesPath: filepath.Join("invalid", "path"),
-// 			},
-// 			expectedOutput: "",
-// 			expectedError:  true,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			c := &Client{}
-// 			c.ScanParams = &tt.scanParams
-// 			v, err := getSecretsRegexRules(c.ScanParams.SecretsRegexesPath)
-
-// 			require.Equal(t, tt.expectedOutput, v)
-// 			if tt.expectedError {
-// 				require.Error(t, err)
-// 			} else {
-// 				require.NoError(t, err)
-// 			}
-// 		})
-// 	}
-// }
 
 func Test_CreateQueryFilter(t *testing.T) {
 	tests := []struct {

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -129,7 +129,7 @@ var queryMedium2 = model.QueryResult{
 	Severity:  model.SeverityMedium,
 	Files: []model.VulnerableFile{
 		{
-			FileName:         filepath.Join("assets", "queries", "terraform", "aws", "guardduty_detector_disabled", "test", "positive.tf"),
+			FileName:         filepath.Join("testdata", "guardduty_detector_disabled", "positive.tf"),
 			Line:             2,
 			IssueType:        "IncorrectValue",
 			SearchKey:        "aws_guardduty_detector[positive1].enable",
@@ -150,7 +150,7 @@ var queryInfo = model.QueryResult{
 	Severity:  model.SeverityInfo,
 	Files: []model.VulnerableFile{
 		{
-			FileName:         filepath.Join("assets", "queries", "terraform", "aws", "guardduty_detector_disabled", "test", "negative.tf"),
+			FileName:         filepath.Join("testdata", "guardduty_detector_disabled", "negative.tf"),
 			Line:             1,
 			IssueType:        "MissingAttribute",
 			SearchKey:        "aws_guardduty_detector[{{negative1}}]",
@@ -160,7 +160,7 @@ var queryInfo = model.QueryResult{
 			VulnLines:        &[]model.CodeLine{},
 		},
 		{
-			FileName:         filepath.Join("assets", "queries", "terraform", "aws", "guardduty_detector_disabled", "test", "positive.tf"),
+			FileName:         filepath.Join("testdata", "guardduty_detector_disabled", "positive.tf"),
 			Line:             1,
 			IssueType:        "MissingAttribute",
 			SearchKey:        "aws_guardduty_detector[{{positive1}}]",
@@ -214,7 +214,7 @@ var queryMediumCycloneCWE = model.QueryResult{
 	Severity:  model.SeverityMedium,
 	Files: []model.VulnerableFile{
 		{
-			FileName:         filepath.Join("assets", "queries", "terraform", "aws", "guardduty_detector_disabled", "test", "negative.tf"),
+			FileName:         filepath.Join("testdata", "guardduty_detector_disabled", "negative.tf"),
 			Line:             2,
 			IssueType:        "IncorrectValue",
 			SearchKey:        "aws_guardduty_detector[negative1].enable",


### PR DESCRIPTION
## Summary

Now that `assets/queries/` is gone, a few corners of the test suite were either silently no-op-ing or pointing at paths that no longer exist. This PR is pure test housekeeping:

- **`pkg/scan/scan_test.go::Test_ExecuteScan`**: now exercises the real scan pipeline against a synthetic in-memory rule via a new `Client.querySourceFactory` hook. Previously the test ran with zero rules (because `assets/queries/` was deleted) and asserted nothing meaningful.
- **`internal/console/helpers/helpers_test.go::TestHelpers_GetDefaultQueryPath`**: swap the corpus path for `assets/libraries` (still on disk) and drop a misleading comment about embedded queries.
- **`test/helpers.go` + `pkg/report/model/cyclonedx_test.go`**: replace the mock `FileName` labels under `assets/queries/...` with corpus-neutral `testdata/...` strings. They are just identifiers shared between the two files; nothing reads them from disk.
- **`pkg/engine/source/filesystem_test.go`**: drop `BenchmarkFilesystemSource_GetQueries` (benchmarked the now-empty corpus) and two stale `// Should be uncommented when UUID are moved to LegacyId` comments.

## Test plan

- [ ] `go test ./...`
- [ ] CI green