### PR TITLE
Fix CloudFormation short-form intrinsic tag parsing and resolve resource names from parameter defaults

### DIFF
--- a/assets/libraries/cloudformation.rego
+++ b/assets/libraries/cloudformation.rego
@@ -262,6 +262,27 @@ get_resource_name(resource, resourceDefinitionName) = name {
 	fieldValue != ""
 	name := fieldValue[_]
 } else = name {
+	field := resourceFieldName[resource.Type]
+	template := resource.Properties[field]["Fn::Sub"]
+	is_string(template)
+	params := input.document[_].Parameters
+	replacements := {old: new |
+		some param_name
+		param := params[param_name]
+		is_string(param.Default)
+		old := sprintf("${%s}", [param_name])
+		new := param.Default
+	}
+	resolved := strings.replace_n(replacements, template)
+	not contains(resolved, "${")
+	resolved != ""
+	name := resolved
+} else = name {
+	field := resourceFieldName[resource.Type]
+	ref_name := resource.Properties[field].Ref
+	name := input.document[_].Parameters[ref_name].Default
+	name != ""
+} else = name {
 	name := common_lib.get_tag_name_if_exists(resource)
 } else = name {
 	name := resourceDefinitionName

--- a/assets/libraries/cloudformation.rego
+++ b/assets/libraries/cloudformation.rego
@@ -249,6 +249,85 @@ resourceFieldName = {
 	"AWS::Serverless::Function": "FunctionName",
 }
 
+pseudo_parameter_default_replacements = {
+	"${AWS::AccountId}":   "aws-account-id",
+	"${AWS::NotificationARNs}": "aws-notification-arns",
+	"${AWS::NoValue}":     "aws-no-value",
+	"${AWS::Partition}":   "aws",
+	"${AWS::Region}":      "aws-region",
+	"${AWS::StackId}":     "aws-stack-id",
+	"${AWS::StackName}":   "aws-stack-name",
+	"${AWS::URLSuffix}":   "amazonaws.com",
+}
+
+parameter_default_replacements = replacements {
+	params := input.document[_].Parameters
+	replacements := {old: new |
+		some param_name
+		param := params[param_name]
+		param.Default != null
+		old := sprintf("${%s}", [param_name])
+		new := sprintf("%v", [param.Default])
+	}
+} else = replacements {
+	replacements := {}
+}
+
+sub_template(sub_expr) = template {
+	is_string(sub_expr)
+	template := sub_expr
+} else = template {
+	is_array(sub_expr)
+	count(sub_expr) > 0
+	is_string(sub_expr[0])
+	template := sub_expr[0]
+}
+
+intrinsic_value_to_string(v) = stringified {
+	is_string(v)
+	stringified := v
+} else = stringified {
+	is_number(v)
+	stringified := sprintf("%v", [v])
+} else = stringified {
+	is_boolean(v)
+	stringified := sprintf("%v", [v])
+} else = stringified {
+	common_lib.valid_key(v, "Ref")
+	ref_name := v.Ref
+	stringified := input.document[_].Parameters[ref_name].Default
+	stringified != null
+} else = stringified {
+	common_lib.valid_key(v, "Ref")
+	ref_name := v.Ref
+	old := sprintf("${%s}", [ref_name])
+	stringified := pseudo_parameter_default_replacements[old]
+}
+
+sequence_sub_replacements(sub_expr) = replacements {
+	is_array(sub_expr)
+	count(sub_expr) > 1
+	vars := sub_expr[1]
+	is_object(vars)
+	replacements := {old: new |
+		some var_name
+		raw := vars[var_name]
+		new := intrinsic_value_to_string(raw)
+		old := sprintf("${%s}", [var_name])
+	}
+} else = replacements {
+	replacements := {}
+}
+
+resolve_sub_name(sub_expr) = resolved {
+	template := sub_template(sub_expr)
+	step1 := strings.replace_n(parameter_default_replacements, template)
+	step2 := strings.replace_n(pseudo_parameter_default_replacements, step1)
+	resolved := strings.replace_n(sequence_sub_replacements(sub_expr), step2)
+	not contains(resolved, "${")
+	resolved != ""
+}
+
 get_resource_name(resource, resourceDefinitionName) = name {
 	field := resourceFieldName[resource.Type]
 	fieldValue := resource.Properties[field]
@@ -263,25 +342,19 @@ get_resource_name(resource, resourceDefinitionName) = name {
 	name := fieldValue[_]
 } else = name {
 	field := resourceFieldName[resource.Type]
-	template := resource.Properties[field]["Fn::Sub"]
-	is_string(template)
-	params := input.document[_].Parameters
-	replacements := {old: new |
-		some param_name
-		param := params[param_name]
-		is_string(param.Default)
-		old := sprintf("${%s}", [param_name])
-		new := param.Default
-	}
-	resolved := strings.replace_n(replacements, template)
-	not contains(resolved, "${")
-	resolved != ""
-	name := resolved
+	sub_expr := resource.Properties[field]["Fn::Sub"]
+	name := resolve_sub_name(sub_expr)
 } else = name {
 	field := resourceFieldName[resource.Type]
 	ref_name := resource.Properties[field].Ref
 	name := input.document[_].Parameters[ref_name].Default
+	name != null
 	name != ""
+} else = name {
+	field := resourceFieldName[resource.Type]
+	ref_name := resource.Properties[field].Ref
+	old := sprintf("${%s}", [ref_name])
+	name := pseudo_parameter_default_replacements[old]
 } else = name {
 	name := common_lib.get_tag_name_if_exists(resource)
 } else = name {

--- a/assets/libraries/cloudformation.rego
+++ b/assets/libraries/cloudformation.rego
@@ -273,6 +273,14 @@ parameter_default_replacements = replacements {
 	replacements := {}
 }
 
+# sub_template extracts the template string from an Fn::Sub value.
+# Fn::Sub has two shapes:
+#   - string form:   "my-app-${Env}"
+#   - sequence form: ["my-app-${Env}", {"Env": "prod"}]
+# In the sequence form the first element is the template and the second is a map
+# of explicit variable bindings. When the template head is itself an intrinsic
+# (e.g. {"Fn::If": [...]}) it is not a string, so no template is produced and
+# callers fall back to the logical id.
 sub_template(sub_expr) = template {
 	is_string(sub_expr)
 	template := sub_expr
@@ -295,8 +303,9 @@ intrinsic_value_to_string(v) = stringified {
 } else = stringified {
 	common_lib.valid_key(v, "Ref")
 	ref_name := v.Ref
-	stringified := input.document[_].Parameters[ref_name].Default
-	stringified != null
+	default_val := input.document[_].Parameters[ref_name].Default
+	default_val != null
+	stringified := sprintf("%v", [default_val])
 } else = stringified {
 	common_lib.valid_key(v, "Ref")
 	ref_name := v.Ref
@@ -304,6 +313,10 @@ intrinsic_value_to_string(v) = stringified {
 	stringified := pseudo_parameter_default_replacements[old]
 }
 
+# sequence_sub_replacements builds the {"${Var}": "value"} replacement map from
+# the explicit variable bindings of a sequence-form Fn::Sub, i.e. the second
+# element of ["template", {"Var": value}]. Values may be literals or a Ref to a
+# parameter/pseudo-parameter, resolved via intrinsic_value_to_string.
 sequence_sub_replacements(sub_expr) = replacements {
 	is_array(sub_expr)
 	count(sub_expr) > 1
@@ -319,11 +332,16 @@ sequence_sub_replacements(sub_expr) = replacements {
 	replacements := {}
 }
 
+# resolve_sub_name resolves an Fn::Sub expression to a concrete name.
+# Replacement precedence matches CloudFormation: explicit variable bindings from
+# the sequence form win over template Parameters, which win over pseudo
+# parameters. If any placeholder remains unresolved the rule fails so callers
+# fall back to the logical id rather than leaking a "${...}" string.
 resolve_sub_name(sub_expr) = resolved {
 	template := sub_template(sub_expr)
-	step1 := strings.replace_n(parameter_default_replacements, template)
-	step2 := strings.replace_n(pseudo_parameter_default_replacements, step1)
-	resolved := strings.replace_n(sequence_sub_replacements(sub_expr), step2)
+	step1 := strings.replace_n(sequence_sub_replacements(sub_expr), template)
+	step2 := strings.replace_n(parameter_default_replacements, step1)
+	resolved := strings.replace_n(pseudo_parameter_default_replacements, step2)
 	not contains(resolved, "${")
 	resolved != ""
 }

--- a/assets/libraries/test/cloudformation_test.rego
+++ b/assets/libraries/test/cloudformation_test.rego
@@ -409,11 +409,44 @@ test_get_resource_name_fn_sub_multiple_params {
 	result == "myapp-prod-bucket"
 }
 
-test_get_resource_name_fn_sub_unresolvable_falls_back {
-	# ${AWS::Region} has no parameter default — falls back to logical id
+test_get_resource_name_fn_sub_sequence_form {
 	resource := {
 		"Type": "AWS::S3::Bucket",
-		"Properties": {"BucketName": {"Fn::Sub": "my-bucket-${AWS::Region}"}},
+		"Properties": {"BucketName": {"Fn::Sub": [
+			"${AppName}-${Env}-bucket",
+			{"AppName": "myapp", "Env": "prod"},
+		]}},
+	}
+	result := get_resource_name(resource, "MyBucket") with input.document as [{"Parameters": {}}]
+	result == "myapp-prod-bucket"
+}
+
+test_get_resource_name_fn_sub_sequence_ref_var {
+	resource := {
+		"Type": "AWS::S3::Bucket",
+		"Properties": {"BucketName": {"Fn::Sub": [
+			"${AppName}-${Env}-bucket",
+			{"AppName": "myapp", "Env": {"Ref": "EnvironmentParam"}},
+		]}},
+	}
+	result := get_resource_name(resource, "MyBucket") with input.document as [{"Parameters": {"EnvironmentParam": {"Default": "prod"}}}]
+	result == "myapp-prod-bucket"
+}
+
+test_get_resource_name_fn_sub_with_pseudo_parameters {
+	resource := {
+		"Type": "AWS::S3::Bucket",
+		"Properties": {"BucketName": {"Fn::Sub": "my-bucket-${AWS::Region}-${AWS::AccountId}"}},
+	}
+	result := get_resource_name(resource, "MyBucket") with input.document as [{"Parameters": {}}]
+	result == "my-bucket-aws-region-aws-account-id"
+}
+
+test_get_resource_name_fn_sub_unresolvable_falls_back {
+	# ${UnknownVar} cannot be resolved — falls back to logical id
+	resource := {
+		"Type": "AWS::S3::Bucket",
+		"Properties": {"BucketName": {"Fn::Sub": "my-bucket-${UnknownVar}"}},
 	}
 	result := get_resource_name(resource, "MyBucket") with input.document as [{"Parameters": {}}]
 	result == "MyBucket"
@@ -435,6 +468,15 @@ test_get_resource_name_ref_no_default_falls_back {
 	}
 	result := get_resource_name(resource, "MyBucket") with input.document as [{"Parameters": {"BucketNameParam": {"Type": "String"}}}]
 	result == "MyBucket"
+}
+
+test_get_resource_name_ref_pseudo_parameter {
+	resource := {
+		"Type": "AWS::S3::Bucket",
+		"Properties": {"BucketName": {"Ref": "AWS::Region"}},
+	}
+	result := get_resource_name(resource, "MyBucket") with input.document as [{"Parameters": {}}]
+	result == "aws-region"
 }
 
 # Test get_resource_accessibility function (basic scenarios)

--- a/assets/libraries/test/cloudformation_test.rego
+++ b/assets/libraries/test/cloudformation_test.rego
@@ -479,6 +479,34 @@ test_get_resource_name_ref_pseudo_parameter {
 	result == "aws-region"
 }
 
+# Explicit sequence-form variables take precedence over a same-named parameter
+# default, matching CloudFormation Fn::Sub semantics.
+test_get_resource_name_fn_sub_sequence_overrides_param_default {
+	resource := {
+		"Type": "AWS::S3::Bucket",
+		"Properties": {"BucketName": {"Fn::Sub": [
+			"${Env}-bucket",
+			{"Env": "dev"},
+		]}},
+	}
+	result := get_resource_name(resource, "MyBucket") with input.document as [{"Parameters": {"Env": {"Default": "prod"}}}]
+	result == "dev-bucket"
+}
+
+# A non-string Fn::Sub template head (here a nested Fn::If) cannot be resolved,
+# so resolution fails and get_resource_name falls back to the logical id.
+test_get_resource_name_fn_sub_complex_head_falls_back {
+	resource := {
+		"Type": "AWS::S3::Bucket",
+		"Properties": {"BucketName": {"Fn::Sub": [
+			{"Fn::If": ["UseProd", "prod-bucket", "dev-bucket"]},
+			{"AppName": "myapp", "Env": "prod"},
+		]}},
+	}
+	result := get_resource_name(resource, "MyBucket") with input.document as [{"Parameters": {}}]
+	result == "MyBucket"
+}
+
 # Test get_resource_accessibility function (basic scenarios)
 test_get_resource_accessibility_unknown {
 	# When no matching policy is found, accessibility should be unknown

--- a/assets/libraries/test/cloudformation_test.rego
+++ b/assets/libraries/test/cloudformation_test.rego
@@ -387,6 +387,56 @@ test_has_secret_manager_missing_resource {
 	not hasSecretManager(str, document)
 }
 
+# Test get_resource_name: Fn::Sub resolved against parameter defaults
+test_get_resource_name_fn_sub_single_param {
+	resource := {
+		"Type": "AWS::S3::Bucket",
+		"Properties": {"BucketName": {"Fn::Sub": "my-app-${Env}"}},
+	}
+	result := get_resource_name(resource, "MyBucket") with input.document as [{"Parameters": {"Env": {"Default": "prod"}}}]
+	result == "my-app-prod"
+}
+
+test_get_resource_name_fn_sub_multiple_params {
+	resource := {
+		"Type": "AWS::S3::Bucket",
+		"Properties": {"BucketName": {"Fn::Sub": "${AppName}-${Env}-bucket"}},
+	}
+	result := get_resource_name(resource, "MyBucket") with input.document as [{"Parameters": {
+		"AppName": {"Default": "myapp"},
+		"Env": {"Default": "prod"},
+	}}]
+	result == "myapp-prod-bucket"
+}
+
+test_get_resource_name_fn_sub_unresolvable_falls_back {
+	# ${AWS::Region} has no parameter default — falls back to logical id
+	resource := {
+		"Type": "AWS::S3::Bucket",
+		"Properties": {"BucketName": {"Fn::Sub": "my-bucket-${AWS::Region}"}},
+	}
+	result := get_resource_name(resource, "MyBucket") with input.document as [{"Parameters": {}}]
+	result == "MyBucket"
+}
+
+test_get_resource_name_ref_param_default {
+	resource := {
+		"Type": "AWS::S3::Bucket",
+		"Properties": {"BucketName": {"Ref": "BucketNameParam"}},
+	}
+	result := get_resource_name(resource, "MyBucket") with input.document as [{"Parameters": {"BucketNameParam": {"Default": "my-ref-bucket"}}}]
+	result == "my-ref-bucket"
+}
+
+test_get_resource_name_ref_no_default_falls_back {
+	resource := {
+		"Type": "AWS::S3::Bucket",
+		"Properties": {"BucketName": {"Ref": "BucketNameParam"}},
+	}
+	result := get_resource_name(resource, "MyBucket") with input.document as [{"Parameters": {"BucketNameParam": {"Type": "String"}}}]
+	result == "MyBucket"
+}
+
 # Test get_resource_accessibility function (basic scenarios)
 test_get_resource_accessibility_unknown {
 	# When no matching policy is found, accessibility should be unknown

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -97,6 +97,9 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 		for i := 0; i < len(val.Content); i += 2 {
 			if val.Content[i].Kind == yaml.ScalarNode {
 				if rewritten, ok := rewriteCFNShortFormIntrinsic(ctx, val.Content[i+1], visited, ignore); ok {
+					if m, ok := rewritten.(map[string]interface{}); ok {
+						m["_kics_lines"] = getLines(val.Content[i+1], val.Content[i].Line)
+					}
 					tmp[val.Content[i].Value] = rewritten
 					continue
 				}

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -40,8 +40,42 @@ var cfnShortFormTags = map[string]string{
 	"!ToJsonString": "Fn::ToJsonString",
 }
 
+// cfnContextKey marks a parsing context as belonging to a CloudFormation
+// template, gating short-form intrinsic rewriting to that platform only.
+type cfnContextKey struct{}
+
+func withCloudFormation(ctx context.Context, isCFN bool) context.Context {
+	return context.WithValue(ctx, cfnContextKey{}, isCFN)
+}
+
+func isCloudFormationContext(ctx context.Context) bool {
+	isCFN, _ := ctx.Value(cfnContextKey{}).(bool)
+	return isCFN
+}
+
+// isCloudFormationDocument reports whether the root YAML mapping node looks like
+// a CloudFormation template. Short-form intrinsic tags (!Ref, !Sub, ...) are
+// CloudFormation-specific, so rewriting must never run on Kubernetes, Ansible,
+// or other YAML that happens to use a custom tag.
+func isCloudFormationDocument(value *yaml.Node) bool {
+	if value == nil || value.Kind != yaml.MappingNode {
+		return false
+	}
+	hasResources := false
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		switch value.Content[i].Value {
+		case "AWSTemplateFormatVersion", "Transform":
+			return true
+		case "Resources":
+			hasResources = true
+		}
+	}
+	return hasResources
+}
+
 // UnmarshalYAML is a custom yaml parser that places line information in the payload
 func (m *Document) UnmarshalYAML(ctx context.Context, value *yaml.Node, ignore *Ignore) error {
+	ctx = withCloudFormation(ctx, isCloudFormationDocument(value))
 	dpc := unmarshal(ctx, value, ignore)
 	if mapDcp, ok := dpc.(map[string]interface{}); ok {
 		// set line information for root level objects
@@ -218,8 +252,9 @@ func scalarNodeResolver(ctx context.Context, val *yaml.Node) interface{} {
 }
 
 // rewriteCFNShortFormIntrinsic converts a short-form CFN intrinsic to its long-form map.
+// It is a no-op for documents that are not CloudFormation templates.
 func rewriteCFNShortFormIntrinsic(ctx context.Context, val *yaml.Node, visited map[*yaml.Node]bool, ignore *Ignore) (interface{}, bool) {
-	if val == nil {
+	if val == nil || !isCloudFormationContext(ctx) {
 		return nil, false
 	}
 	longForm, ok := cfnShortFormTags[val.Tag]

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -9,11 +9,36 @@ import (
 	"context"
 	json "encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"gopkg.in/yaml.v3"
 )
+
+// cfnShortFormTags maps CloudFormation short-form intrinsic tags to long-form keys.
+var cfnShortFormTags = map[string]string{
+	"!Ref":          "Ref",
+	"!Sub":          "Fn::Sub",
+	"!GetAtt":       "Fn::GetAtt",
+	"!Join":         "Fn::Join",
+	"!Select":       "Fn::Select",
+	"!Split":        "Fn::Split",
+	"!FindInMap":    "Fn::FindInMap",
+	"!ImportValue":  "Fn::ImportValue",
+	"!Base64":       "Fn::Base64",
+	"!Cidr":         "Fn::Cidr",
+	"!GetAZs":       "Fn::GetAZs",
+	"!If":           "Fn::If",
+	"!And":          "Fn::And",
+	"!Or":           "Fn::Or",
+	"!Not":          "Fn::Not",
+	"!Equals":       "Fn::Equals",
+	"!Condition":    "Condition",
+	"!Transform":    "Fn::Transform",
+	"!Length":       "Fn::Length",
+	"!ToJsonString": "Fn::ToJsonString",
+}
 
 // UnmarshalYAML is a custom yaml parser that places line information in the payload
 func (m *Document) UnmarshalYAML(ctx context.Context, value *yaml.Node, ignore *Ignore) error {
@@ -71,6 +96,10 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 		// iterate two by two, since first iteration is the key and the second is the value
 		for i := 0; i < len(val.Content); i += 2 {
 			if val.Content[i].Kind == yaml.ScalarNode {
+				if rewritten, ok := rewriteCFNShortFormIntrinsic(ctx, val.Content[i+1], visited, ignore); ok {
+					tmp[val.Content[i].Value] = rewritten
+					continue
+				}
 				switch val.Content[i+1].Kind {
 				case yaml.ScalarNode:
 					tmp[val.Content[i].Value] = scalarNodeResolver(ctx, val.Content[i+1])
@@ -173,6 +202,9 @@ func getSeqLines(val *yaml.Node, def int) map[string]*LineObject {
 
 // scalarNodeResolver transforms a ScalarNode value in its correct type
 func scalarNodeResolver(ctx context.Context, val *yaml.Node) interface{} {
+	if rewritten, ok := rewriteCFNShortFormIntrinsic(ctx, val, nil, nil); ok {
+		return rewritten
+	}
 	contextLogger := logger.FromContext(ctx)
 	var resolved interface{}
 	if err := val.Decode(&resolved); err != nil {
@@ -180,4 +212,68 @@ func scalarNodeResolver(ctx context.Context, val *yaml.Node) interface{} {
 		return val.Value
 	}
 	return resolved
+}
+
+// rewriteCFNShortFormIntrinsic converts a short-form CFN intrinsic to its long-form map.
+func rewriteCFNShortFormIntrinsic(ctx context.Context, val *yaml.Node, visited map[*yaml.Node]bool, ignore *Ignore) (interface{}, bool) {
+	if val == nil {
+		return nil, false
+	}
+	longForm, ok := cfnShortFormTags[val.Tag]
+	if !ok {
+		return nil, false
+	}
+
+	switch val.Kind {
+	case yaml.ScalarNode:
+		var payload interface{} = val.Value
+		if longForm == "Fn::GetAtt" {
+			parts := strings.SplitN(val.Value, ".", 2)
+			converted := make([]interface{}, 0, len(parts))
+			for _, p := range parts {
+				converted = append(converted, p)
+			}
+			payload = converted
+		}
+		return map[string]interface{}{longForm: payload}, true
+	case yaml.SequenceNode:
+		seq := make([]interface{}, 0, len(val.Content))
+		for _, child := range val.Content {
+			seq = append(seq, decodeIntrinsicChild(ctx, child, visited, ignore))
+		}
+		return map[string]interface{}{longForm: seq}, true
+	case yaml.MappingNode:
+		v := visited
+		if v == nil {
+			v = make(map[*yaml.Node]bool)
+		}
+		return map[string]interface{}{longForm: unmarshalWithDepth(ctx, val, v, ignore)}, true
+	}
+	return nil, false
+}
+
+func decodeIntrinsicChild(ctx context.Context, val *yaml.Node, visited map[*yaml.Node]bool, ignore *Ignore) interface{} {
+	if val == nil {
+		return nil
+	}
+	if rewritten, ok := rewriteCFNShortFormIntrinsic(ctx, val, visited, ignore); ok {
+		return rewritten
+	}
+	v := visited
+	if v == nil {
+		v = make(map[*yaml.Node]bool)
+	}
+	switch val.Kind {
+	case yaml.ScalarNode:
+		return scalarNodeResolver(ctx, val)
+	case yaml.MappingNode:
+		return unmarshalWithDepth(ctx, val, v, ignore)
+	case yaml.SequenceNode:
+		seq := make([]interface{}, 0, len(val.Content))
+		for _, child := range val.Content {
+			seq = append(seq, decodeIntrinsicChild(ctx, child, v, ignore))
+		}
+		return seq
+	}
+	return nil
 }

--- a/pkg/model/model_yaml_test.go
+++ b/pkg/model/model_yaml_test.go
@@ -737,6 +737,38 @@ func TestDocument_UnmarshalYAML_CloudFormationShortFormIntrinsics(t *testing.T) 
 	}
 }
 
+// TestDocument_UnmarshalYAML_CFNIntrinsicLineMetadata verifies that rewritten
+// short-form intrinsics carry _kics_lines metadata on the wrapper map,
+// matching what long-form mapping values produce.
+func TestDocument_UnmarshalYAML_CFNIntrinsicLineMetadata(t *testing.T) {
+	ctx := context.Background()
+
+	src := []byte(`Resources:
+  MyBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub my-app-${Env}
+`)
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal(src, &root))
+	require.Equal(t, yaml.DocumentNode, root.Kind)
+
+	doc := &Document{}
+	require.NoError(t, doc.UnmarshalYAML(ctx, root.Content[0], nil))
+
+	raw, err := json.Marshal(doc)
+	require.NoError(t, err)
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+
+	// Walk to BucketName without stripping _kics_lines
+	bucketName := parsed["Resources"].(map[string]interface{})["MyBucket"].(map[string]interface{})["Properties"].(map[string]interface{})["BucketName"]
+	m, ok := bucketName.(map[string]interface{})
+	require.True(t, ok, "BucketName should be a map after rewrite")
+	require.Contains(t, m, "Fn::Sub", "rewritten map should have Fn::Sub key")
+	require.Contains(t, m, "_kics_lines", "rewritten map should carry _kics_lines")
+}
+
 func walkJSONPath(t *testing.T, root interface{}, path []string) interface{} {
 	t.Helper()
 	cur := root

--- a/pkg/model/model_yaml_test.go
+++ b/pkg/model/model_yaml_test.go
@@ -769,6 +769,68 @@ func TestDocument_UnmarshalYAML_CFNIntrinsicLineMetadata(t *testing.T) {
 	require.Contains(t, m, "_kics_lines", "rewritten map should carry _kics_lines")
 }
 
+// TestDocument_UnmarshalYAML_ShortFormIntrinsicNonCloudFormation verifies that
+// short-form intrinsic rewriting only applies to CloudFormation templates. A
+// document without CloudFormation markers (no Resources / Transform /
+// AWSTemplateFormatVersion) must keep custom-tagged scalars untouched.
+func TestDocument_UnmarshalYAML_ShortFormIntrinsicNonCloudFormation(t *testing.T) {
+	ctx := context.Background()
+
+	src := []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+data:
+  value: !Ref SomeKey
+`)
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal(src, &root))
+	require.Equal(t, yaml.DocumentNode, root.Kind)
+
+	doc := &Document{}
+	require.NoError(t, doc.UnmarshalYAML(ctx, root.Content[0], nil))
+
+	raw, err := json.Marshal(doc)
+	require.NoError(t, err)
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+
+	value := parsed["data"].(map[string]interface{})["value"]
+	_, isMap := value.(map[string]interface{})
+	require.False(t, isMap, "non-CloudFormation document must not rewrite !Ref into a map")
+}
+
+// TestDocument_UnmarshalYAML_ShortFormIntrinsicDetectedByTransform verifies that
+// a template identified only by a Transform declaration still gets short-form
+// intrinsic rewriting.
+func TestDocument_UnmarshalYAML_ShortFormIntrinsicDetectedByTransform(t *testing.T) {
+	ctx := context.Background()
+
+	src := []byte(`Transform: AWS::Serverless-2016-10-31
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref OwnerParameter
+`)
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal(src, &root))
+	require.Equal(t, yaml.DocumentNode, root.Kind)
+
+	doc := &Document{}
+	require.NoError(t, doc.UnmarshalYAML(ctx, root.Content[0], nil))
+
+	raw, err := json.Marshal(doc)
+	require.NoError(t, err)
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+
+	bucketName := parsed["Resources"].(map[string]interface{})["Bucket"].(map[string]interface{})["Properties"].(map[string]interface{})["BucketName"]
+	m, ok := bucketName.(map[string]interface{})
+	require.True(t, ok, "CloudFormation document should rewrite !Ref into a map")
+	require.Equal(t, "OwnerParameter", m["Ref"])
+}
+
 func walkJSONPath(t *testing.T, root interface{}, path []string) interface{} {
 	t.Helper()
 	cur := root

--- a/pkg/model/model_yaml_test.go
+++ b/pkg/model/model_yaml_test.go
@@ -622,6 +622,164 @@ func TestDocument_UnmarshalYAML_CircularReference(t *testing.T) {
 	})
 }
 
+func TestDocument_UnmarshalYAML_CloudFormationShortFormIntrinsics(t *testing.T) {
+	ctx := context.Background()
+
+	type cfnCase struct {
+		name     string
+		yaml     string
+		jsonPath []string
+		want     interface{}
+	}
+
+	cases := []cfnCase{
+		{
+			name: "scalar !Sub",
+			yaml: `Resources:
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub my-app-bucket-${Owner}
+`,
+			jsonPath: []string{"Resources", "S3Bucket", "Properties", "BucketName"},
+			want:     map[string]interface{}{"Fn::Sub": "my-app-bucket-${Owner}"},
+		},
+		{
+			name: "scalar !Ref",
+			yaml: `Resources:
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref OwnerParameter
+`,
+			jsonPath: []string{"Resources", "S3Bucket", "Properties", "BucketName"},
+			want:     map[string]interface{}{"Ref": "OwnerParameter"},
+		},
+		{
+			name: "dotted scalar !GetAtt",
+			yaml: `Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !GetAtt OtherBucket.Arn
+`,
+			jsonPath: []string{"Resources", "Bucket", "Properties", "BucketName"},
+			want:     map[string]interface{}{"Fn::GetAtt": []interface{}{"OtherBucket", "Arn"}},
+		},
+		{
+			name: "sequence !Sub with map of variables",
+			yaml: `Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub
+        - "my-app-bucket-${Env}"
+        - Env: "prod"
+`,
+			jsonPath: []string{"Resources", "Bucket", "Properties", "BucketName"},
+			want: map[string]interface{}{"Fn::Sub": []interface{}{
+				"my-app-bucket-${Env}",
+				map[string]interface{}{"Env": "prod"},
+			}},
+		},
+		{
+			name: "sequence !Join",
+			yaml: `Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Join ["-", ["my-app", "prod"]]
+`,
+			jsonPath: []string{"Resources", "Bucket", "Properties", "BucketName"},
+			want: map[string]interface{}{"Fn::Join": []interface{}{
+				"-",
+				[]interface{}{"my-app", "prod"},
+			}},
+		},
+		{
+			name: "scalar in sequence keeps short-form rewrite",
+			yaml: `Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags:
+        - Key: Owner
+          Value: !Ref OwnerParameter
+`,
+			jsonPath: []string{"Resources", "Bucket", "Properties", "Tags"},
+			want: []interface{}{
+				map[string]interface{}{
+					"Key":   "Owner",
+					"Value": map[string]interface{}{"Ref": "OwnerParameter"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var root yaml.Node
+			require.NoError(t, yaml.Unmarshal([]byte(tc.yaml), &root))
+			require.Equal(t, yaml.DocumentNode, root.Kind)
+			require.Len(t, root.Content, 1)
+
+			doc := &Document{}
+			require.NoError(t, doc.UnmarshalYAML(ctx, root.Content[0], nil))
+
+			raw, err := json.Marshal(doc)
+			require.NoError(t, err)
+			var parsed map[string]interface{}
+			require.NoError(t, json.Unmarshal(raw, &parsed))
+
+			got := walkJSONPath(t, parsed, tc.jsonPath)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func walkJSONPath(t *testing.T, root interface{}, path []string) interface{} {
+	t.Helper()
+	cur := root
+	for _, key := range path {
+		m, ok := cur.(map[string]interface{})
+		require.Truef(t, ok, "expected map at path segment %q, got %T", key, cur)
+		next, exists := m[key]
+		require.Truef(t, exists, "missing key %q at path; available keys: %v", key, keysOf(m))
+		cur = next
+	}
+	return stripKicsLines(cur)
+}
+
+func keysOf(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func stripKicsLines(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(t))
+		for k, val := range t {
+			if k == "_kics_lines" {
+				continue
+			}
+			out[k] = stripKicsLines(val)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(t))
+		for i, val := range t {
+			out[i] = stripKicsLines(val)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
 // TestDocument_UnmarshalYAML_FromBytes verifies that parsing real YAML bytes (hex, octal, etc.)
 // produces the correct numeric values via the full node pipeline (decoder sets Tag/Value, then we resolve).
 func TestDocument_UnmarshalYAML_FromBytes(t *testing.T) {


### PR DESCRIPTION
## Summary

- Rewrites CloudFormation short-form intrinsic tags (`!Sub`, `!Ref`, `!GetAtt`, `!Join`, and others) into their canonical long-form map representation in the YAML parser (`pkg/model/model_yaml.go`) so custom tags are preserved instead of being flattened into raw strings.
- Ensures rewritten short-form intrinsic maps also carry `_kics_lines` metadata, matching long-form map behavior for line attribution.
- Extends `get_resource_name` in `assets/libraries/cloudformation.rego` to resolve CloudFormation intrinsic name fields from:
  - scalar `Fn::Sub`
  - sequence-form `Fn::Sub` (`[template, vars]`)
  - `Ref`
  - CloudFormation pseudo-parameters (`AWS::Region`, `AWS::AccountId`, etc.)

## Behavior change

| Template syntax | Before | After |
|---|---|---|
| `BucketName: my-literal-bucket` | `my-literal-bucket` | `my-literal-bucket` |
| `BucketName: !Sub my-app-${Env}` with `Env` default `prod` | `my-app-${Env}` | `my-app-prod` |
| `BucketName: !Sub ["${App}-${Env}", {App: myapp, Env: prod}]` | `S3Bucket` (logical id fallback) | `myapp-prod` |
| `BucketName: !Sub my-app-${AWS::Region}-${AWS::AccountId}` | logical id fallback | `my-app-aws-region-aws-account-id` |
| `BucketName: !Ref BucketParam` with default `my-bucket` | logical id fallback | `my-bucket` |
| `BucketName: !Ref AWS::Region` | logical id fallback | `aws-region` |

## Notes

- `Fn::Sub` name resolution only returns when all placeholders are resolved; unresolved `${...}` still falls back to tag name/logical id.
- For pseudo-parameters we resolve to deterministic placeholders (`aws-region`, `aws-account-id`, etc.) so names stay stable and readable without requiring runtime stack context.

## Test plan

- [x] `go test ./pkg/model/...` (short-form intrinsic parser tests, including `_kics_lines` parity test)
- [x] `opa test assets/libraries/cloudformation.rego assets/libraries/common.rego assets/libraries/test/cloudformation_test.rego --v0-compatible` (69/69 pass, including new sequence-form/pseudo-parameter cases)
- [x] `go test ./e2e/...`
- [x] `golangci-lint run -c .golangci.yml --timeout 20m`
- [x] Local scan of a CloudFormation template with `BucketName: !Sub my-app-${Env}` and `Owner` default `prod` reports `IAC_RESOURCE_NAME:my-app-prod`