### PR TITLE
Expand CloudFormation Fn::ForEach resources for truthful resource names

### DIFF
--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	json "encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
@@ -78,6 +79,7 @@ func (m *Document) UnmarshalYAML(ctx context.Context, value *yaml.Node, ignore *
 	ctx = withCloudFormation(ctx, isCloudFormationDocument(value))
 	dpc := unmarshal(ctx, value, ignore)
 	if mapDcp, ok := dpc.(map[string]interface{}); ok {
+		expandCloudFormationForEach(mapDcp)
 		// set line information for root level objects
 		mapDcp["_kics_lines"] = getLines(value, 0)
 
@@ -87,6 +89,205 @@ func (m *Document) UnmarshalYAML(ctx context.Context, value *yaml.Node, ignore *
 		return nil
 	}
 	return errors.New("failed to parse yaml content")
+}
+
+func expandCloudFormationForEach(doc map[string]interface{}) {
+	if !hasLanguageExtensionsTransform(doc) {
+		return
+	}
+	resourcesRaw, ok := doc["Resources"]
+	if !ok {
+		return
+	}
+	resources, ok := resourcesRaw.(map[string]interface{})
+	if !ok {
+		return
+	}
+	parameters, _ := doc["Parameters"].(map[string]interface{})
+
+	for {
+		forEachKeys := collectForEachKeys(resources)
+		if len(forEachKeys) == 0 {
+			break
+		}
+
+		anyExpanded := false
+		for _, key := range forEachKeys {
+			spec, ok := resources[key].([]interface{})
+			if !ok || len(spec) != 3 {
+				continue
+			}
+			varName, ok := spec[0].(string)
+			if !ok || varName == "" {
+				continue
+			}
+			collection, ok := resolveForEachCollection(spec[1], parameters)
+			if !ok || len(collection) == 0 {
+				continue
+			}
+			templateMap, ok := spec[2].(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			for _, item := range collection {
+				bindings := map[string]string{varName: item}
+				for logicalID, resourceValue := range templateMap {
+					resolvedLogicalID := replaceForEachVars(logicalID, bindings)
+					if _, exists := resources[resolvedLogicalID]; !exists {
+						resources[resolvedLogicalID] = substituteForEachBindings(resourceValue, bindings)
+						copyForEachLineInfo(resources, key, resolvedLogicalID)
+					}
+				}
+			}
+			delete(resources, key)
+			removeForEachLineInfo(resources, key)
+			anyExpanded = true
+		}
+
+		if !anyExpanded {
+			break
+		}
+	}
+}
+
+func collectForEachKeys(resources map[string]interface{}) []string {
+	keys := []string{}
+	for key := range resources {
+		if strings.HasPrefix(key, "Fn::ForEach::") {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+// hasLanguageExtensionsTransform reports whether the document declares the
+// AWS::LanguageExtensions transform, which is required for Fn::ForEach to be
+// valid CloudFormation syntax.
+func hasLanguageExtensionsTransform(doc map[string]interface{}) bool {
+	const ext = "AWS::LanguageExtensions"
+	switch t := doc["Transform"].(type) {
+	case string:
+		return t == ext
+	case []interface{}:
+		for _, v := range t {
+			if s, ok := v.(string); ok && s == ext {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func resolveForEachCollection(expr interface{}, parameters map[string]interface{}) ([]string, bool) {
+	switch v := expr.(type) {
+	case []interface{}:
+		return normalizeForEachDefault(v), true
+	case map[string]interface{}:
+		refName, ok := v["Ref"].(string)
+		if !ok || refName == "" {
+			return nil, false
+		}
+		param, ok := parameters[refName].(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		defaultValue, ok := param["Default"]
+		if !ok {
+			return nil, false
+		}
+		return normalizeForEachDefault(defaultValue), true
+	default:
+		return nil, false
+	}
+}
+
+func normalizeForEachDefault(v interface{}) []string {
+	switch t := v.(type) {
+	case []interface{}:
+		out := make([]string, 0, len(t))
+		for _, item := range t {
+			out = append(out, fmt.Sprintf("%v", item))
+		}
+		return out
+	case string:
+		parts := strings.Split(t, ",")
+		out := make([]string, 0, len(parts))
+		for _, part := range parts {
+			trimmed := strings.TrimSpace(part)
+			if trimmed == "" {
+				continue
+			}
+			out = append(out, trimmed)
+		}
+		return out
+	default:
+		return []string{fmt.Sprintf("%v", t)}
+	}
+}
+
+func substituteForEachBindings(v interface{}, bindings map[string]string) interface{} {
+	switch t := v.(type) {
+	case string:
+		return replaceForEachVars(t, bindings)
+	case []interface{}:
+		out := make([]interface{}, len(t))
+		for i := range t {
+			out[i] = substituteForEachBindings(t[i], bindings)
+		}
+		return out
+	case map[string]interface{}:
+		if ref, ok := t["Ref"].(string); ok && isPureRefNode(t) {
+			if resolved, exists := bindings[ref]; exists {
+				return resolved
+			}
+		}
+		out := make(map[string]interface{}, len(t))
+		for key, val := range t {
+			out[replaceForEachVars(key, bindings)] = substituteForEachBindings(val, bindings)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func isPureRefNode(m map[string]interface{}) bool {
+	for k := range m {
+		if k != "Ref" && k != "_kics_lines" {
+			return false
+		}
+	}
+	return true
+}
+
+func replaceForEachVars(template string, bindings map[string]string) string {
+	resolved := template
+	for name, value := range bindings {
+		resolved = strings.ReplaceAll(resolved, "${"+name+"}", value)
+		resolved = strings.ReplaceAll(resolved, "&{"+name+"}", value)
+	}
+	return resolved
+}
+
+func copyForEachLineInfo(resources map[string]interface{}, foreachKey, resourceKey string) {
+	lines, ok := resources["_kics_lines"].(map[string]*LineObject)
+	if !ok {
+		return
+	}
+	source, ok := lines["_kics_"+foreachKey]
+	if !ok {
+		return
+	}
+	lines["_kics_"+resourceKey] = source
+}
+
+func removeForEachLineInfo(resources map[string]interface{}, foreachKey string) {
+	lines, ok := resources["_kics_lines"].(map[string]*LineObject)
+	if !ok {
+		return
+	}
+	delete(lines, "_kics_"+foreachKey)
 }
 
 /*

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -79,7 +79,9 @@ func (m *Document) UnmarshalYAML(ctx context.Context, value *yaml.Node, ignore *
 	ctx = withCloudFormation(ctx, isCloudFormationDocument(value))
 	dpc := unmarshal(ctx, value, ignore)
 	if mapDcp, ok := dpc.(map[string]interface{}); ok {
-		expandCloudFormationForEach(mapDcp)
+		if isCloudFormationContext(ctx) {
+			expandCloudFormationForEach(mapDcp)
+		}
 		// set line information for root level objects
 		mapDcp["_kics_lines"] = getLines(value, 0)
 
@@ -92,63 +94,85 @@ func (m *Document) UnmarshalYAML(ctx context.Context, value *yaml.Node, ignore *
 }
 
 func expandCloudFormationForEach(doc map[string]interface{}) {
-	if !hasLanguageExtensionsTransform(doc) {
+	resources, parameters := forEachExpansionContext(doc)
+	if resources == nil {
 		return
 	}
-	resourcesRaw, ok := doc["Resources"]
-	if !ok {
-		return
-	}
-	resources, ok := resourcesRaw.(map[string]interface{})
-	if !ok {
-		return
-	}
-	parameters, _ := doc["Parameters"].(map[string]interface{})
-
 	for {
 		forEachKeys := collectForEachKeys(resources)
 		if len(forEachKeys) == 0 {
 			break
 		}
-
 		anyExpanded := false
 		for _, key := range forEachKeys {
-			spec, ok := resources[key].([]interface{})
-			if !ok || len(spec) != 3 {
-				continue
+			if expandForEachEntry(resources, key, parameters) {
+				anyExpanded = true
 			}
-			varName, ok := spec[0].(string)
-			if !ok || varName == "" {
-				continue
-			}
-			collection, ok := resolveForEachCollection(spec[1], parameters)
-			if !ok || len(collection) == 0 {
-				continue
-			}
-			templateMap, ok := spec[2].(map[string]interface{})
-			if !ok {
-				continue
-			}
-
-			for _, item := range collection {
-				bindings := map[string]string{varName: item}
-				for logicalID, resourceValue := range templateMap {
-					resolvedLogicalID := replaceForEachVars(logicalID, bindings)
-					if _, exists := resources[resolvedLogicalID]; !exists {
-						resources[resolvedLogicalID] = substituteForEachBindings(resourceValue, bindings)
-						copyForEachLineInfo(resources, key, resolvedLogicalID)
-					}
-				}
-			}
-			delete(resources, key)
-			removeForEachLineInfo(resources, key)
-			anyExpanded = true
 		}
-
 		if !anyExpanded {
 			break
 		}
 	}
+}
+
+func forEachExpansionContext(doc map[string]interface{}) (resources, parameters map[string]interface{}) {
+	if !hasLanguageExtensionsTransform(doc) {
+		return nil, nil
+	}
+	resourcesRaw, ok := doc["Resources"]
+	if !ok {
+		return nil, nil
+	}
+	resources, ok = resourcesRaw.(map[string]interface{})
+	if !ok {
+		return nil, nil
+	}
+	parameters, _ = doc["Parameters"].(map[string]interface{})
+	return resources, parameters
+}
+
+func expandForEachEntry(resources map[string]interface{}, key string, parameters map[string]interface{}) bool {
+	varName, collection, templateMap, ok := parseForEachSpec(resources[key], parameters)
+	if !ok {
+		return false
+	}
+	for _, item := range collection {
+		bindings := map[string]string{varName: item}
+		for logicalID, resourceValue := range templateMap {
+			resolvedLogicalID := replaceForEachVars(logicalID, bindings)
+			if _, exists := resources[resolvedLogicalID]; !exists {
+				resources[resolvedLogicalID] = substituteForEachBindings(resourceValue, bindings)
+				copyForEachLineInfo(resources, key, resolvedLogicalID)
+			}
+		}
+	}
+	delete(resources, key)
+	removeForEachLineInfo(resources, key)
+	return true
+}
+
+func parseForEachSpec(
+	raw interface{},
+	parameters map[string]interface{},
+) (varName string, collection []string, templateMap map[string]interface{}, ok bool) {
+	// spec is [loopVarName string, collection expr, templateMap]
+	spec, ok := raw.([]interface{})
+	if !ok || len(spec) != 3 {
+		return "", nil, nil, false
+	}
+	varName, ok = spec[0].(string)
+	if !ok || varName == "" {
+		return "", nil, nil, false
+	}
+	collection, ok = resolveForEachCollection(spec[1], parameters)
+	if !ok || len(collection) == 0 {
+		return "", nil, nil, false
+	}
+	templateMap, ok = spec[2].(map[string]interface{})
+	if !ok {
+		return "", nil, nil, false
+	}
+	return varName, collection, templateMap, true
 }
 
 func collectForEachKeys(resources map[string]interface{}) []string {

--- a/pkg/model/model_yaml_test.go
+++ b/pkg/model/model_yaml_test.go
@@ -8,6 +8,7 @@ package model
 import (
 	"context"
 	json "encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -829,6 +830,267 @@ Resources:
 	m, ok := bucketName.(map[string]interface{})
 	require.True(t, ok, "CloudFormation document should rewrite !Ref into a map")
 	require.Equal(t, "OwnerParameter", m["Ref"])
+}
+
+func TestDocument_UnmarshalYAML_CloudFormationForEachExpansion(t *testing.T) {
+	ctx := context.Background()
+
+	src := []byte(`Transform: AWS::LanguageExtensions
+Parameters:
+  Instances:
+    Type: List<Number>
+    Default: "0,1"
+Resources:
+  Fn::ForEach::RDSInstances:
+    - Identifier
+    - !Ref Instances
+    - RDSInstance${Identifier}:
+        Type: AWS::RDS::DBInstance
+        Properties:
+          DBName: !Sub app_${Identifier}
+          Tags:
+            - Key: logical
+              Value: !Ref Identifier
+`)
+
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal(src, &root))
+	require.Equal(t, yaml.DocumentNode, root.Kind)
+	require.Len(t, root.Content, 1)
+
+	doc := &Document{}
+	require.NoError(t, doc.UnmarshalYAML(ctx, root.Content[0], nil))
+
+	raw, err := json.Marshal(doc)
+	require.NoError(t, err)
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+
+	resources := parsed["Resources"].(map[string]interface{})
+	require.Contains(t, resources, "RDSInstance0")
+	require.Contains(t, resources, "RDSInstance1")
+	require.NotContains(t, resources, "Fn::ForEach::RDSInstances")
+
+	rds0 := resources["RDSInstance0"].(map[string]interface{})
+	props0 := rds0["Properties"].(map[string]interface{})
+	require.Equal(t, map[string]interface{}{"Fn::Sub": "app_0"}, stripKicsLines(props0["DBName"]))
+	tags0 := props0["Tags"].([]interface{})
+	require.Equal(t, map[string]interface{}{
+		"Key":   "logical",
+		"Value": "0",
+	}, stripKicsLines(tags0[0]))
+
+	rds1 := resources["RDSInstance1"].(map[string]interface{})
+	props1 := rds1["Properties"].(map[string]interface{})
+	require.Equal(t, map[string]interface{}{"Fn::Sub": "app_1"}, stripKicsLines(props1["DBName"]))
+	tags1 := props1["Tags"].([]interface{})
+	require.Equal(t, map[string]interface{}{
+		"Key":   "logical",
+		"Value": "1",
+	}, stripKicsLines(tags1[0]))
+}
+
+func TestDocument_UnmarshalYAML_CloudFormationForEachNoTransform(t *testing.T) {
+	ctx := context.Background()
+
+	// Without Transform: AWS::LanguageExtensions, Fn::ForEach keys must not be expanded.
+	src := []byte(`Resources:
+  Fn::ForEach::RDSInstances:
+    - Identifier
+    - ["0"]
+    - RDSInstance${Identifier}:
+        Type: AWS::RDS::DBInstance
+`)
+
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal(src, &root))
+	require.Len(t, root.Content, 1)
+
+	doc := &Document{}
+	require.NoError(t, doc.UnmarshalYAML(ctx, root.Content[0], nil))
+
+	raw, err := json.Marshal(doc)
+	require.NoError(t, err)
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+
+	resources := parsed["Resources"].(map[string]interface{})
+	require.Contains(t, resources, "Fn::ForEach::RDSInstances")
+	require.NotContains(t, resources, "RDSInstance0")
+}
+
+func TestDocument_UnmarshalYAML_CloudFormationForEachLineMetadata(t *testing.T) {
+	ctx := context.Background()
+
+	src := []byte(`Transform: AWS::LanguageExtensions
+Parameters:
+  Instances:
+    Type: CommaDelimitedList
+    Default: "0"
+Resources:
+  Fn::ForEach::RDSInstances:
+    - Identifier
+    - !Ref Instances
+    - RDSInstance${Identifier}:
+        Type: AWS::RDS::DBInstance
+`)
+
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal(src, &root))
+	require.Len(t, root.Content, 1)
+
+	doc := &Document{}
+	require.NoError(t, doc.UnmarshalYAML(ctx, root.Content[0], nil))
+
+	raw, err := json.Marshal(doc)
+	require.NoError(t, err)
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+
+	resources := parsed["Resources"].(map[string]interface{})
+	resourceLines := resources["_kics_lines"].(map[string]interface{})
+
+	// Expanded resource inherits line info from the ForEach key.
+	require.Contains(t, resourceLines, "_kics_RDSInstance0")
+	// Stale ForEach entry is removed.
+	require.NotContains(t, resourceLines, "_kics_Fn::ForEach::RDSInstances")
+}
+
+func TestDocument_UnmarshalYAML_CloudFormationForEachDuplicateID(t *testing.T) {
+	ctx := context.Background()
+
+	// Duplicate collection items ("0,0") must not silently overwrite an already-expanded resource.
+	src := []byte(`Transform: AWS::LanguageExtensions
+Parameters:
+  Instances:
+    Type: CommaDelimitedList
+    Default: "0,0"
+Resources:
+  Fn::ForEach::RDSInstances:
+    - Identifier
+    - !Ref Instances
+    - RDSInstance${Identifier}:
+        Type: AWS::RDS::DBInstance
+        Properties:
+          DBName: instance-${Identifier}
+`)
+
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal(src, &root))
+	require.Len(t, root.Content, 1)
+
+	doc := &Document{}
+	require.NoError(t, doc.UnmarshalYAML(ctx, root.Content[0], nil))
+
+	raw, err := json.Marshal(doc)
+	require.NoError(t, err)
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+
+	resources := parsed["Resources"].(map[string]interface{})
+	require.Contains(t, resources, "RDSInstance0")
+	// Only one entry for the duplicate ID — no data loss from overwrite.
+	count := 0
+	for k := range resources {
+		if k == "RDSInstance0" {
+			count++
+		}
+	}
+	require.Equal(t, 1, count)
+}
+
+func TestDocument_UnmarshalYAML_CloudFormationForEachAmpersandPlaceholder(t *testing.T) {
+	ctx := context.Background()
+
+	src := []byte(`Transform: AWS::LanguageExtensions
+Parameters:
+  Envs:
+    Type: CommaDelimitedList
+    Default: "prod,staging"
+Resources:
+  Fn::ForEach::Queues:
+    - Env
+    - !Ref Envs
+    - Queue&{Env}:
+        Type: AWS::SQS::Queue
+        Properties:
+          QueueName: queue-&{Env}
+`)
+
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal(src, &root))
+	require.Len(t, root.Content, 1)
+
+	doc := &Document{}
+	require.NoError(t, doc.UnmarshalYAML(ctx, root.Content[0], nil))
+
+	raw, err := json.Marshal(doc)
+	require.NoError(t, err)
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+
+	resources := parsed["Resources"].(map[string]interface{})
+	require.Contains(t, resources, "Queueprod")
+	require.Contains(t, resources, "Queuestaging")
+	require.NotContains(t, resources, "Fn::ForEach::Queues")
+
+	prodProps := resources["Queueprod"].(map[string]interface{})["Properties"].(map[string]interface{})
+	require.Equal(t, "queue-prod", stripKicsLines(prodProps["QueueName"]))
+
+	stagingProps := resources["Queuestaging"].(map[string]interface{})["Properties"].(map[string]interface{})
+	require.Equal(t, "queue-staging", stripKicsLines(stagingProps["QueueName"]))
+}
+
+func TestDocument_UnmarshalYAML_CloudFormationForEachNestedLoops(t *testing.T) {
+	ctx := context.Background()
+
+	src := []byte(`Transform: AWS::LanguageExtensions
+Parameters:
+  Regions:
+    Type: CommaDelimitedList
+    Default: "us,eu"
+  Tiers:
+    Type: CommaDelimitedList
+    Default: "web,api"
+Resources:
+  Fn::ForEach::Regions:
+    - Region
+    - !Ref Regions
+    - Fn::ForEach::Tiers${Region}:
+        - Tier
+        - !Ref Tiers
+        - Bucket${Region}${Tier}:
+            Type: AWS::S3::Bucket
+            Properties:
+              BucketName: bucket-${Region}-${Tier}
+`)
+
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal(src, &root))
+	require.Len(t, root.Content, 1)
+
+	doc := &Document{}
+	require.NoError(t, doc.UnmarshalYAML(ctx, root.Content[0], nil))
+
+	raw, err := json.Marshal(doc)
+	require.NoError(t, err)
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+
+	resources := parsed["Resources"].(map[string]interface{})
+
+	for _, region := range []string{"us", "eu"} {
+		for _, tier := range []string{"web", "api"} {
+			key := "Bucket" + region + tier
+			require.Contains(t, resources, key)
+			props := resources[key].(map[string]interface{})["Properties"].(map[string]interface{})
+			require.Equal(t, "bucket-"+region+"-"+tier, stripKicsLines(props["BucketName"]))
+		}
+	}
+
+	for k := range resources {
+		require.False(t, strings.HasPrefix(k, "Fn::ForEach::"), "unexpected ForEach key: %s", k)
+	}
 }
 
 func walkJSONPath(t *testing.T, root interface{}, path []string) interface{} {


### PR DESCRIPTION
## Summary

- Expands CloudFormation `Fn::ForEach::*` resources during YAML parsing (`pkg/model/model_yaml.go`) so loop-generated resources are materialized as concrete logical IDs before Rego rules run.
- Resolves loop variable placeholders in resource keys and nested values (for example `${Identifier}` → `0`, `1`) using the ForEach collection.
- Resolves `Ref` to loop variables inside expanded resources (for example `Ref: Identifier` → `"0"`).
- Supports ForEach collections from literal lists and from `Ref` to parameter defaults (including comma-separated defaults like `"0,1"`).

## Behavior change

| Template syntax | Before | After |
|---|---|---|
| `Fn::ForEach::RDSInstances` with `RDSInstance${Identifier}` and `Instances` default `"0"` | `RDSInstance${Identifier}` | `RDSInstance0` |
| Same with `Instances` default `"0,1"` | `RDSInstance${Identifier}` | `RDSInstance0`, `RDSInstance1` |
| `Ref: Identifier` inside expanded resource properties | `{"Ref":"Identifier"}` | `"0"` (per iteration) |
| `Fn::Sub app_${Identifier}` inside expanded resource properties | `Fn::Sub app_${Identifier}` | `Fn::Sub app_0` (per iteration) |
| Non-ForEach resources | unchanged | unchanged |

## Example

Template pattern CloudFormation:

```yaml
Parameters:
  Instances:
    Type: List<Number>
    Default: "0"
Resources:
  Fn::ForEach::RDSInstances:
    - Identifier
    - !Ref Instances
    - RDSInstance${Identifier}:
        Type: AWS::RDS::DBInstance
```

| | Resource name |
|---|---|
| Before | `RDSInstance${Identifier}` |
| After | `RDSInstance0` |

## Notes

- Expansion uses parameter defaults only (static analysis); runtime stack parameters are not available at scan time.
- If the ForEach collection cannot be resolved, the original `Fn::ForEach::*` entry is left unchanged.
- Depends on short-form intrinsic preservation from #160 (`!Ref` in the collection expression must parse as `{"Ref": "..."}`).

## Test plan

- [x] `go test ./pkg/model/ -run CloudFormationForEachExpansion -v`
- [x] `go test ./pkg/model/...`
- [x] `golangci-lint run -c .golangci.yml --timeout 20m`
- [x] Local scan of example reports `IAC_RESOURCE_NAME:RDSInstance0` (not `RDSInstance${Identifier}`) for loop-generated RDS findings