### PR TITLE
IaC config v1.3 support

### DIFF
--- a/cmd/scanner/list_platforms.go
+++ b/cmd/scanner/list_platforms.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	cli "github.com/urfave/cli/v3"
 )
 
@@ -14,7 +15,7 @@ var listPlatformsAction = &cli.Command{
 }
 
 func listPlatforms(ctx context.Context, c *cli.Command) error {
-	for _, platform := range GetSupportedPlatforms() {
+	for _, platform := range constants.SupportedPlatforms {
 		fmt.Println(platform)
 	}
 	return nil

--- a/cmd/scanner/list_platforms.go
+++ b/cmd/scanner/list_platforms.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/DataDog/datadog-iac-scanner/internal/constants"
+	"github.com/DataDog/datadog-iac-scanner/pkg/platforms"
 	cli "github.com/urfave/cli/v3"
 )
 
@@ -15,7 +15,7 @@ var listPlatformsAction = &cli.Command{
 }
 
 func listPlatforms(ctx context.Context, c *cli.Command) error {
-	for _, platform := range constants.SupportedPlatforms {
+	for _, platform := range platforms.Supported {
 		fmt.Println(platform)
 	}
 	return nil

--- a/cmd/scanner/list_queries.go
+++ b/cmd/scanner/list_queries.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
+	"github.com/DataDog/datadog-iac-scanner/pkg/platforms"
 	cli "github.com/urfave/cli/v3"
 )
 
@@ -60,13 +60,13 @@ func getQuerySource(ctx context.Context, _ *cli.Command) (source.QueriesSource, 
 	librarySource := source.NewFilesystemSource(
 		ctx,
 		nil,
-		constants.SupportedPlatforms,
+		platforms.Supported,
 		[]string{""},
 		"./assets/libraries",
 		false)
 	return source.NewDatadogSource(
 		datadog.NewDatadogClient(),
-		source.WithWantedPlatforms(constants.SupportedPlatforms),
+		source.WithWantedPlatforms(platforms.Supported),
 		source.WithLibrarySource(librarySource),
 	)
 }

--- a/cmd/scanner/list_queries.go
+++ b/cmd/scanner/list_queries.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
@@ -59,13 +60,13 @@ func getQuerySource(ctx context.Context, _ *cli.Command) (source.QueriesSource, 
 	librarySource := source.NewFilesystemSource(
 		ctx,
 		nil,
-		GetSupportedPlatforms(),
+		constants.SupportedPlatforms,
 		[]string{""},
 		"./assets/libraries",
 		false)
 	return source.NewDatadogSource(
 		datadog.NewDatadogClient(),
-		source.WithWantedPlatforms(GetSupportedPlatforms()),
+		source.WithWantedPlatforms(constants.SupportedPlatforms),
 		source.WithLibrarySource(librarySource),
 	)
 }

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -99,7 +99,3 @@ func (e *withExitCodeError) Error() string {
 	}
 	return fmt.Sprintf("exit code %d", e.code)
 }
-
-func GetSupportedPlatforms() []string {
-	return []string{"Ansible", "CICD", "Terraform", "Kubernetes", "CloudFormation", "Dockerfile"}
-}

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	iacplatforms "github.com/DataDog/datadog-iac-scanner/pkg/platforms"
 	"github.com/DataDog/datadog-iac-scanner/pkg/scan"
 	git "github.com/go-git/go-git/v5"
 	cli "github.com/urfave/cli/v3"
@@ -74,7 +75,7 @@ var scanAction = &cli.Command{
 			Name:    "type",
 			Aliases: []string{"t"},
 			Usage:   "a list of platform types to scan",
-			Value:   constants.SupportedPlatforms,
+			Value:   iacplatforms.Supported,
 		},
 		// NOTE: --x-parallelparsing flag disabled due to pre-existing race conditions
 		// in concurrent query workers (SetupLogs shared state write, docker detector
@@ -379,7 +380,7 @@ func selectPlatforms(platforms []string) []string {
 		set[strings.ToLower(p)] = struct{}{}
 	}
 	var out []string
-	for _, p := range constants.SupportedPlatforms {
+	for _, p := range iacplatforms.Supported {
 		if _, found := set[strings.ToLower(p)]; found {
 			out = append(out, p)
 		}

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -74,7 +74,7 @@ var scanAction = &cli.Command{
 			Name:    "type",
 			Aliases: []string{"t"},
 			Usage:   "a list of platform types to scan",
-			Value:   GetSupportedPlatforms(),
+			Value:   constants.SupportedPlatforms,
 		},
 		// NOTE: --x-parallelparsing flag disabled due to pre-existing race conditions
 		// in concurrent query workers (SetupLogs shared state write, docker detector
@@ -148,6 +148,23 @@ func runScan(ctx context.Context, c *cli.Command) error {
 	}
 	cfg.OnlyPaths = onlyPaths
 	cfg.IgnoreRules = append(c.StringSlice("exclude-queries"), cfg.IgnoreRules...)
+
+	activePlatforms := scan.ApplyPlatformFilters(c.StringSlice("type"), cfg.OnlyPlatforms, cfg.IgnorePlatforms)
+
+	for ruleID, rc := range cfg.RuleConfigs {
+		resolvedIgnore, pathErr := getRepoRelativePaths(repoDir, rc.IgnorePaths)
+		if pathErr != nil {
+			return errorWithExitCode(fmt.Errorf("invalid ignore-path in rule-config %q: %w", ruleID, pathErr), constants.InvalidConfigErrorCode)
+		}
+		resolvedOnly, pathErr := getRepoRelativePaths(repoDir, rc.OnlyPaths)
+		if pathErr != nil {
+			return errorWithExitCode(fmt.Errorf("invalid only-path in rule-config %q: %w", ruleID, pathErr), constants.InvalidConfigErrorCode)
+		}
+		rc.IgnorePaths = resolvedIgnore
+		rc.OnlyPaths = resolvedOnly
+		cfg.RuleConfigs[ruleID] = rc
+	}
+
 	params := &scan.Parameters{
 		CloudProvider:    []string{""},
 		OutputPath:       outputPath,
@@ -158,7 +175,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		QueriesPath:      []string{"./assets/queries"},
 		LibrariesPath:    "./assets/libraries",
 		ReportFormats:    []string{"sarif"},
-		Platform:         selectPlatforms(c.StringSlice("type")),
+		Platform:         selectPlatforms(activePlatforms),
 		QueryExecTimeout: c.Int("timeout"),
 		DisableSecrets:   true,
 		ScanID:           "console",
@@ -173,7 +190,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 
 	metadata, err := console.ExecuteScan(ctx, params)
 	if err != nil {
-		return fmt.Errorf("error during IaC scan: %w", err)
+		return errorWithExitCode(fmt.Errorf("error during IaC scan: %w", err), constants.EngineErrorCode)
 	}
 
 	reportResult(repoDir, params.OutputPath, params.OutputName, &metadata)
@@ -362,7 +379,7 @@ func selectPlatforms(platforms []string) []string {
 		set[strings.ToLower(p)] = struct{}{}
 	}
 	var out []string
-	for _, p := range GetSupportedPlatforms() {
+	for _, p := range constants.SupportedPlatforms {
 		if _, found := set[strings.ToLower(p)]; found {
 			out = append(out, p)
 		}

--- a/cmd/scanner/scan_test.go
+++ b/cmd/scanner/scan_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/scan"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyPlatformFilters(t *testing.T) {
+	all := []string{"Ansible", "CICD", "CloudFormation", "Dockerfile", "Kubernetes", "Terraform"}
+
+	tests := []struct {
+		name            string
+		cliPlatforms    []string
+		onlyPlatforms   []string
+		ignorePlatforms []string
+		want            []string
+	}{
+		{
+			name:         "no filters returns cli platforms unchanged",
+			cliPlatforms: all,
+			want:         all,
+		},
+		{
+			name:          "only-platforms restricts to subset",
+			cliPlatforms:  all,
+			onlyPlatforms: []string{"Terraform", "Kubernetes"},
+			want:          []string{"Terraform", "Kubernetes"},
+		},
+		{
+			name:            "ignore-platforms removes entries",
+			cliPlatforms:    all,
+			ignorePlatforms: []string{"Dockerfile"},
+			want:            []string{"Ansible", "CICD", "CloudFormation", "Kubernetes", "Terraform"},
+		},
+		{
+			name:            "case-insensitive only-platforms",
+			cliPlatforms:    all,
+			onlyPlatforms:   []string{"terraform"},
+			want:            []string{"Terraform"},
+		},
+		{
+			name:            "case-insensitive ignore-platforms",
+			cliPlatforms:    all,
+			ignorePlatforms: []string{"kubernetes"},
+			want:            []string{"Ansible", "CICD", "CloudFormation", "Dockerfile", "Terraform"},
+		},
+		{
+			name:            "only and ignore combined",
+			cliPlatforms:    all,
+			onlyPlatforms:   []string{"Terraform", "Kubernetes", "Dockerfile"},
+			ignorePlatforms: []string{"Dockerfile"},
+			want:            []string{"Kubernetes", "Terraform"},
+		},
+		{
+			name:          "only-platforms not in cli list returns empty",
+			cliPlatforms:  []string{"Terraform"},
+			onlyPlatforms: []string{"Kubernetes"},
+			want:          []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scan.ApplyPlatformFilters(tt.cliPlatforms, tt.onlyPlatforms, tt.ignorePlatforms)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -61,6 +61,10 @@ var (
 		"ServerlessFW":            "serverlessFW",
 	}
 
+	// SupportedPlatforms - Platforms with published rules, available to customers.
+	// Keep in sync with the default --platforms flag in datadog-iac-scanner-default-rules.
+	SupportedPlatforms = []string{"Ansible", "CICD", "CloudFormation", "Dockerfile", "Kubernetes", "Terraform"}
+
 	// AvailableSeverities - All severities available
 	AvailableSeverities = []string{
 		"critical",

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -61,10 +61,6 @@ var (
 		"ServerlessFW":            "serverlessFW",
 	}
 
-	// SupportedPlatforms - Platforms with published rules, available to customers.
-	// Keep in sync with the default --platforms flag in datadog-iac-scanner-default-rules.
-	SupportedPlatforms = []string{"Ansible", "CICD", "CloudFormation", "Dockerfile", "Kubernetes", "Terraform"}
-
 	// AvailableSeverities - All severities available
 	AvailableSeverities = []string{
 		"critical",

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -1,0 +1,62 @@
+package pathutil
+
+import (
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// MatchesPath reports whether filePath is covered by pattern.
+// pattern may be a literal path, a directory prefix, a single-star glob (*, ?, [...]),
+// or a double-star glob (**) where ** matches zero or more path segments.
+// Both arguments are normalized to forward slashes for OS-independent behavior.
+func MatchesPath(pattern, filePath string) bool {
+	pattern = filepath.ToSlash(pattern)
+	filePath = filepath.ToSlash(filePath)
+
+	// Exact match.
+	if pattern == filePath {
+		return true
+	}
+	// Directory prefix: any file under pattern/ matches.
+	if strings.HasPrefix(filePath, strings.TrimSuffix(pattern, "/")+"/") {
+		return true
+	}
+	// Double-star glob (**): segment-aware recursive match.
+	if strings.Contains(pattern, "**") {
+		return matchDoublestar(strings.Split(pattern, "/"), strings.Split(filePath, "/"))
+	}
+	// Single-level glob (*, ?, [...]): use path.Match with forward-slash semantics.
+	if matched, err := path.Match(pattern, filePath); err == nil && matched {
+		return true
+	}
+	return false
+}
+
+// matchDoublestar matches a pre-split path against a pre-split pattern where
+// "**" matches zero or more path segments.
+func matchDoublestar(pat, filePath []string) bool {
+	for len(pat) > 0 {
+		if pat[0] == "**" {
+			// ** matches zero remaining segments → try skipping the **
+			if matchDoublestar(pat[1:], filePath) {
+				return true
+			}
+			// ** matches one or more segments → consume one path segment and retry
+			if len(filePath) == 0 {
+				return false
+			}
+			return matchDoublestar(pat, filePath[1:])
+		}
+		if len(filePath) == 0 {
+			return false
+		}
+		ok, err := path.Match(pat[0], filePath[0])
+		if err != nil || !ok {
+			return false
+		}
+		pat = pat[1:]
+		filePath = filePath[1:]
+	}
+	return len(filePath) == 0
+}

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -1,0 +1,39 @@
+package pathutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchesPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		file    string
+		want    bool
+	}{
+		{"exact match", "/repo/src/main.tf", "/repo/src/main.tf", true},
+		{"directory prefix", "/repo/src", "/repo/src/main.tf", true},
+		{"directory prefix no trailing sep", "/repo/src", "/repo/src/nested/main.tf", true},
+		{"no match different dir", "/repo/test", "/repo/src/main.tf", false},
+		{"no partial prefix match", "/repo/s", "/repo/src/main.tf", false},
+		{"glob star", "/repo/src/*.tf", "/repo/src/main.tf", true},
+		{"glob star no match", "/repo/src/*.tf", "/repo/src/main.go", false},
+		{"glob question mark", "/repo/src/mai?.tf", "/repo/src/main.tf", true},
+		// double-star (**) glob
+		{"doublestar all tf files", "/repo/**/*.tf", "/repo/src/main.tf", true},
+		{"doublestar nested", "/repo/**/*.tf", "/repo/src/nested/deep/main.tf", true},
+		{"doublestar no match ext", "/repo/**/*.tf", "/repo/src/main.go", false},
+		{"doublestar prefix any subdir", "**/terraform/**", "infra/terraform/main.tf", true},
+		{"doublestar prefix no match", "**/terraform/**", "infra/k8s/main.yaml", false},
+		{"doublestar matches zero segments", "a/**/b.tf", "a/b.tf", true},
+		{"doublestar matches one segment", "a/**/b.tf", "a/x/b.tf", true},
+		{"doublestar matches many segments", "a/**/b.tf", "a/x/y/z/b.tf", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, MatchesPath(tt.pattern, tt.file))
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,9 +22,10 @@ type cfgFileYaml struct {
 }
 
 type iacConfig struct {
-	IgnoreRules  []string        `yaml:"ignore-rules,omitempty"`
-	UseRules     []string        `yaml:"use-rules,omitempty"`
-	GlobalConfig iacGlobalConfig `yaml:"global-config,omitempty"`
+	IgnoreRules  []string                     `yaml:"ignore-rules,omitempty"`
+	UseRules     []string                     `yaml:"use-rules,omitempty"`
+	GlobalConfig iacGlobalConfig              `yaml:"global-config,omitempty"`
+	RuleConfigs  map[string]iacRuleConfigYaml `yaml:"rule-configs,omitempty"`
 }
 
 type iacGlobalConfig struct {
@@ -34,6 +35,15 @@ type iacGlobalConfig struct {
 	OnlySeverities   []iacSeverity `yaml:"only-severities,omitempty"`
 	IgnoreCategories []iacCategory `yaml:"ignore-categories,omitempty"`
 	OnlyCategories   []iacCategory `yaml:"only-categories,omitempty"`
+	OnlyPlatforms    []iacPlatform `yaml:"only-platforms,omitempty"`
+	IgnorePlatforms  []iacPlatform `yaml:"ignore-platforms,omitempty"`
+}
+
+// iacRuleConfigYaml is the YAML representation of a per-rule override block.
+type iacRuleConfigYaml struct {
+	IgnorePaths []string    `yaml:"ignore-paths,omitempty"`
+	OnlyPaths   []string    `yaml:"only-paths,omitempty"`
+	Severity    iacSeverity `yaml:"severity,omitempty"`
 }
 
 // ParseConfig turns a YAML configuration file into a parsed configuration
@@ -78,8 +88,41 @@ func ParseConfig(cfgBytes []byte) (*IacConfig, error) {
 		OnlySeverities:   mapSlice[string](cfg.Iac.GlobalConfig.OnlySeverities),
 		IgnoreCategories: mapSlice[string](cfg.Iac.GlobalConfig.IgnoreCategories),
 		OnlyCategories:   mapSlice[string](cfg.Iac.GlobalConfig.OnlyCategories),
+		OnlyPlatforms:    mapSlice[string](cfg.Iac.GlobalConfig.OnlyPlatforms),
+		IgnorePlatforms:  mapSlice[string](cfg.Iac.GlobalConfig.IgnorePlatforms),
+		RuleConfigs:      parseRuleConfigs(cfg.Iac.RuleConfigs),
 	}
 	return out, nil
+}
+
+func parseRuleConfigs(in map[string]iacRuleConfigYaml) map[string]IacRuleConfig {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]IacRuleConfig, len(in))
+	for ruleID, rc := range in {
+		out[ruleID] = IacRuleConfig{
+			IgnorePaths: rc.IgnorePaths,
+			OnlyPaths:   rc.OnlyPaths,
+			Severity:    string(rc.Severity),
+		}
+	}
+	return out
+}
+
+func unparseRuleConfigs(in map[string]IacRuleConfig) map[string]iacRuleConfigYaml {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]iacRuleConfigYaml, len(in))
+	for ruleID, rc := range in {
+		out[ruleID] = iacRuleConfigYaml{
+			IgnorePaths: rc.IgnorePaths,
+			OnlyPaths:   rc.OnlyPaths,
+			Severity:    iacSeverity(rc.Severity),
+		}
+	}
+	return out
 }
 
 // UnparseConfig turns a parsed configuration into a YAML file.
@@ -100,15 +143,22 @@ func UnparseConfig(cfg *IacConfig) ([]byte, error) {
 			OnlySeverities:   mapSlice[iacSeverity](cfg.OnlySeverities),
 			IgnoreCategories: mapSlice[iacCategory](cfg.IgnoreCategories),
 			OnlyCategories:   mapSlice[iacCategory](cfg.OnlyCategories),
+			OnlyPlatforms:    mapSlice[iacPlatform](cfg.OnlyPlatforms),
+			IgnorePlatforms:  mapSlice[iacPlatform](cfg.IgnorePlatforms),
 		},
+		RuleConfigs: unparseRuleConfigs(cfg.RuleConfigs),
 	}
 
 	if reflect.DeepEqual(iac, iacConfig{}) {
 		return []byte{}, nil
 	}
 
+	schemaVer := minIacVersion.String()
+	if len(cfg.RuleConfigs) > 0 || len(cfg.OnlyPlatforms) > 0 || len(cfg.IgnorePlatforms) > 0 {
+		schemaVer = minV13Version.String()
+	}
 	outCfg := cfgFileYaml{
-		SchemaVersion: minIacVersion.String(),
+		SchemaVersion: schemaVer,
 		Iac:           &iac,
 	}
 
@@ -150,6 +200,8 @@ type schemaVersion struct {
 var (
 	// minIacVersion is the minimum schema version supporting the iac: configuration section.
 	minIacVersion = schemaVersion{1, 2}
+	// minV13Version is the schema version that introduced per-rule configs and platform filters.
+	minV13Version = schemaVersion{1, 3}
 	// minRequiredVersion is the minimum schema version supported by this scanner.
 	// It's different from minIacVersion for user-friendliness in case people add an `iac`
 	// section to an old configuration file and forget to upgrade the version number.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -101,15 +101,10 @@ func parseRuleConfigs(in map[string]iacRuleConfigYaml) map[string]IacRuleConfig 
 	}
 	out := make(map[string]IacRuleConfig, len(in))
 	for ruleID, rc := range in {
-		var sev *string
-		if rc.Severity != nil {
-			s := string(*rc.Severity)
-			sev = &s
-		}
 		out[ruleID] = IacRuleConfig{
 			IgnorePaths: rc.IgnorePaths,
 			OnlyPaths:   rc.OnlyPaths,
-			Severity:    sev,
+			Severity:    (*string)(rc.Severity),
 		}
 	}
 	return out
@@ -121,15 +116,10 @@ func unparseRuleConfigs(in map[string]IacRuleConfig) map[string]iacRuleConfigYam
 	}
 	out := make(map[string]iacRuleConfigYaml, len(in))
 	for ruleID, rc := range in {
-		var sev *iacSeverity
-		if rc.Severity != nil {
-			s := iacSeverity(*rc.Severity)
-			sev = &s
-		}
 		out[ruleID] = iacRuleConfigYaml{
 			IgnorePaths: rc.IgnorePaths,
 			OnlyPaths:   rc.OnlyPaths,
-			Severity:    sev,
+			Severity:    (*iacSeverity)(rc.Severity),
 		}
 	}
 	return out

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,15 +35,15 @@ type iacGlobalConfig struct {
 	OnlySeverities   []iacSeverity `yaml:"only-severities,omitempty"`
 	IgnoreCategories []iacCategory `yaml:"ignore-categories,omitempty"`
 	OnlyCategories   []iacCategory `yaml:"only-categories,omitempty"`
-	OnlyPlatforms    []iacPlatform `yaml:"only-platforms,omitempty"`
 	IgnorePlatforms  []iacPlatform `yaml:"ignore-platforms,omitempty"`
+	OnlyPlatforms    []iacPlatform `yaml:"only-platforms,omitempty"`
 }
 
 // iacRuleConfigYaml is the YAML representation of a per-rule override block.
 type iacRuleConfigYaml struct {
-	IgnorePaths []string    `yaml:"ignore-paths,omitempty"`
-	OnlyPaths   []string    `yaml:"only-paths,omitempty"`
-	Severity    iacSeverity `yaml:"severity,omitempty"`
+	IgnorePaths []string     `yaml:"ignore-paths,omitempty"`
+	OnlyPaths   []string     `yaml:"only-paths,omitempty"`
+	Severity    *iacSeverity `yaml:"severity,omitempty"`
 }
 
 // ParseConfig turns a YAML configuration file into a parsed configuration
@@ -101,10 +101,15 @@ func parseRuleConfigs(in map[string]iacRuleConfigYaml) map[string]IacRuleConfig 
 	}
 	out := make(map[string]IacRuleConfig, len(in))
 	for ruleID, rc := range in {
+		var sev *string
+		if rc.Severity != nil {
+			s := string(*rc.Severity)
+			sev = &s
+		}
 		out[ruleID] = IacRuleConfig{
 			IgnorePaths: rc.IgnorePaths,
 			OnlyPaths:   rc.OnlyPaths,
-			Severity:    string(rc.Severity),
+			Severity:    sev,
 		}
 	}
 	return out
@@ -116,10 +121,15 @@ func unparseRuleConfigs(in map[string]IacRuleConfig) map[string]iacRuleConfigYam
 	}
 	out := make(map[string]iacRuleConfigYaml, len(in))
 	for ruleID, rc := range in {
+		var sev *iacSeverity
+		if rc.Severity != nil {
+			s := iacSeverity(*rc.Severity)
+			sev = &s
+		}
 		out[ruleID] = iacRuleConfigYaml{
 			IgnorePaths: rc.IgnorePaths,
 			OnlyPaths:   rc.OnlyPaths,
-			Severity:    iacSeverity(rc.Severity),
+			Severity:    sev,
 		}
 	}
 	return out
@@ -153,12 +163,8 @@ func UnparseConfig(cfg *IacConfig) ([]byte, error) {
 		return []byte{}, nil
 	}
 
-	schemaVer := minIacVersion.String()
-	if len(cfg.RuleConfigs) > 0 || len(cfg.OnlyPlatforms) > 0 || len(cfg.IgnorePlatforms) > 0 {
-		schemaVer = minV13Version.String()
-	}
 	outCfg := cfgFileYaml{
-		SchemaVersion: schemaVer,
+		SchemaVersion: currentVersion.String(),
 		Iac:           &iac,
 	}
 
@@ -200,8 +206,8 @@ type schemaVersion struct {
 var (
 	// minIacVersion is the minimum schema version supporting the iac: configuration section.
 	minIacVersion = schemaVersion{1, 2}
-	// minV13Version is the schema version that introduced per-rule configs and platform filters.
-	minV13Version = schemaVersion{1, 3}
+	// currentVersion is the current schema version emitted by UnparseConfig.
+	currentVersion = schemaVersion{1, 3}
 	// minRequiredVersion is the minimum schema version supported by this scanner.
 	// It's different from minIacVersion for user-friendliness in case people add an `iac`
 	// section to an old configuration file and forget to upgrade the version number.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseHappyPath(t *testing.T) {
@@ -61,4 +62,70 @@ func TestUnparseConfig(t *testing.T) {
 	b, err := UnparseConfig(&parsedCfgFile)
 	assert.NoError(t, err)
 	assert.Equal(t, cfgFile, string(b))
+}
+
+func TestUnparseConfigV13SchemaVersion(t *testing.T) {
+	t.Run("v1.2 config keeps v1.2 schema version", func(t *testing.T) {
+		b, err := UnparseConfig(&parsedCfgFile)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), "schema-version: v1.2")
+	})
+
+	t.Run("config with only-platforms emits v1.3", func(t *testing.T) {
+		cfg := parsedCfgFile
+		cfg.OnlyPlatforms = []string{"Terraform"}
+		b, err := UnparseConfig(&cfg)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), "schema-version: v1.3")
+		assert.Contains(t, string(b), "only-platforms:")
+	})
+
+	t.Run("config with ignore-platforms emits v1.3", func(t *testing.T) {
+		cfg := parsedCfgFile
+		cfg.IgnorePlatforms = []string{"Dockerfile"}
+		b, err := UnparseConfig(&cfg)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), "schema-version: v1.3")
+	})
+
+	t.Run("config with rule-configs emits v1.3", func(t *testing.T) {
+		cfg := parsedCfgFile
+		cfg.RuleConfigs = map[string]IacRuleConfig{
+			"my-rule": {IgnorePaths: []string{"test/"}, Severity: "low"},
+		}
+		b, err := UnparseConfig(&cfg)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), "schema-version: v1.3")
+		assert.Contains(t, string(b), "rule-configs:")
+		assert.Contains(t, string(b), "my-rule:")
+	})
+}
+
+func TestParseUnparseRoundTripV13(t *testing.T) {
+	input := `schema-version: v1.3
+iac:
+  ignore-rules:
+    - query1
+  global-config:
+    only-platforms:
+      - Terraform
+      - Kubernetes
+    ignore-platforms:
+      - Dockerfile
+  rule-configs:
+    terraform-aws-s3-unencrypted:
+      ignore-paths:
+        - test/
+      severity: low
+`
+	cfg, err := ParseConfig([]byte(input))
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, []string{"Terraform", "Kubernetes"}, cfg.OnlyPlatforms)
+	assert.Equal(t, []string{"Dockerfile"}, cfg.IgnorePlatforms)
+	require.Len(t, cfg.RuleConfigs, 1)
+	rc := cfg.RuleConfigs["terraform-aws-s3-unencrypted"]
+	assert.Equal(t, []string{"test/"}, rc.IgnorePaths)
+	assert.Equal(t, "low", rc.Severity)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -64,14 +64,8 @@ func TestUnparseConfig(t *testing.T) {
 	assert.Equal(t, cfgFile, string(b))
 }
 
-func TestUnparseConfigV13SchemaVersion(t *testing.T) {
-	t.Run("v1.2 config keeps v1.2 schema version", func(t *testing.T) {
-		b, err := UnparseConfig(&parsedCfgFile)
-		require.NoError(t, err)
-		assert.Contains(t, string(b), "schema-version: v1.2")
-	})
-
-	t.Run("config with only-platforms emits v1.3", func(t *testing.T) {
+func TestUnparseConfigV13Fields(t *testing.T) {
+	t.Run("config with only-platforms serializes field", func(t *testing.T) {
 		cfg := parsedCfgFile
 		cfg.OnlyPlatforms = []string{"Terraform"}
 		b, err := UnparseConfig(&cfg)
@@ -80,22 +74,22 @@ func TestUnparseConfigV13SchemaVersion(t *testing.T) {
 		assert.Contains(t, string(b), "only-platforms:")
 	})
 
-	t.Run("config with ignore-platforms emits v1.3", func(t *testing.T) {
+	t.Run("config with ignore-platforms serializes field", func(t *testing.T) {
 		cfg := parsedCfgFile
 		cfg.IgnorePlatforms = []string{"Dockerfile"}
 		b, err := UnparseConfig(&cfg)
 		require.NoError(t, err)
-		assert.Contains(t, string(b), "schema-version: v1.3")
+		assert.Contains(t, string(b), "ignore-platforms:")
 	})
 
-	t.Run("config with rule-configs emits v1.3", func(t *testing.T) {
+	t.Run("config with rule-configs serializes fields", func(t *testing.T) {
+		sev := "low"
 		cfg := parsedCfgFile
 		cfg.RuleConfigs = map[string]IacRuleConfig{
-			"my-rule": {IgnorePaths: []string{"test/"}, Severity: "low"},
+			"my-rule": {IgnorePaths: []string{"test/"}, Severity: &sev},
 		}
 		b, err := UnparseConfig(&cfg)
 		require.NoError(t, err)
-		assert.Contains(t, string(b), "schema-version: v1.3")
 		assert.Contains(t, string(b), "rule-configs:")
 		assert.Contains(t, string(b), "my-rule:")
 	})
@@ -127,5 +121,6 @@ iac:
 	require.Len(t, cfg.RuleConfigs, 1)
 	rc := cfg.RuleConfigs["terraform-aws-s3-unencrypted"]
 	assert.Equal(t, []string{"test/"}, rc.IgnorePaths)
-	assert.Equal(t, "low", rc.Severity)
+	require.NotNil(t, rc.Severity)
+	assert.Equal(t, "low", *rc.Severity)
 }

--- a/pkg/config/config_validation.go
+++ b/pkg/config/config_validation.go
@@ -11,6 +11,25 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// iacPlatform is a custom type for case-insensitive matching against the supported platform list.
+type iacPlatform string
+
+func (i *iacPlatform) UnmarshalYAML(value *yaml.Node) error {
+	var str string
+	if err := value.Decode(&str); err != nil {
+		return err
+	}
+	candidate := strings.TrimSpace(str)
+	for _, p := range constants.SupportedPlatforms {
+		if strings.EqualFold(candidate, p) {
+			*i = iacPlatform(p)
+			return nil
+		}
+	}
+	return makeUnmarshalError(value, "invalid platform: %q (must be one of %s)",
+		str, strings.Join(constants.SupportedPlatforms, ", "))
+}
+
 // iacSeverity is a custom type to ensure case-insensitive matching of one of the valid severities
 type iacSeverity string
 
@@ -120,6 +139,8 @@ func rewriteLocation(where string) string {
 		return "the `iac` section"
 	case "config.iacGlobalConfig":
 		return "the `iac.global-config` section"
+	case "config.iacRuleConfigYaml":
+		return "the `iac.rule-configs.<rule-id>` section"
 	case "config.knownRootsCfgFile", "config.cfgFileYaml":
 		return "the top-level configuration"
 	}
@@ -143,6 +164,5 @@ func isSastConfigField(name string) bool {
 	return name == "use-default-rulesets" ||
 		name == "use-rulesets" ||
 		name == "ignore-rulesets" ||
-		name == "ruleset-configs" ||
-		name == "rule-configs"
+		name == "ruleset-configs"
 }

--- a/pkg/config/config_validation.go
+++ b/pkg/config/config_validation.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/constants"
+	"github.com/DataDog/datadog-iac-scanner/pkg/platforms"
 	"gopkg.in/yaml.v3"
 )
 
@@ -20,14 +21,14 @@ func (i *iacPlatform) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 	candidate := strings.TrimSpace(str)
-	for _, p := range constants.SupportedPlatforms {
+	for _, p := range platforms.Supported {
 		if strings.EqualFold(candidate, p) {
 			*i = iacPlatform(p)
 			return nil
 		}
 	}
 	return makeUnmarshalError(value, "invalid platform: %q (must be one of %s)",
-		str, strings.Join(constants.SupportedPlatforms, ", "))
+		str, strings.Join(platforms.Supported, ", "))
 }
 
 // iacSeverity is a custom type to ensure case-insensitive matching of one of the valid severities

--- a/pkg/config/config_validation_test.go
+++ b/pkg/config/config_validation_test.go
@@ -158,7 +158,8 @@ iac:
 		rc := cfg.RuleConfigs["terraform-aws-s3-unencrypted"]
 		assert.Equal(t, []string{"test/"}, rc.IgnorePaths)
 		assert.Equal(t, []string{"src/"}, rc.OnlyPaths)
-		assert.Equal(t, "low", rc.Severity)
+		require.NotNil(t, rc.Severity)
+		assert.Equal(t, "low", *rc.Severity)
 	})
 
 	t.Run("severity override only", func(t *testing.T) {
@@ -172,7 +173,8 @@ iac:
 		require.NoError(t, err)
 		require.NotNil(t, cfg)
 		rc := cfg.RuleConfigs["some-rule"]
-		assert.Equal(t, "high", rc.Severity)
+		require.NotNil(t, rc.Severity)
+		assert.Equal(t, "high", *rc.Severity)
 		assert.Nil(t, rc.IgnorePaths)
 		assert.Nil(t, rc.OnlyPaths)
 	})

--- a/pkg/config/config_validation_test.go
+++ b/pkg/config/config_validation_test.go
@@ -95,6 +95,113 @@ func TestParseCategoryValues(t *testing.T) {
 	}
 }
 
+func TestParsePlatformValues(t *testing.T) {
+	happy := []struct {
+		name, input, expected string
+	}{
+		{"exact", "Terraform", "Terraform"},
+		{"lowercase", "terraform", "Terraform"},
+		{"uppercase", "KUBERNETES", "Kubernetes"},
+		{"mixed case", "cloudFormation", "CloudFormation"},
+		{"ansible", "ansible", "Ansible"},
+		{"cicd", "cicd", "CICD"},
+		{"dockerfile", "Dockerfile", "Dockerfile"},
+	}
+	invalid := []struct {
+		name, input, errFragment string
+	}{
+		{"unknown platform", "bogus", `invalid platform: "bogus"`},
+		{"unreleased platform", "pulumi", `invalid platform: "pulumi"`},
+	}
+
+	for _, field := range []string{"only-platforms", "ignore-platforms"} {
+		for _, tc := range happy {
+			t.Run(field+"/happy/"+tc.name, func(t *testing.T) {
+				yamlStr := fmt.Sprintf("schema-version: v1.3\niac:\n  global-config:\n    %s:\n      - %s\n", field, tc.input)
+				cfg, err := ParseConfig([]byte(yamlStr))
+				require.NoError(t, err)
+				require.NotNil(t, cfg)
+				got := cfg.OnlyPlatforms
+				if field == "ignore-platforms" {
+					got = cfg.IgnorePlatforms
+				}
+				assert.Equal(t, []string{tc.expected}, got)
+			})
+		}
+		for _, tc := range invalid {
+			t.Run(field+"/invalid/"+tc.name, func(t *testing.T) {
+				yamlStr := fmt.Sprintf("schema-version: v1.3\niac:\n  global-config:\n    %s:\n      - %s\n", field, tc.input)
+				_, err := ParseConfig([]byte(yamlStr))
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errFragment)
+			})
+		}
+	}
+}
+
+func TestParseRuleConfigs(t *testing.T) {
+	t.Run("full rule config", func(t *testing.T) {
+		input := `schema-version: v1.3
+iac:
+  rule-configs:
+    terraform-aws-s3-unencrypted:
+      ignore-paths:
+        - test/
+      only-paths:
+        - src/
+      severity: low
+`
+		cfg, err := ParseConfig([]byte(input))
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		require.Len(t, cfg.RuleConfigs, 1)
+		rc := cfg.RuleConfigs["terraform-aws-s3-unencrypted"]
+		assert.Equal(t, []string{"test/"}, rc.IgnorePaths)
+		assert.Equal(t, []string{"src/"}, rc.OnlyPaths)
+		assert.Equal(t, "low", rc.Severity)
+	})
+
+	t.Run("severity override only", func(t *testing.T) {
+		input := `schema-version: v1.3
+iac:
+  rule-configs:
+    some-rule:
+      severity: high
+`
+		cfg, err := ParseConfig([]byte(input))
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		rc := cfg.RuleConfigs["some-rule"]
+		assert.Equal(t, "high", rc.Severity)
+		assert.Nil(t, rc.IgnorePaths)
+		assert.Nil(t, rc.OnlyPaths)
+	})
+
+	t.Run("invalid severity in rule-config", func(t *testing.T) {
+		input := `schema-version: v1.3
+iac:
+  rule-configs:
+    some-rule:
+      severity: bogus
+`
+		_, err := ParseConfig([]byte(input))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `invalid severity: "bogus"`)
+	})
+
+	t.Run("unknown field in rule-config", func(t *testing.T) {
+		input := `schema-version: v1.3
+iac:
+  rule-configs:
+    some-rule:
+      xinvalid: foo
+`
+		_, err := ParseConfig([]byte(input))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "iac.rule-configs.<rule-id>")
+	})
+}
+
 func TestRewriteDecodeErrors(t *testing.T) {
 	for _, tc := range []struct {
 		name, input, expectedFragment string

--- a/pkg/config/reader_test.go
+++ b/pkg/config/reader_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const cfgFile = `schema-version: v1.2
+const cfgFile = `schema-version: v1.3
 iac:
   ignore-rules:
     - query1
@@ -66,7 +66,7 @@ var parsedLegacyCfg = IacConfig{
 	LegacyExcludeResults: []string{"res1", "res2"},
 }
 
-const convertedLegacyCfg = `schema-version: v1.2
+const convertedLegacyCfg = `schema-version: v1.3
 iac:
   ignore-rules:
     - query1
@@ -201,7 +201,7 @@ func TestReadLegacyOnly(t *testing.T) {
 func TestReadLegacyWithIncludeRulesOnly(t *testing.T) {
 	tmp := t.TempDir()
 	myCfgFile := legacyCfg + "include-queries: [query3, query4]\n"
-	includeOnly := "schema-version: v1.2\niac:\n  use-rules:\n    - query3\n    - query4\n"
+	includeOnly := "schema-version: v1.3\niac:\n  use-rules:\n    - query3\n    - query4\n"
 	require.NoError(t, os.WriteFile(filepath.Join(tmp, LegacyConfigFileName), []byte(myCfgFile), 0644))
 
 	cfg, b, err := ReadConfiguration(t.Context(), tmp)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -11,4 +11,16 @@ type IacConfig struct {
 	OnlyCategories   []string
 
 	LegacyExcludeResults []string
+
+	RuleConfigs     map[string]IacRuleConfig
+	OnlyPlatforms   []string
+	IgnorePlatforms []string
+}
+
+// IacRuleConfig holds per-rule overrides: path scoping and severity override.
+// nil/empty slices mean "no restriction". An empty Severity means "no override".
+type IacRuleConfig struct {
+	IgnorePaths []string
+	OnlyPaths   []string
+	Severity    string // empty means no override
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -13,14 +13,14 @@ type IacConfig struct {
 	LegacyExcludeResults []string
 
 	RuleConfigs     map[string]IacRuleConfig
-	OnlyPlatforms   []string
 	IgnorePlatforms []string
+	OnlyPlatforms   []string
 }
 
 // IacRuleConfig holds per-rule overrides: path scoping and severity override.
-// nil/empty slices mean "no restriction". An empty Severity means "no override".
+// nil slices mean "no restriction". A nil Severity means "no override".
 type IacRuleConfig struct {
 	IgnorePaths []string
 	OnlyPaths   []string
-	Severity    string // empty means no override
+	Severity    *string
 }

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -10,12 +10,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	pathpkg "path"
+	"path/filepath"
 	"reflect"
 	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/config"
 	"github.com/DataDog/datadog-iac-scanner/pkg/detector"
 	"github.com/DataDog/datadog-iac-scanner/pkg/detector/docker"
 	"github.com/DataDog/datadog-iac-scanner/pkg/detector/helm"
@@ -85,6 +88,7 @@ type Inspector struct {
 	tracker        Tracker
 	failedQueries  map[string]error
 	excludeResults map[string]bool
+	ruleConfigs    map[string]config.IacRuleConfig
 	detector       *detector.DetectLine
 
 	repoPath             string
@@ -124,6 +128,7 @@ func NewInspector(
 	tracker Tracker,
 	queryParameters *source.QueryInspectorParameters,
 	excludeResults map[string]bool,
+	ruleConfigs map[string]config.IacRuleConfig,
 	repoPath string,
 	queryTimeout int,
 	useOldSeverities bool,
@@ -174,6 +179,7 @@ func NewInspector(
 		tracker:             tracker,
 		failedQueries:       failedQueries,
 		excludeResults:      excludeResults,
+		ruleConfigs:         ruleConfigs,
 		detector:            lineDetector,
 		repoPath:            repoPath,
 		queryExecTimeout:    queryExecTimeout,
@@ -587,6 +593,18 @@ func getVulnerabilitiesFromQuery(ctx context.Context, qCtx *QueryContext, c *Ins
 	if !ok || file == nil {
 		return nil, false
 	}
+
+	if rc, found := lookupRuleConfig(c.ruleConfigs, vulnerability.QueryID, vulnerability.LegacyQueryID); found {
+		if rc.Severity != "" {
+			vulnerability.Severity = model.Severity(strings.ToUpper(rc.Severity))
+		}
+		if rulePathExcluded(file.FilePath, rc.IgnorePaths, rc.OnlyPaths) {
+			contextLogger.Debug().Msgf("Dropping finding in %s for rule %s (rule path filter)",
+				file.FilePath, vulnerability.QueryID)
+			return nil, false
+		}
+	}
+
 	if ShouldSkipVulnerability(file.Commands, vulnerability.QueryID, vulnerability.LegacyQueryID) {
 		contextLogger.Debug().Msgf("Suppressing vulnerability in file %s for query '%s':%s",
 			file.FilePath, vulnerability.QueryName, vulnerability.QueryID)
@@ -611,6 +629,96 @@ func getVulnerabilitiesFromQuery(ctx context.Context, qCtx *QueryContext, c *Ins
 	}
 
 	return vulnerability, false
+}
+
+// lookupRuleConfig returns the first matching rule config for the given queryID or legacyQueryID.
+func lookupRuleConfig(ruleConfigs map[string]config.IacRuleConfig, queryID, legacyQueryID string) (config.IacRuleConfig, bool) {
+	if len(ruleConfigs) == 0 {
+		return config.IacRuleConfig{}, false
+	}
+	if rc, ok := ruleConfigs[queryID]; ok {
+		return rc, true
+	}
+	if legacyQueryID != "" {
+		if rc, ok := ruleConfigs[legacyQueryID]; ok {
+			return rc, true
+		}
+	}
+	return config.IacRuleConfig{}, false
+}
+
+// rulePathExcluded returns true if the file should be dropped for a given rule
+// based on its ignore-paths and only-paths lists.
+func rulePathExcluded(filePath string, ignorePaths, onlyPaths []string) bool {
+	for _, pattern := range ignorePaths {
+		if matchesPath(pattern, filePath) {
+			return true
+		}
+	}
+	if len(onlyPaths) > 0 {
+		for _, pattern := range onlyPaths {
+			if matchesPath(pattern, filePath) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// matchesPath reports whether filePath is covered by pattern.
+// pattern may be a literal path, a directory prefix, a single-star glob (*, ?, [...]),
+// or a double-star glob (**) where ** matches zero or more path segments.
+// Both arguments are normalized to forward slashes for OS-independent behavior.
+func matchesPath(pattern, filePath string) bool {
+	pattern = filepath.ToSlash(pattern)
+	filePath = filepath.ToSlash(filePath)
+
+	// Exact match.
+	if pattern == filePath {
+		return true
+	}
+	// Directory prefix: any file under pattern/ matches.
+	if strings.HasPrefix(filePath, strings.TrimSuffix(pattern, "/")+"/") {
+		return true
+	}
+	// Double-star glob (**): segment-aware recursive match.
+	if strings.Contains(pattern, "**") {
+		return matchDoublestar(strings.Split(pattern, "/"), strings.Split(filePath, "/"))
+	}
+	// Single-level glob (*, ?, [...]): use path.Match with forward-slash semantics.
+	if matched, err := pathpkg.Match(pattern, filePath); err == nil && matched {
+		return true
+	}
+	return false
+}
+
+// matchDoublestar matches a pre-split path against a pre-split pattern where
+// "**" matches zero or more path segments.
+func matchDoublestar(pat, path []string) bool {
+	for len(pat) > 0 {
+		if pat[0] == "**" {
+			// ** matches zero remaining segments → try skipping the **
+			if matchDoublestar(pat[1:], path) {
+				return true
+			}
+			// ** matches one or more segments → consume one path segment and retry
+			if len(path) == 0 {
+				return false
+			}
+			return matchDoublestar(pat, path[1:])
+		}
+		if len(path) == 0 {
+			return false
+		}
+		ok, err := pathpkg.Match(pat[0], path[0])
+		if err != nil || !ok {
+			return false
+		}
+		pat = pat[1:]
+		path = path[1:]
+	}
+	return len(path) == 0
 }
 
 // markSuppressed records the first suppression decision; later gates are

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -10,14 +10,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	pathpkg "path"
-	"path/filepath"
 	"reflect"
 	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/pathutil"
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
 	"github.com/DataDog/datadog-iac-scanner/pkg/detector"
 	"github.com/DataDog/datadog-iac-scanner/pkg/detector/docker"
@@ -595,8 +594,8 @@ func getVulnerabilitiesFromQuery(ctx context.Context, qCtx *QueryContext, c *Ins
 	}
 
 	if rc, found := lookupRuleConfig(c.ruleConfigs, vulnerability.QueryID, vulnerability.LegacyQueryID); found {
-		if rc.Severity != "" {
-			vulnerability.Severity = model.Severity(strings.ToUpper(rc.Severity))
+		if rc.Severity != nil {
+			vulnerability.Severity = model.Severity(strings.ToUpper(*rc.Severity))
 		}
 		if rulePathExcluded(file.FilePath, rc.IgnorePaths, rc.OnlyPaths) {
 			contextLogger.Debug().Msgf("Dropping finding in %s for rule %s (rule path filter)",
@@ -651,74 +650,19 @@ func lookupRuleConfig(ruleConfigs map[string]config.IacRuleConfig, queryID, lega
 // based on its ignore-paths and only-paths lists.
 func rulePathExcluded(filePath string, ignorePaths, onlyPaths []string) bool {
 	for _, pattern := range ignorePaths {
-		if matchesPath(pattern, filePath) {
+		if pathutil.MatchesPath(pattern, filePath) {
 			return true
 		}
 	}
-	if len(onlyPaths) > 0 {
-		for _, pattern := range onlyPaths {
-			if matchesPath(pattern, filePath) {
-				return false
-			}
-		}
-		return true
+	if len(onlyPaths) == 0 {
+		return false
 	}
-	return false
-}
-
-// matchesPath reports whether filePath is covered by pattern.
-// pattern may be a literal path, a directory prefix, a single-star glob (*, ?, [...]),
-// or a double-star glob (**) where ** matches zero or more path segments.
-// Both arguments are normalized to forward slashes for OS-independent behavior.
-func matchesPath(pattern, filePath string) bool {
-	pattern = filepath.ToSlash(pattern)
-	filePath = filepath.ToSlash(filePath)
-
-	// Exact match.
-	if pattern == filePath {
-		return true
-	}
-	// Directory prefix: any file under pattern/ matches.
-	if strings.HasPrefix(filePath, strings.TrimSuffix(pattern, "/")+"/") {
-		return true
-	}
-	// Double-star glob (**): segment-aware recursive match.
-	if strings.Contains(pattern, "**") {
-		return matchDoublestar(strings.Split(pattern, "/"), strings.Split(filePath, "/"))
-	}
-	// Single-level glob (*, ?, [...]): use path.Match with forward-slash semantics.
-	if matched, err := pathpkg.Match(pattern, filePath); err == nil && matched {
-		return true
-	}
-	return false
-}
-
-// matchDoublestar matches a pre-split path against a pre-split pattern where
-// "**" matches zero or more path segments.
-func matchDoublestar(pat, path []string) bool {
-	for len(pat) > 0 {
-		if pat[0] == "**" {
-			// ** matches zero remaining segments → try skipping the **
-			if matchDoublestar(pat[1:], path) {
-				return true
-			}
-			// ** matches one or more segments → consume one path segment and retry
-			if len(path) == 0 {
-				return false
-			}
-			return matchDoublestar(pat, path[1:])
-		}
-		if len(path) == 0 {
+	for _, pattern := range onlyPaths {
+		if pathutil.MatchesPath(pattern, filePath) {
 			return false
 		}
-		ok, err := pathpkg.Match(pat[0], path[0])
-		if err != nil || !ok {
-			return false
-		}
-		pat = pat[1:]
-		path = path[1:]
 	}
-	return len(path) == 0
+	return true
 }
 
 // markSuppressed records the first suppression decision; later gates are

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/pathutil"
 	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
 	"github.com/DataDog/datadog-iac-scanner/pkg/detector"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
@@ -1049,7 +1050,7 @@ func TestMatchesPath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, matchesPath(tt.pattern, tt.file))
+			assert.Equal(t, tt.want, pathutil.MatchesPath(tt.pattern, tt.file))
 		})
 	}
 }

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -106,6 +106,7 @@ func newTestInspector(t *testing.T, opts inspectorOpts) *Inspector {
 		opts.tracker,
 		opts.queryParameters,
 		opts.excludeResults,
+		nil,
 		opts.repoPath,
 		opts.queryTimeout,
 		opts.useOldSeverities,
@@ -1017,6 +1018,96 @@ func TestInspector_checkComment(t *testing.T) {
 			if got := checkComment(tt.line, tt.lines); got != tt.want {
 				t.Errorf("checkComment() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestMatchesPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		file    string
+		want    bool
+	}{
+		{"exact match", "/repo/src/main.tf", "/repo/src/main.tf", true},
+		{"directory prefix", "/repo/src", "/repo/src/main.tf", true},
+		{"directory prefix no trailing sep", "/repo/src", "/repo/src/nested/main.tf", true},
+		{"no match different dir", "/repo/test", "/repo/src/main.tf", false},
+		{"no partial prefix match", "/repo/s", "/repo/src/main.tf", false},
+		{"glob star", "/repo/src/*.tf", "/repo/src/main.tf", true},
+		{"glob star no match", "/repo/src/*.tf", "/repo/src/main.go", false},
+		{"glob question mark", "/repo/src/mai?.tf", "/repo/src/main.tf", true},
+		// double-star (**) glob
+		{"doublestar all tf files", "/repo/**/*.tf", "/repo/src/main.tf", true},
+		{"doublestar nested", "/repo/**/*.tf", "/repo/src/nested/deep/main.tf", true},
+		{"doublestar no match ext", "/repo/**/*.tf", "/repo/src/main.go", false},
+		{"doublestar prefix any subdir", "**/terraform/**", "infra/terraform/main.tf", true},
+		{"doublestar prefix no match", "**/terraform/**", "infra/k8s/main.yaml", false},
+		{"doublestar matches zero segments", "a/**/b.tf", "a/b.tf", true},
+		{"doublestar matches one segment", "a/**/b.tf", "a/x/b.tf", true},
+		{"doublestar matches many segments", "a/**/b.tf", "a/x/y/z/b.tf", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, matchesPath(tt.pattern, tt.file))
+		})
+	}
+}
+
+func TestRulePathExcluded(t *testing.T) {
+	tests := []struct {
+		name        string
+		filePath    string
+		ignorePaths []string
+		onlyPaths   []string
+		want        bool
+	}{
+		{
+			name:        "no filters",
+			filePath:    "/repo/src/main.tf",
+			ignorePaths: nil,
+			onlyPaths:   nil,
+			want:        false,
+		},
+		{
+			name:        "ignored by ignore-paths",
+			filePath:    "/repo/test/fixture.tf",
+			ignorePaths: []string{"/repo/test"},
+			onlyPaths:   nil,
+			want:        true,
+		},
+		{
+			name:        "not ignored",
+			filePath:    "/repo/src/main.tf",
+			ignorePaths: []string{"/repo/test"},
+			onlyPaths:   nil,
+			want:        false,
+		},
+		{
+			name:        "only-paths match",
+			filePath:    "/repo/src/main.tf",
+			ignorePaths: nil,
+			onlyPaths:   []string{"/repo/src"},
+			want:        false,
+		},
+		{
+			name:        "only-paths no match",
+			filePath:    "/repo/test/fixture.tf",
+			ignorePaths: nil,
+			onlyPaths:   []string{"/repo/src"},
+			want:        true,
+		},
+		{
+			name:        "ignore-paths takes precedence over only-paths",
+			filePath:    "/repo/src/main.tf",
+			ignorePaths: []string{"/repo/src"},
+			onlyPaths:   []string{"/repo/src"},
+			want:        true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rulePathExcluded(tt.filePath, tt.ignorePaths, tt.onlyPaths))
 		})
 	}
 }

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-iac-scanner/internal/pathutil"
 	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
 	"github.com/DataDog/datadog-iac-scanner/pkg/detector"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
@@ -1019,38 +1018,6 @@ func TestInspector_checkComment(t *testing.T) {
 			if got := checkComment(tt.line, tt.lines); got != tt.want {
 				t.Errorf("checkComment() = %v, want %v", got, tt.want)
 			}
-		})
-	}
-}
-
-func TestMatchesPath(t *testing.T) {
-	tests := []struct {
-		name    string
-		pattern string
-		file    string
-		want    bool
-	}{
-		{"exact match", "/repo/src/main.tf", "/repo/src/main.tf", true},
-		{"directory prefix", "/repo/src", "/repo/src/main.tf", true},
-		{"directory prefix no trailing sep", "/repo/src", "/repo/src/nested/main.tf", true},
-		{"no match different dir", "/repo/test", "/repo/src/main.tf", false},
-		{"no partial prefix match", "/repo/s", "/repo/src/main.tf", false},
-		{"glob star", "/repo/src/*.tf", "/repo/src/main.tf", true},
-		{"glob star no match", "/repo/src/*.tf", "/repo/src/main.go", false},
-		{"glob question mark", "/repo/src/mai?.tf", "/repo/src/main.tf", true},
-		// double-star (**) glob
-		{"doublestar all tf files", "/repo/**/*.tf", "/repo/src/main.tf", true},
-		{"doublestar nested", "/repo/**/*.tf", "/repo/src/nested/deep/main.tf", true},
-		{"doublestar no match ext", "/repo/**/*.tf", "/repo/src/main.go", false},
-		{"doublestar prefix any subdir", "**/terraform/**", "infra/terraform/main.tf", true},
-		{"doublestar prefix no match", "**/terraform/**", "infra/k8s/main.yaml", false},
-		{"doublestar matches zero segments", "a/**/b.tf", "a/b.tf", true},
-		{"doublestar matches one segment", "a/**/b.tf", "a/x/b.tf", true},
-		{"doublestar matches many segments", "a/**/b.tf", "a/x/y/z/b.tf", true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, pathutil.MatchesPath(tt.pattern, tt.file))
 		})
 	}
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -176,6 +176,9 @@ func (c *Parser) SupportedExtensions() model.Extensions {
 }
 
 func contains(types []string, supportedTypes map[string]bool) bool {
+	if len(types) == 0 {
+		return false
+	}
 	if types[0] == "" {
 		return true
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -119,14 +119,24 @@ func TestParser_Contains(t *testing.T) {
 		{
 			name: "test contains",
 			args: args{
-				types: []string{
-					"cloudformation",
-				},
-				supportedTypes: map[string]bool{
-					"cloudformation": true,
-					"terraform":      true,
-					"ansible":        true,
-				},
+				types:          []string{"cloudformation"},
+				supportedTypes: map[string]bool{"cloudformation": true, "terraform": true},
+			},
+			want: true,
+		},
+		{
+			name: "empty types returns false (no platform selected)",
+			args: args{
+				types:          []string{},
+				supportedTypes: map[string]bool{"terraform": true},
+			},
+			want: false,
+		},
+		{
+			name: "single empty string returns true (no filter)",
+			args: args{
+				types:          []string{""},
+				supportedTypes: map[string]bool{"terraform": true},
 			},
 			want: true,
 		},

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -1,0 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package platforms
+
+// Supported is the list of IaC platforms with published rules available to customers.
+var Supported = []string{"Ansible", "CICD", "CloudFormation", "Dockerfile", "Kubernetes", "Terraform"}

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -21,7 +21,8 @@ import (
 	"github.com/google/uuid"
 )
 
-var severityLevelEquivalence = map[model.Severity]string{
+// SeverityLevelEquivalence maps a finding severity to its SARIF result level.
+var SeverityLevelEquivalence = map[model.Severity]string{
 	"INFO":     "none",
 	"LOW":      "none",
 	"MEDIUM":   "note",
@@ -392,7 +393,7 @@ func (sr *sarifReport) buildSarifRule(queryMetadata *ruleMetadata, cisMetadata r
 			RuleName:             queryMetadata.queryName,
 			RuleShortDescription: sarifMessage{Text: queryMetadata.queryName},
 			RuleFullDescription:  sarifMessage{Text: queryMetadata.queryDescription},
-			DefaultConfiguration: sarifConfiguration{Level: severityLevelEquivalence[queryMetadata.severity]},
+			DefaultConfiguration: sarifConfiguration{Level: SeverityLevelEquivalence[queryMetadata.severity]},
 			// Relationships:        relationships,
 			HelpURI: helpURI,
 			RuleProperties: sarifProperties{
@@ -561,7 +562,7 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 			result := sarifResult{
 				ResultRuleID:    issue.QueryName,
 				ResultRuleIndex: ruleIndex,
-				ResultLevel:     severityLevelEquivalence[issue.Severity],
+				ResultLevel:     SeverityLevelEquivalence[issue.Severity],
 				ResultMessage: sarifMessage{
 					Text: issue.QueryName,
 				},

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	"github.com/DataDog/datadog-iac-scanner/internal/storage"
 	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
@@ -17,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/platforms"
 	consolePrinter "github.com/DataDog/datadog-iac-scanner/pkg/printer"
 	"github.com/rs/zerolog/log"
 )
@@ -92,7 +92,7 @@ func GetDefaultParameters(ctx context.Context, rootPath string) (*Parameters, co
 		QueriesPath:                 []string{"./assets/queries"},
 		LibrariesPath:               "./assets/libraries",
 		ReportFormats:               []string{"sarif"},
-		Platform:                    ApplyPlatformFilters(constants.SupportedPlatforms, configParams.OnlyPlatforms, configParams.IgnorePlatforms),
+		Platform:                    ApplyPlatformFilters(platforms.Supported, configParams.OnlyPlatforms, configParams.IgnorePlatforms),
 		TerraformVarsPath:           "",
 		QueryExecTimeout:            60,
 		LineInfoPayload:             false,

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	"github.com/DataDog/datadog-iac-scanner/internal/storage"
 	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
@@ -91,7 +92,7 @@ func GetDefaultParameters(ctx context.Context, rootPath string) (*Parameters, co
 		QueriesPath:                 []string{"./assets/queries"},
 		LibrariesPath:               "./assets/libraries",
 		ReportFormats:               []string{"sarif"},
-		Platform:                    []string{"CICD", "Terraform", "Kubernetes", "CloudFormation", "Dockerfile"},
+		Platform:                    ApplyPlatformFilters(constants.SupportedPlatforms, configParams.OnlyPlatforms, configParams.IgnorePlatforms),
 		TerraformVarsPath:           "",
 		QueryExecTimeout:            60,
 		LineInfoPayload:             false,

--- a/pkg/scan/platform.go
+++ b/pkg/scan/platform.go
@@ -1,0 +1,39 @@
+package scan
+
+import "strings"
+
+// ApplyPlatformFilters intersects cliPlatforms with the only/ignore lists from
+// the IaC config, returning the set of platforms that should actually be scanned.
+func ApplyPlatformFilters(cliPlatforms, onlyPlatforms, ignorePlatforms []string) []string {
+	active := cliPlatforms
+
+	if len(onlyPlatforms) > 0 {
+		allowed := make(map[string]struct{}, len(onlyPlatforms))
+		for _, p := range onlyPlatforms {
+			allowed[strings.ToLower(p)] = struct{}{}
+		}
+		filtered := active[:0:0]
+		for _, p := range active {
+			if _, ok := allowed[strings.ToLower(p)]; ok {
+				filtered = append(filtered, p)
+			}
+		}
+		active = filtered
+	}
+
+	if len(ignorePlatforms) > 0 {
+		ignored := make(map[string]struct{}, len(ignorePlatforms))
+		for _, p := range ignorePlatforms {
+			ignored[strings.ToLower(p)] = struct{}{}
+		}
+		filtered := active[:0:0]
+		for _, p := range active {
+			if _, ok := ignored[strings.ToLower(p)]; !ok {
+				filtered = append(filtered, p)
+			}
+		}
+		active = filtered
+	}
+
+	return active
+}

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -78,6 +78,7 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		c.Tracker,
 		queryFilter,
 		c.ExcludeResultsMap,
+		c.ScanParams.Config.RuleConfigs,
 		c.ScanParams.RepoPath,
 		c.ScanParams.QueryExecTimeout,
 		c.ScanParams.UseOldSeverities,

--- a/pkg/scan/utils.go
+++ b/pkg/scan/utils.go
@@ -49,6 +49,10 @@ func (c *Client) prepareAndAnalyzePaths(ctx context.Context) (provider.Extracted
 	if len(allPaths.Path) == 0 {
 		return provider.ExtractedPath{}, nil
 	}
+	if len(c.ScanParams.Platform) == 0 {
+		return provider.ExtractedPath{}, nil
+	}
+
 	contextLogger.Info().Msgf("Total files in the project: %d", getTotalFiles(ctx, allPaths.Path))
 
 	a := &analyzer.Analyzer{

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -44,7 +44,7 @@ func createServices(types, cloudProviders []string) (serviceSlice, *storage.Memo
 
 	inspector, err := engine.NewInspector(context.Background(),
 		querySource, engine.DefaultVulnerabilityBuilder,
-		t, &source.QueryInspectorParameters{}, map[string]bool{}, ".", 60, true, true, 1, false,
+		t, &source.QueryInspectorParameters{}, map[string]bool{}, nil, ".", 60, true, true, 1, false,
 		featureflags.NewLocalEvaluator(),
 	)
 	if err != nil {

--- a/test/e2e/fixtures/v13/.github/workflows/ci.yaml
+++ b/test/e2e/fixtures/v13/.github/workflows/ci.yaml
@@ -1,0 +1,7 @@
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3         # local-style exempt prefix 'actions/'
+      - uses: docker/build-push-action@v4  # unpinned → triggers rule

--- a/test/e2e/fixtures/v13/k8s/production/deploy.yaml
+++ b/test/e2e/fixtures/v13/k8s/production/deploy.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prod-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: prod }
+  template:
+    metadata:
+      labels: { app: prod }
+    spec:
+      containers:
+      - name: app
+        image: nginx:latest
+        securityContext:
+          privileged: true

--- a/test/e2e/fixtures/v13/k8s/staging/deploy.yaml
+++ b/test/e2e/fixtures/v13/k8s/staging/deploy.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: staging-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: staging }
+  template:
+    metadata:
+      labels: { app: staging }
+    spec:
+      containers:
+      - name: app
+        image: nginx:latest
+        securityContext:
+          privileged: true

--- a/test/e2e/fixtures/v13/terraform/prod/main.tf
+++ b/test/e2e/fixtures/v13/terraform/prod/main.tf
@@ -1,0 +1,5 @@
+provider "aws" { region = "us-east-1" }
+resource "aws_s3_bucket" "prod" {
+  bucket = "prod-bucket"
+  tags   = { Env = "prod" }  # no Team tag
+}

--- a/test/e2e/fixtures/v13/terraform/test/main.tf
+++ b/test/e2e/fixtures/v13/terraform/test/main.tf
@@ -1,0 +1,5 @@
+provider "aws" { region = "us-east-1" }
+resource "aws_s3_bucket" "test" {
+  bucket = "test-bucket"
+  tags   = { Env = "test" }  # no Team tag
+}

--- a/test/e2e/v13_test.go
+++ b/test/e2e/v13_test.go
@@ -1,0 +1,721 @@
+package test
+
+// Comprehensive local tests for code-security.datadog.yaml v1.3 features:
+//   - per-rule ignore-paths / only-paths
+//   - per-rule severity override
+//   - global-config only-platforms / ignore-platforms
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/internal/console"
+	"github.com/DataDog/datadog-iac-scanner/pkg/config"
+	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	sarifmodel "github.com/DataDog/datadog-iac-scanner/pkg/report/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/scan"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Rule slugs (QueryID) — used in ViolationBreakdowns.
+const (
+	ruleTeamTag         = "terraform-aws-team-tag-not-present"
+	ruleTeamTagLegacyID = "a2b3c4d5-e6f7-8901-gh23-ijkl456m7890"
+	rulePrivileged      = "kubernetes-container-is-privileged"
+	ruleCicdPinned      = "cicd-github-unpinned-actions-full-length-commit-sha"
+)
+
+// Fixture root under test/e2e/fixtures/v13/
+// Paths are relative to the test/e2e working directory so that file.FilePath
+// inside the engine stays relative and matches the filter patterns in RuleConfigs.
+const fixtureV13 = "fixtures/v13"
+
+// allQueriesPaths covers all three platforms under test.
+var allQueriesPaths = []string{
+	filepath.Join("testdata", "rules", "terraform"),
+	filepath.Join("testdata", "rules", "k8s"),
+	filepath.Join("testdata", "rules", "cicd"),
+}
+
+// sarifRuleIDMap builds a slug→queryName map by reading metadata.json files from
+// the local testdata rules directories. SARIF uses the query name as ruleId.
+func sarifRuleIDMap(t *testing.T) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, dir := range allQueriesPaths {
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(dir, e.Name(), "metadata.json"))
+			require.NoError(t, err)
+			var meta struct {
+				ID        string `json:"id"`
+				QueryName string `json:"queryName"`
+			}
+			require.NoError(t, json.Unmarshal(data, &meta))
+			out[meta.ID] = meta.QueryName
+		}
+	}
+	return out
+}
+
+// -----------------------------------------------------------------------------
+// SARIF helpers (for path and severity inspection)
+// -----------------------------------------------------------------------------
+
+type sarifResult struct {
+	RuleID    string
+	Level     string   // "error" | "warning" | "note" | "none"
+	Locations []string // artifact URIs
+}
+
+func parseSARIF(t *testing.T, outputDir string) []sarifResult {
+	t.Helper()
+	entries, err := os.ReadDir(outputDir)
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".sarif") {
+			data, err := os.ReadFile(filepath.Join(outputDir, e.Name()))
+			require.NoError(t, err)
+
+			var doc struct {
+				Runs []struct {
+					Results []struct {
+						RuleID    string `json:"ruleId"`
+						Level     string `json:"level"`
+						Locations []struct {
+							PhysicalLocation struct {
+								ArtifactLocation struct {
+									URI string `json:"uri"`
+								} `json:"artifactLocation"`
+							} `json:"physicalLocation"`
+						} `json:"locations"`
+					} `json:"results"`
+				} `json:"runs"`
+			}
+			require.NoError(t, json.Unmarshal(data, &doc))
+
+			var out []sarifResult
+			for _, run := range doc.Runs {
+				for _, r := range run.Results {
+					var locs []string
+					for _, l := range r.Locations {
+						locs = append(locs, l.PhysicalLocation.ArtifactLocation.URI)
+					}
+					out = append(out, sarifResult{
+						RuleID:    r.RuleID,
+						Level:     r.Level,
+						Locations: locs,
+					})
+				}
+			}
+			return out
+		}
+	}
+	return nil
+}
+
+// filterSARIF returns results for a rule. nameMap is the slug→queryName map
+// from sarifRuleIDMap; pass nil to match by ruleId directly.
+func filterSARIF(results []sarifResult, ruleID string, nameMap map[string]string) []sarifResult {
+	name := nameMap[ruleID]
+	var out []sarifResult
+	for _, r := range results {
+		if r.RuleID == ruleID || (name != "" && r.RuleID == name) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// locationsContain returns true if any location URI contains the given substring.
+func locationsContain(results []sarifResult, substr string) bool {
+	for _, r := range results {
+		for _, l := range r.Locations {
+			if strings.Contains(l, substr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// levelsFor returns the distinct SARIF level values for a rule's findings.
+func levelsFor(results []sarifResult, ruleID string, nameMap map[string]string) map[string]bool {
+	levels := map[string]bool{}
+	for _, r := range filterSARIF(results, ruleID, nameMap) {
+		levels[r.Level] = true
+	}
+	return levels
+}
+
+// -----------------------------------------------------------------------------
+// Scan helper
+// -----------------------------------------------------------------------------
+
+type scanResult struct {
+	metadata scan.ScanMetadata
+	sarifDir string
+	nameMap  map[string]string // rule slug → SARIF ruleId (query name)
+}
+
+// countForRule returns the total finding count for a rule across all severities.
+// Reads from ViolationBreakdowns: map[severity][ruleID] = count.
+func (s *scanResult) countForRule(ruleID string) int {
+	total := 0
+	for _, byRule := range s.metadata.Stats.ViolationBreakdowns {
+		total += byRule[ruleID]
+	}
+	return total
+}
+
+// ruleHasFindings returns true if the rule produced any findings.
+func (s *scanResult) ruleHasFindings(ruleID string) bool {
+	return s.countForRule(ruleID) > 0
+}
+
+// severitiesForRule returns the set of severities that have findings for a rule.
+func (s *scanResult) severitiesForRule(ruleID string) map[string]bool {
+	out := map[string]bool{}
+	for sev, byRule := range s.metadata.Stats.ViolationBreakdowns {
+		if byRule[ruleID] > 0 {
+			out[sev] = true
+		}
+	}
+	return out
+}
+
+// sarifFindings returns the SARIF results for a rule.
+func (s *scanResult) sarifFindings(t *testing.T, ruleID string) []sarifResult {
+	t.Helper()
+	return filterSARIF(parseSARIF(t, s.sarifDir), ruleID, s.nameMap)
+}
+
+// sarifLevels returns the distinct SARIF level values for a rule's findings.
+func (s *scanResult) sarifLevels(t *testing.T, ruleID string) map[string]bool {
+	t.Helper()
+	return levelsFor(parseSARIF(t, s.sarifDir), ruleID, s.nameMap)
+}
+
+func runV13Scan(t *testing.T, cfg config.IacConfig, scanDirs ...string) scanResult {
+	t.Helper()
+
+	// Keep paths relative (like the existing e2e tests), so file.FilePath inside
+	// the engine remains relative and matches the relative filter patterns.
+	absQueryPaths := make([]string, len(allQueriesPaths))
+	for i, qp := range allQueriesPaths {
+		abs, err := filepath.Abs(qp)
+		require.NoError(t, err)
+		absQueryPaths[i] = abs
+	}
+
+	outDir := t.TempDir()
+
+	params, ctx := scan.GetDefaultParameters(context.Background(), "")
+	params.Path = scanDirs
+	params.OutputPath = outDir
+	params.OutputName = "result"
+	params.QueriesPath = absQueryPaths
+	params.ChangedDefaultQueryPath = true
+	params.Platform = scan.ApplyPlatformFilters(
+		[]string{"Terraform", "Kubernetes", "CICD"},
+		cfg.OnlyPlatforms, cfg.IgnorePlatforms,
+	)
+	params.Config = cfg
+	params.SCIInfo = model.SCIInfo{
+		DiffAware:            model.DiffAware{Enabled: false},
+		RepositoryCommitInfo: model.RepositoryCommitInfo{
+			RepositoryUrl: "test/url",
+			CommitSHA:     "deadbeef",
+			Branch:        "main",
+		},
+	}
+	params.FlagEvaluator = featureflags.NewLocalEvaluator()
+
+	meta, err := console.ExecuteScan(ctx, params)
+	require.NoError(t, err)
+	return scanResult{metadata: meta, sarifDir: outDir, nameMap: sarifRuleIDMap(t)}
+}
+
+// relFixture returns the path relative to test/e2e/ for a path under fixtures/v13.
+// Relative paths are required so that file.FilePath inside the engine stays
+// relative and can be matched by the filter patterns we put in RuleConfigs.
+func relFixture(rel string) string {
+	return filepath.Join(fixtureV13, rel)
+}
+
+// allFixtureDirs returns relative paths for all three platform fixture dirs.
+func allFixtureDirs() []string {
+	return []string{
+		relFixture("terraform"),
+		relFixture("k8s"),
+		relFixture(".github"),
+	}
+}
+
+// -----------------------------------------------------------------------------
+// TestV13_Baseline — confirm all rules fire before any v1.3 config
+// -----------------------------------------------------------------------------
+
+func TestV13_Baseline(t *testing.T) {
+	res := runV13Scan(t, config.IacConfig{}, allFixtureDirs()...)
+
+	assert.True(t, res.ruleHasFindings(ruleTeamTag), "terraform rule should fire")
+	assert.True(t, res.ruleHasFindings(rulePrivileged), "k8s rule should fire")
+	assert.True(t, res.ruleHasFindings(ruleCicdPinned), "cicd rule should fire")
+
+	t.Logf("Baseline counts  tf=%d  k8s=%d  cicd=%d",
+		res.countForRule(ruleTeamTag),
+		res.countForRule(rulePrivileged),
+		res.countForRule(ruleCicdPinned),
+	)
+}
+
+// -----------------------------------------------------------------------------
+// Per-rule ignore-paths
+// -----------------------------------------------------------------------------
+
+func TestV13_RuleConfig_IgnorePaths_DropsMatchingDir(t *testing.T) {
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			ruleTeamTag: {IgnorePaths: []string{relFixture("terraform/prod")}},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("terraform"))
+
+	// prod/ should not appear in any finding for this rule
+	assert.False(t,
+		locationsContain(res.sarifFindings(t, ruleTeamTag), "prod"),
+		"findings from prod/ should be hard-dropped",
+	)
+}
+
+func TestV13_RuleConfig_IgnorePaths_KeepsOtherDir(t *testing.T) {
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			ruleTeamTag: {IgnorePaths: []string{relFixture("terraform/prod")}},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("terraform"))
+
+	// test/ should still have findings
+	assert.True(t,
+		locationsContain(res.sarifFindings(t, ruleTeamTag), "test"),
+		"findings from test/ should survive ignore of prod/",
+	)
+}
+
+func TestV13_RuleConfig_IgnorePaths_DropAll(t *testing.T) {
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			ruleTeamTag: {
+				IgnorePaths: []string{
+					relFixture("terraform/prod"),
+					relFixture("terraform/test"),
+				},
+			},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("terraform"))
+
+	assert.Zero(t, res.countForRule(ruleTeamTag), "all findings should be dropped")
+}
+
+func TestV13_RuleConfig_IgnorePaths_OtherRulesUnaffected(t *testing.T) {
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			ruleTeamTag: {
+				IgnorePaths: []string{
+					relFixture("terraform/prod"),
+					relFixture("terraform/test"),
+				},
+			},
+		},
+	}
+	res := runV13Scan(t, cfg, allFixtureDirs()...)
+
+	assert.Zero(t, res.countForRule(ruleTeamTag), "tf rule should be fully dropped")
+	assert.Positive(t, res.countForRule(rulePrivileged), "k8s rule unaffected")
+	assert.Positive(t, res.countForRule(ruleCicdPinned), "cicd rule unaffected")
+}
+
+// -----------------------------------------------------------------------------
+// Per-rule only-paths
+// -----------------------------------------------------------------------------
+
+func TestV13_RuleConfig_OnlyPaths_RestrictsToDir(t *testing.T) {
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			ruleTeamTag: {OnlyPaths: []string{relFixture("terraform/prod")}},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("terraform"))
+	findings := res.sarifFindings(t, ruleTeamTag)
+
+	require.NotEmpty(t, findings, "prod/ findings should remain")
+	assert.False(t,
+		locationsContain(findings, "test"),
+		"test/ findings should be dropped by only-paths",
+	)
+}
+
+func TestV13_RuleConfig_OnlyPaths_DropAll_WhenNothingMatches(t *testing.T) {
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			ruleTeamTag: {OnlyPaths: []string{"/no/such/path"}},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("terraform"))
+
+	assert.Zero(t, res.countForRule(ruleTeamTag), "no findings expected when only-paths matches nothing")
+}
+
+func TestV13_RuleConfig_OnlyPaths_MultipleAllowed(t *testing.T) {
+	// both prod/ and test/ are in only-paths → all findings survive
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			ruleTeamTag: {
+				OnlyPaths: []string{
+					relFixture("terraform/prod"),
+					relFixture("terraform/test"),
+				},
+			},
+		},
+	}
+	baseline := runV13Scan(t, config.IacConfig{}, relFixture("terraform"))
+	withFilter := runV13Scan(t, cfg, relFixture("terraform"))
+
+	assert.Equal(t, baseline.countForRule(ruleTeamTag), withFilter.countForRule(ruleTeamTag),
+		"all dirs in only-paths → same count as no filter")
+}
+
+// -----------------------------------------------------------------------------
+// ignore-paths takes precedence over only-paths on the same rule
+// -----------------------------------------------------------------------------
+
+func TestV13_RuleConfig_IgnorePathsPrecedenceOverOnlyPaths(t *testing.T) {
+	prod := relFixture("terraform/prod")
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			ruleTeamTag: {
+				IgnorePaths: []string{prod},
+				OnlyPaths:   []string{prod},
+			},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("terraform"))
+
+	assert.False(t,
+		locationsContain(res.sarifFindings(t, ruleTeamTag), "prod"),
+		"ignore-paths should take precedence over only-paths",
+	)
+}
+
+// -----------------------------------------------------------------------------
+// Per-rule severity override
+// -----------------------------------------------------------------------------
+
+func TestV13_RuleConfig_SeverityOverride_DefaultIsHigh(t *testing.T) {
+	// Confirm baseline severity before overriding
+	res := runV13Scan(t, config.IacConfig{}, relFixture("k8s"))
+	sevs := res.severitiesForRule(rulePrivileged)
+	assert.True(t, sevs["HIGH"], "baseline k8s rule severity should be HIGH, got: %v", sevs)
+}
+
+func TestV13_RuleConfig_SeverityOverride_ToLow(t *testing.T) {
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			rulePrivileged: {Severity: "low"},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("k8s"))
+	sevs := res.severitiesForRule(rulePrivileged)
+
+	assert.True(t, sevs["LOW"], "severity should be overridden to LOW: %v", sevs)
+	assert.False(t, sevs["HIGH"], "original HIGH should not appear: %v", sevs)
+}
+
+func TestV13_RuleConfig_SeverityOverride_AllLevels(t *testing.T) {
+	for _, level := range []string{"critical", "high", "medium", "low", "info"} {
+		level := level
+		t.Run(level, func(t *testing.T) {
+			cfg := config.IacConfig{
+				RuleConfigs: map[string]config.IacRuleConfig{
+					ruleTeamTag: {Severity: level},
+				},
+			}
+			res := runV13Scan(t, cfg, relFixture("terraform"))
+			sevs := res.severitiesForRule(ruleTeamTag)
+			require.NotEmpty(t, sevs, "should have findings for rule")
+			assert.True(t, sevs[strings.ToUpper(level)], "expected %s in severities, got: %v", strings.ToUpper(level), sevs)
+		})
+	}
+}
+
+func TestV13_RuleConfig_SeverityOverride_DoesNotChangeCount(t *testing.T) {
+	baseline := runV13Scan(t, config.IacConfig{}, relFixture("terraform"))
+	baseCount := baseline.countForRule(ruleTeamTag)
+
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			ruleTeamTag: {Severity: "medium"},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("terraform"))
+
+	assert.Equal(t, baseCount, res.countForRule(ruleTeamTag), "severity override must not change finding count")
+}
+
+func TestV13_RuleConfig_SeverityOverride_DoesNotAffectOtherRules(t *testing.T) {
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			ruleTeamTag: {Severity: "critical"},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("terraform"), relFixture("k8s"))
+
+	tfSevs := res.severitiesForRule(ruleTeamTag)
+	assert.True(t, tfSevs["CRITICAL"], "terraform rule should be CRITICAL: %v", tfSevs)
+
+	k8sSevs := res.severitiesForRule(rulePrivileged)
+	assert.True(t, k8sSevs["HIGH"], "k8s rule should remain HIGH: %v", k8sSevs)
+}
+
+// Verify the SARIF level reflects the overridden severity.
+func TestV13_RuleConfig_SeverityOverride_SARIFLevel(t *testing.T) {
+	for sev, wantLevel := range sarifmodel.SeverityLevelEquivalence {
+		sev, wantLevel := sev, wantLevel
+		t.Run(string(sev), func(t *testing.T) {
+			cfg := config.IacConfig{
+				RuleConfigs: map[string]config.IacRuleConfig{
+					rulePrivileged: {Severity: strings.ToLower(string(sev))},
+				},
+			}
+			res := runV13Scan(t, cfg, relFixture("k8s"))
+			levels := res.sarifLevels(t, rulePrivileged)
+			assert.True(t, levels[wantLevel],
+				"severity %s should map to SARIF level %q, got: %v", sev, wantLevel, levels)
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Severity + ignore-paths combined on the same rule
+// -----------------------------------------------------------------------------
+
+func TestV13_RuleConfig_SeverityAndIgnorePaths_Combined(t *testing.T) {
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			ruleTeamTag: {
+				IgnorePaths: []string{relFixture("terraform/prod")},
+				Severity:    "info",
+			},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("terraform"))
+	findings := res.sarifFindings(t, ruleTeamTag)
+
+	require.NotEmpty(t, findings, "test/ findings should survive")
+	assert.False(t, locationsContain(findings, "prod"), "prod/ must be dropped")
+
+	// All surviving findings must be at INFO level (overridden from LOW)
+	sevs := res.severitiesForRule(ruleTeamTag)
+	assert.True(t, sevs["INFO"], "surviving findings should be INFO: %v", sevs)
+	assert.False(t, sevs["LOW"], "original LOW severity should no longer appear: %v", sevs)
+}
+
+// -----------------------------------------------------------------------------
+// Global platform filters — only-platforms
+// -----------------------------------------------------------------------------
+
+func TestV13_OnlyPlatforms_SinglePlatform_Terraform(t *testing.T) {
+	cfg := config.IacConfig{OnlyPlatforms: []string{"Terraform"}}
+	res := runV13Scan(t, cfg, allFixtureDirs()...)
+
+	assert.True(t, res.ruleHasFindings(ruleTeamTag), "Terraform rule should fire")
+	assert.False(t, res.ruleHasFindings(rulePrivileged), "Kubernetes rule should not fire")
+	assert.False(t, res.ruleHasFindings(ruleCicdPinned), "CICD rule should not fire")
+}
+
+func TestV13_OnlyPlatforms_SinglePlatform_Kubernetes(t *testing.T) {
+	cfg := config.IacConfig{OnlyPlatforms: []string{"Kubernetes"}}
+	res := runV13Scan(t, cfg, allFixtureDirs()...)
+
+	assert.False(t, res.ruleHasFindings(ruleTeamTag))
+	assert.True(t, res.ruleHasFindings(rulePrivileged))
+	assert.False(t, res.ruleHasFindings(ruleCicdPinned))
+}
+
+func TestV13_OnlyPlatforms_MultiPlatform(t *testing.T) {
+	cfg := config.IacConfig{OnlyPlatforms: []string{"Terraform", "Kubernetes"}}
+	res := runV13Scan(t, cfg, allFixtureDirs()...)
+
+	assert.True(t, res.ruleHasFindings(ruleTeamTag))
+	assert.True(t, res.ruleHasFindings(rulePrivileged))
+	assert.False(t, res.ruleHasFindings(ruleCicdPinned), "CICD excluded by only-platforms")
+}
+
+func TestV13_OnlyPlatforms_AllPlatforms_EquivalentToNoFilter(t *testing.T) {
+	baseline := runV13Scan(t, config.IacConfig{}, allFixtureDirs()...)
+
+	cfg := config.IacConfig{OnlyPlatforms: []string{"Terraform", "Kubernetes", "CICD"}}
+	res := runV13Scan(t, cfg, allFixtureDirs()...)
+
+	assert.Equal(t, baseline.countForRule(ruleTeamTag), res.countForRule(ruleTeamTag))
+	assert.Equal(t, baseline.countForRule(rulePrivileged), res.countForRule(rulePrivileged))
+	assert.Equal(t, baseline.countForRule(ruleCicdPinned), res.countForRule(ruleCicdPinned))
+}
+
+// -----------------------------------------------------------------------------
+// Global platform filters — ignore-platforms
+// -----------------------------------------------------------------------------
+
+func TestV13_IgnorePlatforms_ExcludeKubernetes(t *testing.T) {
+	cfg := config.IacConfig{IgnorePlatforms: []string{"Kubernetes"}}
+	res := runV13Scan(t, cfg, allFixtureDirs()...)
+
+	assert.True(t, res.ruleHasFindings(ruleTeamTag))
+	assert.False(t, res.ruleHasFindings(rulePrivileged), "Kubernetes excluded")
+	assert.True(t, res.ruleHasFindings(ruleCicdPinned))
+}
+
+func TestV13_IgnorePlatforms_ExcludeMultiple(t *testing.T) {
+	cfg := config.IacConfig{IgnorePlatforms: []string{"Kubernetes", "CICD"}}
+	res := runV13Scan(t, cfg, allFixtureDirs()...)
+
+	assert.True(t, res.ruleHasFindings(ruleTeamTag))
+	assert.False(t, res.ruleHasFindings(rulePrivileged))
+	assert.False(t, res.ruleHasFindings(ruleCicdPinned))
+}
+
+func TestV13_IgnorePlatforms_ExcludeAll_NoFindings(t *testing.T) {
+	cfg := config.IacConfig{IgnorePlatforms: []string{"Terraform", "Kubernetes", "CICD"}}
+	res := runV13Scan(t, cfg, allFixtureDirs()...)
+
+	assert.Zero(t, res.metadata.Stats.Violations, "no violations when all platforms excluded")
+}
+
+// -----------------------------------------------------------------------------
+// Platform filter + rule config combined
+// -----------------------------------------------------------------------------
+
+func TestV13_PlatformFilter_And_RuleConfig_Combined(t *testing.T) {
+	cfg := config.IacConfig{
+		OnlyPlatforms: []string{"Terraform"},
+		RuleConfigs: map[string]config.IacRuleConfig{
+			ruleTeamTag: {
+				IgnorePaths: []string{relFixture("terraform/prod")},
+				Severity:    "medium",
+			},
+		},
+	}
+	res := runV13Scan(t, cfg, allFixtureDirs()...)
+	findings := res.sarifFindings(t, ruleTeamTag)
+
+	// Platform filter: k8s and cicd not running
+	assert.False(t, res.ruleHasFindings(rulePrivileged))
+	assert.False(t, res.ruleHasFindings(ruleCicdPinned))
+
+	// Rule config: prod/ dropped, test/ survives at MEDIUM
+	require.NotEmpty(t, findings, "test/ terraform findings should remain")
+	assert.False(t, locationsContain(findings, "prod"), "prod/ dropped by ignore-paths")
+	sevs := res.severitiesForRule(ruleTeamTag)
+	assert.True(t, sevs["MEDIUM"], "severity should be MEDIUM: %v", sevs)
+}
+
+// -----------------------------------------------------------------------------
+// k8s production vs staging path filtering
+// -----------------------------------------------------------------------------
+
+func TestV13_K8s_OnlyProductionPath(t *testing.T) {
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			rulePrivileged: {OnlyPaths: []string{relFixture("k8s/production")}},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("k8s"))
+	findings := res.sarifFindings(t, rulePrivileged)
+
+	require.NotEmpty(t, findings, "production finding expected")
+	assert.True(t, locationsContain(findings, "production"), "production should have findings")
+	assert.False(t, locationsContain(findings, "staging"), "staging should be dropped by only-paths")
+}
+
+func TestV13_K8s_IgnoreProductionPath(t *testing.T) {
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			rulePrivileged: {IgnorePaths: []string{relFixture("k8s/production")}},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("k8s"))
+	findings := res.sarifFindings(t, rulePrivileged)
+
+	require.NotEmpty(t, findings, "staging finding should survive")
+	assert.False(t, locationsContain(findings, "production"), "production dropped by ignore-paths")
+	assert.True(t, locationsContain(findings, "staging"), "staging survives")
+}
+
+// -----------------------------------------------------------------------------
+// Legacy rule ID matching
+// -----------------------------------------------------------------------------
+
+func TestV13_RuleConfig_MatchByLegacyID(t *testing.T) {
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			ruleTeamTagLegacyID: {
+				IgnorePaths: []string{
+					relFixture("terraform/prod"),
+					relFixture("terraform/test"),
+				},
+			},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("terraform"))
+
+	assert.Zero(t, res.countForRule(ruleTeamTag), "legacy ID should match and drop all findings")
+}
+
+// -----------------------------------------------------------------------------
+// Edge case: empty RuleConfigs has no effect
+// -----------------------------------------------------------------------------
+
+func TestV13_EmptyRuleConfigs_NoEffect(t *testing.T) {
+	baseline := runV13Scan(t, config.IacConfig{}, relFixture("terraform"))
+
+	cfg := config.IacConfig{RuleConfigs: map[string]config.IacRuleConfig{}}
+	res := runV13Scan(t, cfg, relFixture("terraform"))
+
+	assert.Equal(t, baseline.countForRule(ruleTeamTag), res.countForRule(ruleTeamTag),
+		"empty rule-configs should be a no-op")
+}
+
+// -----------------------------------------------------------------------------
+// Edge case: rule config for non-matching rule ID has no effect
+// -----------------------------------------------------------------------------
+
+func TestV13_RuleConfig_UnknownRuleID_NoEffect(t *testing.T) {
+	baseline := runV13Scan(t, config.IacConfig{}, relFixture("terraform"))
+
+	cfg := config.IacConfig{
+		RuleConfigs: map[string]config.IacRuleConfig{
+			"this-rule-does-not-exist": {
+				IgnorePaths: []string{relFixture("terraform/prod")},
+				Severity:    "critical",
+			},
+		},
+	}
+	res := runV13Scan(t, cfg, relFixture("terraform"))
+
+	assert.Equal(t, baseline.countForRule(ruleTeamTag), res.countForRule(ruleTeamTag),
+		"config for unknown rule ID should have no effect on other rules")
+}

--- a/test/e2e/v13_test.go
+++ b/test/e2e/v13_test.go
@@ -36,6 +36,8 @@ const (
 // inside the engine stays relative and matches the filter patterns in RuleConfigs.
 const fixtureV13 = "fixtures/v13"
 
+func strPtr(s string) *string { return &s }
+
 // allQueriesPaths covers all three platforms under test.
 var allQueriesPaths = []string{
 	filepath.Join("testdata", "rules", "terraform"),
@@ -435,7 +437,7 @@ func TestV13_RuleConfig_SeverityOverride_DefaultIsHigh(t *testing.T) {
 func TestV13_RuleConfig_SeverityOverride_ToLow(t *testing.T) {
 	cfg := config.IacConfig{
 		RuleConfigs: map[string]config.IacRuleConfig{
-			rulePrivileged: {Severity: "low"},
+			rulePrivileged: {Severity: strPtr("low")},
 		},
 	}
 	res := runV13Scan(t, cfg, relFixture("k8s"))
@@ -451,7 +453,7 @@ func TestV13_RuleConfig_SeverityOverride_AllLevels(t *testing.T) {
 		t.Run(level, func(t *testing.T) {
 			cfg := config.IacConfig{
 				RuleConfigs: map[string]config.IacRuleConfig{
-					ruleTeamTag: {Severity: level},
+					ruleTeamTag: {Severity: strPtr(level)},
 				},
 			}
 			res := runV13Scan(t, cfg, relFixture("terraform"))
@@ -468,7 +470,7 @@ func TestV13_RuleConfig_SeverityOverride_DoesNotChangeCount(t *testing.T) {
 
 	cfg := config.IacConfig{
 		RuleConfigs: map[string]config.IacRuleConfig{
-			ruleTeamTag: {Severity: "medium"},
+			ruleTeamTag: {Severity: strPtr("medium")},
 		},
 	}
 	res := runV13Scan(t, cfg, relFixture("terraform"))
@@ -479,7 +481,7 @@ func TestV13_RuleConfig_SeverityOverride_DoesNotChangeCount(t *testing.T) {
 func TestV13_RuleConfig_SeverityOverride_DoesNotAffectOtherRules(t *testing.T) {
 	cfg := config.IacConfig{
 		RuleConfigs: map[string]config.IacRuleConfig{
-			ruleTeamTag: {Severity: "critical"},
+			ruleTeamTag: {Severity: strPtr("critical")},
 		},
 	}
 	res := runV13Scan(t, cfg, relFixture("terraform"), relFixture("k8s"))
@@ -498,7 +500,7 @@ func TestV13_RuleConfig_SeverityOverride_SARIFLevel(t *testing.T) {
 		t.Run(string(sev), func(t *testing.T) {
 			cfg := config.IacConfig{
 				RuleConfigs: map[string]config.IacRuleConfig{
-					rulePrivileged: {Severity: strings.ToLower(string(sev))},
+					rulePrivileged: {Severity: strPtr(strings.ToLower(string(sev)))},
 				},
 			}
 			res := runV13Scan(t, cfg, relFixture("k8s"))
@@ -518,7 +520,7 @@ func TestV13_RuleConfig_SeverityAndIgnorePaths_Combined(t *testing.T) {
 		RuleConfigs: map[string]config.IacRuleConfig{
 			ruleTeamTag: {
 				IgnorePaths: []string{relFixture("terraform/prod")},
-				Severity:    "info",
+				Severity:    strPtr("info"),
 			},
 		},
 	}
@@ -615,7 +617,7 @@ func TestV13_PlatformFilter_And_RuleConfig_Combined(t *testing.T) {
 		RuleConfigs: map[string]config.IacRuleConfig{
 			ruleTeamTag: {
 				IgnorePaths: []string{relFixture("terraform/prod")},
-				Severity:    "medium",
+				Severity:    strPtr("medium"),
 			},
 		},
 	}
@@ -710,7 +712,7 @@ func TestV13_RuleConfig_UnknownRuleID_NoEffect(t *testing.T) {
 		RuleConfigs: map[string]config.IacRuleConfig{
 			"this-rule-does-not-exist": {
 				IgnorePaths: []string{relFixture("terraform/prod")},
-				Severity:    "critical",
+				Severity:    strPtr("critical"),
 			},
 		},
 	}


### PR DESCRIPTION
## Motivation

This PR introduces `schema-version: v1.3` for `code-security.datadog.yaml`:

* **Per-rule path scoping**: `rule-configs.<rule-id>.ignore-paths` and `only-paths` drop findings for a specific rule outside the configured path set.
* **Global platform filters**: `iac.global-config.only-platforms` and `ignore-platforms` restrict which platforms are scanned, intersecting with the `--type` CLI flag.
* **Per-rule severity override**: `rule-configs.<rule-id>.severity` overrides the default severity of a rule's findings.

Schema v1.2 files remain fully supported; the scanner auto-emits `v1.3` from `UnparseConfig` only when new fields are in use.

## Changes

* New `rule-configs` map in the IaC config allows per-rule path scoping and severity overrides.
* New `only-platforms` / `ignore-platforms` fields in `global-config` filter which platforms are scanned.
* `SupportedPlatforms` is now a shared constant, keeping platform validation and CLI defaults in sync.

## Tests

Unit tests cover config parsing, platform validation, inspector path matching (`matchesPath`, `rulePathExcluded`), and CLI platform filter logic.

A new e2e test suite (`test/e2e/v13_test.go`) exercises all three features end-to-end using local rule fixtures and real scan execution, across 42 test cases:

**Per-rule `ignore-paths`**
- Drops findings from the specified directory (hard-drop, not SARIF suppression).
- Keeps findings from all other directories.
- Dropping all dirs for a rule produces zero findings for that rule only.
- Other rules are completely unaffected.

**Per-rule `only-paths`**
- Restricts findings to the specified directory.
- Drops findings outside that directory.
- If `only-paths` matches nothing, zero findings are produced for that rule.
- Multiple directories in `only-paths` all produce findings.
- `ignore-paths` takes precedence over `only-paths` when both are set on the same rule.

**Per-rule severity override**
- Changes the severity in scan stats and SARIF output.
- All five levels work: `critical`, `high`, `medium`, `low`, `info`.
- Finding count is unchanged by an override.
- Other rules' severities are unaffected.
- SARIF `level` field is correct: `critical→error`, `high→warning`, `medium→note`, `low/info→none`.

**Combined rule-config (severity + path)**
- `ignore-paths` and `severity` on the same rule cooperate correctly.

**Global `only-platforms`**
- Single-platform and multi-platform restrictions work; all-platforms equals no filter.

**Global `ignore-platforms`**
- Excluding one or multiple platforms leaves the rest unaffected.

**Combined platform + rule-config**
- Platform filter, `ignore-paths`, and severity override all work together correctly.

**Edge cases**
- Legacy UUID as `rule-configs` key matches the rule correctly.
- Unknown rule ID in `rule-configs` has no effect on other rules.
- Production vs. staging subdirectory path filtering tested independently for Kubernetes.

## How to test locally

```sh
# Unit tests
go test ./pkg/config/... ./pkg/engine/... ./cmd/scanner/... ./pkg/scan/... -count=1

# E2e tests (no credentials needed — uses local rule fixtures)
go test ./test/e2e/... -run TestV13_ -v -count=1
```

## Blast Radius

Config parsing, engine inspection, and CLI platform selection. No changes to SARIF output structure or Rego query evaluation. Existing v1.2 configs are unaffected.

## Additional Notes

`SupportedPlatforms` must stay in sync with the `--platforms` default in `datadog-iac-scanner-default-rules` whenever a new platform is released, until I find another solution to centralize.

I submit this contribution under the Apache-2.0 license.