### PR TITLE
Move platform filtering to the scan function

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -150,8 +150,6 @@ func runScan(ctx context.Context, c *cli.Command) error {
 	cfg.OnlyPaths = onlyPaths
 	cfg.IgnoreRules = append(c.StringSlice("exclude-queries"), cfg.IgnoreRules...)
 
-	activePlatforms := scan.ApplyPlatformFilters(c.StringSlice("type"), cfg.OnlyPlatforms, cfg.IgnorePlatforms)
-
 	for ruleID, rc := range cfg.RuleConfigs {
 		resolvedIgnore, pathErr := getRepoRelativePaths(repoDir, rc.IgnorePaths)
 		if pathErr != nil {
@@ -176,7 +174,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		QueriesPath:      []string{"./assets/queries"},
 		LibrariesPath:    "./assets/libraries",
 		ReportFormats:    []string{"sarif"},
-		Platform:         selectPlatforms(activePlatforms),
+		Platform:         selectPlatforms(c.StringSlice("type")),
 		QueryExecTimeout: c.Int("timeout"),
 		DisableSecrets:   true,
 		ScanID:           "console",

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -59,6 +59,10 @@ type Parameters struct {
 	Config                      config.IacConfig
 }
 
+func (p *Parameters) GetEffectivePlatforms() []string {
+	return ApplyPlatformFilters(p.Platform, p.Config.OnlyPlatforms, p.Config.IgnorePlatforms)
+}
+
 // Client represents a scan client
 type Client struct {
 	ScanParams        *Parameters
@@ -92,7 +96,7 @@ func GetDefaultParameters(ctx context.Context, rootPath string) (*Parameters, co
 		QueriesPath:                 []string{"./assets/queries"},
 		LibrariesPath:               "./assets/libraries",
 		ReportFormats:               []string{"sarif"},
-		Platform:                    ApplyPlatformFilters(platforms.Supported, configParams.OnlyPlatforms, configParams.IgnorePlatforms),
+		Platform:                    platforms.Supported,
 		TerraformVarsPath:           "",
 		QueryExecTimeout:            60,
 		LineInfoPayload:             false,

--- a/pkg/scan/platform.go
+++ b/pkg/scan/platform.go
@@ -12,7 +12,7 @@ func ApplyPlatformFilters(cliPlatforms, onlyPlatforms, ignorePlatforms []string)
 		for _, p := range onlyPlatforms {
 			allowed[strings.ToLower(p)] = struct{}{}
 		}
-		filtered := active[:0:0]
+		var filtered []string
 		for _, p := range active {
 			if _, ok := allowed[strings.ToLower(p)]; ok {
 				filtered = append(filtered, p)
@@ -26,7 +26,7 @@ func ApplyPlatformFilters(cliPlatforms, onlyPlatforms, ignorePlatforms []string)
 		for _, p := range ignorePlatforms {
 			ignored[strings.ToLower(p)] = struct{}{}
 		}
-		filtered := active[:0:0]
+		var filtered []string
 		for _, p := range active {
 			if _, ok := ignored[strings.ToLower(p)]; !ok {
 				filtered = append(filtered, p)

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -60,7 +60,7 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		return nil, nil
 	}
 
-	paramsPlatforms := c.ScanParams.Platform
+	paramsPlatforms := c.ScanParams.GetEffectivePlatforms()
 	useDifferentPlatformQueries(&paramsPlatforms)
 	querySource, err := c.createQuerySource(ctx, paramsPlatforms)
 	if err != nil {

--- a/pkg/scan/utils.go
+++ b/pkg/scan/utils.go
@@ -49,7 +49,8 @@ func (c *Client) prepareAndAnalyzePaths(ctx context.Context) (provider.Extracted
 	if len(allPaths.Path) == 0 {
 		return provider.ExtractedPath{}, nil
 	}
-	if len(c.ScanParams.Platform) == 0 {
+	platforms := c.ScanParams.GetEffectivePlatforms()
+	if len(platforms) == 0 {
 		return provider.ExtractedPath{}, nil
 	}
 
@@ -58,7 +59,7 @@ func (c *Client) prepareAndAnalyzePaths(ctx context.Context) (provider.Extracted
 	a := &analyzer.Analyzer{
 		RepoPath:          c.ScanParams.RepoPath,
 		Paths:             allPaths.Path,
-		Types:             c.ScanParams.Platform,
+		Types:             platforms,
 		ExcludeTypes:      c.ScanParams.ExcludePlatform,
 		Exc:               c.ScanParams.Config.IgnorePaths,
 		Only:              c.ScanParams.Config.OnlyPaths,

--- a/test/e2e/v13_test.go
+++ b/test/e2e/v13_test.go
@@ -229,13 +229,10 @@ func runV13Scan(t *testing.T, cfg config.IacConfig, scanDirs ...string) scanResu
 	params.OutputName = "result"
 	params.QueriesPath = absQueryPaths
 	params.ChangedDefaultQueryPath = true
-	params.Platform = scan.ApplyPlatformFilters(
-		[]string{"Terraform", "Kubernetes", "CICD"},
-		cfg.OnlyPlatforms, cfg.IgnorePlatforms,
-	)
+	params.Platform = []string{"Terraform", "Kubernetes", "CICD"}
 	params.Config = cfg
 	params.SCIInfo = model.SCIInfo{
-		DiffAware:            model.DiffAware{Enabled: false},
+		DiffAware: model.DiffAware{Enabled: false},
 		RepositoryCommitInfo: model.RepositoryCommitInfo{
 			RepositoryUrl: "test/url",
 			CommitSHA:     "deadbeef",


### PR DESCRIPTION
## Motivation

Instead of filtering the platforms when the ScanParameters object is created, filter them when they are required (using the Configuration object that's in the ScanParameters.)

I submit this contribution under the Apache-2.0 license.
