### PR TITLE
Fix Helm chart templates scanned twice as raw YAML

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -595,16 +595,26 @@ func checkReturnType(ctx context.Context, path, returnType, ext string, content 
 	return returnType
 }
 
+// checkHelm reports whether the file belongs to a Helm chart by looking for a
+// Chart.yaml in any ancestor directory, since templates can be nested below the
+// chart root (e.g. templates/sub/ or charts/<subchart>/templates/).
 func checkHelm(ctx context.Context, path string) bool {
 	contextLogger := logger.FromContext(ctx)
-	_, err := os.Stat(filepath.Join(filepath.Dir(path), "Chart.yaml"))
-	if errors.Is(err, os.ErrNotExist) {
-		return false
-	} else if err != nil {
-		contextLogger.Error().Msgf("failed to check helm: %s", err)
+	dir := filepath.Dir(path)
+	for {
+		_, err := os.Stat(filepath.Join(dir, "Chart.yaml"))
+		if err == nil {
+			return true
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			contextLogger.Error().Msgf("failed to check helm: %s", err)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
 	}
-
-	return true
 }
 
 func checkYamlPlatform(ctx context.Context, content []byte, path string) string {

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -466,6 +466,43 @@ func Test_checkYamlPlatform_emptyFile(t *testing.T) {
 	}
 }
 
+func Test_checkHelm(t *testing.T) {
+	helm := filepath.FromSlash("../../test/fixtures/analyzer_test/helm")
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "template one level below chart root",
+			path: filepath.Join(helm, "templates", "service.yaml"),
+			want: true,
+		},
+		{
+			name: "template nested several levels below chart root",
+			path: filepath.Join(helm, "templates", "sub", "deep", "service.yaml"),
+			want: true,
+		},
+		{
+			name: "chart root file",
+			path: filepath.Join(helm, "values.yaml"),
+			want: true,
+		},
+		{
+			name: "file outside any chart",
+			path: filepath.FromSlash("../../test/fixtures/analyzer_test/k8s.yaml"),
+			want: false,
+		},
+	}
+
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, checkHelm(ctx, tt.path))
+		})
+	}
+}
+
 func Test_isInsideAnsibleTemplatesDir(t *testing.T) {
 	tests := []struct {
 		path string

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -226,7 +226,6 @@ func (s *FileSystemSourceProvider) GetParallelSources(ctx context.Context,
 // collectFiles walks the directory tree and collects file paths without processing them, except Helm files
 func (s *FileSystemSourceProvider) collectFiles(ctx context.Context, scanPath string,
 	resolverSink ResolverSink, extensions model.Extensions) (files []string, err error) {
-	contextLogger := logger.FromContext(ctx)
 	var resolvedChartPaths []string
 
 	err = filepath.Walk(scanPath, func(path string, info os.FileInfo, err error) error {
@@ -240,17 +239,7 @@ func (s *FileSystemSourceProvider) collectFiles(ctx context.Context, scanPath st
 
 		// ------------------ Helm resolver --------------------------------
 		if info.IsDir() {
-			excluded, errRes := resolverSink(ctx, strings.ReplaceAll(path, "\\", "/"))
-			if errRes != nil {
-				return nil
-			}
-			s.mu.Lock()
-			if errAdd := s.addExcluded(ctx, excluded); errAdd != nil {
-				contextLogger.Err(errAdd).Msgf("Filesystem files provider couldn't exclude rendered Chart files, Chart=%s", info.Name())
-			}
-			s.mu.Unlock()
-			resolvedChartPaths = append(resolvedChartPaths, path)
-			return nil
+			return s.resolveChartDir(ctx, path, resolverSink, &resolvedChartPaths)
 		}
 		// -----------------------------------------------------------------
 
@@ -368,7 +357,6 @@ func (s *FileSystemSourceProvider) feedFilesToWorkers(ctx context.Context, files
 
 func (s *FileSystemSourceProvider) walkDir(ctx context.Context, scanPath string,
 	sink Sink, resolverSink ResolverSink, extensions model.Extensions) error {
-	contextLogger := logger.FromContext(ctx)
 	var resolvedChartPaths []string
 	return filepath.Walk(scanPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -381,17 +369,7 @@ func (s *FileSystemSourceProvider) walkDir(ctx context.Context, scanPath string,
 
 		// ------------------ Helm resolver --------------------------------
 		if info.IsDir() {
-			excluded, errRes := resolverSink(ctx, strings.ReplaceAll(path, "\\", "/"))
-			if errRes != nil {
-				return nil
-			}
-			s.mu.Lock()
-			if errAdd := s.addExcluded(ctx, excluded); errAdd != nil {
-				contextLogger.Err(errAdd).Msgf("Filesystem files provider couldn't exclude rendered Chart files, Chart=%s", info.Name())
-			}
-			s.mu.Unlock()
-			resolvedChartPaths = append(resolvedChartPaths, path)
-			return nil
+			return s.resolveChartDir(ctx, path, resolverSink, &resolvedChartPaths)
 		}
 		// -----------------------------------------------------------------
 
@@ -473,6 +451,31 @@ func (s *FileSystemSourceProvider) checkConditions(ctx context.Context, info os.
 		return true, nil
 	}
 	return false, nil
+}
+
+// resolveChartDir renders a Helm chart directory through the resolver. On success
+// it returns filepath.SkipDir so the chart subtree is not walked again as raw,
+// unrendered templates (which would yield bogus names like name: {{ .Release.Revision }}).
+// On failure it returns nil to fall back to scanning the raw files.
+func (s *FileSystemSourceProvider) resolveChartDir(ctx context.Context, path string,
+	resolverSink ResolverSink, resolvedChartPaths *[]string) error {
+	contextLogger := logger.FromContext(ctx)
+	excluded, errRes := resolverSink(ctx, strings.ReplaceAll(path, "\\", "/"))
+	if errRes != nil {
+		// resolverSink returns an error only for actual chart directories (with Chart.yaml).
+		// For non-chart directories it returns nil/[] and we should not log.
+		if _, statErr := os.Stat(filepath.Join(path, "Chart.yaml")); statErr == nil {
+			contextLogger.Warn().Msgf("Failed to render Helm chart '%s'; scanning its raw files as a fallback", path)
+		}
+		return nil
+	}
+	s.mu.Lock()
+	if errAdd := s.addExcluded(ctx, excluded); errAdd != nil {
+		contextLogger.Err(errAdd).Msgf("Filesystem files provider couldn't exclude rendered Chart files, Chart=%s", filepath.Base(path))
+	}
+	s.mu.Unlock()
+	*resolvedChartPaths = append(*resolvedChartPaths, path)
+	return filepath.SkipDir
 }
 
 func isUnderResolvedChart(path string, resolvedChartPaths []string) bool {

--- a/pkg/engine/provider/filesystem_test.go
+++ b/pkg/engine/provider/filesystem_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -711,4 +712,61 @@ func TestGetSources_multipleHelmCharts(t *testing.T) {
 
 	require.ElementsMatch(t, []string{"chart-a", "chart-b"}, resolvedDirs,
 		"both sibling Helm charts must be sent to the resolver, not just the first one")
+}
+
+// TestGetSources_helmChartSkipsRawTemplates ensures that once a Helm chart is
+// rendered by the resolver, its raw template files are not also scanned as plain YAML.
+func TestGetSources_helmChartSkipsRawTemplates(t *testing.T) {
+	if err := test.ChangeCurrentDir("datadog-iac-scanner"); err != nil {
+		t.Fatalf("failed to change dir: %s", err)
+	}
+
+	ctx := context.Background()
+	const chartDir = "test/fixtures/test_helm"
+
+	var mu sync.Mutex
+	var sinkedFiles, resolvedDirs []string
+
+	recordingSink := func(_ context.Context, filename string, _ io.ReadCloser) error {
+		mu.Lock()
+		sinkedFiles = append(sinkedFiles, filepath.ToSlash(filename))
+		mu.Unlock()
+		return nil
+	}
+	recordingResolverSink := func(_ context.Context, filename string) ([]string, error) {
+		if _, chartErr := os.Stat(filepath.Join(filename, "Chart.yaml")); chartErr == nil {
+			mu.Lock()
+			resolvedDirs = append(resolvedDirs, filepath.ToSlash(filename))
+			mu.Unlock()
+		}
+		return []string{}, nil
+	}
+
+	run := func(t *testing.T, scan func(*FileSystemSourceProvider) error) {
+		t.Helper()
+		mu.Lock()
+		sinkedFiles, resolvedDirs = nil, nil
+		mu.Unlock()
+
+		fs, err := NewFileSystemSourceProvider(ctx, []string{filepath.FromSlash(chartDir)}, []string{}, []string{})
+		require.NoError(t, err)
+		require.NoError(t, scan(fs))
+
+		require.Contains(t, resolvedDirs, chartDir, "the Helm chart directory must be sent to the resolver")
+		for _, f := range sinkedFiles {
+			require.NotContains(t, f, chartDir+"/",
+				"raw files under a resolved Helm chart must not be scanned as plain YAML, got %q", f)
+		}
+	}
+
+	t.Run("sequential", func(t *testing.T) {
+		run(t, func(fs *FileSystemSourceProvider) error {
+			return fs.GetSources(ctx, model.Extensions{".yaml": {}}, recordingSink, recordingResolverSink)
+		})
+	})
+	t.Run("parallel", func(t *testing.T) {
+		run(t, func(fs *FileSystemSourceProvider) error {
+			return fs.GetParallelSources(ctx, model.Extensions{".yaml": {}}, recordingSink, recordingResolverSink)
+		})
+	})
 }

--- a/pkg/kics/resolver_sink.go
+++ b/pkg/kics/resolver_sink.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/minified"
@@ -43,6 +44,12 @@ func (s *Service) resolverSink(
 		if err != nil {
 			if documents.Kind == "break" {
 				return []string{}, nil
+			}
+			// A Helm template may render to only comments when all range iterations are
+			// conditionally skipped (e.g. a service disabled in prod). That's expected;
+			// skip silently rather than logging a spurious error.
+			if kind == model.KindHELM && isCommentOnlyContent(rfile.Content) {
+				continue
 			}
 			contextLogger.Error().Msgf("failed to parse file content '%s' with fileType '%s'", rfile.FileName, kind)
 			return []string{}, nil
@@ -103,6 +110,17 @@ func (s *Service) resolverSink(
 		}
 	}
 	return resFiles.Excluded, nil
+}
+
+// isCommentOnlyContent returns true when every non-blank line in content starts
+// with '#', meaning the Helm renderer produced no real YAML document.
+func isCommentOnlyContent(content []byte) bool {
+	for _, line := range strings.Split(string(content), "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Service) getOriginalIgnoreLines(ctx context.Context, filename string,


### PR DESCRIPTION
## Motivation

When a directory contains `Chart.yaml`, the scanner renders the Helm chart and scans the output, but the file walk also continued into `templates/` and parsed those files as plain Kubernetes YAML. Findings then used unresolved Go template syntax in `resource_name` (for example `name-r{{ .Release.Revision }}`) and the same rules could fire twice on one resource.

## Changes

**Scan pipeline**
- After a successful chart render, stop walking that chart directory so raw templates are not scanned again.
- If rendering fails, still walk the chart and scan raw files so nothing is silently skipped.

**Platform detection**
- Recognize Helm template files when `Chart.yaml` exists in any ancestor directory, not only the parent folder.

**Helm resolver**
- Ignore rendered splits that contain only comments (no YAML document) instead of logging a parse error.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- CI should pass
- `make build && ./bin/datadog-iac-scanner scan -p test/fixtures/test_helm -t Kubernetes -o /tmp/helm-scan-out`, no `{{` in `resource_name`; chart `templates/` should not be ingested as plain YAML after render.
- Scan `test/fixtures/multi_helm`, each chart under that tree should still be resolved once.

## Impact

Affects CLI scans of repositories that include Helm charts. Resolved `resource_name` values and fewer duplicate findings when render succeeds. No changes to rule definitions or SARIF schema.

## Additional Notes

I submit this contribution under the Apache-2.0 License.