### PR TITLE
[K9CODESEC-2075] Include Helm chart CRD manifests in scan coverage

### DIFF
--- a/pkg/detector/helm/helm_detect.go
+++ b/pkg/detector/helm/helm_detect.go
@@ -101,14 +101,15 @@ func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata
 		}
 		// Update found line
 		curLineRes.lineRes = removeLines(curLineRes.lineRes, lineRemove)
+		adjustedLine := curLineRes.lineRes + 1
 		return model.VulnerabilityLines{
-			Line:                  curLineRes.lineRes + 1,
+			Line:                  adjustedLine,
 			VulnLines:             detector.GetAdjacentVulnLines(curLineRes.lineRes, outputLines, lines),
 			LineWithVulnerability: strings.Split(lines[curLineRes.lineRes], ": ")[0],
 			ResolvedFile:          file.FilePath,
 			VulnerablilityLocation: model.ResourceLocation{
-				Start: start,
-				End:   end,
+				Start: model.ResourceLine{Line: adjustedLine, Col: start.Col},
+				End:   model.ResourceLine{Line: adjustedLine, Col: end.Col},
 			},
 		}
 	}
@@ -213,10 +214,24 @@ func detectLastSingle(line int, dis map[int]int, idInfo map[int]interface{}, id 
 	if idInfo == nil {
 		return true
 	}
+	var containsLine func(int) bool
+	switch originalLines := idInfo[id].(type) {
+	case model.HelmIDLineRange:
+		containsLine = func(line int) bool {
+			return line >= originalLines.Start && line <= originalLines.End
+		}
+	case map[int]int:
+		containsLine = func(line int) bool {
+			_, ok := originalLines[line]
+			return ok
+		}
+	default:
+		return true
+	}
 	for key, value := range dis {
 		if value == dis[line] && key != line {
 			// check if we are only looking at original data equivalent to the vulnerability
-			if ok := idInfo[id].(map[int]int)[key]; ok != 0 {
+			if containsLine(key) {
 				return false
 			}
 		}

--- a/pkg/detector/helm/helm_detect.go
+++ b/pkg/detector/helm/helm_detect.go
@@ -45,7 +45,9 @@ const (
 func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata, searchKey string,
 	outputLines int) model.VulnerabilityLines {
 	contextLogger := logger.FromContext(ctx)
-	searchKey = fmt.Sprintf("%s.%s", strings.TrimRight(strings.TrimLeft(file.HelmID, "# "), ":"), searchKey)
+	if file.HelmID != "" {
+		searchKey = fmt.Sprintf("%s.%s", strings.TrimRight(strings.TrimLeft(file.HelmID, "# "), ":"), searchKey)
+	}
 
 	lines := make([]string, len(*file.LinesOriginalData))
 	copy(lines, *file.LinesOriginalData)
@@ -142,6 +144,14 @@ func removeLines(current int, lineRemove map[int]int) int {
 	return current
 }
 
+func containsHelmKey(line, key string) bool {
+	if strings.Contains(line, key) {
+		return true
+	}
+	key = strings.TrimSuffix(key, ":")
+	return strings.Contains(line, `"`+key+`":`) || strings.Contains(line, `'`+key+`':`)
+}
+
 // nolint:gocritic
 func (d detectCurlLine) detectCurrentLine(lines []string, str1,
 	str2 string, byKey bool, idInfo map[int]interface{}, id int) (detectCurlLine, model.ResourceLine, model.ResourceLine) {
@@ -155,7 +165,7 @@ func (d detectCurlLine) detectCurrentLine(lines []string, str1,
 				ends[i] = model.ResourceLine{Line: i + 1, Col: len(lines[i])}
 			}
 		} else if str1 != "" {
-			if strings.Contains(lines[i], str1) {
+			if containsHelmKey(lines[i], str1) {
 				distances[i] = levenshtein.ComputeDistance(
 					detector.ExtractLineFragment(strings.TrimSpace(lines[i]), str1, byKey), str1)
 				starts[i] = model.ResourceLine{Line: i + 1, Col: 0}

--- a/pkg/detector/helm/helm_detect_test.go
+++ b/pkg/detector/helm/helm_detect_test.go
@@ -148,11 +148,11 @@ func TestEngine_detectHelmLine(t *testing.T) { //nolint
 				ResolvedFile:          "test-connection.yaml",
 				VulnerablilityLocation: model.ResourceLocation{
 					Start: model.ResourceLine{
-						Line: 11,
+						Line: 10,
 						Col:  0,
 					},
 					End: model.ResourceLine{
-						Line: 11,
+						Line: 10,
 						Col:  13,
 					},
 				},
@@ -190,11 +190,11 @@ func TestEngine_detectHelmLine(t *testing.T) { //nolint
 				ResolvedFile:          "test-dup_values.yaml",
 				VulnerablilityLocation: model.ResourceLocation{
 					Start: model.ResourceLine{
-						Line: 11,
+						Line: 9,
 						Col:  0,
 					},
 					End: model.ResourceLine{
-						Line: 11,
+						Line: 9,
 						Col:  13,
 					},
 				},
@@ -229,11 +229,11 @@ func TestEngine_detectHelmLine(t *testing.T) { //nolint
 				ResolvedFile:          "test-dups.yaml",
 				VulnerablilityLocation: model.ResourceLocation{
 					Start: model.ResourceLine{
-						Line: 28,
+						Line: 26,
 						Col:  0,
 					},
 					End: model.ResourceLine{
-						Line: 28,
+						Line: 26,
 						Col:  13,
 					},
 				},
@@ -268,11 +268,11 @@ func TestEngine_detectHelmLine(t *testing.T) { //nolint
 				ResolvedFile:          "deployment.yaml",
 				VulnerablilityLocation: model.ResourceLocation{
 					Start: model.ResourceLine{
-						Line: 11,
+						Line: 10,
 						Col:  0,
 					},
 					End: model.ResourceLine{
-						Line: 11,
+						Line: 10,
 						Col:  29,
 					},
 				},
@@ -289,6 +289,30 @@ func TestEngine_detectHelmLine(t *testing.T) { //nolint
 				t.Errorf("detectHelmLine() = %v, want = %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDetectLastSingleMissingHelmID(t *testing.T) {
+	distances := map[int]int{2: 1, 5: 1}
+	idInfo := map[int]interface{}{0: map[int]int{2: 2}}
+
+	if !detectLastSingle(2, distances, idInfo, -1) {
+		t.Fatal("missing Helm ID mapping should not mark the line as a duplicate")
+	}
+}
+
+func TestDetectLastSingleUsesHelmIDLineRange(t *testing.T) {
+	distances := map[int]int{2: 1, 5: 1}
+	idInfo := map[int]interface{}{
+		0: model.HelmIDLineRange{Start: 0, End: 3},
+		1: model.HelmIDLineRange{Start: 4, End: 7},
+	}
+
+	if !detectLastSingle(2, distances, idInfo, 0) {
+		t.Fatal("duplicate outside the selected Helm range must remain unique")
+	}
+	if detectLastSingle(2, map[int]int{2: 1, 3: 1}, idInfo, 0) {
+		t.Fatal("duplicate inside the selected Helm range must not be unique")
 	}
 }
 

--- a/pkg/detector/helm/helm_detect_test.go
+++ b/pkg/detector/helm/helm_detect_test.go
@@ -291,3 +291,29 @@ func TestEngine_detectHelmLine(t *testing.T) { //nolint
 		})
 	}
 }
+
+func TestDetectLine_JSONCRD(t *testing.T) {
+	original := `{
+  "apiVersion": "apiextensions.k8s.io/v1",
+  "kind": "CustomResourceDefinition",
+  "metadata": {
+    "name": "gadgets.example.com"
+  }
+}`
+	file := &model.FileMetadata{
+		Kind:              model.KindHELM,
+		FilePath:          "crds/gadget.json",
+		OriginalData:      original,
+		LinesOriginalData: utils.SplitLines(original),
+		IDInfo:            map[int]interface{}{-1: map[int]int{}},
+	}
+
+	got := (DetectKindLine{}).DetectLine(context.Background(), file, "metadata.name", 1)
+
+	if got.Line != 5 {
+		t.Fatalf("DetectLine() line = %d, want 5", got.Line)
+	}
+	if got.LineWithVulnerability != `    "name"` {
+		t.Fatalf("DetectLine() vulnerable line = %q, want JSON name key", got.LineWithVulnerability)
+	}
+}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -135,6 +135,12 @@ type ExtractedPathObject struct {
 // CommentsCommands list of commands on a file that will be parsed
 type CommentsCommands map[string]string
 
+// HelmIDLineRange is the inclusive source-line range owned by a Helm marker.
+type HelmIDLineRange struct {
+	Start int
+	End   int
+}
+
 // lineInfoState holds lazy line-info state behind a pointer so FileMetadata
 // copies stay copylocks-clean (sync.Mutex must not be struct-copied).
 type lineInfoState struct {
@@ -321,11 +327,13 @@ type ResolvedFiles struct {
 
 // ResolvedHelm keeps the information of a file/template resolved
 type ResolvedHelm struct {
-	FileName     string
-	Content      []byte
-	OriginalData []byte
-	SplitID      string
-	IDInfo       map[int]interface{}
+	FileName            string
+	Content             []byte
+	OriginalData        []byte
+	SplitID             string
+	SourceDocumentIndex int
+	IDInfo              map[int]interface{}
+	IsCRD               bool
 }
 
 // Extensions represents a list of supported extensions

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -167,44 +167,66 @@ func (c *Parser) Parse(
 	fileContent []byte,
 	openAPIResolveReferences, isMinified bool,
 	maxResolverDepth int) (ParsedDocument, error) {
+	if !c.isValidExtension(ctx, filePath) {
+		return unsupportedDocument(), ErrNotSupportedFile
+	}
+	return c.parseContent(ctx, filePath, fileContent, openAPIResolveReferences, isMinified, maxResolverDepth)
+}
+
+// ParseContent uses the selected parser regardless of the file extension.
+func (c *Parser) ParseContent(
+	ctx context.Context,
+	filePath string,
+	fileContent []byte,
+	openAPIResolveReferences, isMinified bool,
+	maxResolverDepth int) (ParsedDocument, error) {
+	return c.parseContent(ctx, filePath, fileContent, openAPIResolveReferences, isMinified, maxResolverDepth)
+}
+
+func (c *Parser) parseContent(
+	ctx context.Context,
+	filePath string,
+	fileContent []byte,
+	openAPIResolveReferences, isMinified bool,
+	maxResolverDepth int) (ParsedDocument, error) {
 	contextLogger := logger.FromContext(ctx)
 	fileContent = utils.DecryptAnsibleVault(ctx, fileContent, utils.GetVaultPassword())
 
-	if c.isValidExtension(ctx, filePath) {
-		resolved, obj, igLines, resolvedFiles, err := c.Parsers.Parse(ctx, fileContent, filePath, openAPIResolveReferences, maxResolverDepth)
-		if err != nil {
-			return ParsedDocument{}, err
-		}
-
-		cont, err := c.Parsers.StringifyContent(fileContent)
-		if err != nil {
-			contextLogger.Error().Msgf("failed to stringify original content: %s", err)
-			cont = string(fileContent)
-		}
-
-		kind := c.Parsers.GetKind()
-		if ck, ok := c.Parsers.(contentKindParser); ok {
-			if refined, override := ck.KindForContent(resolved); override {
-				kind = refined
-			}
-		}
-
-		return ParsedDocument{
-			Docs:          obj,
-			Kind:          kind,
-			Content:       cont,
-			IgnoreLines:   igLines,
-			CountLines:    bytes.Count(resolved, []byte{'\n'}) + 1,
-			ResolvedFiles: resolvedFiles,
-			IsMinified:    isMinified,
-		}, nil
+	resolved, obj, igLines, resolvedFiles, err := c.Parsers.Parse(
+		ctx, fileContent, filePath, openAPIResolveReferences, maxResolverDepth)
+	if err != nil {
+		return ParsedDocument{}, err
 	}
+
+	cont, err := c.Parsers.StringifyContent(fileContent)
+	if err != nil {
+		contextLogger.Error().Msgf("failed to stringify original content: %s", err)
+		cont = string(fileContent)
+	}
+
+	kind := c.Parsers.GetKind()
+	if ck, ok := c.Parsers.(contentKindParser); ok {
+		if refined, override := ck.KindForContent(resolved); override {
+			kind = refined
+		}
+	}
+
 	return ParsedDocument{
-		Docs:        nil,
+		Docs:          obj,
+		Kind:          kind,
+		Content:       cont,
+		IgnoreLines:   igLines,
+		CountLines:    bytes.Count(resolved, []byte{'\n'}) + 1,
+		ResolvedFiles: resolvedFiles,
+		IsMinified:    isMinified,
+	}, nil
+}
+
+func unsupportedDocument() ParsedDocument {
+	return ParsedDocument{
 		Kind:        "break",
-		Content:     "",
 		IgnoreLines: []int{},
-	}, ErrNotSupportedFile
+	}
 }
 
 // SupportedExtensions returns extensions supported by the scanner

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -70,6 +70,28 @@ func TestParser_Empty(t *testing.T) {
 	}
 }
 
+func TestParser_ParseContentIgnoresExtension(t *testing.T) {
+	ctx := context.Background()
+	parsers, err := NewBuilder(ctx).
+		Add(&yamlParser.Parser{}).
+		Build([]string{"kubernetes"}, nil)
+	require.NoError(t, err)
+	require.Len(t, parsers, 1)
+
+	documents, err := parsers[0].ParseContent(
+		ctx,
+		"chart/crds/widget.json",
+		[]byte(`{"apiVersion":"v1","kind":"ConfigMap"}`),
+		false,
+		false,
+		15,
+	)
+	require.NoError(t, err)
+	require.Len(t, documents.Docs, 1)
+	require.Equal(t, "chart/crds/widget.json", documents.Docs[0]["_path"])
+	require.Equal(t, "ConfigMap", documents.Docs[0]["kind"])
+}
+
 // TestParser_SupportedExtensions tests the functions [SupportedExtensions()] and all the methods called by them
 func TestParser_SupportedExtensions(t *testing.T) {
 	p := initilizeBuilder()

--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -35,6 +37,12 @@ const (
 	maxCandidateMinor = 40
 	minCandidateMinor = 0
 	maxCandidatePatch = 30
+
+	crdDirPrefix = "crds/"
+	extYAML      = ".yaml"
+	extYML       = ".yml"
+	extJSON      = ".json"
+	crdDirName   = "crds"
 )
 
 var (
@@ -91,7 +99,7 @@ func chartKubeVersionConstraint(ch *chart.Chart) string {
 }
 
 func runInstall(ctx context.Context, args []string, client *action.Install,
-	valueOpts *values.Options) (*release.Release, []string, error) {
+	valueOpts *values.Options) (*release.Release, *chart.Chart, []string, error) {
 	contextLogger := logger.FromContext(ctx)
 	log.SetOutput(io.Discard)
 	defer log.SetOutput(os.Stderr)
@@ -105,21 +113,21 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 
 	name, charts, err := client.NameAndChart(args)
 	if err != nil {
-		return nil, []string{}, err
+		return nil, nil, []string{}, err
 	}
 	contextLogger.Debug().Msgf("Parsed chart name: '%s', chart path: '%s'", name, charts)
 	client.ReleaseName = name
 
 	cp, err := client.LocateChart(charts, settings)
 	if err != nil {
-		return nil, []string{}, err
+		return nil, nil, []string{}, err
 	}
 	contextLogger.Debug().Msgf("Located chart at path: '%s'", cp)
 
 	p := getter.All(settings)
 	vals, err := valueOpts.MergeValues(p)
 	if err != nil {
-		return nil, []string{}, err
+		return nil, nil, []string{}, err
 	}
 	contextLogger.Debug().Msgf("Merged helm values successfully, values count: %d", len(vals))
 
@@ -127,7 +135,7 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 	contextLogger.Debug().Msgf("Loading chart from path: '%s'", cp)
 	chartRequested, err := loader.Load(cp)
 	if err != nil {
-		return nil, []string{}, err
+		return nil, nil, []string{}, err
 	}
 
 	// Set KubeVersion; clear the constraint only when unsatisfiable.
@@ -143,7 +151,7 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 	chartRequested = setID(chartRequested)
 
 	if instErr := checkIfInstallable(chartRequested); instErr != nil {
-		return nil, []string{}, instErr
+		return nil, nil, []string{}, instErr
 	}
 	contextLogger.Debug().Msg("Chart installability check passed")
 
@@ -151,12 +159,12 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 	contextLogger.Debug().Msgf("Running helm chart with namespace: '%s', release name: '%s'", client.Namespace, client.ReleaseName)
 	helmRelease, err := client.Run(chartRequested, vals)
 	if err != nil {
-		return nil, []string{}, err
+		return nil, nil, []string{}, err
 	}
 
 	contextLogger.Debug().Msgf("Successfully rendered helm chart '%s', manifest length: %d bytes",
 		chartRequested.Metadata.Name, len(helmRelease.Manifest))
-	return helmRelease, excluded, nil
+	return helmRelease, chartRequested, excluded, nil
 }
 
 // checkIfInstallable validates if a chart can be installed
@@ -182,7 +190,7 @@ func newClient(ctx context.Context) *action.Install {
 	client.Replace = true // Skip the name check
 	client.ClientOnly = true
 	client.APIVersions = chartutil.VersionSet([]string{})
-	client.IncludeCRDs = false
+	client.IncludeCRDs = true
 
 	contextLogger.Debug().Msgf("Configured helm client - DryRun: %t, ClientOnly: %t, IncludeCRDs: %t, ReleaseName: '%s'",
 		client.DryRun, client.ClientOnly, client.IncludeCRDs, client.ReleaseName)
@@ -404,6 +412,12 @@ func setID(chartReq *chart.Chart) *chart.Chart {
 			continue
 		}
 	}
+	// Stamp YAML CRDs for line mapping; JSON CRDs are skipped (YAML comments corrupt JSON).
+	for _, f := range localCRDFiles(chartReq) {
+		if isYAMLCRD(f.Name) {
+			addID(f)
+		}
+	}
 	for _, dep := range chartReq.Dependencies() {
 		dep = setID(dep)
 		if dep != nil {
@@ -414,19 +428,126 @@ func setID(chartReq *chart.Chart) *chart.Chart {
 }
 
 // addID will add auxiliary lines used to detect line
-// one for each "apiVersion:" where the id will be the line
+// one for each top-level "apiVersion:" where the id will be the line
 func addID(file *chart.File) *chart.File {
 	split := strings.Split(string(file.Data), "\n")
-	for i := 0; i < len(split); i++ {
-		if strings.Contains(split[i], "apiVersion:") {
-			split = append(split, "")
-			copy(split[i+1:], split[i:])
-			split[i] = fmt.Sprintf("# KICS_HELM_ID_%d:", i)
-			i++
+	apiVersionLines, parsed := topLevelAPIVersionLines(file.Data)
+	if !parsed {
+		apiVersionLines = make(map[int]struct{})
+		for i, line := range split {
+			if strings.HasPrefix(line, "apiVersion:") {
+				apiVersionLines[i] = struct{}{}
+			}
 		}
 	}
-	file.Data = []byte(strings.Join(split, "\n"))
+
+	stamped := make([]string, 0, len(split)+len(apiVersionLines))
+	for i, line := range split {
+		if _, ok := apiVersionLines[i]; ok {
+			stamped = append(stamped, fmt.Sprintf("# KICS_HELM_ID_%d:", len(stamped)))
+		}
+		stamped = append(stamped, line)
+	}
+	file.Data = []byte(strings.Join(stamped, "\n"))
 	return file
+}
+
+func topLevelAPIVersionLines(data []byte) (map[int]struct{}, bool) {
+	lines := make(map[int]struct{})
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	for {
+		var document yaml.Node
+		if err := decoder.Decode(&document); err != nil {
+			return lines, err == io.EOF
+		}
+		if len(document.Content) == 0 {
+			continue
+		}
+		root := document.Content[0]
+		if root.Kind != yaml.MappingNode {
+			continue
+		}
+		for i := 0; i+1 < len(root.Content); i += 2 {
+			key := root.Content[i]
+			if key.Value == "apiVersion" {
+				lines[key.Line-1] = struct{}{}
+				break
+			}
+		}
+	}
+}
+
+// normalizeChartPath converts a chart file path to forward-slash form.
+func normalizeChartPath(name string) string {
+	return strings.ReplaceAll(filepath.ToSlash(name), "\\", "/")
+}
+
+// isCRDManifest reports whether a chart file is a CRD manifest under crds/.
+func isCRDManifest(name string) bool {
+	name = normalizeChartPath(name)
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext != extYAML && ext != extYML && ext != extJSON {
+		return false
+	}
+	return strings.HasPrefix(name, crdDirPrefix)
+}
+
+// isYAMLCRD reports whether a raw chart file is a YAML CRD. JSON is excluded
+// because addID stamps files with YAML comments that would corrupt JSON content.
+func isYAMLCRD(name string) bool {
+	name = normalizeChartPath(name)
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext != extYAML && ext != extYML {
+		return false
+	}
+	return strings.HasPrefix(name, crdDirPrefix)
+}
+
+// crdChartRelativePath returns the chart-relative crds/ path for a CRD file name.
+func crdChartRelativePath(name string) string {
+	name = normalizeChartPath(name)
+	if idx := strings.Index(name, "/crds/"); idx >= 0 {
+		return name[idx+1:]
+	}
+	if strings.HasPrefix(name, crdDirPrefix) {
+		return name
+	}
+	parts := strings.Split(name, "/")
+	for i, part := range parts {
+		if part == crdDirName && i+1 < len(parts) {
+			return strings.Join(parts[i:], "/")
+		}
+	}
+	return name
+}
+
+// resolvedChartFilePath maps a chart-relative path to an on-disk path beside chartPath.
+func resolvedChartFilePath(chartPath, chartRelative string) string {
+	subFolder := filepath.Base(chartPath)
+	return filepath.Join(filepath.Dir(chartPath), subFolder, filepath.FromSlash(chartRelative))
+}
+
+func localCRDFiles(ch *chart.Chart) []*chart.File {
+	if ch == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	out := make([]*chart.File, 0)
+	add := func(f *chart.File) {
+		if f == nil || !isCRDManifest(f.Name) {
+			return
+		}
+		key := chartSourceKey(crdChartRelativePath(f.Name))
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		out = append(out, f)
+	}
+	for _, f := range ch.Files {
+		add(f)
+	}
+	return out
 }
 
 // getExcluded will return all files rendered to be excluded from scan

--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -1,7 +1,6 @@
 package helm
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -31,6 +30,7 @@ import (
 
 // Fixed dry-run cluster version for Helm scan rendering.
 const defaultDryRunKubeVersion = "v1.30.0"
+const helmIDNumberBase = 10
 
 // Search bounds when the default does not satisfy a chart's kubeVersion.
 const (
@@ -428,53 +428,133 @@ func setID(chartReq *chart.Chart) *chart.Chart {
 }
 
 // addID will add auxiliary lines used to detect line
-// one for each top-level "apiVersion:" where the id will be the line
+// one for each top-level "apiVersion:" where the id is the source line index.
 func addID(file *chart.File) *chart.File {
 	split := strings.Split(string(file.Data), "\n")
-	apiVersionLines, parsed := topLevelAPIVersionLines(file.Data)
-	if !parsed {
-		apiVersionLines = make(map[int]struct{})
-		for i, line := range split {
-			if strings.HasPrefix(line, "apiVersion:") {
-				apiVersionLines[i] = struct{}{}
-			}
-		}
-	}
+	apiVersionLines := topLevelAPIVersionLines(split, isYAMLCRD(file.Name))
 
-	stamped := make([]string, 0, len(split)+len(apiVersionLines))
+	stamped := make([]byte, 0, len(file.Data)+len(apiVersionLines)*24)
+	nextAPIVersion := 0
 	for i, line := range split {
-		if _, ok := apiVersionLines[i]; ok {
-			stamped = append(stamped, fmt.Sprintf("# KICS_HELM_ID_%d:", len(stamped)))
+		if nextAPIVersion < len(apiVersionLines) && apiVersionLines[nextAPIVersion] == i {
+			stamped = append(stamped, "# KICS_HELM_ID_"...)
+			stamped = strconv.AppendInt(stamped, int64(i), helmIDNumberBase)
+			stamped = append(stamped, ':', '\n')
+			nextAPIVersion++
 		}
-		stamped = append(stamped, line)
+		stamped = append(stamped, line...)
+		if i+1 < len(split) {
+			stamped = append(stamped, '\n')
+		}
 	}
-	file.Data = []byte(strings.Join(stamped, "\n"))
+	file.Data = stamped
 	return file
 }
 
-func topLevelAPIVersionLines(data []byte) (map[int]struct{}, bool) {
-	lines := make(map[int]struct{})
-	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	for {
-		var document yaml.Node
-		if err := decoder.Decode(&document); err != nil {
-			return lines, err == io.EOF
+func topLevelAPIVersionLines(lines []string, exhaustive bool) []int {
+	var result []int
+	for documentStart := 0; documentStart < len(lines); {
+		documentEnd := documentStart
+		for documentEnd < len(lines) && !isYAMLDocumentBoundary(lines[documentEnd]) {
+			documentEnd++
 		}
-		if len(document.Content) == 0 {
-			continue
-		}
-		root := document.Content[0]
-		if root.Kind != yaml.MappingNode {
-			continue
-		}
-		for i := 0; i+1 < len(root.Content); i += 2 {
-			key := root.Content[i]
-			if key.Value == "apiVersion" {
-				lines[key.Line-1] = struct{}{}
-				break
-			}
+		result = appendDocumentAPIVersionLine(result, lines, documentStart, documentEnd, exhaustive)
+
+		documentStart = documentEnd + 1
+		if documentEnd == len(lines) {
+			break
 		}
 	}
+	return result
+}
+
+func appendDocumentAPIVersionLine(
+	result []int, lines []string, documentStart, documentEnd int, exhaustive bool,
+) []int {
+	minIndent := -1
+	for lineNumber := documentStart; lineNumber < documentEnd; lineNumber++ {
+		line := lines[lineNumber]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "%") {
+			continue
+		}
+		indent := len(line) - len(strings.TrimLeft(line, " "))
+		if minIndent < 0 || indent < minIndent {
+			minIndent = indent
+		}
+	}
+
+	resultStart := len(result)
+	mayNeedFallback := false
+	for lineNumber := documentStart; lineNumber < documentEnd; lineNumber++ {
+		line := lines[lineNumber]
+		mayNeedFallback = mayNeedFallback || strings.Contains(line, "apiVersion")
+		indent := len(line) - len(strings.TrimLeft(line, " "))
+		if indent == minIndent && isAPIVersionKey(line[indent:]) {
+			result = append(result, lineNumber)
+		}
+	}
+	if len(result) == resultStart && (exhaustive || mayNeedFallback) {
+		if lineNumber, ok := parsedAPIVersionLine(lines[documentStart:documentEnd]); ok {
+			result = append(result, documentStart+lineNumber)
+		}
+	}
+	return result
+}
+
+func parsedAPIVersionLine(lines []string) (int, bool) {
+	var document yaml.Node
+	if err := yaml.Unmarshal([]byte(strings.Join(lines, "\n")), &document); err != nil ||
+		len(document.Content) == 0 {
+		return 0, false
+	}
+	root := document.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return 0, false
+	}
+	for index := 0; index+1 < len(root.Content); index += 2 {
+		key := root.Content[index]
+		if key.Value == "apiVersion" {
+			return key.Line - 1, true
+		}
+	}
+	return 0, false
+}
+
+func isYAMLDocumentBoundary(line string) bool {
+	line = strings.TrimRight(line, " \t\r")
+	if len(line) < 3 || (line[:3] != "---" && line[:3] != "...") {
+		return false
+	}
+	return len(line) == 3 || strings.HasPrefix(strings.TrimSpace(line[3:]), "#")
+}
+
+func isAPIVersionKey(line string) bool {
+	line = strings.TrimSpace(line)
+	if strings.HasPrefix(line, "{") {
+		line = strings.TrimSpace(line[1:])
+	}
+	explicitKey := strings.HasPrefix(line, "?")
+	if explicitKey {
+		line = strings.TrimSpace(line[1:])
+	}
+
+	var remainder string
+	switch {
+	case strings.HasPrefix(line, "'apiVersion'"):
+		remainder = line[len("'apiVersion'"):]
+	case strings.HasPrefix(line, `"apiVersion"`):
+		remainder = line[len(`"apiVersion"`):]
+	case strings.HasPrefix(line, "apiVersion"):
+		remainder = line[len("apiVersion"):]
+	default:
+		return false
+	}
+	remainder = strings.TrimSpace(remainder)
+	if explicitKey {
+		return remainder == "" || strings.HasPrefix(remainder, "#")
+	}
+	return strings.HasPrefix(remainder, ":")
 }
 
 // normalizeChartPath converts a chart file path to forward-slash form.
@@ -506,11 +586,11 @@ func isYAMLCRD(name string) bool {
 // crdChartRelativePath returns the chart-relative crds/ path for a CRD file name.
 func crdChartRelativePath(name string) string {
 	name = normalizeChartPath(name)
-	if idx := strings.Index(name, "/crds/"); idx >= 0 {
-		return name[idx+1:]
-	}
 	if strings.HasPrefix(name, crdDirPrefix) {
 		return name
+	}
+	if idx := strings.Index(name, "/crds/"); idx >= 0 {
+		return name[idx+1:]
 	}
 	parts := strings.Split(name, "/")
 	for i, part := range parts {

--- a/pkg/resolver/helm/resolver.go
+++ b/pkg/resolver/helm/resolver.go
@@ -3,7 +3,7 @@ package helm
 import (
 	"context"
 	"path/filepath"
-	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -14,6 +14,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/releaseutil"
 )
 
 // Resolver is an instance of the helm resolver
@@ -44,7 +45,7 @@ func (r *Resolver) Resolve(ctx context.Context, filePath string) (model.Resolved
 			masterUtils.HandlePanic(ctx, r, errMessage)
 		}
 	}()
-	splits, excluded, err := renderHelm(ctx, filePath)
+	splits, excluded, loadedChart, err := renderHelm(ctx, filePath)
 	if err != nil {
 		return model.ResolvedFiles{}, errors.Wrap(err, "failed to render helm chart")
 	}
@@ -52,14 +53,15 @@ func (r *Resolver) Resolve(ctx context.Context, filePath string) (model.Resolved
 		Excluded: excluded,
 	}
 	contextLogger.Debug().Msgf("Processing %d helm manifest splits from chart '%s'", len(*splits), filePath)
+	seenCRDs := make(map[string]struct{}, len(*splits))
 	for _, split := range *splits {
-		subFolder := filepath.Base(filePath)
-
-		splitPath := strings.Split(split.path, getPathSeparator(split.path))
-
-		splited := filepath.Join(splitPath[1:]...)
-
-		origpath := filepath.Join(filepath.Dir(filePath), subFolder, splited)
+		sourceKey := chartSourceKey(split.path)
+		seenCRDs[sourceKey] = struct{}{}
+		chartRelative, ok := chartRelativeFromSource(sourceKey)
+		if !ok {
+			continue
+		}
+		origpath := resolvedChartFilePath(filePath, chartRelative)
 		rfiles.File = append(rfiles.File, model.ResolvedHelm{
 			FileName:     origpath,
 			Content:      split.content,
@@ -68,7 +70,10 @@ func (r *Resolver) Resolve(ctx context.Context, filePath string) (model.Resolved
 			IDInfo:       split.splitIDMap,
 		})
 	}
-	contextLogger.Debug().Msgf("Successfully processed %d helm files from chart '%s'", len(*splits), filePath)
+	if err := appendDirectCRDFiles(&rfiles, filePath, loadedChart, seenCRDs); err != nil {
+		return model.ResolvedFiles{}, err
+	}
+	contextLogger.Debug().Msgf("Successfully processed %d helm files from chart '%s'", len(rfiles.File), filePath)
 	return rfiles, nil
 }
 
@@ -78,29 +83,41 @@ func (r *Resolver) SupportedTypes() []model.FileKind {
 }
 
 // renderHelm will use helm library to render helm charts
-func renderHelm(ctx context.Context, path string) (*[]splitManifest, []string, error) {
+func renderHelm(ctx context.Context, path string) (*[]splitManifest, []string, *chart.Chart, error) {
 	contextLogger := logger.FromContext(ctx)
 	client := newClient(ctx)
 	contextLogger.Debug().Msg("Running helm install")
-	manifest, excluded, err := runInstall(ctx, []string{path}, client, &values.Options{})
+	manifest, loadedChart, excluded, err := runInstall(ctx, []string{path}, client, &values.Options{})
 	if err != nil {
-		return nil, []string{}, err
+		return nil, []string{}, nil, err
 	}
-	splitted, err := splitManifestYAML(manifest)
+	splitted, err := splitManifestYAML(manifest, loadedChart)
 	if err != nil {
-		return nil, []string{}, err
+		return nil, []string{}, nil, err
 	}
-	return splitted, excluded, nil
+	return splitted, excluded, loadedChart, nil
 }
 
 // splitManifestYAML will split the rendered file and return its content by template as well as the template path
-func splitManifestYAML(template *release.Release) (*[]splitManifest, error) {
+func splitManifestYAML(template *release.Release, loadedChart *chart.Chart) (*[]splitManifest, error) {
+	sourceChart := loadedChart
+	if sourceChart == nil {
+		sourceChart = template.Chart
+	}
 	sources := make([]*chart.File, 0)
-	sources = updateName(sources, template.Chart, template.Chart.Name())
+	sources = updateName(sources, sourceChart, sourceChart.Name())
 	var splitedManifest []splitManifest
-	splitedSource := strings.Split(template.Manifest, "---") // split manifest by '---'
+	splitedSource := splitHelmManifest(template.Manifest)
 	origData := toMap(sources)
+	// crdSplitCount and markersBySource support multi-document CRD files: Helm renders
+	// each document as a separate split without repeating the Source header, and omits
+	// KICS_HELM_ID markers. We attribute sourceless splits to lastSource and pick the
+	// Nth cached marker for the Nth occurrence of a given source path.
+	crdSplitCount := make(map[string]int)
+	markersBySource := make(map[string][]string)
+	var lastSource string
 	for _, splited := range splitedSource {
+		splited = strings.ReplaceAll(splited, "\r", "")
 		var lineID string
 		for _, line := range strings.Split(splited, "\n") {
 			if strings.Contains(line, kicsHelmID) {
@@ -108,22 +125,52 @@ func splitManifestYAML(template *release.Release) (*[]splitManifest, error) {
 				break
 			}
 		}
-		path := strings.Split(strings.TrimPrefix(splited, "\n# Source: "), "\n") // get source of split yaml
-		// ignore auxiliary files used to render chart
-		if path[0] == "" {
+
+		sourcePath, hasSource := parseManifestSource(splited)
+		if hasSource {
+			sourcePath = chartSourceKey(sourcePath)
+			if origData[sourcePath] == nil {
+				hasSource = false
+			}
+		}
+		if !hasSource {
+			// Helm omits the Source header on later documents from a multi-document CRD.
+			if lastSource != "" && looksLikeManifest(splited) {
+				sourcePath = lastSource
+			} else {
+				continue
+			}
+		} else {
+			lastSource = sourcePath
+		}
+
+		sourcePath = chartSourceKey(sourcePath)
+		sourceKey := sourcePath
+		if origData[sourceKey] == nil {
 			continue
 		}
-		if origData[filepath.FromSlash(path[0])] == nil {
-			continue
-		}
-		idMap, err := getIDMap(origData[filepath.FromSlash(path[0])])
+		original := origData[sourceKey]
+		idMap, err := getIDMap(original)
 		if err != nil {
 			return nil, err
 		}
+		// CRDs have no inline markers in the rendered output; use the Nth stamped marker.
+		if lineID == "" {
+			markers, ok := markersBySource[sourcePath]
+			if !ok {
+				markers = extractHelmMarkers(original)
+				markersBySource[sourcePath] = markers
+			}
+			n := crdSplitCount[sourcePath]
+			if n < len(markers) {
+				lineID = markers[n]
+			}
+			crdSplitCount[sourcePath]++
+		}
 		splitedManifest = append(splitedManifest, splitManifest{
-			path:       path[0],
+			path:       sourcePath,
 			content:    []byte(strings.ReplaceAll(splited, "\r", "")),
-			original:   origData[filepath.FromSlash(path[0])], // get original data from template
+			original:   original,
 			splitID:    lineID,
 			splitIDMap: idMap,
 		})
@@ -131,28 +178,178 @@ func splitManifestYAML(template *release.Release) (*[]splitManifest, error) {
 	return &splitedManifest, nil
 }
 
+func splitHelmManifest(manifest string) []string {
+	manifests := releaseutil.SplitManifests(manifest)
+	keys := make([]string, 0, len(manifests))
+	for key := range manifests {
+		keys = append(keys, key)
+	}
+	sort.Sort(releaseutil.BySplitManifestsOrder(keys))
+
+	splits := make([]string, 0, len(keys))
+	for _, key := range keys {
+		splits = append(splits, "\n"+manifests[key]+"\n")
+	}
+	return splits
+}
+
+// parseManifestSource extracts the Helm # Source header from a manifest split.
+func parseManifestSource(split string) (source string, ok bool) {
+	for _, line := range strings.Split(split, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "# Source: ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "# Source: ")), true
+		}
+		return "", false
+	}
+	return "", false
+}
+
+func looksLikeManifest(split string) bool {
+	apiVersionLines, parsed := topLevelAPIVersionLines([]byte(split))
+	return parsed && len(apiVersionLines) > 0
+}
+
+// extractHelmMarkers returns all KICS_HELM_ID lines from content in order.
+func extractHelmMarkers(data []byte) []string {
+	var markers []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, kicsHelmID) {
+			markers = append(markers, strings.TrimSpace(line))
+		}
+	}
+	return markers
+}
+
+// chartSourceKey normalizes Helm source paths for cross-platform lookup.
+func chartSourceKey(path string) string {
+	path = strings.ReplaceAll(path, `\`, `/`)
+	return filepath.ToSlash(filepath.Clean(path))
+}
+
+// chartRelativeFromSource strips the leading chart name segment from a normalized
+// Helm manifest source path (e.g. test_helm/crds/widget.yaml -> crds/widget.yaml).
+func chartRelativeFromSource(sourceKey string) (string, bool) {
+	parts := strings.Split(sourceKey, "/")
+	if len(parts) < 2 {
+		return "", false
+	}
+	return strings.Join(parts[1:], "/"), true
+}
+
+// helmChartPath joins Helm chart-relative segments with forward slashes.
+func helmChartPath(parts ...string) string {
+	elems := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = filepath.ToSlash(part)
+		for _, segment := range strings.Split(part, "/") {
+			if segment != "" && segment != "." {
+				elems = append(elems, segment)
+			}
+		}
+	}
+	return strings.Join(elems, "/")
+}
+
 // toMap will convert to map original data having the path as it's key
 func toMap(files []*chart.File) map[string][]byte {
 	mapFiles := make(map[string][]byte)
 	for _, file := range files {
-		mapFiles[file.Name] = []byte(strings.ReplaceAll(string(file.Data), "\r", ""))
+		mapFiles[chartSourceKey(file.Name)] = []byte(strings.ReplaceAll(string(file.Data), "\r", ""))
 	}
 	return mapFiles
 }
 
 // updateName will update the templates name as well as its dependencies
 func updateName(template []*chart.File, charts *chart.Chart, name string) []*chart.File {
+	name = helmChartPath(name)
 	if name != charts.Name() {
-		name = filepath.Join(name, charts.Name())
+		name = helmChartPath(name, charts.Name())
 	}
 	for _, temp := range charts.Templates {
-		temp.Name = filepath.Join(name, temp.Name)
+		temp.Name = helmChartPath(name, temp.Name)
 	}
 	template = append(template, charts.Templates...)
+	for _, f := range localCRDFiles(charts) {
+		rel := crdChartRelativePath(f.Name)
+		template = append(template, &chart.File{
+			Name: helmChartPath(name, rel),
+			Data: f.Data,
+		})
+	}
 	for _, dep := range charts.Dependencies() {
-		template = updateName(template, dep, filepath.Join(name, "charts"))
+		template = updateName(template, dep, helmChartPath(name, "charts"))
 	}
 	return template
+}
+
+func crdDocuments(data []byte) [][]byte {
+	text := strings.ReplaceAll(string(data), "\r", "")
+	parts := splitHelmManifest(text)
+	docs := make([][]byte, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		docs = append(docs, []byte(part))
+	}
+	return docs
+}
+
+func appendDirectCRDFiles(
+	rfiles *model.ResolvedFiles, chartPath string, ch *chart.Chart, seen map[string]struct{},
+) error {
+	if ch == nil {
+		return nil
+	}
+	rootKey := chartSourceKey(ch.Name())
+	var walk func(prefix string, chart *chart.Chart) error
+	walk = func(prefix string, chart *chart.Chart) error {
+		chartPrefix := helmChartPath(prefix, chart.Name())
+		for _, f := range localCRDFiles(chart) {
+			rel := crdChartRelativePath(f.Name)
+			sourceKey := chartSourceKey(helmChartPath(chartPrefix, rel))
+			if _, ok := seen[sourceKey]; ok {
+				continue
+			}
+			chartRelative := strings.TrimPrefix(sourceKey, rootKey+"/")
+			if chartRelative == sourceKey {
+				continue
+			}
+			origpath := resolvedChartFilePath(chartPath, chartRelative)
+			original := append([]byte(nil), f.Data...)
+			idMap, err := getIDMap(original)
+			if err != nil {
+				return err
+			}
+			markers := extractHelmMarkers(original)
+			docs := crdDocuments(original)
+			for i, doc := range docs {
+				lineID := ""
+				if i < len(markers) {
+					lineID = markers[i]
+				}
+				rfiles.File = append(rfiles.File, model.ResolvedHelm{
+					FileName:     origpath,
+					Content:      append([]byte(nil), doc...),
+					OriginalData: original,
+					SplitID:      lineID,
+					IDInfo:       idMap,
+				})
+			}
+			seen[sourceKey] = struct{}{}
+		}
+		for _, dep := range chart.Dependencies() {
+			if err := walk(helmChartPath(chartPrefix, "charts"), dep); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return walk("", ch)
 }
 
 // getIdMap will construct a map with ids with the corresponding lines as keys
@@ -183,13 +380,4 @@ func getIDMap(originalData []byte) (map[int]interface{}, error) {
 	ids[idHelm] = mapLines
 
 	return ids, nil
-}
-
-func getPathSeparator(path string) string {
-	if matched, err := regexp.MatchString(`[a-zA-Z0-9_\/-]+(\[a-zA-Z0-9_\/-]+)*`, path); matched && err == nil {
-		return "/"
-	} else if matched, err := regexp.MatchString(`[a-z0-9_.$-]+(\\[a-z0-9_.$-]+)*`, path); matched && err == nil {
-		return "\\"
-	}
-	return ""
 }

--- a/pkg/resolver/helm/resolver.go
+++ b/pkg/resolver/helm/resolver.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"bytes"
 	"context"
 	"path/filepath"
 	"sort"
@@ -23,11 +24,13 @@ type Resolver struct {
 
 // splitManifest keeps the information of the manifest splitted by source
 type splitManifest struct {
-	path       string
-	content    []byte
-	original   []byte
-	splitID    string
-	splitIDMap map[int]interface{}
+	path                string
+	content             []byte
+	original            []byte
+	splitID             string
+	sourceDocumentIndex int
+	splitIDMap          map[int]interface{}
+	isCRD               bool
 }
 
 const (
@@ -45,7 +48,7 @@ func (r *Resolver) Resolve(ctx context.Context, filePath string) (model.Resolved
 			masterUtils.HandlePanic(ctx, r, errMessage)
 		}
 	}()
-	splits, excluded, loadedChart, err := renderHelm(ctx, filePath)
+	splits, excluded, err := renderHelm(ctx, filePath)
 	if err != nil {
 		return model.ResolvedFiles{}, errors.Wrap(err, "failed to render helm chart")
 	}
@@ -53,25 +56,22 @@ func (r *Resolver) Resolve(ctx context.Context, filePath string) (model.Resolved
 		Excluded: excluded,
 	}
 	contextLogger.Debug().Msgf("Processing %d helm manifest splits from chart '%s'", len(*splits), filePath)
-	seenCRDs := make(map[string]struct{}, len(*splits))
 	for _, split := range *splits {
 		sourceKey := chartSourceKey(split.path)
-		seenCRDs[sourceKey] = struct{}{}
 		chartRelative, ok := chartRelativeFromSource(sourceKey)
 		if !ok {
 			continue
 		}
 		origpath := resolvedChartFilePath(filePath, chartRelative)
 		rfiles.File = append(rfiles.File, model.ResolvedHelm{
-			FileName:     origpath,
-			Content:      split.content,
-			OriginalData: split.original,
-			SplitID:      split.splitID,
-			IDInfo:       split.splitIDMap,
+			FileName:            origpath,
+			Content:             split.content,
+			OriginalData:        split.original,
+			SplitID:             split.splitID,
+			SourceDocumentIndex: split.sourceDocumentIndex,
+			IDInfo:              split.splitIDMap,
+			IsCRD:               split.isCRD,
 		})
-	}
-	if err := appendDirectCRDFiles(&rfiles, filePath, loadedChart, seenCRDs); err != nil {
-		return model.ResolvedFiles{}, err
 	}
 	contextLogger.Debug().Msgf("Successfully processed %d helm files from chart '%s'", len(rfiles.File), filePath)
 	return rfiles, nil
@@ -83,19 +83,19 @@ func (r *Resolver) SupportedTypes() []model.FileKind {
 }
 
 // renderHelm will use helm library to render helm charts
-func renderHelm(ctx context.Context, path string) (*[]splitManifest, []string, *chart.Chart, error) {
+func renderHelm(ctx context.Context, path string) (*[]splitManifest, []string, error) {
 	contextLogger := logger.FromContext(ctx)
 	client := newClient(ctx)
 	contextLogger.Debug().Msg("Running helm install")
 	manifest, loadedChart, excluded, err := runInstall(ctx, []string{path}, client, &values.Options{})
 	if err != nil {
-		return nil, []string{}, nil, err
+		return nil, []string{}, err
 	}
 	splitted, err := splitManifestYAML(manifest, loadedChart)
 	if err != nil {
-		return nil, []string{}, nil, err
+		return nil, []string{}, err
 	}
-	return splitted, excluded, loadedChart, nil
+	return splitted, excluded, nil
 }
 
 // splitManifestYAML will split the rendered file and return its content by template as well as the template path
@@ -108,29 +108,17 @@ func splitManifestYAML(template *release.Release, loadedChart *chart.Chart) (*[]
 	sources = updateName(sources, sourceChart, sourceChart.Name())
 	var splitedManifest []splitManifest
 	splitedSource := splitHelmManifest(template.Manifest)
-	origData := toMap(sources)
-	// crdSplitCount and markersBySource support multi-document CRD files: Helm renders
-	// each document as a separate split without repeating the Source header, and omits
-	// KICS_HELM_ID markers. We attribute sourceless splits to lastSource and pick the
-	// Nth cached marker for the Nth occurrence of a given source path.
-	crdSplitCount := make(map[string]int)
-	markersBySource := make(map[string][]string)
+	sourceData := indexSources(sources)
+	sourceDocumentIndices := make(map[string]int)
 	var lastSource string
 	for _, splited := range splitedSource {
 		splited = strings.ReplaceAll(splited, "\r", "")
-		var lineID string
-		for _, line := range strings.Split(splited, "\n") {
-			if strings.Contains(line, kicsHelmID) {
-				lineID = line // get auxiliary line id
-				break
-			}
-		}
-
 		sourcePath, hasSource := parseManifestSource(splited)
 		if hasSource {
 			sourcePath = chartSourceKey(sourcePath)
-			if origData[sourcePath] == nil {
-				hasSource = false
+			if sourceData[sourcePath] == nil {
+				lastSource = ""
+				continue
 			}
 		}
 		if !hasSource {
@@ -146,33 +134,26 @@ func splitManifestYAML(template *release.Release, loadedChart *chart.Chart) (*[]
 
 		sourcePath = chartSourceKey(sourcePath)
 		sourceKey := sourcePath
-		if origData[sourceKey] == nil {
+		source := sourceData[sourceKey]
+		if source == nil {
 			continue
 		}
-		original := origData[sourceKey]
-		idMap, err := getIDMap(original)
-		if err != nil {
+		if err := source.ensureIDMap(); err != nil {
 			return nil, err
 		}
-		// CRDs have no inline markers in the rendered output; use the Nth stamped marker.
-		if lineID == "" {
-			markers, ok := markersBySource[sourcePath]
-			if !ok {
-				markers = extractHelmMarkers(original)
-				markersBySource[sourcePath] = markers
-			}
-			n := crdSplitCount[sourcePath]
-			if n < len(markers) {
-				lineID = markers[n]
-			}
-			crdSplitCount[sourcePath]++
+		splitID := firstHelmMarker(splited)
+		sourceDocumentIndex := sourceDocumentIndices[sourceKey]
+		if !source.isCRD || splitID != "" || strings.EqualFold(filepath.Ext(sourcePath), ".json") {
+			sourceDocumentIndices[sourceKey]++
 		}
 		splitedManifest = append(splitedManifest, splitManifest{
-			path:       sourcePath,
-			content:    []byte(strings.ReplaceAll(splited, "\r", "")),
-			original:   original,
-			splitID:    lineID,
-			splitIDMap: idMap,
+			path:                sourcePath,
+			content:             []byte(splited),
+			original:            source.original,
+			splitID:             splitID,
+			sourceDocumentIndex: sourceDocumentIndex,
+			splitIDMap:          source.idMap,
+			isCRD:               source.isCRD,
 		})
 	}
 	return &splitedManifest, nil
@@ -195,7 +176,15 @@ func splitHelmManifest(manifest string) []string {
 
 // parseManifestSource extracts the Helm # Source header from a manifest split.
 func parseManifestSource(split string) (source string, ok bool) {
-	for _, line := range strings.Split(split, "\n") {
+	for split != "" {
+		lineEnd := strings.IndexByte(split, '\n')
+		line := split
+		if lineEnd >= 0 {
+			line = split[:lineEnd]
+			split = split[lineEnd+1:]
+		} else {
+			split = ""
+		}
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
@@ -207,20 +196,21 @@ func parseManifestSource(split string) (source string, ok bool) {
 	return "", false
 }
 
-func looksLikeManifest(split string) bool {
-	apiVersionLines, parsed := topLevelAPIVersionLines([]byte(split))
-	return parsed && len(apiVersionLines) > 0
+func firstHelmMarker(content string) string {
+	index := strings.Index(content, kicsHelmID)
+	if index < 0 {
+		return ""
+	}
+	lineStart := strings.LastIndexByte(content[:index], '\n') + 1
+	lineEnd := strings.IndexByte(content[index:], '\n')
+	if lineEnd < 0 {
+		return content[lineStart:]
+	}
+	return content[lineStart : index+lineEnd]
 }
 
-// extractHelmMarkers returns all KICS_HELM_ID lines from content in order.
-func extractHelmMarkers(data []byte) []string {
-	var markers []string
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.Contains(line, kicsHelmID) {
-			markers = append(markers, strings.TrimSpace(line))
-		}
-	}
-	return markers
+func looksLikeManifest(split string) bool {
+	return len(topLevelAPIVersionLines(strings.Split(split, "\n"), true)) > 0
 }
 
 // chartSourceKey normalizes Helm source paths for cross-platform lookup.
@@ -253,13 +243,58 @@ func helmChartPath(parts ...string) string {
 	return strings.Join(elems, "/")
 }
 
-// toMap will convert to map original data having the path as it's key
-func toMap(files []*chart.File) map[string][]byte {
-	mapFiles := make(map[string][]byte)
-	for _, file := range files {
-		mapFiles[chartSourceKey(file.Name)] = []byte(strings.ReplaceAll(string(file.Data), "\r", ""))
+type sourceMetadata struct {
+	original      []byte
+	idMap         map[int]interface{}
+	isCRD         bool
+	idMapPrepared bool
+}
+
+func (s *sourceMetadata) ensureIDMap() error {
+	if s.idMapPrepared {
+		return nil
 	}
-	return mapFiles
+	idMap, err := getIDMap(s.original)
+	if err != nil {
+		return err
+	}
+	s.idMap = idMap
+	s.idMapPrepared = true
+	return nil
+}
+
+func indexSources(files []*chart.File) map[string]*sourceMetadata {
+	sources := make(map[string]*sourceMetadata, len(files))
+	for _, file := range files {
+		original := file.Data
+		if bytes.IndexByte(original, '\r') >= 0 {
+			original = bytes.ReplaceAll(original, []byte{'\r'}, nil)
+		}
+		sources[chartSourceKey(file.Name)] = &sourceMetadata{
+			original: original,
+			isCRD:    isCRDSourcePath(file.Name),
+		}
+	}
+	return sources
+}
+
+func isCRDSourcePath(name string) bool {
+	parts := strings.Split(chartSourceKey(name), "/")
+	if len(parts) == 0 {
+		return false
+	}
+	index := 1
+	for index < len(parts) {
+		switch parts[index] {
+		case crdDirName:
+			return index+1 < len(parts)
+		case "charts":
+			index += 2
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 // updateName will update the templates name as well as its dependencies
@@ -285,99 +320,29 @@ func updateName(template []*chart.File, charts *chart.Chart, name string) []*cha
 	return template
 }
 
-func crdDocuments(data []byte) [][]byte {
-	text := strings.ReplaceAll(string(data), "\r", "")
-	parts := splitHelmManifest(text)
-	docs := make([][]byte, 0, len(parts))
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		docs = append(docs, []byte(part))
-	}
-	return docs
-}
-
-func appendDirectCRDFiles(
-	rfiles *model.ResolvedFiles, chartPath string, ch *chart.Chart, seen map[string]struct{},
-) error {
-	if ch == nil {
-		return nil
-	}
-	rootKey := chartSourceKey(ch.Name())
-	var walk func(prefix string, chart *chart.Chart) error
-	walk = func(prefix string, chart *chart.Chart) error {
-		chartPrefix := helmChartPath(prefix, chart.Name())
-		for _, f := range localCRDFiles(chart) {
-			rel := crdChartRelativePath(f.Name)
-			sourceKey := chartSourceKey(helmChartPath(chartPrefix, rel))
-			if _, ok := seen[sourceKey]; ok {
-				continue
-			}
-			chartRelative := strings.TrimPrefix(sourceKey, rootKey+"/")
-			if chartRelative == sourceKey {
-				continue
-			}
-			origpath := resolvedChartFilePath(chartPath, chartRelative)
-			original := append([]byte(nil), f.Data...)
-			idMap, err := getIDMap(original)
-			if err != nil {
-				return err
-			}
-			markers := extractHelmMarkers(original)
-			docs := crdDocuments(original)
-			for i, doc := range docs {
-				lineID := ""
-				if i < len(markers) {
-					lineID = markers[i]
-				}
-				rfiles.File = append(rfiles.File, model.ResolvedHelm{
-					FileName:     origpath,
-					Content:      append([]byte(nil), doc...),
-					OriginalData: original,
-					SplitID:      lineID,
-					IDInfo:       idMap,
-				})
-			}
-			seen[sourceKey] = struct{}{}
-		}
-		for _, dep := range chart.Dependencies() {
-			if err := walk(helmChartPath(chartPrefix, "charts"), dep); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-	return walk("", ch)
-}
-
 // getIdMap will construct a map with ids with the corresponding lines as keys
 // for use in detector
 func getIDMap(originalData []byte) (map[int]interface{}, error) {
 	ids := make(map[int]interface{})
-	mapLines := make(map[int]int)
 	idHelm := -1
+	lineRange := model.HelmIDLineRange{Start: 1, End: 0}
 	for line, stringLine := range strings.Split(string(originalData), "\n") {
 		if strings.Contains(stringLine, kicsHelmID) {
 			id, err := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(stringLine, kicsHelmID), ":"))
 			if err != nil {
 				return nil, err
 			}
-			if idHelm == -1 {
-				idHelm = id
-				mapLines[line] = line
-			} else {
-				ids[idHelm] = mapLines
-				mapLines = make(map[int]int)
-				idHelm = id
-				mapLines[line] = line
+			if idHelm != -1 {
+				lineRange.End = line - 1
+				ids[idHelm] = lineRange
 			}
+			idHelm = id
+			lineRange = model.HelmIDLineRange{Start: line, End: line}
 		} else if idHelm != -1 {
-			mapLines[line] = line
+			lineRange.End = line
 		}
 	}
-	ids[idHelm] = mapLines
+	ids[idHelm] = lineRange
 
 	return ids, nil
 }

--- a/pkg/resolver/helm/resolver_test.go
+++ b/pkg/resolver/helm/resolver_test.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	helmdetector "github.com/DataDog/datadog-iac-scanner/pkg/detector/helm"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -83,6 +85,7 @@ func TestHelm_Resolve_WithCRDs(t *testing.T) {
 		{suffix: "crds/widget.yaml", kind: "CustomResourceDefinition", name: "widgets.example.com", fullLineMap: true},
 		{suffix: "crds/gadget.json", kind: "CustomResourceDefinition", name: "gadgets.example.com", fullLineMap: false},
 		{suffix: "crds/nested/device.yaml", kind: "CustomResourceDefinition", name: "devices.example.com", fullLineMap: true},
+		{suffix: "crds/nested/crds/repeated.yaml", kind: "CustomResourceDefinition", name: "repeated.example.com", fullLineMap: true},
 	}
 
 	for _, want := range wantCRDs {
@@ -96,9 +99,9 @@ func TestHelm_Resolve_WithCRDs(t *testing.T) {
 			require.Contains(t, string(f.OriginalData), kicsHelmID, "stamped original required for detector")
 			require.Contains(t, string(f.OriginalData), want.kind)
 			require.Contains(t, string(f.OriginalData), want.name)
-			idInfo, ok := f.IDInfo[0].(map[int]int)
+			idInfo, ok := f.IDInfo[0].(model.HelmIDLineRange)
 			require.True(t, ok, "IDInfo must map helm id 0 to source lines for YAML CRDs")
-			require.NotEmpty(t, idInfo, "IDInfo line map must not be empty for YAML CRDs")
+			require.GreaterOrEqual(t, idInfo.End, idInfo.Start, "IDInfo line range must not be empty for YAML CRDs")
 		} else {
 			require.Empty(t, f.SplitID, "JSON CRD has no inline stamp; SplitID must be empty")
 		}
@@ -248,6 +251,7 @@ func TestIsCRDManifest(t *testing.T) {
 func TestCrdChartRelativePath(t *testing.T) {
 	require.Equal(t, "crds/widget.yaml", crdChartRelativePath(`D:/a/repo/crds/widget.yaml`))
 	require.Equal(t, "crds/widget.yaml", crdChartRelativePath(`charts/subchart/crds/widget.yaml`))
+	require.Equal(t, "crds/zsub/crds/widget.yaml", crdChartRelativePath(`crds/zsub/crds/widget.yaml`))
 }
 
 func TestChartRelativeFromSource(t *testing.T) {
@@ -262,6 +266,25 @@ func TestChartRelativeFromSource(t *testing.T) {
 	rel, ok = chartRelativeFromSource("test_helm_subchart/charts/subchart/crds/widget.yaml")
 	require.True(t, ok)
 	require.Equal(t, "charts/subchart/crds/widget.yaml", rel)
+}
+
+func TestIsCRDSourcePath(t *testing.T) {
+	tests := map[string]bool{
+		"chart/crds/widget.yaml":                               true,
+		`chart\crds\nested\widget.yaml`:                        true,
+		"chart/charts/subchart/crds/widget.yaml":               true,
+		"chart/charts/subchart/charts/nested/crds/widget.yaml": true,
+		"crds/crds/widget.yaml":                                true,
+		"crds/templates/widget.yaml":                           false,
+		"chart/templates/widget.yaml":                          false,
+		"chart/templates/crds/widget.yaml":                     false,
+		"chart/files/crds/widget.yaml":                         false,
+	}
+	for path, expected := range tests {
+		t.Run(path, func(t *testing.T) {
+			require.Equal(t, expected, isCRDSourcePath(path))
+		})
+	}
 }
 
 func TestSplitManifestYAML_windowsCRDSourcePath(t *testing.T) {
@@ -282,9 +305,10 @@ func TestSplitManifestYAML_windowsCRDSourcePath(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, *splits, 1)
 	require.Equal(t, "test_helm_with_crds/crds/widget.yaml", (*splits)[0].path)
+	require.True(t, (*splits)[0].isCRD)
 }
 
-func TestSplitManifestYAML_userSourceCommentInLaterDocument(t *testing.T) {
+func TestSplitManifestYAML_dropsUnknownSourceHeader(t *testing.T) {
 	ch, err := loader.Load(helmFixturePath(t, "test_helm_with_crds"))
 	require.NoError(t, err)
 	setID(ch)
@@ -298,19 +322,59 @@ func TestSplitManifestYAML_userSourceCommentInLaterDocument(t *testing.T) {
 		"# Source: user-authored",
 		"apiVersion: apiextensions.k8s.io/v1",
 		"kind: CustomResourceDefinition",
+		"---",
+		"apiVersion: apiextensions.k8s.io/v1",
+		"kind: CustomResourceDefinition",
 	}, "\n")
 
 	splits, err := splitManifestYAML(&release.Release{Manifest: manifest}, ch)
 	require.NoError(t, err)
-	require.Len(t, *splits, 2)
+	require.Len(t, *splits, 1)
 	require.Equal(t, "test_helm_with_crds/crds/widget.yaml", (*splits)[0].path)
-	require.Equal(t, "test_helm_with_crds/crds/widget.yaml", (*splits)[1].path)
+}
+
+func TestSplitManifestYAML_emptyCRDDocumentDoesNotShiftSourceIndex(t *testing.T) {
+	crd := &chart.File{
+		Name: "crds/leading-empty.yaml",
+		Data: []byte(strings.Join([]string{
+			"# comment-only document",
+			"---",
+			"apiVersion: apiextensions.k8s.io/v1",
+			"kind: CustomResourceDefinition",
+			"metadata:",
+			"  name: widgets.example.com",
+		}, "\n")),
+	}
+	ch := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "test"},
+		Files:    []*chart.File{crd},
+	}
+	setID(ch)
+
+	manifest := strings.Join([]string{
+		"---",
+		"# Source: test/crds/leading-empty.yaml",
+		string(crd.Data),
+	}, "\n")
+	splits, err := splitManifestYAML(&release.Release{Manifest: manifest}, ch)
+	require.NoError(t, err)
+	require.NotEmpty(t, *splits)
+
+	var resourceSplit *splitManifest
+	for i := range *splits {
+		if (*splits)[i].splitID != "" {
+			resourceSplit = &(*splits)[i]
+			break
+		}
+	}
+	require.NotNil(t, resourceSplit)
+	require.Zero(t, resourceSplit.sourceDocumentIndex)
 }
 
 func TestLocalCRDFiles_fromLoadedFixture(t *testing.T) {
 	ch, err := loader.Load(helmFixturePath(t, "test_helm_with_crds"))
 	require.NoError(t, err)
-	require.Len(t, localCRDFiles(ch), 4)
+	require.Len(t, localCRDFiles(ch), 5)
 }
 
 func TestLocalCRDFiles_keepsDependencyCRDsOnDependency(t *testing.T) {
@@ -331,9 +395,99 @@ func TestLocalCRDFiles_windowsSeparators(t *testing.T) {
 	require.Len(t, localCRDFiles(ch), 1)
 }
 
+func TestLocalCRDFiles_keepsDistinctNestedCRDPaths(t *testing.T) {
+	ch := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "test"},
+		Files: []*chart.File{
+			{Name: "crds/widget.yaml", Data: []byte("apiVersion: v1\n")},
+			{Name: "crds/nested/crds/widget.yaml", Data: []byte("apiVersion: v1\n")},
+		},
+	}
+
+	files := localCRDFiles(ch)
+	require.Len(t, files, 2)
+	require.Equal(t, "crds/widget.yaml", crdChartRelativePath(files[0].Name))
+	require.Equal(t, "crds/nested/crds/widget.yaml", crdChartRelativePath(files[1].Name))
+}
+
+func TestAddID_multiDocumentUsesSourceLineIDs(t *testing.T) {
+	original := strings.Join([]string{
+		"apiVersion: v1",
+		"kind: Service",
+		"metadata:",
+		"  name: nested-one",
+		"spec:",
+		"  ports:",
+		"  - name: nested-one",
+		"---",
+		"apiVersion: v1",
+		"kind: Service",
+		"metadata:",
+		"  name: nested-two",
+		"spec:",
+		"  ports:",
+		"  - name: nested-two",
+	}, "\n")
+	file := addID(&chart.File{Name: "templates/nested.yaml", Data: []byte(original)})
+
+	require.Contains(t, string(file.Data), "# KICS_HELM_ID_0:\napiVersion: v1")
+	require.Contains(t, string(file.Data), "# KICS_HELM_ID_8:\napiVersion: v1")
+}
+
+func TestDetectLine_MultiDocumentTemplateUsesSourceLines(t *testing.T) {
+	original := strings.Join([]string{
+		"apiVersion: v1",
+		"kind: Service",
+		"metadata:",
+		"  name: nested-one",
+		"spec:",
+		"  ports:",
+		"  - name: nested-one",
+		"---",
+		"apiVersion: v1",
+		"kind: Service",
+		"metadata:",
+		"  name: nested-two",
+		"spec:",
+		"  ports:",
+		"  - name: nested-two",
+	}, "\n")
+	file := addID(&chart.File{Name: "templates/nested.yaml", Data: []byte(original)})
+	idMap, err := getIDMap(file.Data)
+	require.NoError(t, err)
+
+	got := (helmdetector.DetectKindLine{}).DetectLine(context.Background(), &model.FileMetadata{
+		Kind:              model.KindHELM,
+		FilePath:          "templates/nested.yaml",
+		HelmID:            "# KICS_HELM_ID_8:",
+		OriginalData:      string(file.Data),
+		LinesOriginalData: utils.SplitLines(string(file.Data)),
+		IDInfo:            idMap,
+	}, "KICS_HELM_ID_8.spec", 1)
+
+	require.Equal(t, 13, got.Line)
+	require.Equal(t, 13, got.VulnerablilityLocation.Start.Line)
+	require.Equal(t, 13, got.VulnerablilityLocation.End.Line)
+
+	got = (helmdetector.DetectKindLine{}).DetectLine(context.Background(), &model.FileMetadata{
+		Kind:              model.KindHELM,
+		FilePath:          "templates/nested.yaml",
+		HelmID:            "# KICS_HELM_ID_8:",
+		OriginalData:      string(file.Data),
+		LinesOriginalData: utils.SplitLines(string(file.Data)),
+		IDInfo:            idMap,
+	}, "KICS_HELM_ID_8.spec.ports", 1)
+
+	require.Equal(t, 14, got.Line)
+	require.Equal(t, 14, got.VulnerablilityLocation.Start.Line)
+	require.Equal(t, 14, got.VulnerablilityLocation.End.Line)
+}
+
 func TestAddID_ignoresIndentedAPIVersion(t *testing.T) {
 	original := `description: |
   apiVersion: v1
+  ---
+  apiVersion: v2
   kind: Pod
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -354,6 +508,39 @@ func TestAddID_stampsIndentedRootAPIVersion(t *testing.T) {
 	require.Contains(t, string(file.Data), "# KICS_HELM_ID_0:\n  apiVersion: v1")
 }
 
+func TestAddID_stampsValidAPIVersionKeyStyles(t *testing.T) {
+	file := &chart.File{Data: []byte(`"apiVersion": v1
+kind: ConfigMap
+---
+'apiVersion' : v1
+kind: Secret
+---
+{apiVersion: v1, kind: Service}
+---
+? apiVersion
+: v1
+kind: Pod
+---
+{
+  apiVersion: v1,
+  kind: ConfigMap
+}
+---
+!tag apiVersion: v1
+kind: Secret
+---
+&key apiVersion: v1
+kind: Service
+---
+"api\u0056ersion": v1
+kind: Pod
+`)}
+	file.Name = "crds/keys.yaml"
+	addID(file)
+
+	require.Equal(t, 8, strings.Count(string(file.Data), kicsHelmID))
+}
+
 func TestHelm_SupportedTypes(t *testing.T) {
 	res := &Resolver{}
 	want := []model.FileKind{model.KindHELM}
@@ -371,10 +558,12 @@ func TestHelm_Resolve(t *testing.T) { //nolint
 		filePath string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    model.ResolvedFiles
-		wantErr bool
+		name            string
+		args            args
+		fixture         string
+		compareBySuffix bool
+		want            model.ResolvedFiles
+		wantErr         bool
 	}{
 		{
 			name: "test_resolve_helm",
@@ -386,8 +575,7 @@ func TestHelm_Resolve(t *testing.T) { //nolint
 					{
 						SplitID:  "# KICS_HELM_ID_0:",
 						FileName: filepath.FromSlash("../../../test/fixtures/test_helm/templates/service.yaml"),
-						IDInfo: map[int]interface{}{0: map[int]int{0: 0, 1: 1, 2: 2, 3: 3, 4: 4,
-							5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10, 11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16}},
+						IDInfo:   map[int]interface{}{0: model.HelmIDLineRange{Start: 0, End: 16}},
 						Content: []byte(`
 # Source: test_helm/templates/service.yaml
 # KICS_HELM_ID_0:
@@ -443,17 +631,15 @@ spec:
 			wantErr: true,
 		},
 		{
-			name: "test_with_dependencies",
-			args: args{
-				filePath: filepath.FromSlash("../../../test/fixtures/test_helm_subchart"),
-			},
+			name:            "test_with_dependencies",
+			fixture:         "test_helm_subchart",
+			compareBySuffix: true,
 			want: model.ResolvedFiles{
 				File: []model.ResolvedHelm{
 					{
 						FileName: filepath.FromSlash("../../../test/fixtures/test_helm_subchart/templates/serviceaccount.yaml"),
 						SplitID:  "# KICS_HELM_ID_1:",
-						IDInfo: map[int]interface{}{1: map[int]int{1: 1, 2: 2, 3: 3, 4: 4,
-							5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10, 11: 11, 12: 12, 13: 13}},
+						IDInfo:   map[int]interface{}{1: model.HelmIDLineRange{Start: 1, End: 13}},
 						Content: []byte(`
 # Source: test_helm_subchart/templates/serviceaccount.yaml
 # KICS_HELM_ID_1:
@@ -486,8 +672,7 @@ metadata:
 					{
 						FileName: filepath.FromSlash("../../../test/fixtures/test_helm_subchart/charts/subchart/templates/service.yaml"),
 						SplitID:  "# KICS_HELM_ID_0:",
-						IDInfo: map[int]interface{}{0: map[int]int{0: 0, 1: 1, 2: 2, 3: 3, 4: 4,
-							5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10, 11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16}},
+						IDInfo:   map[int]interface{}{0: model.HelmIDLineRange{Start: 0, End: 16}},
 						Content: []byte(`
 # Source: test_helm_subchart/charts/subchart/templates/service.yaml
 # KICS_HELM_ID_0:
@@ -540,14 +725,14 @@ spec:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			filePath := tt.args.filePath
-			if tt.name == "test_with_dependencies" {
-				filePath = helmFixturePath(t, "test_helm_subchart")
+			if tt.fixture != "" {
+				filePath = helmFixturePath(t, tt.fixture)
 			}
 			got, err := res.Resolve(ctx, filePath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Resolve() = %v, wantErr = %v", err, tt.wantErr)
 			}
-			if tt.name == "test_with_dependencies" {
+			if tt.compareBySuffix {
 				require.NoError(t, err)
 				require.NotEmpty(t, got.Excluded)
 				for _, want := range tt.want.File {

--- a/pkg/resolver/helm/resolver_test.go
+++ b/pkg/resolver/helm/resolver_test.go
@@ -4,11 +4,355 @@ import (
 	"context"
 	"path/filepath"
 	"reflect"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/release"
 )
+
+func helmFixturePath(t *testing.T, parts ...string) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(1)
+	require.True(t, ok)
+	root, err := filepath.Abs(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	require.NoError(t, err)
+	return filepath.Join(append([]string{root, "test", "fixtures"}, parts...)...)
+}
+
+func pathSuffix(t *testing.T, path string) string {
+	t.Helper()
+	normalized := filepath.ToSlash(path)
+	if idx := strings.Index(normalized, "test/fixtures/"); idx >= 0 {
+		parts := strings.Split(strings.TrimPrefix(normalized[idx+len("test/fixtures/"):], "/"), "/")
+		if len(parts) > 1 {
+			return strings.Join(parts[1:], "/")
+		}
+	}
+	if idx := strings.Index(normalized, "test_helm_subchart/"); idx >= 0 {
+		return normalized[idx:]
+	}
+	return filepath.Base(normalized)
+}
+
+func findResolvedBySuffix(t *testing.T, files []model.ResolvedHelm, suffix string) model.ResolvedHelm {
+	t.Helper()
+	suffix = filepath.ToSlash(suffix)
+	var matches []model.ResolvedHelm
+	for _, f := range files {
+		if strings.HasSuffix(filepath.ToSlash(f.FileName), suffix) {
+			matches = append(matches, f)
+		}
+	}
+	require.Len(t, matches, 1, "expected exactly one resolved file ending with %q", suffix)
+	return matches[0]
+}
+
+func findAllResolvedBySuffix(t *testing.T, files []model.ResolvedHelm, suffix string) []model.ResolvedHelm {
+	t.Helper()
+	suffix = filepath.ToSlash(suffix)
+	var matches []model.ResolvedHelm
+	for _, f := range files {
+		if strings.HasSuffix(filepath.ToSlash(f.FileName), suffix) {
+			matches = append(matches, f)
+		}
+	}
+	return matches
+}
+
+func TestHelm_Resolve_WithCRDs(t *testing.T) {
+	res := &Resolver{}
+	ctx := context.Background()
+	chartPath := helmFixturePath(t, "test_helm_with_crds")
+
+	got, err := res.Resolve(ctx, chartPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, got.Excluded, "excluded list should be non-empty after render")
+
+	type crdExpect struct {
+		suffix      string
+		kind        string
+		name        string
+		fullLineMap bool // true for YAML CRDs, false for JSON (helmID=-1)
+	}
+	wantCRDs := []crdExpect{
+		{suffix: "crds/widget.yaml", kind: "CustomResourceDefinition", name: "widgets.example.com", fullLineMap: true},
+		{suffix: "crds/gadget.json", kind: "CustomResourceDefinition", name: "gadgets.example.com", fullLineMap: false},
+		{suffix: "crds/nested/device.yaml", kind: "CustomResourceDefinition", name: "devices.example.com", fullLineMap: true},
+	}
+
+	for _, want := range wantCRDs {
+		f := findResolvedBySuffix(t, got.File, want.suffix)
+
+		require.Contains(t, string(f.Content), want.kind)
+		require.Contains(t, string(f.Content), want.name)
+
+		if want.fullLineMap {
+			require.Equal(t, "# KICS_HELM_ID_0:", f.SplitID, "YAML CRD SplitID must anchor line mapping")
+			require.Contains(t, string(f.OriginalData), kicsHelmID, "stamped original required for detector")
+			require.Contains(t, string(f.OriginalData), want.kind)
+			require.Contains(t, string(f.OriginalData), want.name)
+			idInfo, ok := f.IDInfo[0].(map[int]int)
+			require.True(t, ok, "IDInfo must map helm id 0 to source lines for YAML CRDs")
+			require.NotEmpty(t, idInfo, "IDInfo line map must not be empty for YAML CRDs")
+		} else {
+			require.Empty(t, f.SplitID, "JSON CRD has no inline stamp; SplitID must be empty")
+		}
+	}
+}
+
+func Test_looksLikeManifest(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "real manifest",
+			input: "\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n",
+			want:  true,
+		},
+		{
+			name:  "real manifest with leading blank lines and comments",
+			input: "\n\n# comment\napiVersion: v1\nkind: ConfigMap\n",
+			want:  true,
+		},
+		{
+			name:  "indented manifest",
+			input: "\n  apiVersion: v1\n  kind: ConfigMap\n",
+			want:  true,
+		},
+		{
+			name:  "empty split",
+			input: "   \n  \n",
+			want:  false,
+		},
+		{
+			name:  "kind before apiVersion",
+			input: "\nkind: CustomResourceDefinition\napiVersion: apiextensions.k8s.io/v1\n",
+			want:  true,
+		},
+		{
+			name:  "source header after CRLF",
+			input: "\r\n# Source: test_helm_with_crds/crds/widget.yaml\r\napiVersion: apiextensions.k8s.io/v1\n",
+			want:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, looksLikeManifest(tc.input))
+		})
+	}
+}
+
+func TestHelm_Resolve_MultiDocCRD(t *testing.T) {
+	res := &Resolver{}
+	ctx := context.Background()
+
+	got, err := res.Resolve(ctx, helmFixturePath(t, "test_helm_with_crds"))
+	require.NoError(t, err)
+
+	splits := findAllResolvedBySuffix(t, got.File, "crds/multi.yaml")
+	require.Len(t, splits, 2, "multi-document CRD file must produce one split per document")
+
+	// Both splits must have distinct, non-empty SplitIDs anchored to their document.
+	require.Equal(t, "# KICS_HELM_ID_0:", splits[0].SplitID, "first document must use first marker")
+	require.NotEmpty(t, splits[1].SplitID, "second document must have a non-empty SplitID")
+	require.NotEqual(t, splits[0].SplitID, splits[1].SplitID, "each document must map to a distinct marker")
+
+	// Both SplitIDs must exist in the shared stamped original.
+	original := string(splits[0].OriginalData)
+	require.Contains(t, original, splits[0].SplitID, "first SplitID must be present in stamped original")
+	require.Contains(t, original, splits[1].SplitID, "second SplitID must be present in stamped original")
+
+	// Content of each split must contain the right resource.
+	require.Contains(t, string(splits[0].Content), "alphas.example.com")
+	require.Contains(t, string(splits[1].Content), "betas.example.com")
+}
+
+func TestSplitHelmManifest_onlySplitsDocumentBoundaries(t *testing.T) {
+	manifest := `---
+# Source: chart/crds/gadget.json
+{"description":"literal --- separator"}
+---
+# Source: chart/crds/widget.yaml
+description: |
+  literal --- separator
+apiVersion: v1
+kind: ConfigMap
+`
+
+	splits := splitHelmManifest(manifest)
+	require.Len(t, splits, 2)
+	require.Contains(t, splits[0], `"literal --- separator"`)
+	require.Contains(t, splits[1], "literal --- separator")
+}
+
+func Test_parseManifestSource(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		wantSource string
+		wantOK     bool
+	}{
+		{
+			name:       "unix header",
+			input:      "\n# Source: test_helm/templates/service.yaml\napiVersion: v1\n",
+			wantSource: "test_helm/templates/service.yaml",
+			wantOK:     true,
+		},
+		{
+			name:       "crlf header",
+			input:      "\r\n# Source: test_helm_with_crds/crds/widget.yaml\r\napiVersion: apiextensions.k8s.io/v1\n",
+			wantSource: "test_helm_with_crds/crds/widget.yaml",
+			wantOK:     true,
+		},
+		{
+			name:   "missing header",
+			input:  "\napiVersion: v1\nkind: ConfigMap\n",
+			wantOK: false,
+		},
+		{
+			name:   "user source comment after manifest start",
+			input:  "\napiVersion: v1\n# Source: user-authored\nkind: ConfigMap\n",
+			wantOK: false,
+		},
+		{
+			name:   "indented user source comment",
+			input:  "\n  # Source: user-authored\napiVersion: v1\n",
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			source, ok := parseManifestSource(tc.input)
+			require.Equal(t, tc.wantOK, ok)
+			if ok {
+				require.Equal(t, tc.wantSource, source)
+			}
+		})
+	}
+}
+
+func TestIsCRDManifest(t *testing.T) {
+	require.True(t, isCRDManifest("crds/widget.yaml"))
+	require.True(t, isCRDManifest(`crds\nested\widget.yaml`))
+	require.False(t, isCRDManifest("examples/crds/widget.yaml"))
+	require.False(t, isCRDManifest("templates/service.yaml"))
+}
+
+func TestCrdChartRelativePath(t *testing.T) {
+	require.Equal(t, "crds/widget.yaml", crdChartRelativePath(`D:/a/repo/crds/widget.yaml`))
+	require.Equal(t, "crds/widget.yaml", crdChartRelativePath(`charts/subchart/crds/widget.yaml`))
+}
+
+func TestChartRelativeFromSource(t *testing.T) {
+	rel, ok := chartRelativeFromSource("test_helm_with_crds/crds/widget.yaml")
+	require.True(t, ok)
+	require.Equal(t, "crds/widget.yaml", rel)
+
+	rel, ok = chartRelativeFromSource(chartSourceKey(`test_helm_with_crds\crds\widget.yaml`))
+	require.True(t, ok)
+	require.Equal(t, "crds/widget.yaml", rel)
+
+	rel, ok = chartRelativeFromSource("test_helm_subchart/charts/subchart/crds/widget.yaml")
+	require.True(t, ok)
+	require.Equal(t, "charts/subchart/crds/widget.yaml", rel)
+}
+
+func TestSplitManifestYAML_windowsCRDSourcePath(t *testing.T) {
+	ch, err := loader.Load(helmFixturePath(t, "test_helm_with_crds"))
+	require.NoError(t, err)
+	setID(ch)
+
+	manifest := strings.Join([]string{
+		"---",
+		"# Source: test_helm_with_crds\\crds\\widget.yaml",
+		"apiVersion: apiextensions.k8s.io/v1",
+		"kind: CustomResourceDefinition",
+		"metadata:",
+		"  name: widgets.example.com",
+	}, "\n")
+
+	splits, err := splitManifestYAML(&release.Release{Manifest: manifest}, ch)
+	require.NoError(t, err)
+	require.Len(t, *splits, 1)
+	require.Equal(t, "test_helm_with_crds/crds/widget.yaml", (*splits)[0].path)
+}
+
+func TestSplitManifestYAML_userSourceCommentInLaterDocument(t *testing.T) {
+	ch, err := loader.Load(helmFixturePath(t, "test_helm_with_crds"))
+	require.NoError(t, err)
+	setID(ch)
+
+	manifest := strings.Join([]string{
+		"---",
+		"# Source: test_helm_with_crds/crds/widget.yaml",
+		"apiVersion: apiextensions.k8s.io/v1",
+		"kind: CustomResourceDefinition",
+		"---",
+		"# Source: user-authored",
+		"apiVersion: apiextensions.k8s.io/v1",
+		"kind: CustomResourceDefinition",
+	}, "\n")
+
+	splits, err := splitManifestYAML(&release.Release{Manifest: manifest}, ch)
+	require.NoError(t, err)
+	require.Len(t, *splits, 2)
+	require.Equal(t, "test_helm_with_crds/crds/widget.yaml", (*splits)[0].path)
+	require.Equal(t, "test_helm_with_crds/crds/widget.yaml", (*splits)[1].path)
+}
+
+func TestLocalCRDFiles_fromLoadedFixture(t *testing.T) {
+	ch, err := loader.Load(helmFixturePath(t, "test_helm_with_crds"))
+	require.NoError(t, err)
+	require.Len(t, localCRDFiles(ch), 4)
+}
+
+func TestLocalCRDFiles_keepsDependencyCRDsOnDependency(t *testing.T) {
+	ch, err := loader.Load(helmFixturePath(t, "test_helm_subchart"))
+	require.NoError(t, err)
+	require.Empty(t, localCRDFiles(ch))
+	require.Len(t, ch.Dependencies(), 1)
+	require.Len(t, localCRDFiles(ch.Dependencies()[0]), 1)
+}
+
+func TestLocalCRDFiles_windowsSeparators(t *testing.T) {
+	ch := &chart.Chart{
+		Metadata: &chart.Metadata{Name: "test"},
+		Files: []*chart.File{
+			{Name: `crds\widget.yaml`, Data: []byte("apiVersion: v1\n")},
+		},
+	}
+	require.Len(t, localCRDFiles(ch), 1)
+}
+
+func TestAddID_ignoresIndentedAPIVersion(t *testing.T) {
+	original := `description: |
+  apiVersion: v1
+  kind: Pod
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+`
+	file := &chart.File{Data: []byte(original)}
+	addID(file)
+
+	require.Equal(t, 1, strings.Count(string(file.Data), kicsHelmID))
+	require.Contains(t, string(file.Data), "  apiVersion: v1")
+	require.Contains(t, string(file.Data), kicsHelmID)
+}
+
+func TestAddID_stampsIndentedRootAPIVersion(t *testing.T) {
+	file := &chart.File{Data: []byte("  apiVersion: v1\n  kind: ConfigMap\n")}
+	addID(file)
+
+	require.Equal(t, 1, strings.Count(string(file.Data), kicsHelmID))
+	require.Contains(t, string(file.Data), "# KICS_HELM_ID_0:\n  apiVersion: v1")
+}
 
 func TestHelm_SupportedTypes(t *testing.T) {
 	res := &Resolver{}
@@ -195,15 +539,35 @@ spec:
 	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := res.Resolve(ctx, tt.args.filePath)
+			filePath := tt.args.filePath
+			if tt.name == "test_with_dependencies" {
+				filePath = helmFixturePath(t, "test_helm_subchart")
+			}
+			got, err := res.Resolve(ctx, filePath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Resolve() = %v, wantErr = %v", err, tt.wantErr)
 			}
-			if !reflect.DeepEqual(got.File, tt.want.File) {
-				t.Errorf("Resolve() = %v, want = %v", got, tt.want)
-			}
-			if err == nil {
+			if tt.name == "test_with_dependencies" {
+				require.NoError(t, err)
 				require.NotEmpty(t, got.Excluded)
+				for _, want := range tt.want.File {
+					gotFile := findResolvedBySuffix(t, got.File, pathSuffix(t, want.FileName))
+					require.Equal(t, want.SplitID, gotFile.SplitID)
+					require.True(t, reflect.DeepEqual(want.IDInfo, gotFile.IDInfo))
+					require.Equal(t, want.Content, gotFile.Content)
+					require.Equal(t, want.OriginalData, gotFile.OriginalData)
+				}
+				crd := findResolvedBySuffix(t, got.File, "charts/subchart/crds/widget.yaml")
+				require.Equal(t, "# KICS_HELM_ID_0:", crd.SplitID)
+				require.Contains(t, string(crd.OriginalData), "# KICS_HELM_ID_")
+				require.Contains(t, string(crd.Content), "widgets.subchart.example.com")
+			} else {
+				if !reflect.DeepEqual(got.File, tt.want.File) {
+					t.Errorf("Resolve() = %v, want = %v", got, tt.want)
+				}
+				if err == nil {
+					require.NotEmpty(t, got.Excluded)
+				}
 			}
 		})
 	}

--- a/pkg/runner/prepare.go
+++ b/pkg/runner/prepare.go
@@ -9,7 +9,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/analyzer"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -84,7 +86,13 @@ func dispatchChart(ctx context.Context,
 	if err := fsp.ExcludePaths(ctx, resFiles.Excluded); err != nil {
 		contextLogger.Err(err).Msgf("could not exclude rendered chart files: %s", chartPath)
 	}
-	for _, s := range services {
+	routed := services
+	if kind == model.KindHELM {
+		if platform, ok := analyzer.PlatformForKind(kind); ok {
+			routed = servicesForPlatformAndParserKind(services, platform, model.KindYAML)
+		}
+	}
+	for _, s := range routed {
 		s.storeResolvedFiles(ctx, resFiles, kind, scanID, openAPIResolveReferences, maxResolverDepth)
 	}
 	return true
@@ -99,6 +107,7 @@ func dispatchFile(ctx context.Context,
 	if len(services) == 0 {
 		return nil
 	}
+	services = servicesForPlatform(services, sharedFilePlatform(services, filePath))
 
 	var c *Content
 	var getErr error
@@ -134,6 +143,38 @@ func dispatchFile(ctx context.Context,
 	return nil
 }
 
+func sharedFilePlatform(services []*Service, filePath string) string {
+	path := filepath.ToSlash(filePath)
+	platform := ""
+	for _, service := range services {
+		candidate, ok := service.FilePlatform[path]
+		if !ok {
+			continue
+		}
+		if platform != "" && !strings.EqualFold(platform, candidate) {
+			return ""
+		}
+		platform = candidate
+	}
+	return platform
+}
+
+func servicesForPlatform(services []*Service, platform string) []*Service {
+	if platform == "" {
+		return services
+	}
+	routed := make([]*Service, 0, len(services))
+	for _, service := range services {
+		if containsPlatformFold(service.Parser.Platform, platform) {
+			routed = append(routed, service)
+		}
+	}
+	if len(routed) == 0 {
+		return services
+	}
+	return routed
+}
+
 func cloneContent(c *Content) *Content {
 	if c == nil {
 		return nil
@@ -148,6 +189,33 @@ func cloneContent(c *Content) *Content {
 		IsMinified:     c.IsMinified,
 		CountResources: c.CountResources,
 	}
+}
+
+func servicesForPlatformAndParserKind(
+	services []*Service,
+	platform string,
+	kind model.FileKind,
+) []*Service {
+	routed := make([]*Service, 0, len(services))
+	for _, service := range services {
+		if service.Parser.Parsers.GetKind() == kind &&
+			containsPlatformFold(service.Parser.Platform, platform) {
+			routed = append(routed, service)
+		}
+	}
+	if len(routed) == 0 {
+		return services
+	}
+	return routed
+}
+
+func containsPlatformFold(platforms []string, wanted string) bool {
+	for _, platform := range platforms {
+		if strings.EqualFold(platform, wanted) {
+			return true
+		}
+	}
+	return false
 }
 
 func unionExtensions(services []*Service) model.Extensions {

--- a/pkg/runner/prepare_test.go
+++ b/pkg/runner/prepare_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/analyzer"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser"
 	"github.com/DataDog/datadog-iac-scanner/pkg/resolver"
 	"github.com/DataDog/datadog-iac-scanner/pkg/resolver/helm"
@@ -95,6 +96,25 @@ func documentFingerprint(t *testing.T, store *storage.MemoryStorage) map[string]
 	return fp
 }
 
+func requireSharedDocumentParity(
+	t *testing.T,
+	perService, shared map[string]int,
+	routeClassifiedYAML bool,
+) {
+	t.Helper()
+	require.Equal(t, keysSorted(perService), keysSorted(shared),
+		"shared walk and per-service walk must prepare the same documents")
+	for key, expectedCount := range perService {
+		isHelm := strings.Contains(key, "|HELM|")
+		isClassifiedYAML := strings.Contains(key, "|YAML|") && !strings.HasPrefix(key, "|")
+		if isHelm || routeClassifiedYAML && isClassifiedYAML {
+			require.Equal(t, 1, shared[key], "shared walk must route each classified document once")
+			continue
+		}
+		require.Equal(t, expectedCount, shared[key], "non-Helm document count changed for %s", key)
+	}
+}
+
 func TestPrepareSharedWalk_MatchesPerService(t *testing.T) {
 	ctx := context.Background()
 
@@ -147,10 +167,7 @@ func TestPrepareSharedWalk_MatchesPerService(t *testing.T) {
 	shared := documentFingerprint(t, sharedStore)
 	perService := documentFingerprint(t, perServiceStore)
 
-	require.Equal(t, keysSorted(perService), keysSorted(shared),
-		"shared walk and per-service walk must prepare the same documents")
-	require.Equal(t, perService, shared,
-		"shared walk and per-service walk must prepare the same document multiset")
+	requireSharedDocumentParity(t, perService, shared, false)
 }
 
 // TestPrepareSharedWalk_PrebuiltWalk_MatchesPerService drives the CLI hot path:
@@ -221,10 +238,7 @@ func TestPrepareSharedWalk_PrebuiltWalk_MatchesPerService(t *testing.T) {
 	shared := documentFingerprint(t, sharedStore)
 	perService := documentFingerprint(t, perServiceStore)
 
-	require.Equal(t, keysSorted(perService), keysSorted(shared),
-		"prebuilt shared walk and per-service walk must prepare the same documents")
-	require.Equal(t, perService, shared,
-		"prebuilt shared walk and per-service walk must prepare the same document multiset")
+	requireSharedDocumentParity(t, perService, shared, true)
 
 	tfvarsPrepared := false
 	for key := range shared {
@@ -234,6 +248,94 @@ func TestPrepareSharedWalk_PrebuiltWalk_MatchesPerService(t *testing.T) {
 		}
 	}
 	require.True(t, tfvarsPrepared, "tfvars document should be prepared by the shared walk")
+}
+
+func TestPrepareSharedWalk_RoutesHelmToKubernetesParser(t *testing.T) {
+	ctx := context.Background()
+	chartPath, err := filepath.Abs("../../test/fixtures/test_helm_with_crds")
+	require.NoError(t, err)
+	services, _ := buildParityServices(t, ctx, []string{chartPath})
+	fsp, ok := SharedWalkProvider(services)
+	require.True(t, ok)
+	require.NoError(t, PrepareSharedWalk(ctx, fsp, services, "helm-routing", false, 5))
+
+	for _, service := range services {
+		helmDocs := 0
+		crdDocs := 0
+		for _, file := range service.files {
+			if file.Kind != model.KindHELM {
+				continue
+			}
+			helmDocs++
+			if file.Document["kind"] == "CustomResourceDefinition" {
+				crdDocs++
+			}
+		}
+		switch service.Parser.Parsers.(type) {
+		case *cicdParser.Parser:
+			require.Zero(t, helmDocs)
+		case *yamlParser.Parser:
+			require.Equal(t, 7, helmDocs)
+			require.Equal(t, 6, crdDocs)
+		}
+	}
+}
+
+func TestPrepareSharedWalk_RoutesKnownYAMLPlatforms(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	deployPath := filepath.Join(dir, "deploy.yaml")
+	workflowPath := filepath.Join(dir, "workflow.yaml")
+	writeFile(t, deployPath, "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: web\n")
+	writeFile(t, workflowPath, "name: ci\non: [push]\njobs:\n  build:\n    runs-on: ubuntu-latest\n")
+
+	services, _ := buildParityServices(t, ctx, []string{dir})
+	filePlatforms := map[string]string{
+		filepath.ToSlash(deployPath):   "kubernetes",
+		filepath.ToSlash(workflowPath): "cicd",
+	}
+	for _, service := range services {
+		service.FilePlatform = filePlatforms
+	}
+	fsp, ok := SharedWalkProvider(services)
+	require.True(t, ok)
+	require.NoError(t, PrepareSharedWalk(ctx, fsp, services, "routing", false, 5))
+
+	for _, service := range services {
+		paths := make([]string, 0, len(service.files))
+		for _, file := range service.files {
+			paths = append(paths, filepath.ToSlash(file.FilePath))
+		}
+		switch service.Parser.Parsers.(type) {
+		case *cicdParser.Parser:
+			require.Equal(t, []string{filepath.ToSlash(workflowPath)}, paths)
+		case *yamlParser.Parser:
+			require.Equal(t, []string{filepath.ToSlash(deployPath)}, paths)
+		}
+	}
+}
+
+func TestServicesForPlatformAndParserKindFallsBackWhenUnmatched(t *testing.T) {
+	ctx := context.Background()
+	services, _ := buildParityServices(t, ctx, []string{t.TempDir()})
+
+	routed := servicesForPlatformAndParserKind(services, "kubernetes", model.KindYAML)
+	require.Len(t, routed, 1)
+	_, ok := routed[0].Parser.Parsers.(*yamlParser.Parser)
+	require.True(t, ok)
+
+	cicdServices := make([]*Service, 0, 1)
+	for _, service := range services {
+		if _, ok := service.Parser.Parsers.(*cicdParser.Parser); ok {
+			cicdServices = append(cicdServices, service)
+		}
+	}
+	require.Equal(t, cicdServices,
+		servicesForPlatformAndParserKind(cicdServices, "kubernetes", model.KindYAML))
+
+	yamlServices := buildExtensionRouting(services)[".yaml"]
+	require.Equal(t, yamlServices, servicesForPlatform(yamlServices, ""))
+	require.Equal(t, yamlServices, servicesForPlatform(yamlServices, "unknown"))
 }
 
 func TestPrepareSharedWalk_DanglingChartYamlSymlinkStillScansTerraform(t *testing.T) {

--- a/pkg/runner/resolver_sink.go
+++ b/pkg/runner/resolver_sink.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/minified"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser"
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/google/uuid"
 )
@@ -60,13 +62,17 @@ func (s *Service) storeResolvedFiles(
 	maxResolverDepth int) {
 	contextLogger := logger.FromContext(ctx)
 	for _, rfile := range resFiles.File {
+		if isHelmJSONFile(kind, rfile.FileName) && s.Parser.Parsers.GetKind() != model.KindYAML {
+			continue
+		}
 		s.Tracker.TrackFileFound(rfile.FileName)
 
 		isMinified := minified.IsMinified(rfile.FileName, rfile.Content)
-		documents, err := s.Parser.Parse(ctx, rfile.FileName, rfile.Content, openAPIResolveReferences, isMinified, maxResolverDepth)
+		documents, err := s.parseResolvedFile(
+			ctx, rfile.FileName, rfile.Content, kind, openAPIResolveReferences, isMinified, maxResolverDepth)
 		if err != nil {
 			if documents.Kind == "break" {
-				return
+				continue
 			}
 			// A Helm template may render to only comments when all range iterations are
 			// conditionally skipped (e.g. a service disabled in prod). That's expected;
@@ -75,13 +81,13 @@ func (s *Service) storeResolvedFiles(
 				continue
 			}
 			contextLogger.Error().Err(err).Msgf("failed to parse file content '%s' with fileType '%s'", rfile.FileName, kind)
-			return
+			continue
 		}
 
 		if kind == model.KindHELM {
 			ignoreList, errorIL := s.getOriginalIgnoreLines(ctx,
 				rfile.FileName, rfile.OriginalData,
-				openAPIResolveReferences, isMinified, maxResolverDepth)
+				kind, openAPIResolveReferences, isMinified, maxResolverDepth)
 			if errorIL == nil {
 				documents.IgnoreLines = ignoreList
 
@@ -150,6 +156,26 @@ func (s *Service) storeResolvedFiles(
 	}
 }
 
+func (s *Service) parseResolvedFile(
+	ctx context.Context,
+	filename string,
+	content []byte,
+	kind model.FileKind,
+	openAPIResolveReferences, isMinified bool,
+	maxResolverDepth int,
+) (parser.ParsedDocument, error) {
+	if isHelmJSONFile(kind, filename) && s.Parser.Parsers.GetKind() == model.KindYAML {
+		return s.Parser.ParseContent(
+			ctx, filename, content, openAPIResolveReferences, isMinified, maxResolverDepth)
+	}
+	return s.Parser.Parse(
+		ctx, filename, content, openAPIResolveReferences, isMinified, maxResolverDepth)
+}
+
+func isHelmJSONFile(kind model.FileKind, filename string) bool {
+	return kind == model.KindHELM && strings.EqualFold(filepath.Ext(filename), ".json")
+}
+
 // logResolverResolveError logs a Helm resolve/render failure as debug when it
 // matches missing deploy-time values (expected at scan time), otherwise as error.
 // Both paths fall back to raw-file scanning; only expected failures call
@@ -206,12 +232,14 @@ func isCommentOnlyContent(content []byte) bool {
 
 func (s *Service) getOriginalIgnoreLines(ctx context.Context, filename string,
 	originalFile []uint8,
+	kind model.FileKind,
 	openAPIResolveReferences, isMinified bool,
 	maxResolverDepth int) (ignoreLines []int, err error) {
 	refactor := regexp.MustCompile(`.*\n?.*KICS_HELM_ID.+\n`).ReplaceAll(originalFile, []uint8{})
 	refactor = regexp.MustCompile(`{{-\s*(.*?)\s*}}`).ReplaceAll(refactor, []uint8{})
 
-	documentsOriginal, err := s.Parser.Parse(ctx, filename, refactor, openAPIResolveReferences, isMinified, maxResolverDepth)
+	documentsOriginal, err := s.parseResolvedFile(
+		ctx, filename, refactor, kind, openAPIResolveReferences, isMinified, maxResolverDepth)
 	if err == nil {
 		ignoreLines = documentsOriginal.IgnoreLines
 	}

--- a/pkg/runner/resolver_sink.go
+++ b/pkg/runner/resolver_sink.go
@@ -8,7 +8,6 @@ package runner
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -61,6 +60,7 @@ func (s *Service) storeResolvedFiles(
 	openAPIResolveReferences bool,
 	maxResolverDepth int) {
 	contextLogger := logger.FromContext(ctx)
+	sourceCache := make(map[string]*resolvedSourceData)
 	for _, rfile := range resFiles.File {
 		if isHelmJSONFile(kind, rfile.FileName) && s.Parser.Parsers.GetKind() != model.KindYAML {
 			continue
@@ -84,63 +84,48 @@ func (s *Service) storeResolvedFiles(
 			continue
 		}
 
-		if kind == model.KindHELM {
-			ignoreList, errorIL := s.getOriginalIgnoreLines(ctx,
-				rfile.FileName, rfile.OriginalData,
-				kind, openAPIResolveReferences, isMinified, maxResolverDepth)
-			if errorIL == nil {
-				documents.IgnoreLines = ignoreList
+		s.setResolvedLineMetadata(ctx, &documents, &rfile, sourceCache, kind,
+			openAPIResolveReferences, isMinified, maxResolverDepth)
 
-				// Need to ignore #KICS_HELM_ID Line
-				documents.CountLines = bytes.Count(rfile.OriginalData, []byte{'\n'})
-			} else {
-				// Parsing the original template failed (e.g. unstrippable {{ }} expressions),
-				// so IgnoreLines came from the rendered YAML. Strip scanner-injected header
-				// lines (# Source: / # KICS_HELM_ID_N:) that would otherwise cause false
-				// suppression when the Helm detector resolves vulnerability.Line to them.
-				documents.IgnoreLines = filterHelmGeneratedLines(rfile.Content, documents.IgnoreLines)
-			}
-		} else {
-			documents.CountLines = bytes.Count(rfile.OriginalData, []byte{'\n'}) + 1
+		cached := sourceCache[rfile.FileName]
+		if len(documents.IgnoreLines) > 0 {
+			sort.Ints(documents.IgnoreLines)
 		}
+		platform := s.classifyPlatform(ctx, kind, rfile.FileName, rfile.Content)
+		ownedRenderedContent := ownedHelmRenderedContent(kind, rfile.IsCRD, rfile.Content)
 
-		fileCommands := s.Parser.CommentsCommands(ctx, rfile.FileName, rfile.OriginalData)
-		originalData := string(rfile.OriginalData)
-		// Computed once per rendered file and shared (same pointer) across every
-		// document's FileMetadata below; see the equivalent comment in sink.go.
-		linesOriginalData := utils.SplitLines(originalData)
-
-		for _, document := range documents.Docs {
-			_, err = json.Marshal(document)
+		for docIdx, document := range documents.Docs {
+			preparedDocument, prepareErr := prepareResolvedScanDocument(document, kind)
+			err = prepareErr
 			if err != nil {
 				continue
 			}
 
-			if len(documents.IgnoreLines) > 0 {
-				sort.Ints(documents.IgnoreLines)
+			lineInfoDocument := document
+			if kind == model.KindHELM {
+				lineInfoDocument = nil
 			}
-
 			file := model.FileMetadata{
-				ID:           uuid.New().String(),
-				ScanID:       scanID,
-				Document:     PrepareScanDocument(ctx, document, kind),
-				OriginalData: originalData,
-				// Not lazily loaded here (unlike sink.go): OriginalData is the
-				// unrendered Helm/OpenAPI source, but parsing (and thus a
-				// reconstructed LineInfoDocument) needs rfile.Content, the
-				// resolved/rendered text. Keeping it eager avoids the risk of
-				// silently re-parsing the wrong content.
-				LineInfoDocument:  document,
+				ID:                uuid.New().String(),
+				ScanID:            scanID,
+				Document:          preparedDocument,
+				OriginalData:      cached.originalData,
+				LineInfoDocument:  lineInfoDocument,
 				Kind:              kind,
 				FilePath:          rfile.FileName,
 				HelmID:            rfile.SplitID,
-				Commands:          fileCommands,
+				Commands:          cached.commands,
 				IDInfo:            rfile.IDInfo,
 				LinesIgnore:       documents.IgnoreLines,
 				ResolvedFiles:     documents.ResolvedFiles,
-				LinesOriginalData: linesOriginalData,
+				LinesOriginalData: cached.linesOriginalData,
 				IsMinified:        documents.IsMinified,
-				Platform:          s.classifyPlatform(ctx, kind, rfile.FileName, rfile.Content),
+				Platform:          platform,
+			}
+			if kind == model.KindHELM {
+				file.SetLineInfoLoader(newHelmLineInfoLoader(
+					s.Parser, &rfile, ownedRenderedContent, docIdx,
+					openAPIResolveReferences, isMinified, maxResolverDepth))
 			}
 			s.saveToFile(ctx, &file)
 		}
@@ -153,6 +138,88 @@ func (s *Service) storeResolvedFiles(
 			resourceCount := GetCountTerraformResources(rfile.Content)
 			s.Tracker.TrackFileFoundCountResources(resourceCount)
 		}
+	}
+}
+
+func ownedHelmRenderedContent(kind model.FileKind, isCRD bool, content []byte) string {
+	if kind != model.KindHELM || isCRD {
+		return ""
+	}
+	return string(content)
+}
+
+// Helm line info is reparsed lazily, so its parsed tree is exclusively owned
+// by the scan document and can be sanitized without a JSON round-trip.
+func prepareResolvedScanDocument(
+	document map[string]interface{},
+	kind model.FileKind,
+) (map[string]interface{}, error) {
+	if kind == model.KindHELM {
+		prepareScanDocumentRoot(document, kind)
+		return document, nil
+	}
+	return prepareScanDocument(document, kind)
+}
+
+type resolvedSourceData struct {
+	originalData      string
+	linesOriginalData *[]string
+	commands          model.CommentsCommands
+	countLines        int
+	ignoreLines       []int
+	ignoreErr         error
+	ignorePrepared    bool
+}
+
+func (s *Service) setResolvedLineMetadata(
+	ctx context.Context,
+	documents *parser.ParsedDocument,
+	rfile *model.ResolvedHelm,
+	sourceCache map[string]*resolvedSourceData,
+	kind model.FileKind,
+	openAPIResolveReferences, isMinified bool,
+	maxResolverDepth int,
+) {
+	cached := sourceCache[rfile.FileName]
+	if cached == nil {
+		cached = newResolvedSourceData(ctx, s, rfile)
+		sourceCache[rfile.FileName] = cached
+	}
+	if kind != model.KindHELM {
+		documents.CountLines = cached.countLines + 1
+		return
+	}
+
+	if rfile.IsCRD && !bytes.Contains(rfile.OriginalData, []byte("dd-iac-scan")) {
+		documents.IgnoreLines = nil
+		documents.CountLines = cached.countLines
+		return
+	}
+	if !cached.ignorePrepared {
+		cached.ignoreLines, cached.ignoreErr = s.getOriginalIgnoreLines(ctx,
+			rfile.FileName, rfile.OriginalData,
+			kind, openAPIResolveReferences, isMinified, maxResolverDepth)
+		cached.ignorePrepared = true
+	}
+	if cached.ignoreErr == nil {
+		documents.IgnoreLines = cached.ignoreLines
+	} else {
+		documents.IgnoreLines = filterHelmGeneratedLines(rfile.Content, documents.IgnoreLines)
+	}
+	documents.CountLines = cached.countLines
+}
+
+func newResolvedSourceData(
+	ctx context.Context,
+	s *Service,
+	rfile *model.ResolvedHelm,
+) *resolvedSourceData {
+	originalData := string(rfile.OriginalData)
+	return &resolvedSourceData{
+		originalData:      originalData,
+		linesOriginalData: utils.SplitLines(originalData),
+		commands:          s.Parser.CommentsCommands(ctx, rfile.FileName, rfile.OriginalData),
+		countLines:        bytes.Count(rfile.OriginalData, []byte{'\n'}),
 	}
 }
 
@@ -174,6 +241,65 @@ func (s *Service) parseResolvedFile(
 
 func isHelmJSONFile(kind model.FileKind, filename string) bool {
 	return kind == model.KindHELM && strings.EqualFold(filepath.Ext(filename), ".json")
+}
+
+func newHelmLineInfoLoader(
+	p *parser.Parser,
+	rfile *model.ResolvedHelm,
+	renderedContent string,
+	renderedDocumentIndex int,
+	openAPIResolveReferences bool,
+	isMinified bool,
+	maxResolverDepth int,
+) func(context.Context, *model.FileMetadata) (map[string]interface{}, error) {
+	if rfile.IsCRD {
+		return newOriginalResolvedLineInfoLoader(
+			p, rfile.FileName, rfile.SourceDocumentIndex,
+			openAPIResolveReferences, isMinified, maxResolverDepth)
+	}
+	return newResolvedLineInfoLoader(
+		p, rfile.FileName, renderedContent, renderedDocumentIndex,
+		openAPIResolveReferences, isMinified, maxResolverDepth)
+}
+
+func newResolvedLineInfoLoader(
+	p *parser.Parser,
+	filename, renderedContent string,
+	docIdx int,
+	openAPIResolveReferences bool,
+	isMinified bool,
+	maxResolverDepth int,
+) func(context.Context, *model.FileMetadata) (map[string]interface{}, error) {
+	return newLineInfoLoaderWithReparser(filename, docIdx,
+		func(ctx context.Context, _ *model.FileMetadata) (parser.ParsedDocument, error) {
+			content := []byte(renderedContent)
+			if isHelmJSONFile(model.KindHELM, filename) && p.Parsers.GetKind() == model.KindYAML {
+				return p.ParseContent(
+					ctx, filename, content, openAPIResolveReferences, isMinified, maxResolverDepth)
+			}
+			return p.Parse(
+				ctx, filename, content, openAPIResolveReferences, isMinified, maxResolverDepth)
+		})
+}
+
+func newOriginalResolvedLineInfoLoader(
+	p *parser.Parser,
+	filename string,
+	sourceDocumentIndex int,
+	openAPIResolveReferences bool,
+	isMinified bool,
+	maxResolverDepth int,
+) func(context.Context, *model.FileMetadata) (map[string]interface{}, error) {
+	return newLineInfoLoaderWithReparser(filename, sourceDocumentIndex,
+		func(ctx context.Context, f *model.FileMetadata) (parser.ParsedDocument, error) {
+			content := []byte(f.OriginalData)
+			if isHelmJSONFile(model.KindHELM, filename) && p.Parsers.GetKind() == model.KindYAML {
+				return p.ParseContent(
+					ctx, filename, content, openAPIResolveReferences, isMinified, maxResolverDepth)
+			}
+			return p.Parse(
+				ctx, filename, content, openAPIResolveReferences, isMinified, maxResolverDepth)
+		})
 }
 
 // logResolverResolveError logs a Helm resolve/render failure as debug when it
@@ -230,13 +356,18 @@ func isCommentOnlyContent(content []byte) bool {
 	return true
 }
 
+var (
+	helmIDLinePattern         = regexp.MustCompile(`(?m)^[ \t]*# KICS_HELM_ID_\d+:[^\r\n]*(?:\r?\n|$)`)
+	helmTemplateActionPattern = regexp.MustCompile(`{{-\s*(.*?)\s*}}`)
+)
+
 func (s *Service) getOriginalIgnoreLines(ctx context.Context, filename string,
 	originalFile []uint8,
 	kind model.FileKind,
 	openAPIResolveReferences, isMinified bool,
 	maxResolverDepth int) (ignoreLines []int, err error) {
-	refactor := regexp.MustCompile(`.*\n?.*KICS_HELM_ID.+\n`).ReplaceAll(originalFile, []uint8{})
-	refactor = regexp.MustCompile(`{{-\s*(.*?)\s*}}`).ReplaceAll(refactor, []uint8{})
+	refactor := helmIDLinePattern.ReplaceAll(originalFile, nil)
+	refactor = helmTemplateActionPattern.ReplaceAll(refactor, nil)
 
 	documentsOriginal, err := s.parseResolvedFile(
 		ctx, filename, refactor, kind, openAPIResolveReferences, isMinified, maxResolverDepth)

--- a/pkg/runner/resolver_sink_test.go
+++ b/pkg/runner/resolver_sink_test.go
@@ -7,6 +7,7 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/internal/storage"
 	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
+	"github.com/DataDog/datadog-iac-scanner/pkg/detector"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser"
 	"github.com/DataDog/datadog-iac-scanner/pkg/resolver/helm"
@@ -47,6 +49,31 @@ func newYAMLResolverSinkService(
 	return service, store
 }
 
+func TestPrepareResolvedScanDocumentPreparesHelmInPlace(t *testing.T) {
+	nested := map[string]interface{}{
+		"_dd_lines": map[string]interface{}{"name": 2},
+		"name":      "widget",
+	}
+	document := map[string]interface{}{
+		"_dd_lines": map[string]interface{}{"metadata": 1},
+		"metadata":  nested,
+		"versions": []interface{}{
+			map[string]interface{}{
+				"_dd_lines": map[string]interface{}{"name": 5},
+				"name":      "v1",
+			},
+		},
+	}
+
+	prepared, err := prepareResolvedScanDocument(document, model.KindHELM)
+	require.NoError(t, err)
+	require.NotContains(t, prepared, "_dd_lines")
+	require.NotContains(t, nested, "_dd_lines")
+	require.NotContains(t, prepared["versions"].([]interface{})[0], "_dd_lines")
+	prepared["prepared-only"] = true
+	require.True(t, document["prepared-only"].(bool))
+}
+
 func TestStoreResolvedFilesParsesHelmJSONWithYAMLParser(t *testing.T) {
 	ctx := context.Background()
 	chartPath, err := filepath.Abs("../../test/fixtures/test_helm_with_crds")
@@ -60,14 +87,15 @@ func TestStoreResolvedFilesParsesHelmJSONWithYAMLParser(t *testing.T) {
 
 	files, err := store.GetFiles(ctx, "helm-crds")
 	require.NoError(t, err)
-	require.Len(t, files, 6)
+	require.Len(t, files, 7)
 
 	expectedPaths := map[string]int{
-		"crds/gadget.json":        1,
-		"crds/multi.yaml":         2,
-		"crds/nested/device.yaml": 1,
-		"crds/widget.yaml":        1,
-		"templates/service.yaml":  1,
+		"crds/gadget.json":               1,
+		"crds/multi.yaml":                2,
+		"crds/nested/device.yaml":        1,
+		"crds/nested/crds/repeated.yaml": 1,
+		"crds/widget.yaml":               1,
+		"templates/service.yaml":         1,
 	}
 	for _, file := range files {
 		normalized := filepath.ToSlash(file.FilePath)
@@ -87,6 +115,106 @@ func TestStoreResolvedFilesParsesHelmJSONWithYAMLParser(t *testing.T) {
 	for suffix, remaining := range expectedPaths {
 		require.Zero(t, remaining, "missing stored Helm document for %s", suffix)
 	}
+}
+
+func TestStoreResolvedFilesLazilyReconstructsHelmCRDLineInfo(t *testing.T) {
+	ctx := context.Background()
+	chartPath, err := filepath.Abs("../../test/fixtures/test_helm_with_crds")
+	require.NoError(t, err)
+	resolved, err := (&helm.Resolver{}).Resolve(ctx, chartPath)
+	require.NoError(t, err)
+
+	service, store := newYAMLResolverSinkService(t, ctx)
+	expectedByName := make(map[string]map[string]interface{})
+	for _, rfile := range resolved.File {
+		if !rfile.IsCRD {
+			continue
+		}
+		parsed, parseErr := service.parseResolvedFile(
+			ctx, rfile.FileName, rfile.OriginalData, model.KindHELM, false, false, 15)
+		require.NoError(t, parseErr)
+		require.Greater(t, len(parsed.Docs), rfile.SourceDocumentIndex)
+		expectedDocument := parsed.Docs[rfile.SourceDocumentIndex]
+		metadata, ok := expectedDocument["metadata"].(map[string]interface{})
+		require.True(t, ok)
+		name, ok := metadata["name"].(string)
+		require.True(t, ok)
+		expectedByName[name] = expectedDocument
+	}
+	require.Len(t, expectedByName, 6)
+
+	service.storeResolvedFiles(ctx, resolved, model.KindHELM, "lazy-crd-line-info", false, 15)
+	files, err := store.GetFiles(ctx, "lazy-crd-line-info")
+	require.NoError(t, err)
+
+	actualCRDs := 0
+	for _, file := range files {
+		if file.Document["kind"] != "CustomResourceDefinition" {
+			continue
+		}
+		actualCRDs++
+		metadata, ok := file.Document["metadata"].(map[string]interface{})
+		require.True(t, ok)
+		name, ok := metadata["name"].(string)
+		require.True(t, ok)
+
+		require.Nil(t, file.LineInfoDocument)
+		lineBeforeLoad := detector.NewDetectLine(1).DetectLine(ctx, file, "metadata.name")
+		require.Greater(t, lineBeforeLoad.Line, 0)
+		originalData := file.OriginalData
+		require.NoError(t, file.EnsureLineInfoDocument(ctx))
+		require.Equal(t, originalData, file.OriginalData)
+
+		eagerJSON, marshalErr := json.Marshal(expectedByName[name])
+		require.NoError(t, marshalErr)
+		lazyJSON, marshalErr := json.Marshal(file.LineInfoDocument)
+		require.NoError(t, marshalErr)
+		require.JSONEq(t, string(eagerJSON), string(lazyJSON))
+
+		lineAfterLoad := detector.NewDetectLine(1).DetectLine(ctx, file, "metadata.name")
+		require.Equal(t, lineBeforeLoad, lineAfterLoad, name)
+	}
+	require.Equal(t, len(expectedByName), actualCRDs)
+}
+
+func TestStoreResolvedFilesKeepsRenderedLineInfoForHelmTemplates(t *testing.T) {
+	ctx := context.Background()
+	service, store := newYAMLResolverSinkService(t, ctx)
+	service.storeResolvedFiles(ctx, model.ResolvedFiles{
+		File: []model.ResolvedHelm{{
+			FileName:     "chart/templates/service.yaml",
+			Content:      []byte("apiVersion: v1\nkind: Service\nmetadata:\n  name: api\n"),
+			OriginalData: []byte("apiVersion: v1\nkind: Service\nmetadata:\n  name: {{ .Values.name }}\n"),
+		}},
+	}, model.KindHELM, "rendered-template-line-info", false, 15)
+
+	files, err := store.GetFiles(ctx, "rendered-template-line-info")
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.NoError(t, files[0].EnsureLineInfoDocument(ctx))
+	metadata, ok := files[0].LineInfoDocument["metadata"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "api", metadata["name"])
+}
+
+func TestStoreResolvedFilesKeepsCRDSuppressionLines(t *testing.T) {
+	ctx := context.Background()
+	service, store := newYAMLResolverSinkService(t, ctx)
+	original := []byte("# dd-iac-scan ignore-block\n# KICS_HELM_ID_1:\napiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n")
+	content := []byte("\n# Source: chart/crds/widget.yaml\n" + string(original))
+	service.storeResolvedFiles(ctx, model.ResolvedFiles{
+		File: []model.ResolvedHelm{{
+			FileName:     "chart/crds/widget.yaml",
+			Content:      content,
+			OriginalData: original,
+			IsCRD:        true,
+		}},
+	}, model.KindHELM, "crd-suppression", false, 15)
+
+	files, err := store.GetFiles(ctx, "crd-suppression")
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, []int{1, 2, 3}, files[0].LinesIgnore)
 }
 
 func TestStoreResolvedFilesContinuesAfterUnsupportedFile(t *testing.T) {

--- a/pkg/runner/resolver_sink_test.go
+++ b/pkg/runner/resolver_sink_test.go
@@ -6,11 +6,162 @@
 package runner
 
 import (
+	"context"
 	"errors"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/storage"
+	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser"
+	"github.com/DataDog/datadog-iac-scanner/pkg/resolver/helm"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/stretchr/testify/require"
+
+	jsonParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/json"
+	yamlParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/default"
 )
+
+func newYAMLResolverSinkService(
+	t *testing.T, ctx context.Context,
+) (*Service, *storage.MemoryStorage) {
+	t.Helper()
+	parsers, err := parser.NewBuilder(ctx).
+		WithFS(vfs.DiskFS{}).
+		Add(&yamlParser.Parser{}).
+		Build([]string{"kubernetes"}, nil)
+	require.NoError(t, err)
+	require.Len(t, parsers, 1)
+
+	trk, err := tracker.NewTracker(1)
+	require.NoError(t, err)
+	store := storage.NewMemoryStorage()
+	service := &Service{
+		Storage:   store,
+		Parser:    parsers[0],
+		Tracker:   trk,
+		Platforms: []string{"kubernetes"},
+	}
+	return service, store
+}
+
+func TestStoreResolvedFilesParsesHelmJSONWithYAMLParser(t *testing.T) {
+	ctx := context.Background()
+	chartPath, err := filepath.Abs("../../test/fixtures/test_helm_with_crds")
+	require.NoError(t, err)
+	resolved, err := (&helm.Resolver{}).Resolve(ctx, chartPath)
+	require.NoError(t, err)
+
+	service, store := newYAMLResolverSinkService(t, ctx)
+
+	service.storeResolvedFiles(ctx, resolved, model.KindHELM, "helm-crds", false, 15)
+
+	files, err := store.GetFiles(ctx, "helm-crds")
+	require.NoError(t, err)
+	require.Len(t, files, 6)
+
+	expectedPaths := map[string]int{
+		"crds/gadget.json":        1,
+		"crds/multi.yaml":         2,
+		"crds/nested/device.yaml": 1,
+		"crds/widget.yaml":        1,
+		"templates/service.yaml":  1,
+	}
+	for _, file := range files {
+		normalized := filepath.ToSlash(file.FilePath)
+		for suffix, remaining := range expectedPaths {
+			if remaining > 0 && strings.HasSuffix(normalized, suffix) {
+				expectedPaths[suffix]--
+				if suffix == "crds/gadget.json" {
+					require.Equal(t, "CustomResourceDefinition", file.Document["kind"])
+					metadata, ok := file.Document["metadata"].(map[string]interface{})
+					require.True(t, ok)
+					require.Equal(t, "gadgets.example.com", metadata["name"])
+				}
+				break
+			}
+		}
+	}
+	for suffix, remaining := range expectedPaths {
+		require.Zero(t, remaining, "missing stored Helm document for %s", suffix)
+	}
+}
+
+func TestStoreResolvedFilesContinuesAfterUnsupportedFile(t *testing.T) {
+	ctx := context.Background()
+	service, store := newYAMLResolverSinkService(t, ctx)
+	resolved := model.ResolvedFiles{
+		File: []model.ResolvedHelm{
+			{FileName: "chart/notes.txt", Content: []byte("unsupported")},
+			{
+				FileName:     "chart/templates/service.yaml",
+				Content:      []byte("apiVersion: v1\nkind: Service\nmetadata:\n  name: api\n"),
+				OriginalData: []byte("apiVersion: v1\nkind: Service\nmetadata:\n  name: api\n"),
+			},
+		},
+	}
+
+	service.storeResolvedFiles(ctx, resolved, model.KindHELM, "unsupported-sibling", false, 15)
+
+	files, err := store.GetFiles(ctx, "unsupported-sibling")
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "chart/templates/service.yaml", files[0].FilePath)
+}
+
+func TestStoreResolvedFilesContinuesAfterMalformedFile(t *testing.T) {
+	ctx := context.Background()
+	service, store := newYAMLResolverSinkService(t, ctx)
+	resolved := model.ResolvedFiles{
+		File: []model.ResolvedHelm{
+			{FileName: "chart/crds/broken.yaml", Content: []byte("spec: [")},
+			{
+				FileName:     "chart/templates/service.yaml",
+				Content:      []byte("apiVersion: v1\nkind: Service\nmetadata:\n  name: api\n"),
+				OriginalData: []byte("apiVersion: v1\nkind: Service\nmetadata:\n  name: api\n"),
+			},
+		},
+	}
+
+	service.storeResolvedFiles(ctx, resolved, model.KindHELM, "malformed-sibling", false, 15)
+
+	files, err := store.GetFiles(ctx, "malformed-sibling")
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "chart/templates/service.yaml", files[0].FilePath)
+}
+
+func TestStoreResolvedFilesSkipsHelmJSONOnJSONParser(t *testing.T) {
+	ctx := context.Background()
+	parsers, err := parser.NewBuilder(ctx).
+		Add(&jsonParser.Parser{}).
+		Build([]string{"kubernetes"}, nil)
+	require.NoError(t, err)
+	require.Len(t, parsers, 1)
+
+	trk, err := tracker.NewTracker(1)
+	require.NoError(t, err)
+	store := storage.NewMemoryStorage()
+	service := &Service{
+		Storage: store,
+		Parser:  parsers[0],
+		Tracker: trk,
+	}
+	resolved := model.ResolvedFiles{
+		File: []model.ResolvedHelm{{
+			FileName: "chart/crds/gadget.json",
+			Content:  []byte(`{"apiVersion":"v1","kind":"ConfigMap"}`),
+		}},
+	}
+
+	service.storeResolvedFiles(ctx, resolved, model.KindHELM, "json-parser", false, 15)
+
+	files, err := store.GetFiles(ctx, "json-parser")
+	require.NoError(t, err)
+	require.Empty(t, files)
+}
 
 func TestIsExpectedHelmRenderError(t *testing.T) {
 	tests := []struct {

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -307,9 +307,20 @@ func newLineInfoLoader(
 	isMinified bool,
 	maxResolverDepth int,
 ) func(ctx context.Context, f *model.FileMetadata) (map[string]interface{}, error) {
+	return newLineInfoLoaderWithReparser(filename, docIdx,
+		func(ctx context.Context, f *model.FileMetadata) (parser.ParsedDocument, error) {
+			return p.Parse(
+				ctx, filename, []byte(f.OriginalData), openAPIResolveReferences, isMinified, maxResolverDepth)
+		})
+}
+
+func newLineInfoLoaderWithReparser(
+	filename string,
+	docIdx int,
+	reparse func(context.Context, *model.FileMetadata) (parser.ParsedDocument, error),
+) func(ctx context.Context, f *model.FileMetadata) (map[string]interface{}, error) {
 	return func(ctx context.Context, f *model.FileMetadata) (map[string]interface{}, error) {
-		reparsed, err := p.Parse(
-			ctx, filename, []byte(f.OriginalData), openAPIResolveReferences, isMinified, maxResolverDepth)
+		reparsed, err := reparse(ctx, f)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to reparse %s for line info", filename)
 		}

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -40,6 +40,8 @@ func newTestServer(t *testing.T) *Server {
 
 const syntheticRuleID = "test-terraform-resource-missing-owner"
 
+var analyzeCompiledQueryCacheTestMu sync.Mutex
+
 // syntheticRule imports both test-only pushed libraries. Its identifiers and
 // behavior are deliberately unrelated to the production rule corpus.
 func syntheticRule() datadog.Rule {
@@ -675,6 +677,9 @@ func TestAnalyze_MissingPlatformLibraryReportedAsFailedQuery(t *testing.T) {
 }
 
 func TestAnalyze_RequestLibrariesInvalidateSharedRuleCache(t *testing.T) {
+	analyzeCompiledQueryCacheTestMu.Lock()
+	t.Cleanup(analyzeCompiledQueryCacheTestMu.Unlock)
+
 	engine.ResetCompiledQueryCachesForTest()
 	t.Cleanup(engine.ResetCompiledQueryCachesForTest)
 
@@ -729,6 +734,9 @@ func TestAnalyze_RequestLibrariesDoNotCallBackend(t *testing.T) {
 }
 
 func TestAnalyze_LogsFailedQueryCount(t *testing.T) {
+	analyzeCompiledQueryCacheTestMu.Lock()
+	t.Cleanup(analyzeCompiledQueryCacheTestMu.Unlock)
+
 	engine.ResetCompiledQueryCachesForTest()
 	t.Cleanup(engine.ResetCompiledQueryCachesForTest)
 
@@ -740,7 +748,9 @@ func TestAnalyze_LogsFailedQueryCount(t *testing.T) {
 
 import rego.v1
 
-DatadogPolicy contains "invalid-result"`)
+DatadogPolicy contains result if {
+	undefined_reference
+}`)
 	req := analyzeRequest{
 		Files: []analyzeFile{{
 			Path:    "infra/main.tf",

--- a/test/fixtures/test_helm_subchart/charts/subchart/crds/widget.yaml
+++ b/test/fixtures/test_helm_subchart/charts/subchart/crds/widget.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.subchart.example.com
+spec:
+  group: subchart.example.com
+  names:
+    kind: Widget
+    plural: widgets
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/test/fixtures/test_helm_with_crds/Chart.yaml
+++ b/test/fixtures/test_helm_with_crds/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: test_helm_with_crds
+description: Test chart with CRD files
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/test/fixtures/test_helm_with_crds/crds/gadget.json
+++ b/test/fixtures/test_helm_with_crds/crds/gadget.json
@@ -1,0 +1,28 @@
+{
+  "apiVersion": "apiextensions.k8s.io/v1",
+  "kind": "CustomResourceDefinition",
+  "metadata": {
+    "name": "gadgets.example.com"
+  },
+  "spec": {
+    "group": "example.com",
+    "names": {
+      "kind": "Gadget",
+      "plural": "gadgets"
+    },
+    "scope": "Namespaced",
+    "versions": [
+      {
+        "name": "v1",
+        "served": true,
+        "storage": true,
+        "schema": {
+          "openAPIV3Schema": {
+            "type": "object",
+            "description": "literal --- separator"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/test_helm_with_crds/crds/multi.yaml
+++ b/test/fixtures/test_helm_with_crds/crds/multi.yaml
@@ -1,0 +1,29 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: alphas.example.com
+spec:
+  group: example.com
+  names:
+    kind: Alpha
+    plural: alphas
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: betas.example.com
+spec:
+  group: example.com
+  names:
+    kind: Beta
+    plural: betas
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/test/fixtures/test_helm_with_crds/crds/nested/crds/repeated.yaml
+++ b/test/fixtures/test_helm_with_crds/crds/nested/crds/repeated.yaml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: repeated.example.com
+spec:
+  group: example.com
+  names:
+    kind: Repeated
+    plural: repeated
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object

--- a/test/fixtures/test_helm_with_crds/crds/nested/device.yaml
+++ b/test/fixtures/test_helm_with_crds/crds/nested/device.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: devices.example.com
+spec:
+  group: example.com
+  names:
+    kind: Device
+    plural: devices
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/test/fixtures/test_helm_with_crds/crds/widget.yaml
+++ b/test/fixtures/test_helm_with_crds/crds/widget.yaml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+    plural: widgets
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object

--- a/test/fixtures/test_helm_with_crds/templates/service.yaml
+++ b/test/fixtures/test_helm_with_crds/templates/service.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-svc
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}

--- a/test/fixtures/test_helm_with_crds/values.yaml
+++ b/test/fixtures/test_helm_with_crds/values.yaml
@@ -1,0 +1,3 @@
+service:
+  type: ClusterIP
+  port: 80


### PR DESCRIPTION
## Motivation

Helm charts can ship CustomResourceDefinitions under `crds/`, but the scanner did not analyze them on a successful chart render. The dry-run client omitted CRDs from rendered output, and the filesystem walk skipped the chart subtree after render.

Related ticket: [K9CODESEC-2075](https://datadoghq.atlassian.net/browse/K9CODESEC-2075)

## Changes

**Helm resolver**

Enable `IncludeCRDs` so CRD manifests are part of the rendered output. Stamp YAML CRD files with `KICS_HELM_ID` markers for line mapping, include CRD files in source mapping (including subcharts), and map rendered CRD splits back to their originals. Multi-document CRD files are attributed via inline Helm markers and by carrying forward the last known `# Source:` when Helm omits it on later documents. Unknown source headers are dropped, nested `crds/.../crds/...` paths stay distinct, and chart source paths are normalized for cross-platform lookup.

**Runner and detection**

Helm CRD line info is reconstructed lazily from the stamped original instead of retaining rendered copies. Helm YAML is routed only to the matching parser service to avoid duplicate parsing across Kubernetes/CICD YAML handlers. Helm documents are prepared in place where safe, and compact `HelmIDLineRange` metadata replaces large per-line `IDInfo` maps. Marker IDs use original source line indices so multi-document templates and CRDs report correct line numbers.

**JSON CRDs**

JSON CRD files are included in scan output but are not stamped (YAML comments would corrupt JSON). They are parsed through the YAML parser while preserving their CRD source path, with degraded line attribution when markers are absent.

## QA Instruction

1. `go test ./pkg/resolver/helm/... ./pkg/runner/... ./pkg/detector/helm/...`
2. `make build && ./bin/datadog-iac-scanner scan -p test/fixtures/test_helm_with_crds -t Kubernetes -o /tmp/helm-crd-out` — CRD resources from `crds/` should appear in SARIF with correct paths; no duplicate raw-template findings from `templates/`.
3. Scan `test/fixtures/test_helm_subchart` and confirm the subchart CRD under `charts/subchart/crds/` is resolved.
4. Confirm nested, multi-document, and JSON CRD fixtures under `test/fixtures/test_helm_with_crds/` are all present in scan output.

## Impact

Affects CLI scans of repositories that include Helm charts with `crds/`. YAML CRDs gain full scan coverage and line mapping; JSON CRDs are scanned with degraded line precision. CRDs reach the engine with correct `_path` values even though the bundled public rule set does not currently emit CRD-specific findings by default. Peak memory on the Helm regression corpus is at or below `main`. No changes to rule definitions or SARIF schema.

[K9CODESEC-2075]: https://datadoghq.atlassian.net/browse/K9CODESEC-2075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ