### PR TITLE
Fix false suppression of Helm scan findings

### DIFF
--- a/pkg/kics/resolver_sink.go
+++ b/pkg/kics/resolver_sink.go
@@ -64,6 +64,12 @@ func (s *Service) resolverSink(
 
 				// Need to ignore #KICS_HELM_ID Line
 				documents.CountLines = bytes.Count(rfile.OriginalData, []byte{'\n'})
+			} else {
+				// Parsing the original template failed (e.g. unstrippable {{ }} expressions),
+				// so IgnoreLines came from the rendered YAML. Strip scanner-injected header
+				// lines (# Source: / # KICS_HELM_ID_N:) that would otherwise cause false
+				// suppression when the Helm detector resolves vulnerability.Line to them.
+				documents.IgnoreLines = filterHelmGeneratedLines(rfile.Content, documents.IgnoreLines)
 			}
 		} else {
 			documents.CountLines = bytes.Count(rfile.OriginalData, []byte{'\n'}) + 1
@@ -135,4 +141,25 @@ func (s *Service) getOriginalIgnoreLines(ctx context.Context, filename string,
 		ignoreLines = documentsOriginal.IgnoreLines
 	}
 	return
+}
+
+// filterHelmGeneratedLines drops entries from ignoreLines whose corresponding
+// line in content is a scanner-injected Helm header ("# Source: …" or
+// "# KICS_HELM_ID_N:"). These headers are picked up by the YAML parser as
+// regular head comments and can coincide with vulnerability.Line, causing false
+// suppression. User-authored suppression comments are unaffected.
+func filterHelmGeneratedLines(content []byte, ignoreLines []int) []int {
+	lines := strings.Split(string(content), "\n")
+	out := make([]int, 0, len(ignoreLines))
+	for _, n := range ignoreLines {
+		if n >= 1 && n <= len(lines) {
+			trimmed := strings.TrimSpace(lines[n-1])
+			if strings.HasPrefix(trimmed, "# Source:") ||
+				strings.HasPrefix(trimmed, "# KICS_HELM_ID_") {
+				continue
+			}
+		}
+		out = append(out, n)
+	}
+	return out
 }

--- a/pkg/kics/resolver_sink_test.go
+++ b/pkg/kics/resolver_sink_test.go
@@ -1,0 +1,94 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package kics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterHelmGeneratedLines(t *testing.T) {
+	// Rendered Helm split content that resembles real scanner output.
+	// Line 1: empty
+	// Line 2: # Source: … (Helm-generated)
+	// Line 3: # KICS_HELM_ID_2: (scanner-injected)
+	// Line 4: apiVersion: apps/v1
+	// Line 5: kind: Deployment
+	// Line 6: # some user comment
+	// Line 7: metadata:
+	renderedContent := []byte("\n# Source: dsm-demo/templates/deployment.yaml\n# KICS_HELM_ID_2:\napiVersion: apps/v1\nkind: Deployment\n# some user comment\nmetadata:\n")
+
+	tests := []struct {
+		name        string
+		content     []byte
+		ignoreLines []int
+		want        []int
+	}{
+		{
+			name:        "removes Source and KICS_HELM_ID lines",
+			content:     renderedContent,
+			ignoreLines: []int{2, 3, 6},
+			want:        []int{6},
+		},
+		{
+			name:        "keeps user comment lines untouched",
+			content:     renderedContent,
+			ignoreLines: []int{6, 7},
+			want:        []int{6, 7},
+		},
+		{
+			name:        "no generated lines present — input unchanged",
+			content:     renderedContent,
+			ignoreLines: []int{4, 5, 7},
+			want:        []int{4, 5, 7},
+		},
+		{
+			name:        "empty ignore list stays empty",
+			content:     renderedContent,
+			ignoreLines: []int{},
+			want:        []int{},
+		},
+		{
+			name:        "out-of-range line numbers are kept as-is",
+			content:     renderedContent,
+			ignoreLines: []int{99, 100},
+			want:        []int{99, 100},
+		},
+		{
+			name:        "only generated lines — all removed",
+			content:     renderedContent,
+			ignoreLines: []int{2, 3},
+			want:        []int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterHelmGeneratedLines(tt.content, tt.ignoreLines)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFilterHelmGeneratedLines_DDIacScanCommentKept(t *testing.T) {
+	// Content where the dd-iac-scan directive appears alongside generated headers.
+	// Line 1: empty
+	// Line 2: # Source: chart/templates/deploy.yaml
+	// Line 3: # KICS_HELM_ID_0:
+	// Line 4: # dd-iac-scan ignore-block
+	// Line 5: apiVersion: apps/v1
+	content := []byte("\n# Source: chart/templates/deploy.yaml\n# KICS_HELM_ID_0:\n# dd-iac-scan ignore-block\napiVersion: apps/v1\n")
+
+	// Suppose processBlock added lines 4 and 5 (not 2 and 3, since it anchors to
+	// apiVersion.Line and apiVersion.Line-1). But even if 2 and 3 were included,
+	// they should be removed while 4 stays.
+	ignoreLines := []int{2, 3, 4, 5}
+	got := filterHelmGeneratedLines(content, ignoreLines)
+
+	// Lines 2 and 3 are generated; lines 4 and 5 are real content.
+	require.Equal(t, []int{4, 5}, got)
+}


### PR DESCRIPTION
## Motivation

When scanning Helm charts whose templates contain `{{ … }}` expressions (without a leading dash), the scanner's attempt to parse the original template for suppression directives fails. As a fallback, suppression line numbers are derived from the rendered YAML instead. The rendered YAML always begins with two scanner-injected header lines, `# Source: …` added by Helm, and `# KICS_HELM_ID_N:` added by the scanner, which the YAML parser treats as regular head comments and adds to the ignore-line list. The Helm line detector can resolve `vulnerability.Line` to those same positions (via a duplicate-attribute fallback), causing any finding whose line coincides with them to be silently marked as suppressed with justification `dd-iac-scan ignore`, even though no suppression directive was ever written by the user.

## Changes

**Scan pipeline: Helm resolver sink**

When `getOriginalIgnoreLines` fails, the ignore-line list from the rendered YAML parse is now filtered to remove entries whose corresponding line is a scanner-injected header (`# Source:` or `# KICS_HELM_ID_N:`). User-authored `dd-iac-scan ignore-line` and `ignore-block` directives do not match either prefix and are unaffected.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. CI should pass
2. Scan a Helm chart that uses `{{ .Values.something }}` expressions and confirm that findings previously reported as suppressed (with justification `dd-iac-scan ignore`) are now reported as active when no suppression directive exists in the source.

## Blast Radius

Only affects the Helm scan path, and only for templates where `getOriginalIgnoreLines` fails (templates with non-dash `{{ }}` expressions). The change removes false suppression; it cannot introduce new false positives. Templates that already parse correctly via `getOriginalIgnoreLines` are untouched.

## Additional Notes

I submit this contribution under the Apache-2.0 license.