### PR TITLE
Add v13 Docker fixture for platform filter testing

### DIFF
--- a/test/e2e/fixtures/v13/docker/Dockerfile
+++ b/test/e2e/fixtures/v13/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.19
+# Positive fixture for dockerfile-add-instead-of-copy (same idea as iac_rules_configuration_jeff add_instead_of_copy/test/positive.dockerfile).
+# The first ADD source must not contain ".tar" or ".tar." (see query.rego), so we use a build-arg path, not a .tar.gz URL.
+# USER avoids dockerfile-missing-user-instruction so you can focus on platform exclusion for the ADD rule.
+# Use with code-security.datadog.yaml v1.3 ignore-platforms / only-platforms (platform key: Dockerfile).
+ARG JAR_FILE=app.jar
+RUN echo "fixture"
+ADD ${JAR_FILE} /app.jar
+USER 65534:65534


### PR DESCRIPTION
## Motivation

Developers validating `schema-version: v1.3` **ignore-platforms** / **only-platforms** need a tiny Dockerfile under the existing v13 fixture tree that reliably triggers the **ADD instead of COPY** rule without extra noise from other Dockerfile checks.

## Changes

**Fixtures**

A new `test/e2e/fixtures/v13/docker/Dockerfile` mirrors the intent of the internal add-instead-of-copy positive pattern (`ADD` with a non-`.tar` source via `ARG`), includes `USER` so the missing-user rule does not fire, and documents the `Dockerfile` platform key for config experiments. Existing v13 e2e tests still scan only Terraform, Kubernetes, and CICD paths, so CI behavior is unchanged.

JIRA Ticket: N/A

## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `make build` (if needed), then `./bin/datadog-iac-scanner scan -p test/e2e/fixtures/v13/docker -o /tmp/iac-out`.
2. Confirm SARIF includes **ADD instead of COPY** on the `ADD ${JAR_FILE}` line and that `ignore-platforms: [Dockerfile]` in `code-security.datadog.yaml` removes Dockerfile findings when scanning a wider tree.

## Blast Radius

**Impact:** Repository test fixtures only; no scanner logic or default rule bundle changes.

## Additional Notes

I submit this contribution under the Apache-2.0 license.