### PR TITLE
Skip Helm library charts in resolver

### DIFF
--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -7,11 +7,13 @@ package resolver
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"gopkg.in/yaml.v3"
 )
 
 // kindResolver is a type of resolver interface (ex: helm resolver)
@@ -79,9 +81,24 @@ func (r *Resolver) Resolve(ctx context.Context, filePath string, kind model.File
 
 // GetType will analyze the filepath to determine which resolver to use
 func (r *Resolver) GetType(filePath string) model.FileKind {
-	_, err := os.Stat(filepath.Join(filePath, "Chart.yaml"))
-	if err == nil {
-		return model.KindHELM
+	chartFS := os.DirFS(filepath.Clean(filePath))
+	data, err := fs.ReadFile(chartFS, "Chart.yaml")
+	if err != nil {
+		return model.KindCOMMON
 	}
-	return model.KindCOMMON
+	if chartYAMLDeclaresLibrary(data) {
+		return model.KindCOMMON
+	}
+	return model.KindHELM
+}
+
+// chartYAMLDeclaresLibrary reports whether Chart.yaml content declares type: library.
+func chartYAMLDeclaresLibrary(data []byte) bool {
+	var meta struct {
+		Type string `yaml:"type"`
+	}
+	if err := yaml.Unmarshal(data, &meta); err != nil {
+		return false
+	}
+	return meta.Type == "library"
 }

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -26,11 +26,24 @@ func TestGetType(t *testing.T) {
 		args args
 		want model.FileKind
 	}{
-
 		{
 			name: "get_no_type",
 			args: args{
 				filepath: filepath.FromSlash("../../test/fixtures/all_auth_users_get_read_access"),
+			},
+			want: model.KindCOMMON,
+		},
+		{
+			name: "application_helm_chart_returns_helm_kind",
+			args: args{
+				filepath: filepath.FromSlash("../../test/fixtures/test_helm"),
+			},
+			want: model.KindHELM,
+		},
+		{
+			name: "library_helm_chart_returns_common_kind",
+			args: args{
+				filepath: filepath.FromSlash("../../test/fixtures/test_helm_library"),
 			},
 			want: model.KindCOMMON,
 		},

--- a/test/fixtures/test_helm_library/Chart.yaml
+++ b/test/fixtures/test_helm_library/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: test_helm_library
+description: A Helm library chart (shared helpers, not deployable)
+type: library
+version: 0.1.0


### PR DESCRIPTION
## Motivation

Helm library charts (`type: library`) cannot be installed; the scanner was still running the Helm dry-run path and logging errors such as `chart is not installable: library charts are not installable (only 'application' type charts are supported)`, which added noise to `service:iac-scanning` without improving coverage (library charts have no deployable manifests).

## Changes

**Resolver**

`GetType` reads `Chart.yaml` and returns `KindCOMMON` for `type: library`, so the Helm resolver is not invoked for those directories (same skip behavior as non-chart paths).

**Tests**

Fixture `test/fixtures/test_helm_library` and `TestGetType` cases for application vs library charts.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

CI should pass.

## Blast Radius

Only the Helm classification path in `pkg/resolver`; library chart directories are no longer passed to the Helm renderer.

## Additional Notes

I submit this contribution under the Apache-2.0 license.