### PR TITLE
Bypass Chart kubeVersion for Helm scan renders

### DIFF
--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -49,22 +49,17 @@ func dryRunKubeVersion() *chartutil.KubeVersion {
 	return cachedKubeVersion
 }
 
-// resolveChartKubeVersion returns a version satisfying constraint; true means
-// nothing in range satisfies it (caller should drop the constraint).
-func resolveChartKubeVersion(constraint string) (*chartutil.KubeVersion, bool) {
+// resolveChartKubeVersion returns a version satisfying constraint; unsatisfiable
+// means nothing in range satisfies it (caller should drop the constraint).
+func resolveChartKubeVersion(constraint string) (kv *chartutil.KubeVersion, unsatisfiable bool) {
 	def := dryRunKubeVersion()
 	if constraint == "" || chartutil.IsCompatibleRange(constraint, def.Version) {
 		return def, false
 	}
 	defMinor, _ := strconv.Atoi(def.Minor)
 	// Walk minors outward from the default, probing all patch levels per minor.
-	for d := 0; d <= maxCandidateMinor; d++ {
-		var minors []int
-		if d == 0 {
-			minors = []int{defMinor}
-		} else {
-			minors = []int{defMinor - d, defMinor + d}
-		}
+	minors := []int{defMinor}
+	for d := 1; d <= maxCandidateMinor+1; d++ {
 		for _, minor := range minors {
 			if minor < minCandidateMinor || minor > maxCandidateMinor {
 				continue
@@ -81,6 +76,7 @@ func resolveChartKubeVersion(constraint string) (*chartutil.KubeVersion, bool) {
 				}
 			}
 		}
+		minors = []int{defMinor - d, defMinor + d}
 	}
 	return def, true
 }

--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -7,7 +7,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/pkg/errors"
@@ -23,9 +25,72 @@ import (
 
 // credit: https://github.com/helm/helm
 
+// Fixed dry-run cluster version for Helm scan rendering.
+const defaultDryRunKubeVersion = "v1.30.0"
+
+// Search bounds when the default does not satisfy a chart's kubeVersion.
+const (
+	maxCandidateMinor = 40
+	minCandidateMinor = 0
+	maxCandidatePatch = 30
+)
+
 var (
 	settings = cli.New()
+
+	kubeVersionOnce   sync.Once
+	cachedKubeVersion *chartutil.KubeVersion
 )
+
+func dryRunKubeVersion() *chartutil.KubeVersion {
+	kubeVersionOnce.Do(func() {
+		cachedKubeVersion, _ = chartutil.ParseKubeVersion(defaultDryRunKubeVersion)
+	})
+	return cachedKubeVersion
+}
+
+// resolveChartKubeVersion returns a version satisfying constraint; true means
+// nothing in range satisfies it (caller should drop the constraint).
+func resolveChartKubeVersion(constraint string) (*chartutil.KubeVersion, bool) {
+	def := dryRunKubeVersion()
+	if constraint == "" || chartutil.IsCompatibleRange(constraint, def.Version) {
+		return def, false
+	}
+	defMinor, _ := strconv.Atoi(def.Minor)
+	// Walk minors outward from the default, probing all patch levels per minor.
+	for d := 0; d <= maxCandidateMinor; d++ {
+		var minors []int
+		if d == 0 {
+			minors = []int{defMinor}
+		} else {
+			minors = []int{defMinor - d, defMinor + d}
+		}
+		for _, minor := range minors {
+			if minor < minCandidateMinor || minor > maxCandidateMinor {
+				continue
+			}
+			for patch := 0; patch <= maxCandidatePatch; patch++ {
+				candidate := fmt.Sprintf("v1.%d.%d", minor, patch)
+				if candidate == def.Version {
+					continue // already checked at the top
+				}
+				if chartutil.IsCompatibleRange(constraint, candidate) {
+					if kv, err := chartutil.ParseKubeVersion(candidate); err == nil {
+						return kv, false
+					}
+				}
+			}
+		}
+	}
+	return def, true
+}
+
+func chartKubeVersionConstraint(ch *chart.Chart) string {
+	if ch == nil || ch.Metadata == nil {
+		return ""
+	}
+	return ch.Metadata.KubeVersion
+}
 
 func runInstall(ctx context.Context, args []string, client *action.Install,
 	valueOpts *values.Options) (*release.Release, []string, error) {
@@ -69,6 +134,13 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 	if err != nil {
 		contextLogger.Error().Msgf("failed to load chart from '%s': %s", cp, err)
 		return nil, []string{}, err
+	}
+
+	// Set KubeVersion; clear the constraint only when unsatisfiable.
+	kubeVersion, dropConstraint := resolveChartKubeVersion(chartKubeVersionConstraint(chartRequested))
+	client.KubeVersion = kubeVersion
+	if dropConstraint && chartRequested.Metadata != nil {
+		chartRequested.Metadata.KubeVersion = ""
 	}
 
 	excluded := getExcluded(ctx, chartRequested, cp)

--- a/pkg/resolver/helm/kube_version_test.go
+++ b/pkg/resolver/helm/kube_version_test.go
@@ -1,0 +1,77 @@
+package helm
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDryRunKubeVersionNonNil(t *testing.T) {
+	if kv := dryRunKubeVersion(); kv == nil || kv.Version == "" {
+		t.Fatal("dryRunKubeVersion() returned empty version")
+	}
+}
+
+func TestResolveChartKubeVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint string
+		wantVer    string
+		wantDrop   bool
+	}{
+		{name: "no constraint uses default", constraint: "", wantVer: "v1.30.0", wantDrop: false},
+		{name: "lower bound satisfied by default", constraint: ">= 1.22.0-0", wantVer: "v1.30.0", wantDrop: false},
+		{name: "upper bound satisfied by default", constraint: "< 1.31.0", wantVer: "v1.30.0", wantDrop: false},
+		{name: "range below default picks closest", constraint: ">= 1.22.0-0, < 1.25.0", wantVer: "v1.24.0", wantDrop: false},
+		{name: "upper bound below default", constraint: "< 1.16.0", wantVer: "v1.15.0", wantDrop: false},
+		{name: "patch lower-bound within default minor", constraint: ">= 1.30.1, < 1.31.0", wantVer: "v1.30.1", wantDrop: false},
+		{name: "tilde patch constraint", constraint: "~1.30.1", wantVer: "v1.30.1", wantDrop: false},
+		{name: "patch lower-bound in non-default minor", constraint: ">= 1.25.1, < 1.26.0", wantVer: "v1.25.1", wantDrop: false},
+		{name: "high patch number (>= 20)", constraint: ">= 1.18.20, < 1.19.0", wantVer: "v1.18.20", wantDrop: false},
+		{name: "out of range drops constraint", constraint: ">= 1.99.0-0", wantVer: "v1.30.0", wantDrop: true},
+		{name: "malformed drops constraint", constraint: "not-a-constraint", wantVer: "v1.30.0", wantDrop: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv, drop := resolveChartKubeVersion(tt.constraint)
+			if kv.Version != tt.wantVer {
+				t.Errorf("version = %q, want %q", kv.Version, tt.wantVer)
+			}
+			if drop != tt.wantDrop {
+				t.Errorf("drop = %v, want %v", drop, tt.wantDrop)
+			}
+		})
+	}
+}
+
+// Lower-bound kubeVersion; rendered output must still include the constraint string.
+func TestKubeVersionGateChart(t *testing.T) {
+	res := &Resolver{}
+	resolved, err := res.Resolve(context.Background(), filepath.FromSlash("../../../test/fixtures/test_helm_kube_version_gate"))
+	if err != nil {
+		t.Fatalf("expected chart with kubeVersion >= 1.22 to render successfully, got error: %v", err)
+	}
+	if len(resolved.File) == 0 {
+		t.Fatal("expected at least one rendered file, got none")
+	}
+	var rendered string
+	for _, f := range resolved.File {
+		rendered += string(f.Content)
+	}
+	if !strings.Contains(rendered, ">= 1.22.0-0") {
+		t.Errorf("expected .Chart.KubeVersion to be preserved in rendered output, got:\n%s", rendered)
+	}
+}
+
+// Unsatisfiable kubeVersion; constraint is dropped so render succeeds.
+func TestKubeVersionConstraintBypassed(t *testing.T) {
+	res := &Resolver{}
+	resolved, err := res.Resolve(context.Background(), filepath.FromSlash("../../../test/fixtures/test_helm_kube_version_incompatible"))
+	if err != nil {
+		t.Fatalf("expected chart with an incompatible kubeVersion to still render, got error: %v", err)
+	}
+	if len(resolved.File) == 0 {
+		t.Fatal("expected at least one rendered file, got none")
+	}
+}

--- a/test/fixtures/test_helm_kube_version_gate/Chart.yaml
+++ b/test/fixtures/test_helm_kube_version_gate/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: test_helm_kube_version_gate
+description: Fixture chart with a lower-bound kubeVersion constraint.
+type: application
+version: 0.1.0
+kubeVersion: ">= 1.22.0-0"

--- a/test/fixtures/test_helm_kube_version_gate/templates/configmap.yaml
+++ b/test/fixtures/test_helm_kube_version_gate/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+data:
+  key: value
+  chartKubeVersion: "{{ .Chart.KubeVersion }}"

--- a/test/fixtures/test_helm_kube_version_incompatible/Chart.yaml
+++ b/test/fixtures/test_helm_kube_version_incompatible/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: test_helm_kube_version_incompatible
+description: Fixture chart with an unsatisfiable kubeVersion for dry-run (gate bypass test).
+type: application
+version: 0.1.0
+kubeVersion: ">= 1.99.0-0"

--- a/test/fixtures/test_helm_kube_version_incompatible/templates/configmap.yaml
+++ b/test/fixtures/test_helm_kube_version_incompatible/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+data:
+  key: value


### PR DESCRIPTION
## Motivation

Helm client-only dry-run uses a synthetic cluster, not the user’s real Kubernetes version. When `Chart.yaml` declares `kubeVersion`, Helm can refuse to render before any manifest exists. A too-old default failed charts with higher lower bounds, and picking a single “new” version from build metadata could still fail charts with upper bounds or other constraints. Those failures only reduced scan coverage without modeling a real install.

## Changes

**Helm resolver**

After loading a chart for scan-time rendering, clear `metadata.kubeVersion` so Helm does not gate rendering on that field. `newClient` sets `KubeVersion` to a fixed value (`v1.30.0`) so `.Capabilities.KubeVersion` in templates stays stable across builds and dependency bumps. Tests and fixtures cover a lower-bound chart and a deliberately unsatisfiable `kubeVersion` so we keep rendering for scanning.

## QA Instruction

1. `go test ./pkg/resolver/helm/...`
2. Optional: run a scan against a chart that declares `kubeVersion` (including upper-bound only) and confirm Helm still produces rendered manifests without a version incompatibility error.

## Impact

Helm dry-run rendering during scans only (no cluster API). Scan-time rendering no longer honors `Chart.yaml` `kubeVersion` for pass/fail; templates that branch on `.Capabilities.KubeVersion` still see the fixed dry-run version.

## Additional Notes

This contribution is licensed under Apache-2.0.