### PR TITLE
Rename Rego entry-point from package Cx/CxPolicy to package datadog/DatadogPolicy

### DIFF
--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -775,6 +775,7 @@ func (q QueryLoader) LoadQuery(ctx context.Context, query *model.QueryMetadata,
 			rego.Module("Common", q.commonLibrary.LibraryCode),
 			rego.Module("Generic", platformGeneralQuery.LibraryCode),
 			rego.Module(query.Query, query.Content),
+			rego.Module("dd_iac_compat.rego", utils.RegoCompatShim),
 			rego.Store(store),
 			rego.UnsafeBuiltins(unsafeRegoFunctions),
 		).PrepareForEval(ctx)

--- a/pkg/engine/testdata/simid/query.rego
+++ b/pkg/engine/testdata/simid/query.rego
@@ -1,8 +1,8 @@
-package Cx
+package datadog
 
 # Minimal rule for TestInspectorSimilarityID: fires on every aws_instance resource.
 # Deliberately avoids library imports so it works with the stubQueriesSource library stub.
-CxPolicy[result] {
+DatadogPolicy[result] {
 	resource := input.document[i].resource.aws_instance[name]
 	result := {
 		"documentId": input.document[i].id,

--- a/pkg/scan/scan_test.go
+++ b/pkg/scan/scan_test.go
@@ -33,9 +33,9 @@ func (s *stubQuerySource) GetQueryLibrary(_ context.Context, platform string) (s
 // so the assertions are decoupled from the rule corpus.
 func Test_ExecuteScan(t *testing.T) {
 	const ruleID = "test-execute-scan-rule"
-	rego := `package Cx
+	rego := `package datadog
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	resource := input.document[i].resource.aws_s3_bucket[name]
 	result := {
 		"documentId": input.document[i].id,

--- a/pkg/utils/query.go
+++ b/pkg/utils/query.go
@@ -17,7 +17,20 @@ const (
 	DefaultQueryURI             = "https://github.com/DataDog/datadog-iac-scanner/"
 	UnresolvedPlaceholder       = "__UNRESOLVED__"
 
-	RegoQuery = `result = data.Cx.CxPolicy`
+	// RegoQuery is the OPA query evaluated against every rule module.
+	// It delegates to RegoCompatShim so both legacy (package Cx / CxPolicy) and
+	// current (package datadog / DatadogPolicy) rules are accepted during migration.
+	RegoQuery = `result = data.dd_iac_compat.policy`
+
+	// RegoCompatShim is injected as an extra OPA module alongside every rule.
+	// The two incremental definitions union CxPolicy and DatadogPolicy results,
+	// so each evaluates to an empty set when the corresponding package is absent.
+	// Once all rules have been migrated to DatadogPolicy, this shim can be removed
+	// and RegoQuery simplified back to `result = data.datadog.DatadogPolicy`.
+	RegoCompatShim = `package dd_iac_compat
+policy[r] { r = data.Cx.CxPolicy[_] }
+policy[r] { r = data.datadog.DatadogPolicy[_] }
+`
 )
 
 func ChooseQueryID(queryID, legacyQueryID string) string {

--- a/test/e2e/testdata/rules/cicd/unpinned_actions_full_length_commit_sha/query.rego
+++ b/test/e2e/testdata/rules/cicd/unpinned_actions_full_length_commit_sha/query.rego
@@ -1,9 +1,9 @@
-package Cx
+package datadog
 
 import data.generic.cicd as cicd_lib
 import data.generic.common as common_lib
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	doc := input.document[i]
 	cicd_lib.check_provider(doc) == "github"
 
@@ -24,7 +24,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	doc := input.document[i]
 	cicd_lib.check_provider(doc) == "github"
 
@@ -46,7 +46,7 @@ CxPolicy[result] {
 }
 
 # Composite action: `uses` references under `runs.steps[*]` must also be SHA-pinned.
-CxPolicy[result] {
+DatadogPolicy[result] {
 	doc := input.document[i]
 	cicd_lib.check_provider(doc) == "github"
 	

--- a/test/e2e/testdata/rules/k8s/container_is_privileged/query.rego
+++ b/test/e2e/testdata/rules/k8s/container_is_privileged/query.rego
@@ -1,10 +1,10 @@
-package Cx
+package datadog
 
 import data.generic.k8s as k8sLib
 
 types := {"initContainers", "containers"}
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	document := input.document[i]
 	metadata := document.metadata
 

--- a/test/e2e/testdata/rules/terraform/team_tag_not_present/query.rego
+++ b/test/e2e/testdata/rules/terraform/team_tag_not_present/query.rego
@@ -1,4 +1,4 @@
-package Cx
+package datadog
 
 import data.generic.common as common_lib
 import data.generic.terraform as tf_lib
@@ -7,7 +7,7 @@ import data.generic.terraform as tf_lib
 required_tags := {"Team"}
 
 # Case where "tags" block exists but required tags are missing (including merge({...}, {...}))
-CxPolicy[result] {
+DatadogPolicy[result] {
     startswith(resource_name, "aws_")
     tf_lib.check_aws_resource_supports_tags(resource_name)
 
@@ -41,7 +41,7 @@ CxPolicy[result] {
 }
 
 # Case where "tags" block is completely missing
-CxPolicy[result] {
+DatadogPolicy[result] {
     # Only consider resources whose type begins with "aws_"
     startswith(resource_type, "aws_")
 

--- a/test/fixtures/all_auth_users_get_read_access/query.rego
+++ b/test/fixtures/all_auth_users_get_read_access/query.rego
@@ -1,6 +1,6 @@
-package Cx
+package datadog
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	resource := input.document[i].resource.aws_s3_bucket[name]
 	role = "authenticated-read"
 	resource.acl == role

--- a/test/fixtures/common_query_test/query.rego
+++ b/test/fixtures/common_query_test/query.rego
@@ -1,6 +1,6 @@
-package Cx
+package datadog
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	input.document[i]
 
 	result := {

--- a/test/fixtures/experimental_test/queries/redis_disable_experimental/query.rego
+++ b/test/fixtures/experimental_test/queries/redis_disable_experimental/query.rego
@@ -1,6 +1,6 @@
-package Cx
+package datadog
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	resource := input.document[i].resource.aws_elasticache_cluster[name]
 	resource.engine != "redis"
 

--- a/test/fixtures/experimental_test/queries/redis_disabled/query.rego
+++ b/test/fixtures/experimental_test/queries/redis_disabled/query.rego
@@ -1,6 +1,6 @@
-package Cx
+package datadog
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	resource := input.document[i].resource.aws_elasticache_cluster[name]
 	resource.engine != "redis"
 

--- a/test/fixtures/get_queries_test/common_query.rego
+++ b/test/fixtures/get_queries_test/common_query.rego
@@ -1,6 +1,6 @@
-package Cx
+package datadog
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	input.document[i]
 
 	result := {

--- a/test/fixtures/get_queries_test/content_get_queries.rego
+++ b/test/fixtures/get_queries_test/content_get_queries.rego
@@ -1,6 +1,6 @@
-package Cx
+package datadog
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	resource := input.document[i].resource.aws_s3_bucket[name]
 	role = "authenticated-read"
 	resource.acl == role

--- a/test/fixtures/test_critical_custom_queries/amazon_mq_broker_encryption_disabled/query/query.rego
+++ b/test/fixtures/test_critical_custom_queries/amazon_mq_broker_encryption_disabled/query/query.rego
@@ -1,9 +1,9 @@
-package Cx
+package datadog
 
 import data.generic.common as common_lib
 import data.generic.cloudformation as cf_lib
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::AmazonMQ::Broker"

--- a/test/fixtures/test_critical_custom_queries/run_block_injection/query/query.rego
+++ b/test/fixtures/test_critical_custom_queries/run_block_injection/query/query.rego
@@ -1,8 +1,8 @@
-package Cx
+package datadog
 
 import data.generic.common as common_lib
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["pull_request_target"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -31,7 +31,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issues"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -54,7 +54,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issue_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -78,7 +78,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -101,7 +101,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -125,7 +125,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["workflow_run"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -152,7 +152,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["author"]
 	run := input.document[i].jobs[j].steps[k].run

--- a/test/fixtures/test_critical_severity/run_block_injection/query/query.rego
+++ b/test/fixtures/test_critical_severity/run_block_injection/query/query.rego
@@ -1,8 +1,8 @@
-package Cx
+package datadog
 
 import data.generic.common as common_lib
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["pull_request_target"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -31,7 +31,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issues"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -54,7 +54,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issue_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -78,7 +78,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -101,7 +101,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -125,7 +125,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["workflow_run"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -152,7 +152,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["author"]
 	run := input.document[i].jobs[j].steps[k].run

--- a/test/fixtures/test_experimental_queries/experimental_queries_queries/experimental/test/query.rego
+++ b/test/fixtures/test_experimental_queries/experimental_queries_queries/experimental/test/query.rego
@@ -1,11 +1,11 @@
-package Cx
+package datadog
 
 import data.generic.ansible as ansLib
 import data.generic.common as common_lib
 
 modules := {"community.aws.aws_api_gateway", "aws_api_gateway"}
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	task := ansLib.tasks[id][t]
 	api_gateway := task[modules[m]]
 	ansLib.checkState(api_gateway)
@@ -23,7 +23,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	task := ansLib.tasks[id][t]
 	api_gateway := task[modules[m]]
 	ansLib.checkState(api_gateway)

--- a/test/fixtures/test_experimental_queries/experimental_queries_queries/tested/tested_query/query.rego
+++ b/test/fixtures/test_experimental_queries/experimental_queries_queries/tested/tested_query/query.rego
@@ -1,11 +1,11 @@
-package Cx
+package datadog
 
 import data.generic.ansible as ansLib
 import data.generic.common as common_lib
 
 modules := {"community.aws.aws_api_gateway", "aws_api_gateway"}
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	task := ansLib.tasks[id][t]
 	api_gateway := task[modules[m]]
 	ansLib.checkState(api_gateway)
@@ -23,7 +23,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	task := ansLib.tasks[id][t]
 	api_gateway := task[modules[m]]
 	ansLib.checkState(api_gateway)

--- a/test/fixtures/test_old_severity/critical/query.rego
+++ b/test/fixtures/test_old_severity/critical/query.rego
@@ -1,8 +1,8 @@
-package Cx
+package datadog
 
 import data.generic.common as common_lib
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["pull_request_target"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -31,7 +31,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issues"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -54,7 +54,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issue_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -78,7 +78,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -101,7 +101,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -125,7 +125,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["workflow_run"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -152,7 +152,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["author"]
 	run := input.document[i].jobs[j].steps[k].run

--- a/test/fixtures/test_old_severity/high/query.rego
+++ b/test/fixtures/test_old_severity/high/query.rego
@@ -1,8 +1,8 @@
-package Cx
+package datadog
 
 import data.generic.common as common_lib
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["pull_request_target"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -31,7 +31,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issues"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -54,7 +54,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issue_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -78,7 +78,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -101,7 +101,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -125,7 +125,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["workflow_run"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -152,7 +152,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["author"]
 	run := input.document[i].jobs[j].steps[k].run

--- a/test/fixtures/test_old_severity/info/query.rego
+++ b/test/fixtures/test_old_severity/info/query.rego
@@ -1,8 +1,8 @@
-package Cx
+package datadog
 
 import data.generic.common as common_lib
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["pull_request_target"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -31,7 +31,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issues"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -54,7 +54,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issue_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -78,7 +78,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -101,7 +101,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -125,7 +125,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["workflow_run"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -152,7 +152,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["author"]
 	run := input.document[i].jobs[j].steps[k].run

--- a/test/fixtures/test_old_severity/low/query.rego
+++ b/test/fixtures/test_old_severity/low/query.rego
@@ -1,8 +1,8 @@
-package Cx
+package datadog
 
 import data.generic.common as common_lib
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["pull_request_target"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -31,7 +31,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issues"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -54,7 +54,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issue_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -78,7 +78,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -101,7 +101,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -125,7 +125,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["workflow_run"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -152,7 +152,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["author"]
 	run := input.document[i].jobs[j].steps[k].run

--- a/test/fixtures/test_old_severity/medium/query.rego
+++ b/test/fixtures/test_old_severity/medium/query.rego
@@ -1,8 +1,8 @@
-package Cx
+package datadog
 
 import data.generic.common as common_lib
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["pull_request_target"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -31,7 +31,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issues"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -54,7 +54,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issue_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -78,7 +78,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -101,7 +101,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -125,7 +125,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["workflow_run"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -152,7 +152,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["author"]
 	run := input.document[i].jobs[j].steps[k].run

--- a/test/fixtures/test_sarif_cwe_report/run_block_injection/query/query.rego
+++ b/test/fixtures/test_sarif_cwe_report/run_block_injection/query/query.rego
@@ -1,8 +1,8 @@
-package Cx
+package datadog
 
 import data.generic.common as common_lib
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["pull_request_target"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -31,7 +31,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issues"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -54,7 +54,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issue_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -78,7 +78,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -101,7 +101,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion_comment"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -125,7 +125,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["workflow_run"]
 	run := input.document[i].jobs[j].steps[k].run
@@ -152,7 +152,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["author"]
 	run := input.document[i].jobs[j].steps[k].run

--- a/test/fixtures/test_sarif_cwe_report/script_block_injection/query/query.rego
+++ b/test/fixtures/test_sarif_cwe_report/script_block_injection/query/query.rego
@@ -1,8 +1,8 @@
-package Cx
+package datadog
 
 import data.generic.common as common_lib
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["pull_request_target"]
 
@@ -36,7 +36,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issues"]
 
@@ -64,7 +64,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["issue_comment"]
 	
@@ -93,7 +93,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion"]
 	
@@ -121,7 +121,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["discussion_comment"]
 	
@@ -150,7 +150,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["workflow_run"]
 	
@@ -182,7 +182,7 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 
 	input.document[i].on["author"]
 	

--- a/test/fixtures/test_scan_cloudfront_logging_disabled/query.rego
+++ b/test/fixtures/test_scan_cloudfront_logging_disabled/query.rego
@@ -1,9 +1,9 @@
-package Cx
+package datadog
 
 import data.generic.cloudformation as cf_lib
 import data.generic.common as common_lib
 
-CxPolicy[result] {
+DatadogPolicy[result] {
 	docs := input.document[i]
 	[path, Resources] := walk(docs)
 	resource := Resources[name]

--- a/test/fixtures/type-test01/template01/query.rego
+++ b/test/fixtures/type-test01/template01/query.rego
@@ -1,6 +1,6 @@
-package Cx
+package datadog
 
-CxPolicy [ result ] {
+DatadogPolicy [ result ] {
   resource := input.document[i].resource
   resource == "<VALUE>"
 

--- a/test/fixtures/type-test01/template02/query.rego
+++ b/test/fixtures/type-test01/template02/query.rego
@@ -1,6 +1,6 @@
-package Cx
+package datadog
 
-CxPolicy [ result ] {
+DatadogPolicy [ result ] {
   resource := input.document[i].resource
   resource == "<VALUE>"
 

--- a/test/fixtures/type-test01/template03/query.rego
+++ b/test/fixtures/type-test01/template03/query.rego
@@ -1,6 +1,6 @@
-package Cx
+package datadog
 
-CxPolicy [ result ] {
+DatadogPolicy [ result ] {
   resource := input.document[i].resource
   resource == "<VALUE>"
 

--- a/test/fixtures/type-test02/template01/query.rego
+++ b/test/fixtures/type-test02/template01/query.rego
@@ -1,6 +1,6 @@
-package Cx
+package datadog
 
-CxPolicy [ result ] {
+DatadogPolicy [ result ] {
   resource := input.document[i].resource
   resource == "<VALUE>"
 

--- a/test/fixtures/type-test02/template02/query.rego
+++ b/test/fixtures/type-test02/template02/query.rego
@@ -1,6 +1,6 @@
-package Cx
+package datadog
 
-CxPolicy [ result ] {
+DatadogPolicy [ result ] {
   resource := input.document[i].resource
   resource == "<VALUE>"
 


### PR DESCRIPTION
## Motivation

The scanner engine and its default rules were originally forked from KICS (Checkmarx), which used `package Cx` and `CxPolicy` as the Rego namespace and policy entry-point, `Cx` standing for Checkmarx. Before exposing Rego rules to users for customization, this naming should reflect Datadog branding rather than a third-party product.

## Changes

**Engine (pkg/utils, pkg/engine)**

Introduced a backward-compatible shim module (`dd_iac_compat`) that is injected alongside every rule at evaluation time. The shim unions results from both `data.Cx.CxPolicy` (legacy) and `data.datadog.DatadogPolicy` (new) using two incremental Rego rule definitions, so each evaluates to an empty set when the corresponding package is absent. `RegoQuery` now targets `data.dd_iac_compat.policy`. This means the engine and the rules repo can be deployed independently, there is no flag day.

## QA Instruction

1. `go test ./pkg/utils/... ./pkg/engine/... ./pkg/scan/...`
2. Run a full scan against any local IaC fixture and confirm findings are still produced.
3. To verify backward compatibility, temporarily revert `test/fixtures/all_auth_users_get_read_access/query.rego` to `package Cx` / `CxPolicy`, run `go test ./pkg/engine/...`, and confirm the test still passes.

## Blast Radius

Affects the OPA query evaluated for every rule. No change in scan output, findings from both naming conventions are collected and merged. The only observable effect is that the new `package datadog` / `DatadogPolicy` naming is now the canonical form for rule authors.

## Additional Notes

A companion PR renames all 1,770 production `query.rego` files. That PR should be merged after this one is live. Once migration is confirmed complete, the compat shim can be removed in a follow-up and `RegoQuery` simplified back to `result = data.datadog.DatadogPolicy`.