### PR TITLE
Rename pkg/kics to pkg/runner and keep path discovery in pkg/analyzer

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -41,7 +41,7 @@ jobs:
         id: engine-tests
         run: |
           echo "🔍 Running critical tests..."
-          gotestsum --format testname -- -v -short -timeout 15m ./pkg/engine ./pkg/analyzer ./pkg/parser ./pkg/parser/terraform/... ./pkg/parser/yaml ./pkg/engine/source ./pkg/scan ./pkg/scanner ./pkg/builder/... ./pkg/kics ./test/e2e ./pkg/utils ./test/... ./pkg/report/model
+          gotestsum --format testname -- -v -short -timeout 15m ./pkg/engine ./pkg/runner ./pkg/analyzer ./pkg/parser ./pkg/parser/terraform/... ./pkg/parser/yaml ./pkg/engine/source ./pkg/scan ./pkg/scanner ./pkg/builder/... ./test/e2e ./pkg/utils ./test/... ./pkg/report/model
           echo "✅ All critical tests passed!"
 
       - name: Comment on PR (on failure)

--- a/pkg/runner/resolver_sink.go
+++ b/pkg/runner/resolver_sink.go
@@ -3,7 +3,7 @@
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
  */
-package kics
+package runner
 
 import (
 	"bytes"

--- a/pkg/runner/resolver_sink_test.go
+++ b/pkg/runner/resolver_sink_test.go
@@ -3,7 +3,7 @@
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
  */
-package kics
+package runner
 
 import (
 	"testing"

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -53,7 +53,7 @@ type Tracker interface {
 }
 
 // Service is a struct that contains a SourceProvider to receive sources, a storage to save and retrieve scanning informations
-// a parser to parse and provide files in format that KICS understand, a inspector that runs the scanning and a tracker to
+// a parser to parse and provide files in format the scanner understands, an inspector that runs the scanning and a tracker to
 // update scanning numbers
 type Service struct {
 	SourceProvider provider.SourceProvider
@@ -209,7 +209,7 @@ func (s *Service) saveToFile(ctx context.Context, file *model.FileMetadata) {
 	}
 }
 
-// PrepareScanDocument removes _kics_lines from payload and parses json filters
+// PrepareScanDocument removes _dd_lines from payload and parses json filters
 func PrepareScanDocument(ctx context.Context, body map[string]interface{}, kind model.FileKind) map[string]interface{} {
 	contextLogger := logger.FromContext(ctx)
 	var bodyMap map[string]interface{}

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -3,7 +3,7 @@
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
  */
-package kics
+package runner
 
 import (
 	"bytes"

--- a/pkg/runner/service_test.go
+++ b/pkg/runner/service_test.go
@@ -3,7 +3,7 @@
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
  */
-package kics
+package runner
 
 import (
 	"context"

--- a/pkg/runner/sink.go
+++ b/pkg/runner/sink.go
@@ -3,7 +3,7 @@
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
  */
-package kics
+package runner
 
 import (
 	"context"

--- a/pkg/runner/sink_test.go
+++ b/pkg/runner/sink_test.go
@@ -3,7 +3,7 @@
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
  */
-package kics
+package runner
 
 import (
 	"context"

--- a/pkg/runner/terraform_utils.go
+++ b/pkg/runner/terraform_utils.go
@@ -1,4 +1,4 @@
-package kics
+package runner
 
 import "regexp"
 

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
-	"github.com/DataDog/datadog-iac-scanner/pkg/kics"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser"
@@ -30,6 +29,7 @@ import (
 	yamlParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/default"
 	"github.com/DataDog/datadog-iac-scanner/pkg/resolver"
 	"github.com/DataDog/datadog-iac-scanner/pkg/resolver/helm"
+	"github.com/DataDog/datadog-iac-scanner/pkg/runner"
 	"github.com/DataDog/datadog-iac-scanner/pkg/scanner"
 )
 
@@ -42,7 +42,7 @@ type Results struct {
 }
 
 type executeScanParameters struct {
-	services       []*kics.Service
+	services       []*runner.Service
 	inspector      *engine.Inspector
 	extractedPaths provider.ExtractedPath
 }
@@ -242,11 +242,11 @@ func (c *Client) createService(
 	ctx context.Context,
 	inspector *engine.Inspector,
 	paths []string,
-	t kics.Tracker,
-	store kics.Storage,
+	t runner.Tracker,
+	store runner.Storage,
 	types []string,
 	cloudProviders []string,
-	flagEvaluator featureflags.FlagEvaluator) ([]*kics.Service, error) {
+	flagEvaluator featureflags.FlagEvaluator) ([]*runner.Service, error) {
 	filesSource, err := c.getFileSystemSourceProvider(ctx, paths)
 	if err != nil {
 		return nil, err
@@ -278,12 +278,12 @@ func (c *Client) createService(
 		return nil, err
 	}
 
-	services := make([]*kics.Service, 0, len(combinedParser))
+	services := make([]*runner.Service, 0, len(combinedParser))
 
 	for _, p := range combinedParser {
 		services = append(
 			services,
-			&kics.Service{
+			&runner.Service{
 				SourceProvider: filesSource,
 				Storage:        store,
 				Parser:         p,

--- a/pkg/scan/utils_test.go
+++ b/pkg/scan/utils_test.go
@@ -439,4 +439,3 @@ func Test_PreparePaths(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -10,11 +10,11 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
-	"github.com/DataDog/datadog-iac-scanner/pkg/kics"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/DataDog/datadog-iac-scanner/pkg/runner"
 )
 
-type serviceSlice []*kics.Service
+type serviceSlice []*runner.Service
 
 func PrepareAndScan(
 	ctx context.Context,

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
-	"github.com/DataDog/datadog-iac-scanner/pkg/kics"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser"
 	"github.com/DataDog/datadog-iac-scanner/pkg/resolver"
+	"github.com/DataDog/datadog-iac-scanner/pkg/runner"
 	"github.com/stretchr/testify/require"
 
 	jsonParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/json"
@@ -68,10 +68,10 @@ func createServices(types, cloudProviders []string) (serviceSlice, *storage.Memo
 
 	store := storage.NewMemoryStorage()
 
-	services := make([]*kics.Service, 0, len(combinedParser))
+	services := make([]*runner.Service, 0, len(combinedParser))
 
 	for _, parser := range combinedParser {
-		services = append(services, &kics.Service{
+		services = append(services, &runner.Service{
 			SourceProvider: filesSource,
 			Storage:        store,
 			Parser:         parser,


### PR DESCRIPTION
## Motivation

The legacy `pkg/kics` name does not describe the scan pipeline. Path discovery (platform detection, OpenAPI heuristics, `Analyze`) is separate from orchestrating parse + inspect work.

## Layout

- **`pkg/runner`** — scan pipeline (`Service`, sinks, `PrepareScanDocument`, etc.), `package runner`.
- **`pkg/analyzer`** — path discovery only (`Analyzer`, `Analyze`, shared OpenAPI regexes for resolvers), `package analyzer` at the repo root (no nested `paths` package).

Imports: `pkg/scan` and `pkg/scanner` use `runner` for the pipeline; `pkg/scan/utils.go` and `pkg/resolver/file` use `analyzer` for path analysis helpers.

## CI

Critical tests run `./pkg/runner` and `./pkg/analyzer`.

## How to verify

```bash
go build ./...
go test -short ./pkg/runner/... ./pkg/analyzer/... ./pkg/scan/... ./pkg/scanner/...
```

## Impact

Internal Go package layout only. No CLI or rule format changes.