### PR TITLE
Rename _kics_* AST keys to _dd_* with backward-compatible shim

### DIFF
--- a/pkg/detector/search_line_detector.go
+++ b/pkg/detector/search_line_detector.go
@@ -70,7 +70,7 @@ func (d *searchLineDetector) preparePath(pathItems []string) int {
 	}
 
 	if arrayObject == objPath {
-		ArrPath = "_kics_lines._kics_" + arrayObject + "._kics_arr"
+		ArrPath = "_dd_lines._dd_" + arrayObject + "._dd_arr"
 	}
 
 	var treatedPathItems []string
@@ -82,7 +82,7 @@ func (d *searchLineDetector) preparePath(pathItems []string) int {
 	for _, pathItem := range treatedPathItems {
 		// In case of an array present
 		if pathItem == arrayObject {
-			ArrPath += "._kics_lines._kics_" + strings.ReplaceAll(pathItem, ".", "\\.") + "._kics_arr"
+			ArrPath += "._dd_lines._dd_" + strings.ReplaceAll(pathItem, ".", "\\.") + "._dd_arr"
 		} else {
 			ArrPath += "." + strings.ReplaceAll(pathItem, ".", "\\.")
 		}
@@ -99,10 +99,10 @@ func (d *searchLineDetector) preparePath(pathItems []string) int {
 // getResult creates the paths to be used by gjson pkg to find the line in the content
 func (d *searchLineDetector) getResult() int {
 	pathObjects := []string{
-		d.resolvedPath + "._kics_lines._kics_" + d.targetObj + "._kics_line",
-		d.resolvedPath + "." + d.targetObj + "._kics_lines._kics__default._kics_line",
-		d.resolvedArrayPath + "." + d.targetObj + "._kics__default._kics_line",
-		d.resolvedArrayPath + "._kics_" + d.targetObj + "._kics_line",
+		d.resolvedPath + "._dd_lines._dd_" + d.targetObj + "._dd_line",
+		d.resolvedPath + "." + d.targetObj + "._dd_lines._dd__default._dd_line",
+		d.resolvedArrayPath + "." + d.targetObj + "._dd__default._dd_line",
+		d.resolvedArrayPath + "._dd_" + d.targetObj + "._dd_line",
 	}
 
 	result := -1

--- a/pkg/detector/search_line_detector_test.go
+++ b/pkg/detector/search_line_detector_test.go
@@ -28,30 +28,30 @@ func TestGetLineBySearchLine(t *testing.T) { //nolint
 				pathComponents: []string{"father", "son", "grandson"},
 				file: &model.FileMetadata{
 					LineInfoDocument: map[string]interface{}{
-						"_kics_lines": map[string]interface{}{
-							"_kics__default": map[string]interface{}{
-								"_kics_line": 0,
+						"_dd_lines": map[string]interface{}{
+							"_dd__default": map[string]interface{}{
+								"_dd_line": 0,
 							},
-							"_kics_father": map[string]interface{}{
-								"_kics_line": 3,
+							"_dd_father": map[string]interface{}{
+								"_dd_line": 3,
 							},
 						},
 						"father": map[string]interface{}{
-							"_kics_lines": map[string]interface{}{
-								"_kics__default": map[string]interface{}{
-									"_kics_line": 3,
+							"_dd_lines": map[string]interface{}{
+								"_dd__default": map[string]interface{}{
+									"_dd_line": 3,
 								},
-								"_kics_son": map[string]interface{}{
-									"_kics_line": 4,
+								"_dd_son": map[string]interface{}{
+									"_dd_line": 4,
 								},
 							},
 							"son": map[string]interface{}{
-								"_kics_lines": map[string]interface{}{
-									"_kics__default": map[string]interface{}{
-										"_kics_line": 4,
+								"_dd_lines": map[string]interface{}{
+									"_dd__default": map[string]interface{}{
+										"_dd_line": 4,
 									},
-									"_kics_grandson": map[string]interface{}{
-										"_kics_line": 5,
+									"_dd_grandson": map[string]interface{}{
+										"_dd_line": 5,
 									},
 								},
 								"grandson": "value",
@@ -69,37 +69,37 @@ func TestGetLineBySearchLine(t *testing.T) { //nolint
 				pathComponents: []string{"father", "1", "son"},
 				file: &model.FileMetadata{
 					LineInfoDocument: map[string]interface{}{
-						"_kics_lines": map[string]interface{}{
-							"_kics__default": map[string]interface{}{
-								"_kics_line": 0,
+						"_dd_lines": map[string]interface{}{
+							"_dd__default": map[string]interface{}{
+								"_dd_line": 0,
 							},
-							"_kics_father": map[string]interface{}{
-								"_kics_arr": []interface{}{
+							"_dd_father": map[string]interface{}{
+								"_dd_arr": []interface{}{
 									map[string]interface{}{
-										"_kics__default": map[string]interface{}{
-											"_kics_line": 2,
-										}, "_kics_son": map[string]interface{}{
-											"_kics_line": 4,
+										"_dd__default": map[string]interface{}{
+											"_dd_line": 2,
+										}, "_dd_son": map[string]interface{}{
+											"_dd_line": 4,
 										},
 									},
 									map[string]interface{}{
-										"_kics__default": map[string]interface{}{
-											"_kics_line": 2,
+										"_dd__default": map[string]interface{}{
+											"_dd_line": 2,
 										},
-										"_kics_son": map[string]interface{}{
-											"_kics_line": 7,
+										"_dd_son": map[string]interface{}{
+											"_dd_line": 7,
 										},
 									},
 									map[string]interface{}{
-										"_kics__default": map[string]interface{}{
-											"_kics_line": 2,
+										"_dd__default": map[string]interface{}{
+											"_dd_line": 2,
 										},
-										"_kics_son": map[string]interface{}{
-											"_kics_line": 10,
+										"_dd_son": map[string]interface{}{
+											"_dd_line": 10,
 										},
 									},
 								},
-								"_kics_line": 2,
+								"_dd_line": 2,
 							},
 						},
 						"father": []interface{}{
@@ -125,30 +125,30 @@ func TestGetLineBySearchLine(t *testing.T) { //nolint
 				pathComponents: []string{"father", "son.name", "grandson"},
 				file: &model.FileMetadata{
 					LineInfoDocument: map[string]interface{}{
-						"_kics_lines": map[string]interface{}{
-							"_kics__default": map[string]interface{}{
-								"_kics_line": 0,
+						"_dd_lines": map[string]interface{}{
+							"_dd__default": map[string]interface{}{
+								"_dd_line": 0,
 							},
-							"_kics_father": map[string]interface{}{
-								"_kics_line": 2,
+							"_dd_father": map[string]interface{}{
+								"_dd_line": 2,
 							},
 						},
 						"father": map[string]interface{}{
-							"_kics_lines": map[string]interface{}{
-								"_kics__default": map[string]interface{}{
-									"_kics_line": 2,
+							"_dd_lines": map[string]interface{}{
+								"_dd__default": map[string]interface{}{
+									"_dd_line": 2,
 								},
-								"_kics_son.name": map[string]interface{}{
-									"_kics_line": 3,
+								"_dd_son.name": map[string]interface{}{
+									"_dd_line": 3,
 								},
 							},
 							"son.name": map[string]interface{}{
-								"_kics_lines": map[string]interface{}{
-									"_kics__default": map[string]interface{}{
-										"_kics_line": 3,
+								"_dd_lines": map[string]interface{}{
+									"_dd__default": map[string]interface{}{
+										"_dd_line": 3,
 									},
-									"_kics_grandson": map[string]interface{}{
-										"_kics_line": 4,
+									"_dd_grandson": map[string]interface{}{
+										"_dd_line": 4,
 									},
 								},
 								"grandson": "value",
@@ -166,30 +166,30 @@ func TestGetLineBySearchLine(t *testing.T) { //nolint
 				pathComponents: []string{"father", "1", "grandson"},
 				file: &model.FileMetadata{
 					LineInfoDocument: map[string]interface{}{
-						"_kics_lines": map[string]interface{}{
-							"_kics__default": map[string]interface{}{
-								"_kics_line": 0,
+						"_dd_lines": map[string]interface{}{
+							"_dd__default": map[string]interface{}{
+								"_dd_line": 0,
 							},
-							"_kics_father": map[string]interface{}{
-								"_kics_line": 2,
+							"_dd_father": map[string]interface{}{
+								"_dd_line": 2,
 							},
 						},
 						"father": map[string]interface{}{
-							"_kics_lines": map[string]interface{}{
-								"_kics__default": map[string]interface{}{
-									"_kics_line": 2,
+							"_dd_lines": map[string]interface{}{
+								"_dd__default": map[string]interface{}{
+									"_dd_line": 2,
 								},
-								"_kics_son.name": map[string]interface{}{
-									"_kics_line": 3,
+								"_dd_son.name": map[string]interface{}{
+									"_dd_line": 3,
 								},
 							},
 							"1": map[string]interface{}{
-								"_kics_lines": map[string]interface{}{
-									"_kics__default": map[string]interface{}{
-										"_kics_line": 3,
+								"_dd_lines": map[string]interface{}{
+									"_dd__default": map[string]interface{}{
+										"_dd_line": 3,
 									},
-									"_kics_grandson": map[string]interface{}{
-										"_kics_line": 4,
+									"_dd_grandson": map[string]interface{}{
+										"_dd_line": 4,
 									},
 								},
 								"grandson": "value",
@@ -207,40 +207,40 @@ func TestGetLineBySearchLine(t *testing.T) { //nolint
 				pathComponents: []string{"father", "son", "3"},
 				file: &model.FileMetadata{
 					LineInfoDocument: map[string]interface{}{
-						"_kics_lines": map[string]interface{}{
-							"_kics__default": map[string]interface{}{
-								"_kics_line": 0,
+						"_dd_lines": map[string]interface{}{
+							"_dd__default": map[string]interface{}{
+								"_dd_line": 0,
 							},
-							"_kics_father": map[string]interface{}{
-								"_kics_line": 2,
+							"_dd_father": map[string]interface{}{
+								"_dd_line": 2,
 							},
 						},
 						"father": map[string]interface{}{
-							"_kics_lines": map[string]interface{}{
-								"_kics__default": map[string]interface{}{
-									"_kics_line": 2,
+							"_dd_lines": map[string]interface{}{
+								"_dd__default": map[string]interface{}{
+									"_dd_line": 2,
 								},
-								"_kics_son": map[string]interface{}{
-									"_kics_arr": []interface{}{
+								"_dd_son": map[string]interface{}{
+									"_dd_arr": []interface{}{
 										map[string]interface{}{
-											"_kics__default": map[string]interface{}{
-												"_kics_line": 4,
+											"_dd__default": map[string]interface{}{
+												"_dd_line": 4,
 											},
 										}, map[string]interface{}{
-											"_kics__default": map[string]interface{}{
-												"_kics_line": 5,
+											"_dd__default": map[string]interface{}{
+												"_dd_line": 5,
 											},
 										}, map[string]interface{}{
-											"_kics__default": map[string]interface{}{
-												"_kics_line": 6,
+											"_dd__default": map[string]interface{}{
+												"_dd_line": 6,
 											},
 										}, map[string]interface{}{
-											"_kics__default": map[string]interface{}{
-												"_kics_line": 7,
+											"_dd__default": map[string]interface{}{
+												"_dd_line": 7,
 											},
 										},
 									},
-									"_kics_line": 3,
+									"_dd_line": 3,
 								},
 							},
 							"son": []interface{}{

--- a/pkg/engine/vulnerability_builder_test.go
+++ b/pkg/engine/vulnerability_builder_test.go
@@ -539,30 +539,30 @@ func TestEngine_calculate(t *testing.T) { //nolint
 				},
 				file: &model.FileMetadata{
 					LineInfoDocument: map[string]interface{}{
-						"_kics_lines": map[string]interface{}{
-							"_kics__default": map[string]interface{}{
-								"_kics_line": 0,
+						"_dd_lines": map[string]interface{}{
+							"_dd__default": map[string]interface{}{
+								"_dd_line": 0,
 							},
-							"_kics_father": map[string]interface{}{
-								"_kics_line": 3,
+							"_dd_father": map[string]interface{}{
+								"_dd_line": 3,
 							},
 						},
 						"father": map[string]interface{}{
-							"_kics_lines": map[string]interface{}{
-								"_kics__default": map[string]interface{}{
-									"_kics_line": 3,
+							"_dd_lines": map[string]interface{}{
+								"_dd__default": map[string]interface{}{
+									"_dd_line": 3,
 								},
-								"_kics_son": map[string]interface{}{
-									"_kics_line": 4,
+								"_dd_son": map[string]interface{}{
+									"_dd_line": 4,
 								},
 							},
 							"son": map[string]interface{}{
-								"_kics_lines": map[string]interface{}{
-									"_kics__default": map[string]interface{}{
-										"_kics_line": 4,
+								"_dd_lines": map[string]interface{}{
+									"_dd__default": map[string]interface{}{
+										"_dd_line": 4,
 									},
-									"_kics_grandson": map[string]interface{}{
-										"_kics_line": 5,
+									"_dd_grandson": map[string]interface{}{
+										"_dd_line": 5,
 									},
 								},
 								"grandson": "value",

--- a/pkg/kics/service.go
+++ b/pkg/kics/service.go
@@ -238,7 +238,7 @@ func prepareScanDocumentRoot(body interface{}, kind model.FileKind) {
 }
 
 func prepareScanDocumentValue(bodyType map[string]interface{}, kind model.FileKind) {
-	delete(bodyType, "_kics_lines")
+	delete(bodyType, "_dd_lines")
 	for key, v := range bodyType {
 		switch value := v.(type) {
 		case map[string]interface{}:

--- a/pkg/kics/sink_test.go
+++ b/pkg/kics/sink_test.go
@@ -41,47 +41,47 @@ func TestKics_prepareDocument(t *testing.T) {
 								"name": "CIS-4.11-Changes-NACL",
 								"namespace": "CIS_Metric_Alarm_Namespace",
 								"value": "1",
-								"_kics_lines": {
-								  "_kics__default": {
-									"_kics_line": 6
+								"_dd_lines": {
+								  "_dd__default": {
+									"_dd_line": 6
 								  },
-								  "_kics_name": {
-									"_kics_line": 7
+								  "_dd_name": {
+									"_dd_line": 7
 								  },
-								  "_kics_namespace": {
-									"_kics_line": 8
+								  "_dd_namespace": {
+									"_dd_line": 8
 								  },
-								  "_kics_value": {
-									"_kics_line": 9
+								  "_dd_value": {
+									"_dd_line": 9
 								  }
 								}
 							  },
-							  "_kics_lines": {
-								"_kics__default": {
-								  "_kics_line": 1
+							  "_dd_lines": {
+								"_dd__default": {
+								  "_dd_line": 1
 								},
-								"_kics_log_group_name": {
-								  "_kics_line": 4
+								"_dd_log_group_name": {
+								  "_dd_line": 4
 								},
-								"_kics_metric_transformation": {
-								  "_kics_line": 6
+								"_dd_metric_transformation": {
+								  "_dd_line": 6
 								},
-								"_kics_name": {
-								  "_kics_line": 2
+								"_dd_name": {
+								  "_dd_line": 2
 								},
-								"_kics_pattern": {
-								  "_kics_line": 3
+								"_dd_pattern": {
+								  "_dd_line": 3
 								}
 							  }
 							}
 						  }
 						},
-						"_kics_lines": {
-						  "_kics__default": {
-							"_kics_line": 0
+						"_dd_lines": {
+						  "_dd__default": {
+							"_dd_line": 0
 						  },
-						  "_kics_resource": {
-							"_kics_line": 1
+						  "_dd_resource": {
+							"_dd_line": 1
 						  }
 						}
 					  }
@@ -104,7 +104,7 @@ func TestKics_prepareDocument(t *testing.T) {
 							"value": "1"
 						  },
 						  "name": "CIS-4.11-Changes-NACL",
-						  "pattern": "{\"_kics_filter_expr\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAcl\"},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAclEntry\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"DeleteNetworkAcl\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"DeleteNetworkAclEntry\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"ReplaceNetworkAclEntry\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"ReplaceNetworkAclAssociation\"}}}"
+						  "pattern": "{\"_dd_filter_expr\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAcl\"},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAclEntry\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"DeleteNetworkAcl\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"DeleteNetworkAclEntry\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"ReplaceNetworkAclEntry\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"ReplaceNetworkAclAssociation\"}},\"_kics_filter_expr\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAcl\"},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAclEntry\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"DeleteNetworkAcl\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"DeleteNetworkAclEntry\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"ReplaceNetworkAclEntry\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"ReplaceNetworkAclAssociation\"}}}"
 						}
 					  }
 					}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -276,8 +276,8 @@ func (e Extensions) Include(ext string) bool {
 
 // LineObject is the struct that will hold line information for each key
 type LineObject struct {
-	Line int                      `json:"_kics_line"`
-	Arr  []map[string]*LineObject `json:"_kics_arr,omitempty"`
+	Line int                      `json:"_dd_line"`
+	Arr  []map[string]*LineObject `json:"_dd_arr,omitempty"`
 }
 
 // MatchedFilesRegex returns the regex rule to identify if an extension is supported or not

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -83,7 +83,7 @@ func (m *Document) UnmarshalYAML(ctx context.Context, value *yaml.Node, ignore *
 			expandCloudFormationForEach(mapDcp)
 		}
 		// set line information for root level objects
-		mapDcp["_kics_lines"] = getLines(value, 0)
+		mapDcp["_dd_lines"] = getLines(value, 0)
 
 		// place the payload in the Document struct
 		tmp, _ := json.Marshal(mapDcp)
@@ -278,7 +278,7 @@ func substituteForEachBindings(v interface{}, bindings map[string]string) interf
 
 func isPureRefNode(m map[string]interface{}) bool {
 	for k := range m {
-		if k != "Ref" && k != "_kics_lines" {
+		if k != "Ref" && k != "_dd_lines" {
 			return false
 		}
 	}
@@ -295,23 +295,23 @@ func replaceForEachVars(template string, bindings map[string]string) string {
 }
 
 func copyForEachLineInfo(resources map[string]interface{}, foreachKey, resourceKey string) {
-	lines, ok := resources["_kics_lines"].(map[string]*LineObject)
+	lines, ok := resources["_dd_lines"].(map[string]*LineObject)
 	if !ok {
 		return
 	}
-	source, ok := lines["_kics_"+foreachKey]
+	source, ok := lines["_dd_"+foreachKey]
 	if !ok {
 		return
 	}
-	lines["_kics_"+resourceKey] = source
+	lines["_dd_"+resourceKey] = source
 }
 
 func removeForEachLineInfo(resources map[string]interface{}, foreachKey string) {
-	lines, ok := resources["_kics_lines"].(map[string]*LineObject)
+	lines, ok := resources["_dd_lines"].(map[string]*LineObject)
 	if !ok {
 		return
 	}
-	delete(lines, "_kics_"+foreachKey)
+	delete(lines, "_dd_"+foreachKey)
 }
 
 /*
@@ -357,7 +357,7 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 			if val.Content[i].Kind == yaml.ScalarNode {
 				if rewritten, ok := rewriteCFNShortFormIntrinsic(ctx, val.Content[i+1], visited, ignore); ok {
 					if m, ok := rewritten.(map[string]interface{}); ok {
-						m["_kics_lines"] = getLines(val.Content[i+1], val.Content[i].Line)
+						m["_dd_lines"] = getLines(val.Content[i+1], val.Content[i].Line)
 					}
 					tmp[val.Content[i].Value] = rewritten
 					continue
@@ -370,7 +370,7 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 					// unmarshall map value and get its line information
 					result := unmarshalWithDepth(ctx, val.Content[i+1], visited, ignore)
 					if tt, ok := result.(map[string]interface{}); ok {
-						tt["_kics_lines"] = getLines(val.Content[i+1], val.Content[i].Line)
+						tt["_dd_lines"] = getLines(val.Content[i+1], val.Content[i].Line)
 						tmp[val.Content[i].Value] = tt
 					} else {
 						tmp[val.Content[i].Value] = result
@@ -387,7 +387,7 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 					if val.Content[i+1].Alias != nil {
 						result := unmarshalWithDepth(ctx, val.Content[i+1].Alias, visited, ignore)
 						if tt, ok := result.(map[string]interface{}); ok {
-							tt["_kics_lines"] = getLines(val.Content[i+1], val.Content[i].Line)
+							tt["_dd_lines"] = getLines(val.Content[i+1], val.Content[i].Line)
 							utils.MergeMaps(tmp, tt)
 						}
 						if v, ok := result.(string); ok {
@@ -402,12 +402,12 @@ func unmarshalWithDepth(ctx context.Context, val *yaml.Node, visited map[*yaml.N
 }
 
 // getLines creates the map containing the line information for the yaml Node
-// def is the line to be used as "_kics__default"
+// def is the line to be used as "_dd__default"
 func getLines(val *yaml.Node, def int) map[string]*LineObject {
 	lineMap := make(map[string]*LineObject)
 
 	// line information map
-	lineMap["_kics__default"] = &LineObject{
+	lineMap["_dd__default"] = &LineObject{
 		Line: def,
 		Arr:  []map[string]*LineObject{},
 	}
@@ -434,7 +434,7 @@ func getLines(val *yaml.Node, def int) map[string]*LineObject {
 		}
 
 		// line information map of each key of the yaml Node
-		lineMap["_kics_"+val.Content[i].Value] = &LineObject{
+		lineMap["_dd_"+val.Content[i].Value] = &LineObject{
 			Line: val.Content[i].Line,
 			Arr:  lineArr,
 		}
@@ -455,7 +455,7 @@ func getSeqLines(val *yaml.Node, def int) map[string]*LineObject {
 	}
 
 	// create line information of array with its line and elements line information
-	lineMap["_kics__default"] = &LineObject{
+	lineMap["_dd__default"] = &LineObject{
 		Line: def,
 		Arr:  lineArr,
 	}

--- a/pkg/model/model_yaml_test.go
+++ b/pkg/model/model_yaml_test.go
@@ -169,55 +169,55 @@ var tests = []struct {
 		m:       &Document{},
 		wantErr: false,
 		want: `{
-			"_kics_lines": {
-			  "_kics__default": {
-				"_kics_line": 0
+			"_dd_lines": {
+			  "_dd__default": {
+				"_dd_line": 0
 			  },
-			  "_kics_key": {
-				"_kics_line": 1
+			  "_dd_key": {
+				"_dd_line": 1
 			  },
-			  "_kics_key_object": {
-				"_kics_line": 2
+			  "_dd_key_object": {
+				"_dd_line": 2
 			  }
 			},
 			"key": false,
 			"key_object": {
-			  "_kics_lines": {
-				"_kics__default": {
-				  "_kics_line": 2
+			  "_dd_lines": {
+				"_dd__default": {
+				  "_dd_line": 2
 				},
-				"_kics_int_object": {
-				  "_kics_line": 4
+				"_dd_int_object": {
+				  "_dd_line": 4
 				},
-				"_kics_null_object": {
-				  "_kics_line": 3
+				"_dd_null_object": {
+				  "_dd_line": 3
 				},
-				"_kics_seq_object": {
-				  "_kics_arr": [
+				"_dd_seq_object": {
+				  "_dd_arr": [
 					{
-					  "_kics__default": {
-						"_kics_line": 6
+					  "_dd__default": {
+						"_dd_line": 6
 					  },
-					  "_kics_key_seq": {
-						"_kics_line": 6
+					  "_dd_key_seq": {
+						"_dd_line": 6
 					  },
-					  "_kics_key_seq_2": {
-						"_kics_line": 7
+					  "_dd_key_seq_2": {
+						"_dd_line": 7
 					  }
 					},
 					{
-					  "_kics__default": {
-						"_kics_line": 8
+					  "_dd__default": {
+						"_dd_line": 8
 					  },
-					  "_kics_second_key": {
-						"_kics_line": 8
+					  "_dd_second_key": {
+						"_dd_line": 8
 					  },
-					  "_kics_second_key_2": {
-						"_kics_line": 9
+					  "_dd_second_key_2": {
+						"_dd_line": 9
 					  }
 					}
 				  ],
-				  "_kics_line": 5
+				  "_dd_line": 5
 				}
 			  },
 			  "int_object": 24,
@@ -314,44 +314,44 @@ var tests = []struct {
 		},
 		wantErr: false,
 		want: `{
-			"_kics_lines": {
-			  "_kics__default": {
-				"_kics_arr": [
+			"_dd_lines": {
+			  "_dd__default": {
+				"_dd_arr": [
 				  {
-					"_kics__default": {
-					  "_kics_line": 0
+					"_dd__default": {
+					  "_dd_line": 0
 					},
-					"_kics_ansible_object": {
-					  "_kics_line": 2
+					"_dd_ansible_object": {
+					  "_dd_line": 2
 					},
-					"_kics_name": {
-					  "_kics_line": 1
+					"_dd_name": {
+					  "_dd_line": 1
 					}
 				  },
 				  {
-					"_kics__default": {
-					  "_kics_line": 0
+					"_dd__default": {
+					  "_dd_line": 0
 					},
-					"_kics_ansible_object_2": {
-					  "_kics_line": 5
+					"_dd_ansible_object_2": {
+					  "_dd_line": 5
 					},
-					"_kics_name": {
-					  "_kics_line": 4
+					"_dd_name": {
+					  "_dd_line": 4
 					}
 				  }
 				],
-				"_kics_line": 0
+				"_dd_line": 0
 			  }
 			},
 			"playbooks": [
 			  {
 				"ansible_object": {
-				  "_kics_lines": {
-					"_kics__default": {
-					  "_kics_line": 2
+				  "_dd_lines": {
+					"_dd__default": {
+					  "_dd_line": 2
 					},
-					"_kics_name": {
-					  "_kics_line": 3
+					"_dd_name": {
+					  "_dd_line": 3
 					}
 				  },
 				  "name": "object"
@@ -360,12 +360,12 @@ var tests = []struct {
 			  },
 			  {
 				"ansible_object_2": {
-				  "_kics_lines": {
-					"_kics__default": {
-					  "_kics_line": 5
+				  "_dd_lines": {
+					"_dd__default": {
+					  "_dd_line": 5
 					},
-					"_kics_name": {
-					  "_kics_line": 6
+					"_dd_name": {
+					  "_dd_line": 6
 					}
 				  },
 				  "name": "object_2"
@@ -416,29 +416,29 @@ var tests = []struct {
 			},
 		},
 		want: `{
-			"_kics_lines": {
-			  "_kics__default": {
-				"_kics_line": 0
+			"_dd_lines": {
+			  "_dd__default": {
+				"_dd_line": 0
 			  },
-			  "_kics_array": {
-				"_kics_arr": [
+			  "_dd_array": {
+				"_dd_arr": [
 				  {
-					"_kics__default": {
-					  "_kics_line": 2
+					"_dd__default": {
+					  "_dd_line": 2
 					}
 				  },
 				  {
-					"_kics__default": {
-					  "_kics_line": 3
+					"_dd__default": {
+					  "_dd_line": 3
 					}
 				  },
 				  {
-					"_kics__default": {
-					  "_kics_line": 4
+					"_dd__default": {
+					  "_dd_line": 4
 					}
 				  }
 				],
-				"_kics_line": 1
+				"_dd_line": 1
 			  }
 			},
 			"array": [
@@ -469,12 +469,12 @@ var tests = []struct {
 			},
 		},
 		want: `{
-			"_kics_lines": {
-			  "_kics__default": {"_kics_line": 0},
-			  "_kics_hex_int": {"_kics_line": 1},
-			  "_kics_octal_int": {"_kics_line": 2},
-			  "_kics_binary_int": {"_kics_line": 3},
-			  "_kics_underscored_int": {"_kics_line": 4}
+			"_dd_lines": {
+			  "_dd__default": {"_dd_line": 0},
+			  "_dd_hex_int": {"_dd_line": 1},
+			  "_dd_octal_int": {"_dd_line": 2},
+			  "_dd_binary_int": {"_dd_line": 3},
+			  "_dd_underscored_int": {"_dd_line": 4}
 			},
 			"hex_int": 26,
 			"octal_int": 493,
@@ -498,10 +498,10 @@ var tests = []struct {
 			},
 		},
 		want: `{
-			"_kics_lines": {
-			  "_kics__default": {"_kics_line": 0},
-			  "_kics_ratio": {"_kics_line": 1},
-			  "_kics_count": {"_kics_line": 2}
+			"_dd_lines": {
+			  "_dd__default": {"_dd_line": 0},
+			  "_dd_ratio": {"_dd_line": 1},
+			  "_dd_count": {"_dd_line": 2}
 			},
 			"ratio": 3.14,
 			"count": 42
@@ -525,11 +525,11 @@ var tests = []struct {
 			},
 		},
 		want: `{
-			"_kics_lines": {
-			  "_kics__default": {"_kics_line": 0},
-			  "_kics_enabled": {"_kics_line": 1},
-			  "_kics_disabled": {"_kics_line": 2},
-			  "_kics_empty": {"_kics_line": 3}
+			"_dd_lines": {
+			  "_dd__default": {"_dd_line": 0},
+			  "_dd_enabled": {"_dd_line": 1},
+			  "_dd_disabled": {"_dd_line": 2},
+			  "_dd_empty": {"_dd_line": 3}
 			},
 			"enabled": true,
 			"disabled": false,
@@ -739,7 +739,7 @@ func TestDocument_UnmarshalYAML_CloudFormationShortFormIntrinsics(t *testing.T) 
 }
 
 // TestDocument_UnmarshalYAML_CFNIntrinsicLineMetadata verifies that rewritten
-// short-form intrinsics carry _kics_lines metadata on the wrapper map,
+// short-form intrinsics carry _dd_lines metadata on the wrapper map,
 // matching what long-form mapping values produce.
 func TestDocument_UnmarshalYAML_CFNIntrinsicLineMetadata(t *testing.T) {
 	ctx := context.Background()
@@ -762,12 +762,12 @@ func TestDocument_UnmarshalYAML_CFNIntrinsicLineMetadata(t *testing.T) {
 	var parsed map[string]interface{}
 	require.NoError(t, json.Unmarshal(raw, &parsed))
 
-	// Walk to BucketName without stripping _kics_lines
+	// Walk to BucketName without stripping _dd_lines
 	bucketName := parsed["Resources"].(map[string]interface{})["MyBucket"].(map[string]interface{})["Properties"].(map[string]interface{})["BucketName"]
 	m, ok := bucketName.(map[string]interface{})
 	require.True(t, ok, "BucketName should be a map after rewrite")
 	require.Contains(t, m, "Fn::Sub", "rewritten map should have Fn::Sub key")
-	require.Contains(t, m, "_kics_lines", "rewritten map should carry _kics_lines")
+	require.Contains(t, m, "_dd_lines", "rewritten map should carry _dd_lines")
 }
 
 // TestDocument_UnmarshalYAML_ShortFormIntrinsicNonCloudFormation verifies that
@@ -873,21 +873,21 @@ Resources:
 
 	rds0 := resources["RDSInstance0"].(map[string]interface{})
 	props0 := rds0["Properties"].(map[string]interface{})
-	require.Equal(t, map[string]interface{}{"Fn::Sub": "app_0"}, stripKicsLines(props0["DBName"]))
+	require.Equal(t, map[string]interface{}{"Fn::Sub": "app_0"}, stripDDLines(props0["DBName"]))
 	tags0 := props0["Tags"].([]interface{})
 	require.Equal(t, map[string]interface{}{
 		"Key":   "logical",
 		"Value": "0",
-	}, stripKicsLines(tags0[0]))
+	}, stripDDLines(tags0[0]))
 
 	rds1 := resources["RDSInstance1"].(map[string]interface{})
 	props1 := rds1["Properties"].(map[string]interface{})
-	require.Equal(t, map[string]interface{}{"Fn::Sub": "app_1"}, stripKicsLines(props1["DBName"]))
+	require.Equal(t, map[string]interface{}{"Fn::Sub": "app_1"}, stripDDLines(props1["DBName"]))
 	tags1 := props1["Tags"].([]interface{})
 	require.Equal(t, map[string]interface{}{
 		"Key":   "logical",
 		"Value": "1",
-	}, stripKicsLines(tags1[0]))
+	}, stripDDLines(tags1[0]))
 }
 
 func TestDocument_UnmarshalYAML_CloudFormationForEachNoTransform(t *testing.T) {
@@ -948,12 +948,12 @@ Resources:
 	require.NoError(t, json.Unmarshal(raw, &parsed))
 
 	resources := parsed["Resources"].(map[string]interface{})
-	resourceLines := resources["_kics_lines"].(map[string]interface{})
+	resourceLines := resources["_dd_lines"].(map[string]interface{})
 
 	// Expanded resource inherits line info from the ForEach key.
-	require.Contains(t, resourceLines, "_kics_RDSInstance0")
+	require.Contains(t, resourceLines, "_dd_RDSInstance0")
 	// Stale ForEach entry is removed.
-	require.NotContains(t, resourceLines, "_kics_Fn::ForEach::RDSInstances")
+	require.NotContains(t, resourceLines, "_dd_Fn::ForEach::RDSInstances")
 }
 
 func TestDocument_UnmarshalYAML_CloudFormationForEachDuplicateID(t *testing.T) {
@@ -1035,10 +1035,10 @@ Resources:
 	require.NotContains(t, resources, "Fn::ForEach::Queues")
 
 	prodProps := resources["Queueprod"].(map[string]interface{})["Properties"].(map[string]interface{})
-	require.Equal(t, "queue-prod", stripKicsLines(prodProps["QueueName"]))
+	require.Equal(t, "queue-prod", stripDDLines(prodProps["QueueName"]))
 
 	stagingProps := resources["Queuestaging"].(map[string]interface{})["Properties"].(map[string]interface{})
-	require.Equal(t, "queue-staging", stripKicsLines(stagingProps["QueueName"]))
+	require.Equal(t, "queue-staging", stripDDLines(stagingProps["QueueName"]))
 }
 
 func TestDocument_UnmarshalYAML_CloudFormationForEachNestedLoops(t *testing.T) {
@@ -1084,7 +1084,7 @@ Resources:
 			key := "Bucket" + region + tier
 			require.Contains(t, resources, key)
 			props := resources[key].(map[string]interface{})["Properties"].(map[string]interface{})
-			require.Equal(t, "bucket-"+region+"-"+tier, stripKicsLines(props["BucketName"]))
+			require.Equal(t, "bucket-"+region+"-"+tier, stripDDLines(props["BucketName"]))
 		}
 	}
 
@@ -1103,7 +1103,7 @@ func walkJSONPath(t *testing.T, root interface{}, path []string) interface{} {
 		require.Truef(t, exists, "missing key %q at path; available keys: %v", key, keysOf(m))
 		cur = next
 	}
-	return stripKicsLines(cur)
+	return stripDDLines(cur)
 }
 
 func keysOf(m map[string]interface{}) []string {
@@ -1114,21 +1114,21 @@ func keysOf(m map[string]interface{}) []string {
 	return out
 }
 
-func stripKicsLines(v interface{}) interface{} {
+func stripDDLines(v interface{}) interface{} {
 	switch t := v.(type) {
 	case map[string]interface{}:
 		out := make(map[string]interface{}, len(t))
 		for k, val := range t {
-			if k == "_kics_lines" {
+			if k == "_dd_lines" {
 				continue
 			}
-			out[k] = stripKicsLines(val)
+			out[k] = stripDDLines(val)
 		}
 		return out
 	case []interface{}:
 		out := make([]interface{}, len(t))
 		for i, val := range t {
-			out[i] = stripKicsLines(val)
+			out[i] = stripDDLines(val)
 		}
 		return out
 	default:

--- a/pkg/parser/bicep/parser.go
+++ b/pkg/parser/bicep/parser.go
@@ -19,10 +19,10 @@ import (
 type Parser struct {
 }
 
-const kicsPrefix = "_kics_"
-const kicsLine = kicsPrefix + "line"
-const kicsLines = kicsPrefix + "lines"
-const kicsArray = kicsPrefix + "arr"
+const ddPrefix = "_dd_"
+const ddLine = ddPrefix + "line"
+const ddLines = ddPrefix + "lines"
+const ddArray = ddPrefix + "arr"
 
 const CloseParenthesis = "')"
 
@@ -39,7 +39,7 @@ type JSONBicep struct {
 	Resources  []interface{}          `json:"resources"`
 }
 
-type KicsObjectProperty struct {
+type bicepObjectProperty struct {
 	objectProperty map[string]interface{}
 	line           int
 }
@@ -341,13 +341,13 @@ func (s *BicepVisitor) VisitParameterDecl(ctx *parser.ParameterDeclContext) inte
 		}
 	}
 
-	line := map[string]int{kicsLine: ctx.GetStop().GetLine()}
+	line := map[string]int{ddLine: ctx.GetStop().GetLine()}
 	lines := map[string]map[string]int{
-		kicsPrefix + "defaultValue": line,
-		kicsPrefix + "type":         line,
+		"_dd_" + "defaultValue": line,
+		"_dd_" + "type":         line,
 	}
 
-	param[kicsLines] = lines
+	param[ddLines] = lines
 
 	s.paramList[identifier] = param
 
@@ -406,17 +406,17 @@ func (s *BicepVisitor) VisitResourceDecl(ctx *parser.ResourceDeclContext) interf
 	}
 
 	lines := map[string]interface{}{}
-	if resKicsLines, hasLines := resource[kicsLines]; hasLines {
+	if resLines, hasLines := resource[ddLines]; hasLines {
 		var ok bool
-		lines, ok = resKicsLines.(map[string]interface{})
+		lines, ok = resLines.(map[string]interface{})
 		if !ok {
 			lines = map[string]interface{}{}
 		}
 	}
 
-	line := map[string]int{kicsLine: ctx.GetStart().GetLine()}
-	lines[kicsPrefix+"apiVersion"] = line
-	lines[kicsPrefix+"type"] = line
+	line := map[string]int{ddLine: ctx.GetStart().GetLine()}
+	lines["_dd_"+"apiVersion"] = line
+	lines["_dd_"+"type"] = line
 
 	s.resourceList = append(s.resourceList, resource)
 
@@ -712,31 +712,31 @@ func (s *BicepVisitor) VisitObject(ctx *parser.ObjectContext) interface{} {
 	propertiesLines := map[string]interface{}{}
 
 	for _, val := range ctx.AllObjectProperty() {
-		objectProperty, ok := val.Accept(s).(KicsObjectProperty)
+		objectProperty, ok := val.Accept(s).(bicepObjectProperty)
 		if !ok {
 			return object
 		}
 		for key, val := range objectProperty.objectProperty {
 			object[key] = val
-			line := map[string]interface{}{kicsLine: objectProperty.line}
+			line := map[string]interface{}{ddLine: objectProperty.line}
 
 			arr, isArray := val.([]interface{})
 			if isArray {
 				for range arr {
-					arrLine := map[string]int{kicsLine: objectProperty.line}
-					kicsDefault := map[string]interface{}{kicsPrefix + "_default": arrLine}
-					kicsArr := []interface{}{kicsDefault}
-					line[kicsArray] = kicsArr
+					arrLine := map[string]int{ddLine: objectProperty.line}
+					ddDefault := map[string]interface{}{ddPrefix + "_default": arrLine}
+					ddArr := []interface{}{ddDefault}
+					line[ddArray] = ddArr
 				}
 			}
-			propertiesLines[kicsPrefix+key] = line
+			propertiesLines["_dd_"+key] = line
 		}
 	}
 
-	defaultLine := map[string]int{kicsLine: ctx.GetStart().GetLine()}
-	propertiesLines[kicsPrefix+"_default"] = defaultLine
+	defaultLine := map[string]int{ddLine: ctx.GetStart().GetLine()}
+	propertiesLines["_dd_"+"_default"] = defaultLine
 
-	object[kicsLines] = propertiesLines
+	object[ddLines] = propertiesLines
 
 	return object
 }
@@ -764,7 +764,7 @@ func (s *BicepVisitor) VisitObjectProperty(ctx *parser.ObjectPropertyContext) in
 		}
 	}
 
-	return KicsObjectProperty{objectProperty: objectProperty, line: ctx.GetStart().GetLine()}
+	return bicepObjectProperty{objectProperty: objectProperty, line: ctx.GetStart().GetLine()}
 }
 
 func (s *BicepVisitor) VisitIdentifier(ctx *parser.IdentifierContext) interface{} {

--- a/pkg/parser/bicep/parser_test.go
+++ b/pkg/parser/bicep/parser_test.go
@@ -87,12 +87,12 @@ func TestParseBicepFile(t *testing.T) {
 			want: `{
 					"parameters": {
 						"diagnosticLogCategoriesToEnable": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 44
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 44
 								},
-								"_kics_type": {
-									"_kics_line": 44
+								"_dd_type": {
+									"_dd_line": 44
 								}
 							},
 							"allowedValues": [
@@ -110,12 +110,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "array"
 						},
 						"diagnosticMetricsToEnable": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 52
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 52
 								},
-								"_kics_type": {
-									"_kics_line": 52
+								"_dd_type": {
+									"_dd_line": 52
 								}
 							},
 							"allowedValues": [
@@ -132,12 +132,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "array"
 						},
 						"diagnosticSettingsName": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 32
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 32
 								},
-								"_kics_type": {
-									"_kics_line": 32
+								"_dd_type": {
+									"_dd_line": 32
 								}
 							},
 							"defaultValue": "'${parameters('name')}-diagnosticSettings'",
@@ -147,12 +147,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"diagnosticWorkspaceId": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 35
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 35
 								},
-								"_kics_type": {
-									"_kics_line": 35
+								"_dd_type": {
+									"_dd_line": 35
 								}
 							},
 							"defaultValue": "",
@@ -162,12 +162,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"keyvaultName": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 23
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 23
 								},
-								"_kics_type": {
-									"_kics_line": 23
+								"_dd_type": {
+									"_dd_line": 23
 								}
 							},
 							"metadata": {
@@ -176,12 +176,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"name": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 20
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 20
 								},
-								"_kics_type": {
-									"_kics_line": 20
+								"_dd_type": {
+									"_dd_line": 20
 								}
 							},
 							"maxLength": 63,
@@ -194,18 +194,18 @@ func TestParseBicepFile(t *testing.T) {
 					},
 					"resources": [
 						{
-							"_kics_lines": {
-								"_kics__default": {
-									"_kics_line": 110
+							"_dd_lines": {
+								"_dd__default": {
+									"_dd_line": 110
 								},
-								"_kics_apiVersion": {
-									"_kics_line": 110
+								"_dd_apiVersion": {
+									"_dd_line": 110
 								},
-								"_kics_name": {
-									"_kics_line": 111
+								"_dd_name": {
+									"_dd_line": 111
 								},
-								"_kics_type": {
-									"_kics_line": 110
+								"_dd_type": {
+									"_dd_line": 110
 								}
 							},
 							"apiVersion": "2022-11-01",
@@ -232,30 +232,30 @@ func TestParseBicepFile(t *testing.T) {
 						"dogs": {
 							"value": [
 								{
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 73
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 73
 										},
-										"_kics_age": {
-											"_kics_line": 75
+										"_dd_age": {
+											"_dd_line": 75
 										},
-										"_kics_name": {
-											"_kics_line": 74
+										"_dd_name": {
+											"_dd_line": 74
 										}
 									},
 									"age": 3,
 									"name": "Fido"
 								},
 								{
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 77
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 77
 										},
-										"_kics_age": {
-											"_kics_line": 79
+										"_dd_age": {
+											"_dd_line": 79
 										},
-										"_kics_name": {
-											"_kics_line": 78
+										"_dd_name": {
+											"_dd_line": 78
 										}
 									},
 									"age": 7,
@@ -272,12 +272,12 @@ func TestParseBicepFile(t *testing.T) {
 			want: `{
 					"parameters": {
 						"array": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 17
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 17
 								},
-								"_kics_type": {
-									"_kics_line": 17
+								"_dd_type": {
+									"_dd_line": 17
 								}
 							},
 							"defaultValue": [
@@ -286,12 +286,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"isNumber": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 9
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 9
 								},
-								"_kics_type": {
-									"_kics_line": 9
+								"_dd_type": {
+									"_dd_line": 9
 								}
 							},
 							"defaultValue": true,
@@ -301,12 +301,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "bool"
 						},
 						"middleString": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 12
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 12
 								},
-								"_kics_type": {
-									"_kics_line": 12
+								"_dd_type": {
+									"_dd_line": 12
 								}
 							},
 							"defaultValue": "'teste-${parameters('numberNodes')}${parameters('isNumber')}-teste'",
@@ -316,24 +316,24 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"null": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 19
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 19
 								},
-								"_kics_type": {
-									"_kics_line": 19
+								"_dd_type": {
+									"_dd_line": 19
 								}
 							},
 							"defaultValue": null,
 							"type": "string"
 						},
 						"numberNodes": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 6
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 6
 								},
-								"_kics_type": {
-									"_kics_line": 6
+								"_dd_type": {
+									"_dd_line": 6
 								}
 							},
 							"defaultValue": 2,
@@ -343,12 +343,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "int"
 						},
 						"projectName": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 3
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 3
 								},
-								"_kics_type": {
-									"_kics_line": 3
+								"_dd_type": {
+									"_dd_line": 3
 								}
 							},
 							"defaultValue": "[newGuid()]",
@@ -358,12 +358,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "secureString"
 						},
 						"secObj": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 15
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 15
 								},
-								"_kics_type": {
-									"_kics_line": 15
+								"_dd_type": {
+									"_dd_line": 15
 								}
 							},
 							"defaultValue": false,
@@ -404,12 +404,12 @@ func TestParseBicepFile(t *testing.T) {
 			want: `{
 					"parameters": {
 						"OSVersion": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 42
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 42
 								},
-								"_kics_type": {
-									"_kics_line": 42
+								"_dd_type": {
+									"_dd_line": 42
 								}
 							},
 							"allowedValues": [
@@ -437,12 +437,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"adminPassword": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 9
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 9
 								},
-								"_kics_type": {
-									"_kics_line": 9
+								"_dd_type": {
+									"_dd_line": 9
 								}
 							},
 							"metadata": {
@@ -452,12 +452,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "secureString"
 						},
 						"adminUsername": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 4
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 4
 								},
-								"_kics_type": {
-									"_kics_line": 4
+								"_dd_type": {
+									"_dd_line": 4
 								}
 							},
 							"metadata": {
@@ -466,12 +466,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"arrayP": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 136
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 136
 								},
-								"_kics_type": {
-									"_kics_line": 136
+								"_dd_type": {
+									"_dd_line": 136
 								}
 							},
 							"defaultValue": [
@@ -481,12 +481,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "array"
 						},
 						"capacity": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 65
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 65
 								},
-								"_kics_type": {
-									"_kics_line": 65
+								"_dd_type": {
+									"_dd_line": 65
 								}
 							},
 							"allowedValues": [
@@ -507,12 +507,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "int"
 						},
 						"diagnosticLogCategoriesToEnable": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 18
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 18
 								},
-								"_kics_type": {
-									"_kics_line": 18
+								"_dd_type": {
+									"_dd_line": 18
 								}
 							},
 							"allowedValues": [
@@ -530,12 +530,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "array"
 						},
 						"diagnosticMetricsToEnable": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 93
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 93
 								},
-								"_kics_type": {
-									"_kics_line": 93
+								"_dd_type": {
+									"_dd_line": 93
 								}
 							},
 							"allowedValues": [
@@ -552,12 +552,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "array"
 						},
 						"diagnosticSettingsName": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 82
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 82
 								},
-								"_kics_type": {
-									"_kics_line": 82
+								"_dd_type": {
+									"_dd_line": 82
 								}
 							},
 							"defaultValue": "'${name}-diagnosticSettings'",
@@ -567,12 +567,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"diagnosticWorkspaceId": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 85
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 85
 								},
-								"_kics_type": {
-									"_kics_line": 85
+								"_dd_type": {
+									"_dd_line": 85
 								}
 							},
 							"defaultValue": "",
@@ -582,12 +582,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"enableNonSslPort": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 99
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 99
 								},
-								"_kics_type": {
-									"_kics_line": 99
+								"_dd_type": {
+									"_dd_line": 99
 								}
 							},
 							"defaultValue": false,
@@ -597,12 +597,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "bool"
 						},
 						"existingContainerSubnetName": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 126
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 126
 								},
-								"_kics_type": {
-									"_kics_line": 126
+								"_dd_type": {
+									"_dd_line": 126
 								}
 							},
 							"metadata": {
@@ -611,12 +611,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"existingStorageSubnetName": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 123
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 123
 								},
-								"_kics_type": {
-									"_kics_line": 123
+								"_dd_type": {
+									"_dd_line": 123
 								}
 							},
 							"metadata": {
@@ -625,12 +625,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"existingVNETName": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 120
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 120
 								},
-								"_kics_type": {
-									"_kics_line": 120
+								"_dd_type": {
+									"_dd_line": 120
 								}
 							},
 							"metadata": {
@@ -639,12 +639,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"hasPrivateLink": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 96
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 96
 								},
-								"_kics_type": {
-									"_kics_line": 96
+								"_dd_type": {
+									"_dd_line": 96
 								}
 							},
 							"defaultValue": false,
@@ -654,12 +654,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "bool"
 						},
 						"keyvaultName": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 68
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 68
 								},
-								"_kics_type": {
-									"_kics_line": 68
+								"_dd_type": {
+									"_dd_line": 68
 								}
 							},
 							"metadata": {
@@ -668,12 +668,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"location": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 112
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 112
 								},
-								"_kics_type": {
-									"_kics_line": 112
+								"_dd_type": {
+									"_dd_line": 112
 								}
 							},
 							"defaultValue": "[resourceGroup().location]",
@@ -683,12 +683,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"name": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 131
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 131
 								},
-								"_kics_type": {
-									"_kics_line": 131
+								"_dd_type": {
+									"_dd_line": 131
 								}
 							},
 							"maxLength": 63,
@@ -699,30 +699,30 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"parenthesis": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 117
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 117
 								},
-								"_kics_type": {
-									"_kics_line": 117
+								"_dd_type": {
+									"_dd_line": 117
 								}
 							},
 							"defaultValue": "simple-vm",
 							"type": "string"
 						},
 						"redisConfiguration": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 102
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 102
 								},
-								"_kics_type": {
-									"_kics_line": 102
+								"_dd_type": {
+									"_dd_line": 102
 								}
 							},
 							"defaultValue": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 102
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 102
 									}
 								}
 							},
@@ -732,12 +732,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "object"
 						},
 						"replicasPerMaster": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 106
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 106
 								},
-								"_kics_type": {
-									"_kics_line": 106
+								"_dd_type": {
+									"_dd_line": 106
 								}
 							},
 							"defaultValue": 1,
@@ -748,12 +748,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "int"
 						},
 						"replicasPerPrimary": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 49
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 49
 								},
-								"_kics_type": {
-									"_kics_line": 49
+								"_dd_type": {
+									"_dd_line": 49
 								}
 							},
 							"defaultValue": 1,
@@ -764,12 +764,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "int"
 						},
 						"shardCount": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 53
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 53
 								},
-								"_kics_type": {
-									"_kics_line": 53
+								"_dd_type": {
+									"_dd_line": 53
 								}
 							},
 							"defaultValue": 1,
@@ -780,12 +780,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "int"
 						},
 						"skuName": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 76
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 76
 								},
-								"_kics_type": {
-									"_kics_line": 76
+								"_dd_type": {
+									"_dd_line": 76
 								}
 							},
 							"allowedValues": [
@@ -802,12 +802,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"subnetId": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 79
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 79
 								},
-								"_kics_type": {
-									"_kics_line": 79
+								"_dd_type": {
+									"_dd_line": 79
 								}
 							},
 							"defaultValue": "",
@@ -817,18 +817,18 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"tags": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 45
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 45
 								},
-								"_kics_type": {
-									"_kics_line": 45
+								"_dd_type": {
+									"_dd_line": 45
 								}
 							},
 							"defaultValue": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 45
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 45
 									}
 								}
 							},
@@ -838,12 +838,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "object"
 						},
 						"vmName": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 115
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 115
 								},
-								"_kics_type": {
-									"_kics_line": 115
+								"_dd_type": {
+									"_dd_line": 115
 								}
 							},
 							"defaultValue": "simple-vm",
@@ -853,12 +853,12 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "string"
 						},
 						"vmSize": {
-							"_kics_lines": {
-								"_kics_defaultValue": {
-									"_kics_line": 109
+							"_dd_lines": {
+								"_dd_defaultValue": {
+									"_dd_line": 109
 								},
-								"_kics_type": {
-									"_kics_line": 109
+								"_dd_type": {
+									"_dd_line": 109
 								}
 							},
 							"defaultValue": "Standard_D2_v3",
@@ -870,34 +870,34 @@ func TestParseBicepFile(t *testing.T) {
 					},
 					"resources": [
 						{
-							"_kics_lines": {
-								"_kics__default": {
-									"_kics_line": 173
+							"_dd_lines": {
+								"_dd__default": {
+									"_dd_line": 173
 								},
-								"_kics_apiVersion": {
-									"_kics_line": 172
+								"_dd_apiVersion": {
+									"_dd_line": 172
 								},
-								"_kics_dependsOn": {
-									"_kics_arr": [
+								"_dd_dependsOn": {
+									"_dd_arr": [
 										{
-											"_kics__default": {
-												"_kics_line": 222
+											"_dd__default": {
+												"_dd_line": 222
 											}
 										}
 									],
-									"_kics_line": 222
+									"_dd_line": 222
 								},
-								"_kics_location": {
-									"_kics_line": 175
+								"_dd_location": {
+									"_dd_line": 175
 								},
-								"_kics_name": {
-									"_kics_line": 174
+								"_dd_name": {
+									"_dd_line": 174
 								},
-								"_kics_properties": {
-									"_kics_line": 176
+								"_dd_properties": {
+									"_dd_line": 176
 								},
-								"_kics_type": {
-									"_kics_line": 172
+								"_dd_type": {
+									"_dd_line": 172
 								}
 							},
 							"apiVersion": "2021-03-01",
@@ -922,45 +922,45 @@ func TestParseBicepFile(t *testing.T) {
 							},
 							"name": "[parameters('vmName')]",
 							"properties": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 176
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 176
 									},
-									"_kics_diagnosticsProfile": {
-										"_kics_line": 213
+									"_dd_diagnosticsProfile": {
+										"_dd_line": 213
 									},
-									"_kics_hardwareProfile": {
-										"_kics_line": 177
+									"_dd_hardwareProfile": {
+										"_dd_line": 177
 									},
-									"_kics_networkProfile": {
-										"_kics_line": 206
+									"_dd_networkProfile": {
+										"_dd_line": 206
 									},
-									"_kics_osProfile": {
-										"_kics_line": 180
+									"_dd_osProfile": {
+										"_dd_line": 180
 									},
-									"_kics_storageProfile": {
-										"_kics_line": 185
+									"_dd_storageProfile": {
+										"_dd_line": 185
 									}
 								},
 								"diagnosticsProfile": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 213
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 213
 										},
-										"_kics_bootDiagnostics": {
-											"_kics_line": 214
+										"_dd_bootDiagnostics": {
+											"_dd_line": 214
 										}
 									},
 									"bootDiagnostics": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 214
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 214
 											},
-											"_kics_enabled": {
-												"_kics_line": 215
+											"_dd_enabled": {
+												"_dd_line": 215
 											},
-											"_kics_storageUri": {
-												"_kics_line": 216
+											"_dd_storageUri": {
+												"_dd_line": 216
 											}
 										},
 										"enabled": true,
@@ -968,40 +968,40 @@ func TestParseBicepFile(t *testing.T) {
 									}
 								},
 								"hardwareProfile": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 177
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 177
 										},
-										"_kics_vmSize": {
-											"_kics_line": 178
+										"_dd_vmSize": {
+											"_dd_line": 178
 										}
 									},
 									"vmSize": "[parameters('vmSize')]"
 								},
 								"networkProfile": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 206
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 206
 										},
-										"_kics_networkInterfaces": {
-											"_kics_arr": [
+										"_dd_networkInterfaces": {
+											"_dd_arr": [
 												{
-													"_kics__default": {
-														"_kics_line": 207
+													"_dd__default": {
+														"_dd_line": 207
 													}
 												}
 											],
-											"_kics_line": 207
+											"_dd_line": 207
 										}
 									},
 									"networkInterfaces": [
 										{
-											"_kics_lines": {
-												"_kics__default": {
-													"_kics_line": 208
+											"_dd_lines": {
+												"_dd__default": {
+													"_dd_line": 208
 												},
-												"_kics_id": {
-													"_kics_line": 209
+												"_dd_id": {
+													"_dd_line": 209
 												}
 											},
 											"id": {
@@ -1014,18 +1014,18 @@ func TestParseBicepFile(t *testing.T) {
 									]
 								},
 								"osProfile": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 180
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 180
 										},
-										"_kics_adminPassword": {
-											"_kics_line": 183
+										"_dd_adminPassword": {
+											"_dd_line": 183
 										},
-										"_kics_adminUsername": {
-											"_kics_line": 182
+										"_dd_adminUsername": {
+											"_dd_line": 182
 										},
-										"_kics_computerName": {
-											"_kics_line": 181
+										"_dd_computerName": {
+											"_dd_line": 181
 										}
 									},
 									"adminPassword": "[parameters('adminPassword')]",
@@ -1033,41 +1033,41 @@ func TestParseBicepFile(t *testing.T) {
 									"computerName": "computer"
 								},
 								"storageProfile": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 185
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 185
 										},
-										"_kics_dataDisks": {
-											"_kics_arr": [
+										"_dd_dataDisks": {
+											"_dd_arr": [
 												{
-													"_kics__default": {
-														"_kics_line": 198
+													"_dd__default": {
+														"_dd_line": 198
 													}
 												}
 											],
-											"_kics_line": 198
+											"_dd_line": 198
 										},
-										"_kics_imageReference": {
-											"_kics_line": 186
+										"_dd_imageReference": {
+											"_dd_line": 186
 										},
-										"_kics_osDisk": {
-											"_kics_line": 192
+										"_dd_osDisk": {
+											"_dd_line": 192
 										}
 									},
 									"dataDisks": [
 										{
-											"_kics_lines": {
-												"_kics__default": {
-													"_kics_line": 199
+											"_dd_lines": {
+												"_dd__default": {
+													"_dd_line": 199
 												},
-												"_kics_createOption": {
-													"_kics_line": 202
+												"_dd_createOption": {
+													"_dd_line": 202
 												},
-												"_kics_diskSizeGB": {
-													"_kics_line": 200
+												"_dd_diskSizeGB": {
+													"_dd_line": 200
 												},
-												"_kics_lun": {
-													"_kics_line": 201
+												"_dd_lun": {
+													"_dd_line": 201
 												}
 											},
 											"createOption": "Empty",
@@ -1076,21 +1076,21 @@ func TestParseBicepFile(t *testing.T) {
 										}
 									],
 									"imageReference": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 186
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 186
 											},
-											"_kics_offer": {
-												"_kics_line": 188
+											"_dd_offer": {
+												"_dd_line": 188
 											},
-											"_kics_publisher": {
-												"_kics_line": 187
+											"_dd_publisher": {
+												"_dd_line": 187
 											},
-											"_kics_sku": {
-												"_kics_line": 189
+											"_dd_sku": {
+												"_dd_line": 189
 											},
-											"_kics_version": {
-												"_kics_line": 190
+											"_dd_version": {
+												"_dd_line": 190
 											}
 										},
 										"offer": "WindowsServer",
@@ -1099,25 +1099,25 @@ func TestParseBicepFile(t *testing.T) {
 										"version": "latest"
 									},
 									"osDisk": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 192
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 192
 											},
-											"_kics_createOption": {
-												"_kics_line": 193
+											"_dd_createOption": {
+												"_dd_line": 193
 											},
-											"_kics_managedDisk": {
-												"_kics_line": 194
+											"_dd_managedDisk": {
+												"_dd_line": 194
 											}
 										},
 										"createOption": "FromImage",
 										"managedDisk": {
-											"_kics_lines": {
-												"_kics__default": {
-													"_kics_line": 194
+											"_dd_lines": {
+												"_dd__default": {
+													"_dd_line": 194
 												},
-												"_kics_storageAccountType": {
-													"_kics_line": 195
+												"_dd_storageAccountType": {
+													"_dd_line": 195
 												}
 											},
 											"storageAccountType": "StandardSSD_LRS"
@@ -1128,34 +1128,34 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "Microsoft.Compute/virtualMachines"
 						},
 						{
-							"_kics_lines": {
-								"_kics__default": {
-									"_kics_line": 228
+							"_dd_lines": {
+								"_dd__default": {
+									"_dd_line": 228
 								},
-								"_kics_apiVersion": {
-									"_kics_line": 228
+								"_dd_apiVersion": {
+									"_dd_line": 228
 								},
-								"_kics_assignableScopes": {
-									"_kics_arr": [
+								"_dd_assignableScopes": {
+									"_dd_arr": [
 										{
-											"_kics__default": {
-												"_kics_line": 238
+											"_dd__default": {
+												"_dd_line": 238
 											}
 										}
 									],
-									"_kics_line": 238
+									"_dd_line": 238
 								},
-								"_kics_location": {
-									"_kics_line": 230
+								"_dd_location": {
+									"_dd_line": 230
 								},
-								"_kics_name": {
-									"_kics_line": 229
+								"_dd_name": {
+									"_dd_line": 229
 								},
-								"_kics_type": {
-									"_kics_line": 228
+								"_dd_type": {
+									"_dd_line": 228
 								},
-								"_kics_userAssignedIdentities": {
-									"_kics_line": 235
+								"_dd_userAssignedIdentities": {
+									"_dd_line": 235
 								}
 							},
 							"apiVersion": "2021-03-01",
@@ -1168,47 +1168,47 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "Microsoft.Network/networkInterfaces",
 							"userAssignedIdentities": {
 								"'${[resourceId(Microsoft.ManagedIdentity/userAssignedIdentities, variables('nicName'))]}'": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 236
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 236
 										}
 									}
 								},
-								"_kics_lines": {
-									"_kics_'${[resourceId(Microsoft.ManagedIdentity/userAssignedIdentities, variables('nicName'))]}'": {
-										"_kics_line": 236
+								"_dd_lines": {
+									"_dd_'${[resourceId(Microsoft.ManagedIdentity/userAssignedIdentities, variables('nicName'))]}'": {
+										"_dd_line": 236
 									},
-									"_kics__default": {
-										"_kics_line": 235
+									"_dd__default": {
+										"_dd_line": 235
 									}
 								}
 							}
 						},
 						{
-							"_kics_lines": {
-								"_kics__default": {
-									"_kics_line": 241
+							"_dd_lines": {
+								"_dd__default": {
+									"_dd_line": 241
 								},
-								"_kics_apiVersion": {
-									"_kics_line": 241
+								"_dd_apiVersion": {
+									"_dd_line": 241
 								},
-								"_kics_kind": {
-									"_kics_line": 248
+								"_dd_kind": {
+									"_dd_line": 248
 								},
-								"_kics_location": {
-									"_kics_line": 243
+								"_dd_location": {
+									"_dd_line": 243
 								},
-								"_kics_name": {
-									"_kics_line": 242
+								"_dd_name": {
+									"_dd_line": 242
 								},
-								"_kics_properties": {
-									"_kics_line": 249
+								"_dd_properties": {
+									"_dd_line": 249
 								},
-								"_kics_sku": {
-									"_kics_line": 244
+								"_dd_sku": {
+									"_dd_line": 244
 								},
-								"_kics_type": {
-									"_kics_line": 241
+								"_dd_type": {
+									"_dd_line": 241
 								}
 							},
 							"apiVersion": "2019-06-01",
@@ -1217,74 +1217,74 @@ func TestParseBicepFile(t *testing.T) {
 							"location": "[parameters('location')]",
 							"name": "[variables('storageAccountName')]",
 							"properties": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 249
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 249
 									},
-									"_kics_accessTier": {
-										"_kics_line": 278
+									"_dd_accessTier": {
+										"_dd_line": 278
 									},
-									"_kics_encryption": {
-										"_kics_line": 265
+									"_dd_encryption": {
+										"_dd_line": 265
 									},
-									"_kics_networkAcls": {
-										"_kics_line": 250
+									"_dd_networkAcls": {
+										"_dd_line": 250
 									},
-									"_kics_supportsHttpsTrafficOnly": {
-										"_kics_line": 264
+									"_dd_supportsHttpsTrafficOnly": {
+										"_dd_line": 264
 									}
 								},
 								"accessTier": "Cool",
 								"encryption": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 265
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 265
 										},
-										"_kics_keySource": {
-											"_kics_line": 276
+										"_dd_keySource": {
+											"_dd_line": 276
 										},
-										"_kics_services": {
-											"_kics_line": 266
+										"_dd_services": {
+											"_dd_line": 266
 										}
 									},
 									"keySource": "Microsoft.Storage",
 									"services": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 266
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 266
 											},
-											"_kics_blob": {
-												"_kics_line": 271
+											"_dd_blob": {
+												"_dd_line": 271
 											},
-											"_kics_file": {
-												"_kics_line": 267
+											"_dd_file": {
+												"_dd_line": 267
 											}
 										},
 										"blob": {
-											"_kics_lines": {
-												"_kics__default": {
-													"_kics_line": 271
+											"_dd_lines": {
+												"_dd__default": {
+													"_dd_line": 271
 												},
-												"_kics_enabled": {
-													"_kics_line": 273
+												"_dd_enabled": {
+													"_dd_line": 273
 												},
-												"_kics_keyType": {
-													"_kics_line": 272
+												"_dd_keyType": {
+													"_dd_line": 272
 												}
 											},
 											"enabled": true,
 											"keyType": "Account"
 										},
 										"file": {
-											"_kics_lines": {
-												"_kics__default": {
-													"_kics_line": 267
+											"_dd_lines": {
+												"_dd__default": {
+													"_dd_line": 267
 												},
-												"_kics_enabled": {
-													"_kics_line": 269
+												"_dd_enabled": {
+													"_dd_line": 269
 												},
-												"_kics_keyType": {
-													"_kics_line": 268
+												"_dd_keyType": {
+													"_dd_line": 268
 												}
 											},
 											"enabled": true,
@@ -1293,55 +1293,55 @@ func TestParseBicepFile(t *testing.T) {
 									}
 								},
 								"networkAcls": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 250
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 250
 										},
-										"_kics_bypass": {
-											"_kics_line": 251
+										"_dd_bypass": {
+											"_dd_line": 251
 										},
-										"_kics_defaultAction": {
-											"_kics_line": 262
+										"_dd_defaultAction": {
+											"_dd_line": 262
 										},
-										"_kics_virtualNetworkRules": {
-											"_kics_arr": [
+										"_dd_virtualNetworkRules": {
+											"_dd_arr": [
 												{
-													"_kics__default": {
-														"_kics_line": 252
+													"_dd__default": {
+														"_dd_line": 252
 													}
 												}
 											],
-											"_kics_line": 252
+											"_dd_line": 252
 										}
 									},
 									"bypass": "None",
 									"defaultAction": "Deny",
 									"virtualNetworkRules": [
 										{
-											"_kics_lines": {
-												"_kics__default": {
-													"_kics_line": 253
+											"_dd_lines": {
+												"_dd__default": {
+													"_dd_line": 253
 												},
-												"_kics_action": {
-													"_kics_line": 255
+												"_dd_action": {
+													"_dd_line": 255
 												},
-												"_kics_id": {
-													"_kics_line": 254
+												"_dd_id": {
+													"_dd_line": 254
 												}
 											},
 											"action": "Allow",
 											"id": "[variables('containerSubnetRef')]"
 										},
 										{
-											"_kics_lines": {
-												"_kics__default": {
-													"_kics_line": 257
+											"_dd_lines": {
+												"_dd__default": {
+													"_dd_line": 257
 												},
-												"_kics_action": {
-													"_kics_line": 259
+												"_dd_action": {
+													"_dd_line": 259
 												},
-												"_kics_id": {
-													"_kics_line": 258
+												"_dd_id": {
+													"_dd_line": 258
 												}
 											},
 											"action": "Allow",
@@ -1353,27 +1353,27 @@ func TestParseBicepFile(t *testing.T) {
 							},
 							"resources": [
 								{
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 282
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 282
 										},
-										"_kics_apiVersion": {
-											"_kics_line": 282
+										"_dd_apiVersion": {
+											"_dd_line": 282
 										},
-										"_kics_name": {
-											"_kics_line": 284
+										"_dd_name": {
+											"_dd_line": 284
 										},
-										"_kics_parent": {
-											"_kics_line": 283
+										"_dd_parent": {
+											"_dd_line": 283
 										},
-										"_kics_properties": {
-											"_kics_line": 289
+										"_dd_properties": {
+											"_dd_line": 289
 										},
-										"_kics_sku": {
-											"_kics_line": 285
+										"_dd_sku": {
+											"_dd_line": 285
 										},
-										"_kics_type": {
-											"_kics_line": 282
+										"_dd_type": {
+											"_dd_line": 282
 										}
 									},
 									"apiVersion": "2019-06-01",
@@ -1381,21 +1381,21 @@ func TestParseBicepFile(t *testing.T) {
 									"name": "default",
 									"parent": "storageAccount",
 									"properties": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 289
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 289
 											},
-											"_kics_deleteRetentionPolicy": {
-												"_kics_line": 290
+											"_dd_deleteRetentionPolicy": {
+												"_dd_line": 290
 											}
 										},
 										"deleteRetentionPolicy": {
-											"_kics_lines": {
-												"_kics__default": {
-													"_kics_line": 290
+											"_dd_lines": {
+												"_dd__default": {
+													"_dd_line": 290
 												},
-												"_kics_enabled": {
-													"_kics_line": 291
+												"_dd_enabled": {
+													"_dd_line": 291
 												}
 											},
 											"enabled": false
@@ -1403,24 +1403,24 @@ func TestParseBicepFile(t *testing.T) {
 									},
 									"resources": [
 										{
-											"_kics_lines": {
-												"_kics__default": {
-													"_kics_line": 296
+											"_dd_lines": {
+												"_dd__default": {
+													"_dd_line": 296
 												},
-												"_kics_apiVersion": {
-													"_kics_line": 296
+												"_dd_apiVersion": {
+													"_dd_line": 296
 												},
-												"_kics_name": {
-													"_kics_line": 298
+												"_dd_name": {
+													"_dd_line": 298
 												},
-												"_kics_parent": {
-													"_kics_line": 297
+												"_dd_parent": {
+													"_dd_line": 297
 												},
-												"_kics_properties": {
-													"_kics_line": 299
+												"_dd_properties": {
+													"_dd_line": 299
 												},
-												"_kics_type": {
-													"_kics_line": 296
+												"_dd_type": {
+													"_dd_line": 296
 												}
 											},
 											"apiVersion": "2019-06-01",
@@ -1428,25 +1428,25 @@ func TestParseBicepFile(t *testing.T) {
 											"name": "container",
 											"parent": "storageAccountName_default",
 											"properties": {
-												"_kics_lines": {
-													"_kics__default": {
-														"_kics_line": 299
+												"_dd_lines": {
+													"_dd__default": {
+														"_dd_line": 299
 													},
-													"_kics_denyEncryptionScopeOverride": {
-														"_kics_line": 300
+													"_dd_denyEncryptionScopeOverride": {
+														"_dd_line": 300
 													},
-													"_kics_metadata": {
-														"_kics_line": 302
+													"_dd_metadata": {
+														"_dd_line": 302
 													},
-													"_kics_publicAccess": {
-														"_kics_line": 301
+													"_dd_publicAccess": {
+														"_dd_line": 301
 													}
 												},
 												"denyEncryptionScopeOverride": true,
 												"metadata": {
-													"_kics_lines": {
-														"_kics__default": {
-															"_kics_line": 302
+													"_dd_lines": {
+														"_dd__default": {
+															"_dd_line": 302
 														}
 													}
 												},
@@ -1456,15 +1456,15 @@ func TestParseBicepFile(t *testing.T) {
 										}
 									],
 									"sku": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 285
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 285
 											},
-											"_kics_name": {
-												"_kics_line": 286
+											"_dd_name": {
+												"_dd_line": 286
 											},
-											"_kics_tier": {
-												"_kics_line": 287
+											"_dd_tier": {
+												"_dd_line": 287
 											}
 										},
 										"name": "Standard_LRS",
@@ -1474,15 +1474,15 @@ func TestParseBicepFile(t *testing.T) {
 								}
 							],
 							"sku": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 244
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 244
 									},
-									"_kics_name": {
-										"_kics_line": 245
+									"_dd_name": {
+										"_dd_line": 245
 									},
-									"_kics_tier": {
-										"_kics_line": 246
+									"_dd_tier": {
+										"_dd_line": 246
 									}
 								},
 								"name": "Standard_LRS",
@@ -1491,30 +1491,30 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "Microsoft.Storage/storageAccounts"
 						},
 						{
-							"_kics_lines": {
-								"_kics__default": {
-									"_kics_line": 306
+							"_dd_lines": {
+								"_dd__default": {
+									"_dd_line": 306
 								},
-								"_kics_apiVersion": {
-									"_kics_line": 306
+								"_dd_apiVersion": {
+									"_dd_line": 306
 								},
-								"_kics_location": {
-									"_kics_line": 308
+								"_dd_location": {
+									"_dd_line": 308
 								},
-								"_kics_name": {
-									"_kics_line": 307
+								"_dd_name": {
+									"_dd_line": 307
 								},
-								"_kics_properties": {
-									"_kics_line": 311
+								"_dd_properties": {
+									"_dd_line": 311
 								},
-								"_kics_tags": {
-									"_kics_line": 309
+								"_dd_tags": {
+									"_dd_line": 309
 								},
-								"_kics_type": {
-									"_kics_line": 306
+								"_dd_type": {
+									"_dd_line": 306
 								},
-								"_kics_zones": {
-									"_kics_line": 327
+								"_dd_zones": {
+									"_dd_line": 327
 								}
 							},
 							"apiVersion": "2021-06-01",
@@ -1522,39 +1522,39 @@ func TestParseBicepFile(t *testing.T) {
 							"location": "[parameters('location')]",
 							"name": "[parameters('name')]",
 							"properties": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 311
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 311
 									},
-									"_kics_enableNonSslPort": {
-										"_kics_line": 312
+									"_dd_enableNonSslPort": {
+										"_dd_line": 312
 									},
-									"_kics_minimumTlsVersion": {
-										"_kics_line": 313
+									"_dd_minimumTlsVersion": {
+										"_dd_line": 313
 									},
-									"_kics_publicNetworkAccess": {
-										"_kics_line": 314
+									"_dd_publicNetworkAccess": {
+										"_dd_line": 314
 									},
-									"_kics_redisConfiguration": {
-										"_kics_line": 315
+									"_dd_redisConfiguration": {
+										"_dd_line": 315
 									},
-									"_kics_redisVersion": {
-										"_kics_line": 316
+									"_dd_redisVersion": {
+										"_dd_line": 316
 									},
-									"_kics_replicasPerMaster": {
-										"_kics_line": 317
+									"_dd_replicasPerMaster": {
+										"_dd_line": 317
 									},
-									"_kics_replicasPerPrimary": {
-										"_kics_line": 318
+									"_dd_replicasPerPrimary": {
+										"_dd_line": 318
 									},
-									"_kics_shardCount": {
-										"_kics_line": 319
+									"_dd_shardCount": {
+										"_dd_line": 319
 									},
-									"_kics_sku": {
-										"_kics_line": 320
+									"_dd_sku": {
+										"_dd_line": 320
 									},
-									"_kics_subnetId": {
-										"_kics_line": 325
+									"_dd_subnetId": {
+										"_dd_line": 325
 									}
 								},
 								"enableNonSslPort": "[parameters('enableNonSslPort')]",
@@ -1566,18 +1566,18 @@ func TestParseBicepFile(t *testing.T) {
 								"replicasPerPrimary": null,
 								"shardCount": null,
 								"sku": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 320
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 320
 										},
-										"_kics_capacity": {
-											"_kics_line": 321
+										"_dd_capacity": {
+											"_dd_line": 321
 										},
-										"_kics_family": {
-											"_kics_line": 322
+										"_dd_family": {
+											"_dd_line": 322
 										},
-										"_kics_name": {
-											"_kics_line": 323
+										"_dd_name": {
+											"_dd_line": 323
 										}
 									},
 									"capacity": "[parameters('capacity')]",
@@ -1596,18 +1596,18 @@ func TestParseBicepFile(t *testing.T) {
 							"type": "Microsoft.Insights/diagnosticSettings"
 						},
 						{
-							"_kics_lines": {
-								"_kics__default": {
-									"_kics_line": 351
+							"_dd_lines": {
+								"_dd__default": {
+									"_dd_line": 351
 								},
-								"_kics_apiVersion": {
-									"_kics_line": 351
+								"_dd_apiVersion": {
+									"_dd_line": 351
 								},
-								"_kics_name": {
-									"_kics_line": 352
+								"_dd_name": {
+									"_dd_line": 352
 								},
-								"_kics_type": {
-									"_kics_line": 351
+								"_dd_type": {
+									"_dd_line": 351
 								}
 							},
 							"apiVersion": "2022-11-01",
@@ -1615,24 +1615,24 @@ func TestParseBicepFile(t *testing.T) {
 							"name": "[parameters('keyvaultName')]",
 							"resources": [
 								{
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 330
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 330
 										},
-										"_kics_apiVersion": {
-											"_kics_line": 330
+										"_dd_apiVersion": {
+											"_dd_line": 330
 										},
-										"_kics_name": {
-											"_kics_line": 331
+										"_dd_name": {
+											"_dd_line": 331
 										},
-										"_kics_parent": {
-											"_kics_line": 332
+										"_dd_parent": {
+											"_dd_line": 332
 										},
-										"_kics_properties": {
-											"_kics_line": 333
+										"_dd_properties": {
+											"_dd_line": 333
 										},
-										"_kics_type": {
-											"_kics_line": 330
+										"_dd_type": {
+											"_dd_line": 330
 										}
 									},
 									"apiVersion": "2018-02-14",
@@ -1640,12 +1640,12 @@ func TestParseBicepFile(t *testing.T) {
 									"name": "redisConStrSecret",
 									"parent": "keyVault",
 									"properties": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 333
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 333
 											},
-											"_kics_value": {
-												"_kics_line": 334
+											"_dd_value": {
+												"_dd_line": 334
 											}
 										},
 										"value": "['${redisCache.properties.hostName},password=${redisCache.listKeys().primaryKey},ssl=True,abortConnect=False']"

--- a/pkg/parser/buildah/parser.go
+++ b/pkg/parser/buildah/parser.go
@@ -33,7 +33,8 @@ type Command struct {
 	Cmd       string
 	Original  string
 	Value     string
-	StartLine int `json:"_kics_line"`
+	StartLine int `json:"_dd_line"`
+	KicsLine  int `json:"_kics_line"` // legacy field kept for backward compat; drop once all rules use _dd_line
 	EndLine   int
 }
 
@@ -146,6 +147,7 @@ func (i *Info) getStmtInfo(ctx context.Context, stmt *syntax.Stmt, args []*synta
 				Cmd:       cmd,
 				Original:  fullCmd,
 				StartLine: start,
+				KicsLine:  start,
 				EndLine:   end,
 				Value:     strings.TrimSpace(value),
 			}

--- a/pkg/parser/buildah/parser_test.go
+++ b/pkg/parser/buildah/parser_test.go
@@ -47,14 +47,16 @@ func TestParser_Parse(t *testing.T) {
 								"EndLine": 2,
 								"Original": "buildah from fedora",
 								"Value": "fedora",
-								"_kics_line": 2
+								"_dd_line": 2,
+						"_kics_line": 2
 							},
 							{
 								"Cmd": "buildah config",
 								"EndLine": 3,
 								"Original": "buildah config --env GOPATH=/root/buildah $ctr",
 								"Value": "--env GOPATH=/root/buildah $ctr",
-								"_kics_line": 3
+								"_dd_line": 3,
+						"_kics_line": 3
 							}
 						]
 					}
@@ -83,14 +85,16 @@ func TestParser_Parse(t *testing.T) {
 								"EndLine": 2,
 								"Original": "buildah from fedora",
 								"Value": "fedora",
-								"_kics_line": 2
+								"_dd_line": 2,
+						"_kics_line": 2
 							},
 							{
 								"Cmd": "buildah commit",
 								"EndLine": 4,
 								"Original": "buildah commit $ctr buildahupstream",
 								"Value": "$ctr buildahupstream",
-								"_kics_line": 4
+								"_dd_line": 4,
+						"_kics_line": 4
 							}
 						]
 					}
@@ -121,21 +125,24 @@ func TestParser_Parse(t *testing.T) {
 								"EndLine": 2,
 								"Original": "buildah from fedora",
 								"Value": "fedora",
-								"_kics_line": 2
+								"_dd_line": 2,
+						"_kics_line": 2
 							},
 							{
 								"Cmd": "buildah config",
 								"EndLine": 4,
 								"Original": "buildah config --env GOPATH=/root/buildah $ctr",
 								"Value": "--env GOPATH=/root/buildah $ctr",
-								"_kics_line": 4
+								"_dd_line": 4,
+						"_kics_line": 4
 							},
 							{
 								"Cmd": "buildah commit",
 								"EndLine": 5,
 								"Original": "buildah commit $ctr buildahupstream",
 								"Value": "$ctr buildahupstream",
-								"_kics_line": 5
+								"_dd_line": 5,
+						"_kics_line": 5
 							}
 						]
 					}
@@ -166,14 +173,16 @@ func TestParser_Parse(t *testing.T) {
 								"EndLine": 3,
 								"Original": "buildah from fedora",
 								"Value": "fedora",
-								"_kics_line": 3
+								"_dd_line": 3,
+						"_kics_line": 3
 							},
 							{
 								"Cmd": "buildah run",
 								"EndLine": 4,
 								"Original": "buildah run ${ctr} git clone https://github.com/DataDog/datadog-iac-scanner.git",
 								"Value": "${ctr} git clone https://github.com/DataDog/datadog-iac-scanner.git",
-								"_kics_line": 4
+								"_dd_line": 4,
+						"_kics_line": 4
 							}
 						],
 						"fedora2": [
@@ -182,14 +191,16 @@ func TestParser_Parse(t *testing.T) {
 								"EndLine": 5,
 								"Original": "buildah from fedora2",
 								"Value": "fedora2",
-								"_kics_line": 5
+								"_dd_line": 5,
+						"_kics_line": 5
 							},
 							{
 								"Cmd": "buildah run",
 								"EndLine": 6,
 								"Original": "buildah run ${ctr2} git clone https://github.com/DataDog/datadog-iac-scanner.git",
 								"Value": "${ctr2} git clone https://github.com/DataDog/datadog-iac-scanner.git",
-								"_kics_line": 6
+								"_dd_line": 6,
+						"_kics_line": 6
 							}
 						]
 					}
@@ -218,14 +229,16 @@ func TestParser_Parse(t *testing.T) {
 								"EndLine": 2,
 								"Original": "buildah from fedora",
 								"Value": "fedora",
-								"_kics_line": 2
+								"_dd_line": 2,
+						"_kics_line": 2
 							},
 							{
 								"Cmd": "buildah run",
 								"EndLine": 5,
 								"Original": "buildah run $ctr /bin/sh -c 'git clone https://github.com/DataDog/datadog-iac-scanner.git; make'",
 								"Value": "$ctr /bin/sh -c 'git clone https://github.com/DataDog/datadog-iac-scanner.git; make'",
-								"_kics_line": 4
+								"_dd_line": 4,
+						"_kics_line": 4
 							}
 						]
 					}

--- a/pkg/parser/docker/parser.go
+++ b/pkg/parser/docker/parser.go
@@ -29,7 +29,8 @@ type Command struct {
 	Flags     []string
 	Value     []string
 	Original  string
-	StartLine int `json:"_kics_line"`
+	StartLine int `json:"_dd_line"`
+	KicsLine  int `json:"_kics_line"` // legacy field kept for backward compat; drop once all rules use _dd_line
 	EndLine   int
 	JSON      bool
 }
@@ -74,6 +75,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 			Original:  strings.TrimSpace(child.Original),
 			Flags:     child.Flags,
 			StartLine: child.StartLine,
+			KicsLine:  child.StartLine,
 			EndLine:   child.EndLine,
 		}
 

--- a/pkg/parser/grpc/converter/converter.go
+++ b/pkg/parser/grpc/converter/converter.go
@@ -23,7 +23,7 @@ type JSONProto struct {
 	Services         map[string]interface{}      `json:"services"`
 	Imports          map[string]interface{}      `json:"imports"`
 	Options          []Option                    `json:"options"`
-	Lines            map[string]model.LineObject `json:"_kics_lines"`
+	Lines            map[string]model.LineObject `json:"_dd_lines"`
 	linesToIgnore    []int                       `json:"-"`
 	linesNotToIgnore []int                       `json:"-"`
 }
@@ -32,7 +32,7 @@ type JSONProto struct {
 type Service struct {
 	RPC     map[string]RPC              `json:"rpc,omitempty"`
 	Options map[string]Option           `json:"options,omitempty"`
-	Lines   map[string]model.LineObject `json:"_kics_lines,omitempty"`
+	Lines   map[string]model.LineObject `json:"_dd_lines,omitempty"`
 }
 
 // Message is a JSON representation of a proto message
@@ -44,21 +44,21 @@ type Message struct {
 	Map          map[string]*Map             `json:"map,omitempty"`
 	InnerMessage map[string]Message          `json:"inner_message,omitempty"`
 	Options      map[string]Option           `json:"options,omitempty"`
-	Lines        map[string]model.LineObject `json:"_kics_lines,omitempty"`
+	Lines        map[string]model.LineObject `json:"_dd_lines,omitempty"`
 }
 
 // Map is a JSON representation of a proto map
 type Map struct {
 	*Field  `json:"field,omitempty"`
 	KeyType string                      `json:"key_type,omitempty"`
-	Lines   map[string]model.LineObject `json:"_kics_lines,omitempty"`
+	Lines   map[string]model.LineObject `json:"_dd_lines,omitempty"`
 }
 
 // OneOf is a JSON representation of a proto oneof
 type OneOf struct {
 	Field   map[string]*Field           `json:"fields,omitempty"`
 	Options map[string]Option           `json:"options,omitempty"`
-	Lines   map[string]model.LineObject `json:"_kics_lines,omitempty"`
+	Lines   map[string]model.LineObject `json:"_dd_lines,omitempty"`
 }
 
 // Enum is a JSON representation of a proto enum
@@ -66,27 +66,27 @@ type Enum struct {
 	Reserved  []*Reserved                 `json:"reserved,omitempty"`
 	EnumField map[string]EnumValue        `json:"field,omitempty"`
 	Options   map[string]Option           `json:"options,omitempty"`
-	Lines     map[string]model.LineObject `json:"_kics_lines,omitempty"`
+	Lines     map[string]model.LineObject `json:"_dd_lines,omitempty"`
 }
 
 // EnumValue is a JSON representation of a proto enum value
 type EnumValue struct {
 	Value   int                         `json:"value,omitempty"`
 	Options Option                      `json:"options,omitempty"`
-	Lines   map[string]model.LineObject `json:"_kics_lines,omitempty"`
+	Lines   map[string]model.LineObject `json:"_dd_lines,omitempty"`
 }
 
 // Import is a JSON representation of a proto import
 type Import struct {
 	Kind  string                      `json:"kind,omitempty"`
-	Lines map[string]model.LineObject `json:"_kics_lines,omitempty"`
+	Lines map[string]model.LineObject `json:"_dd_lines,omitempty"`
 }
 
 // Reserved is a JSON representation of a proto reserved
 type Reserved struct {
 	Ranges     []proto.Range               `json:"ranges,omitempty"`
 	FieldNames []string                    `json:"fieldNames,omitempty"`
-	Lines      map[string]model.LineObject `json:"_kics_lines,omitempty"`
+	Lines      map[string]model.LineObject `json:"_dd_lines,omitempty"`
 }
 
 // Field is a JSON representation of a proto field
@@ -97,7 +97,7 @@ type Field struct {
 	Required bool                        `json:"required,omitempty"`
 	Optional bool                        `json:"optional,omitempty"`
 	Options  []Option                    `json:"options,omitempty"`
-	Lines    map[string]model.LineObject `json:"_kics_lines,omitempty"`
+	Lines    map[string]model.LineObject `json:"_dd_lines,omitempty"`
 }
 
 // RPC is a JSON representation of a proto service RPC
@@ -107,7 +107,7 @@ type RPC struct {
 	ReturnsType    string                      `json:"returnsType,omitempty"`
 	StreamsReturns bool                        `json:"streamsReturns,omitempty"`
 	Options        []Option                    `json:"options,omitempty"`
-	Lines          map[string]model.LineObject `json:"_kics_lines,omitempty"`
+	Lines          map[string]model.LineObject `json:"_dd_lines,omitempty"`
 }
 
 // Option is a JSON representation of a proto option
@@ -116,7 +116,7 @@ type Option struct {
 	Constant            OptionLiteral               `json:"constant,omitempty"`
 	IsEmbedded          bool                        `json:"isEmbedded,omitempty"`
 	AggregatedConstants []*OptionLiteral            `json:"aggregatedConstants,omitempty"`
-	Lines               map[string]model.LineObject `json:"_kics_lines,omitempty"`
+	Lines               map[string]model.LineObject `json:"_dd_lines,omitempty"`
 }
 
 // OptionLiteral is a JSON representation of a proto option literal
@@ -128,7 +128,7 @@ type OptionLiteral struct {
 	Array      []OptionLiteral             `json:"array,omitempty"`
 	Map        map[string]OptionLiteral    `json:"map,omitempty"`
 	OrderedMap []OptionLiteral             `json:"orderedMap,omitempty"`
-	Lines      map[string]model.LineObject `json:"_kics_lines,omitempty"`
+	Lines      map[string]model.LineObject `json:"_dd_lines,omitempty"`
 }
 
 // newJSONProto creates a new JSONProto struct with default values for all fields
@@ -145,8 +145,6 @@ func newJSONProto() *JSONProto {
 		linesToIgnore: make([]int, 0),
 	}
 }
-
-const kicsLinesKey = "_kics_"
 
 // Convert converts a proto file to a JSONProto struct
 func Convert(ctx context.Context, nodes *proto.Proto) (file *JSONProto, linesIgnore []int) {
@@ -170,21 +168,21 @@ func Convert(ctx context.Context, nodes *proto.Proto) (file *JSONProto, linesIgn
 		case *proto.Message:
 			jproto.processCommentProto(element.Comment, element.Position.Line, element)
 			jproto.Messages[element.Name] = jproto.convertMessage(element)
-			messageLines[kicsLinesKey+element.Name] = model.LineObject{
+			messageLines["_dd_"+element.Name] = model.LineObject{
 				Line: element.Position.Line,
 				Arr:  make([]map[string]*model.LineObject, 0),
 			}
 		case *proto.Service:
 			jproto.processCommentProto(element.Comment, element.Position.Line, element)
 			jproto.convertService(element)
-			serviceLines[kicsLinesKey+element.Name] = model.LineObject{
+			serviceLines["_dd_"+element.Name] = model.LineObject{
 				Line: element.Position.Line,
 				Arr:  make([]map[string]*model.LineObject, 0),
 			}
 		case *proto.Package:
 			jproto.processCommentProto(element.Comment, element.Position.Line, element)
 			jproto.PackageName = element.Name
-			jproto.Lines["_kics_package"] = model.LineObject{
+			jproto.Lines["_dd_package"] = model.LineObject{
 				Line: element.Position.Line,
 			}
 		case *proto.Import:
@@ -192,7 +190,7 @@ func Convert(ctx context.Context, nodes *proto.Proto) (file *JSONProto, linesIgn
 			jproto.Imports[element.Filename] = Import{
 				Kind: element.Kind,
 			}
-			importLines[kicsLinesKey+element.Filename] = model.LineObject{
+			importLines["_dd_"+element.Filename] = model.LineObject{
 				Line: element.Position.Line,
 				Arr:  make([]map[string]*model.LineObject, 0),
 			}
@@ -207,26 +205,26 @@ func Convert(ctx context.Context, nodes *proto.Proto) (file *JSONProto, linesIgn
 		case *proto.Enum:
 			jproto.processCommentProto(element.Comment, element.Position.Line, element)
 			jproto.Enum[element.Name] = jproto.convertEnum(element)
-			enumLines[kicsLinesKey+element.Name] = model.LineObject{
+			enumLines["_dd_"+element.Name] = model.LineObject{
 				Line: element.Position.Line,
 				Arr:  make([]map[string]*model.LineObject, 0),
 			}
 		case *proto.Syntax:
 			jproto.processCommentProto(element.Comment, element.Position.Line, element)
 			jproto.Syntax = element.Value
-			jproto.Lines["_kics_syntax"] = model.LineObject{
+			jproto.Lines["_dd_syntax"] = model.LineObject{
 				Line: element.Position.Line,
 			}
 		}
 	}
 
 	// set line information
-	jproto.Messages["_kics_lines"] = messageLines
-	jproto.Enum["_kics_lines"] = enumLines
-	jproto.Services["_kics_lines"] = serviceLines
-	jproto.Imports["_kics_lines"] = importLines
+	jproto.Messages["_dd_lines"] = messageLines
+	jproto.Enum["_dd_lines"] = enumLines
+	jproto.Services["_dd_lines"] = serviceLines
+	jproto.Imports["_dd_lines"] = importLines
 
-	jproto.Lines["kics__default"] = model.LineObject{
+	jproto.Lines["_dd__default"] = model.LineObject{
 		Line: 0,
 		Arr:  defaultArr,
 	}
@@ -253,7 +251,7 @@ func (j *JSONProto) convertMessage(n *proto.Message) Message {
 		switch field := field.(type) {
 		case *proto.NormalField:
 			j.processCommentProto(field.Comment, field.Position.Line, field)
-			message.Lines[kicsLinesKey+field.Name] = model.LineObject{
+			message.Lines["_dd_"+field.Name] = model.LineObject{
 				Line: field.Position.Line,
 			}
 			message.Field[field.Name] = &Field{
@@ -263,7 +261,7 @@ func (j *JSONProto) convertMessage(n *proto.Message) Message {
 				Required: field.Required,
 				Options:  j.convertOption(field.Options),
 				Lines: map[string]model.LineObject{
-					"_kics__default": {Line: field.Position.Line},
+					"_dd__default": {Line: field.Position.Line},
 				},
 			}
 		case *proto.Reserved:
@@ -277,13 +275,13 @@ func (j *JSONProto) convertMessage(n *proto.Message) Message {
 		case *proto.Oneof:
 			j.processCommentProto(field.Comment, field.Position.Line, field)
 			message.OneOf[field.Name] = j.convertOneOf(field)
-			message.Lines[kicsLinesKey+field.Name] = model.LineObject{
+			message.Lines["_dd_"+field.Name] = model.LineObject{
 				Line: field.Position.Line,
 			}
 		case *proto.Enum:
 			j.processCommentProto(field.Comment, field.Position.Line, field)
 			message.Enum[field.Name] = j.convertEnum(field)
-			message.Lines[kicsLinesKey+field.Name] = model.LineObject{
+			message.Lines["_dd_"+field.Name] = model.LineObject{
 				Line: field.Position.Line,
 			}
 		case *proto.MapField:
@@ -293,31 +291,31 @@ func (j *JSONProto) convertMessage(n *proto.Message) Message {
 					Type:     field.Type,
 					Sequence: field.Sequence,
 					Lines: map[string]model.LineObject{
-						"_kics__default": {Line: field.Position.Line},
+						"_dd__default": {Line: field.Position.Line},
 					},
 				},
 				KeyType: field.KeyType,
 			}
-			message.Lines[kicsLinesKey+field.Name] = model.LineObject{
+			message.Lines["_dd_"+field.Name] = model.LineObject{
 				Line: field.Position.Line,
 			}
 		case *proto.Message:
 			j.processCommentProto(field.Comment, field.Position.Line, field)
 			message.InnerMessage[field.Name] = j.convertMessage(field)
-			message.Lines[kicsLinesKey+field.Name] = model.LineObject{
+			message.Lines["_dd_"+field.Name] = model.LineObject{
 				Line: field.Position.Line,
 			}
 		case *proto.Option:
 			j.processCommentProto(field.Comment, field.Position.Line, field)
 			message.Options[field.Name] = j.convertSingleOption(field)
-			message.Lines[kicsLinesKey+field.Name] = model.LineObject{
+			message.Lines["_dd_"+field.Name] = model.LineObject{
 				Line: field.Position.Line,
 			}
 		}
 		continue
 	}
 
-	message.Lines["_kics__default"] = model.LineObject{
+	message.Lines["_dd__default"] = model.LineObject{
 		Line: n.Position.Line,
 		Arr:  defaultArr,
 	}
@@ -344,10 +342,10 @@ func (j *JSONProto) convertEnum(n *proto.Enum) Enum {
 				Value:   elem.Integer,
 				Options: j.convertSingleOption(elem.ValueOption),
 				Lines: map[string]model.LineObject{
-					"_kics__default": {Line: elem.Position.Line},
+					"_dd__default": {Line: elem.Position.Line},
 				},
 			}
-			enum.Lines[kicsLinesKey+elem.Name] = model.LineObject{
+			enum.Lines["_dd_"+elem.Name] = model.LineObject{
 				Line: elem.Position.Line,
 			}
 		case *proto.Reserved:
@@ -361,14 +359,14 @@ func (j *JSONProto) convertEnum(n *proto.Enum) Enum {
 		case *proto.Option:
 			j.processCommentProto(elem.Comment, elem.Position.Line, elem)
 			enum.Options[elem.Name] = j.convertSingleOption(elem)
-			enum.Lines[kicsLinesKey+elem.Name] = model.LineObject{
+			enum.Lines["_dd_"+elem.Name] = model.LineObject{
 				Line: elem.Position.Line,
 			}
 		}
 		continue
 	}
 
-	enum.Lines["_kics__default"] = model.LineObject{
+	enum.Lines["_dd__default"] = model.LineObject{
 		Line: n.Position.Line,
 		Arr:  defaultArr,
 	}
@@ -383,7 +381,7 @@ func (j *JSONProto) convertOneOf(n *proto.Oneof) OneOf {
 		Options: make(map[string]Option),
 		Lines:   make(map[string]model.LineObject),
 	}
-	oneof.Lines["_kics__default"] = model.LineObject{
+	oneof.Lines["_dd__default"] = model.LineObject{
 		Line: n.Position.Line,
 		Arr:  make([]map[string]*model.LineObject, 0),
 	}
@@ -396,16 +394,16 @@ func (j *JSONProto) convertOneOf(n *proto.Oneof) OneOf {
 				Sequence: elem.Sequence,
 				Options:  j.convertOption(elem.Options),
 				Lines: map[string]model.LineObject{
-					"_kics__default": {Line: elem.Position.Line},
+					"_dd__default": {Line: elem.Position.Line},
 				},
 			}
-			oneof.Lines[kicsLinesKey+elem.Name] = model.LineObject{
+			oneof.Lines["_dd_"+elem.Name] = model.LineObject{
 				Line: elem.Position.Line,
 			}
 		case *proto.Option:
 			j.processCommentProto(elem.Comment, elem.Position.Line, elem)
 			oneof.Options[elem.Name] = j.convertSingleOption(elem)
-			oneof.Lines[kicsLinesKey+elem.Name] = model.LineObject{
+			oneof.Lines["_dd_"+elem.Name] = model.LineObject{
 				Line: elem.Position.Line,
 			}
 		}
@@ -420,7 +418,7 @@ func (j *JSONProto) convertReserved(n *proto.Reserved) *Reserved {
 		Ranges:     n.Ranges,
 		FieldNames: n.FieldNames,
 		Lines: map[string]model.LineObject{
-			"_kics__default": {Line: n.Position.Line},
+			"_dd__default": {Line: n.Position.Line},
 		},
 	}
 }
@@ -433,7 +431,7 @@ func (j *JSONProto) convertService(n *proto.Service) {
 		Lines:   make(map[string]model.LineObject),
 	}
 
-	service.Lines["_kics__default"] = model.LineObject{
+	service.Lines["_dd__default"] = model.LineObject{
 		Line: n.Position.Line,
 		Arr:  make([]map[string]*model.LineObject, 0),
 	}
@@ -443,13 +441,13 @@ func (j *JSONProto) convertService(n *proto.Service) {
 		case *proto.RPC:
 			j.processCommentProto(rpc.Comment, rpc.Position.Line, rpc)
 			service.RPC[rpc.Name] = j.convertRPC(rpc)
-			service.Lines[kicsLinesKey+rpc.Name] = model.LineObject{
+			service.Lines["_dd_"+rpc.Name] = model.LineObject{
 				Line: rpc.Position.Line,
 			}
 		case *proto.Option:
 			j.processCommentProto(rpc.Comment, rpc.Position.Line, rpc)
 			service.Options[rpc.Name] = j.convertSingleOption(rpc)
-			service.Lines[kicsLinesKey+rpc.Name] = model.LineObject{
+			service.Lines["_dd_"+rpc.Name] = model.LineObject{
 				Line: rpc.Position.Line,
 			}
 		}
@@ -472,7 +470,7 @@ func (j *JSONProto) convertOption(n []*proto.Option) []Option {
 			Constant:   j.convertOptionLiteral(&option.Constant),
 			IsEmbedded: option.IsEmbedded,
 			Lines: map[string]model.LineObject{
-				"_kics__default": {Line: option.Position.Line},
+				"_dd__default": {Line: option.Position.Line},
 			},
 		})
 	}
@@ -488,7 +486,7 @@ func (j *JSONProto) convertRPC(n *proto.RPC) RPC {
 		StreamsReturns: n.StreamsReturns,
 		Options:        j.convertOption(n.Options),
 		Lines: map[string]model.LineObject{
-			"_kics__default": {Line: n.Position.Line},
+			"_dd__default": {Line: n.Position.Line},
 		},
 	}
 }
@@ -504,7 +502,7 @@ func (j *JSONProto) convertOptionLiteral(n *proto.Literal) OptionLiteral {
 		Map:        j.getMapLiteral(n.Map),
 		OrderedMap: j.getLiteralMap(n.OrderedMap),
 		Lines: map[string]model.LineObject{
-			"_kics__default": {Line: n.Position.Line},
+			"_dd__default": {Line: n.Position.Line},
 		},
 	}
 }
@@ -520,7 +518,7 @@ func (j *JSONProto) convertOptionNamedLiteral(n *proto.NamedLiteral) OptionLiter
 		Map:        j.getMapLiteral(n.Map),
 		OrderedMap: j.getLiteralMap(n.OrderedMap),
 		Lines: map[string]model.LineObject{
-			"_kics__default": {Line: n.Position.Line},
+			"_dd__default": {Line: n.Position.Line},
 		},
 	}
 }
@@ -535,7 +533,7 @@ func (j *JSONProto) convertSingleOption(n *proto.Option) Option {
 		Constant:   j.convertOptionLiteral(&n.Constant),
 		IsEmbedded: n.IsEmbedded,
 		Lines: map[string]model.LineObject{
-			"_kics__default": {Line: n.Position.Line},
+			"_dd__default": {Line: n.Position.Line},
 		},
 	}
 }

--- a/pkg/parser/grpc/converter/converter_test.go
+++ b/pkg/parser/grpc/converter/converter_test.go
@@ -63,24 +63,24 @@ func TestConvert(t *testing.T) {
 				"syntax": "proto3",
 				"package": "",
 				"messages": {
-					"_kics_lines": {}
+					"_dd_lines": {}
 				},
 				"enum": {
-					"_kics_lines": {}
+					"_dd_lines": {}
 				},
 				"services": {
-					"_kics_lines": {}
+					"_dd_lines": {}
 				},
 				"imports": {
-					"_kics_lines": {}
+					"_dd_lines": {}
 				},
 				"options": [],
-				"_kics_lines": {
-					"kics__default": {
-						"_kics_line":0
+				"_dd_lines": {
+					"_dd__default": {
+						"_dd_line":0
 					},
-					"_kics_syntax": {
-						"_kics_line":2
+					"_dd_syntax": {
+						"_dd_line":2
 					}
 				}
 			}`,
@@ -104,57 +104,57 @@ func TestConvert(t *testing.T) {
 			`),
 			wantIgnoreLines: []int{3, 4, 6, 7, 9, 10, 11, 12},
 			want: `{
-				"_kics_lines": {
-					"_kics_syntax": {
-						"_kics_line": 2
+				"_dd_lines": {
+					"_dd_syntax": {
+						"_dd_line": 2
 					},
-					"kics__default": {
-						"_kics_line": 0
+					"_dd__default": {
+						"_dd_line": 0
 					}
 				},
 				"enum": {
-					"_kics_lines": {}
+					"_dd_lines": {}
 				},
 				"imports": {
-					"_kics_lines": {}
+					"_dd_lines": {}
 				},
 				"messages": {
-					"_kics_lines": {
-						"_kics_test": {
-							"_kics_line": 4
+					"_dd_lines": {
+						"_dd_test": {
+							"_dd_line": 4
 						}
 					},
 					"test": {
-						"_kics_lines": {
-							"_kics_Testing": {
-								"_kics_line": 5
+						"_dd_lines": {
+							"_dd_Testing": {
+								"_dd_line": 5
 							},
-							"_kics__default": {
-								"_kics_line": 4
+							"_dd__default": {
+								"_dd_line": 4
 							},
-							"_kics_payload": {
-								"_kics_line": 10
+							"_dd_payload": {
+								"_dd_line": 10
 							}
 						},
 						"enum": {
 							"Testing": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_arr": [
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_arr": [
 											{
 												"Reserved": {
-													"_kics_line": 7
+													"_dd_line": 7
 												}
 											}
 										],
-										"_kics_line": 5
+										"_dd_line": 5
 									}
 								},
 								"reserved": [
 									{
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 7
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 7
 											}
 										},
 										"fieldNames": [
@@ -167,31 +167,31 @@ func TestConvert(t *testing.T) {
 						},
 						"oneof": {
 							"payload": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 10
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 10
 									},
-									"_kics_json_payload": {
-										"_kics_line": 12
+									"_dd_json_payload": {
+										"_dd_line": 12
 									},
-									"_kics_protobuf_payload": {
-										"_kics_line": 11
+									"_dd_protobuf_payload": {
+										"_dd_line": 11
 									}
 								},
 								"fields": {
 									"json_payload": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 12
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 12
 											}
 										},
 										"sequence": 2,
 										"type": "string"
 									},
 									"protobuf_payload": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 11
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 11
 											}
 										},
 										"sequence": 1,
@@ -205,7 +205,7 @@ func TestConvert(t *testing.T) {
 				"options": [],
 				"package": "",
 				"services": {
-					"_kics_lines": {}
+					"_dd_lines": {}
 				},
 				"syntax": "proto3"
 			}`,
@@ -220,44 +220,44 @@ func TestConvert(t *testing.T) {
 			`),
 			wantIgnoreLines: []int(nil),
 			want: `{
-				"_kics_lines": {
-					"_kics_syntax": {
-						"_kics_line": 2
+				"_dd_lines": {
+					"_dd_syntax": {
+						"_dd_line": 2
 					},
-					"kics__default": {
-						"_kics_line": 0
+					"_dd__default": {
+						"_dd_line": 0
 					}
 				},
 				"enum": {
-					"_kics_lines": {}
+					"_dd_lines": {}
 				},
 				"imports": {
-					"_kics_lines": {}
+					"_dd_lines": {}
 				},
 				"messages": {
-					"_kics_lines": {
-						"_kics_reserved": {
-							"_kics_line": 3
+					"_dd_lines": {
+						"_dd_reserved": {
+							"_dd_line": 3
 						}
 					},
 					"reserved": {
-						"_kics_lines": {
-							"_kics__default": {
-								"_kics_arr": [
+						"_dd_lines": {
+							"_dd__default": {
+								"_dd_arr": [
 									{
 										"Reserved": {
-											"_kics_line": 4
+											"_dd_line": 4
 										}
 									}
 								],
-								"_kics_line": 3
+								"_dd_line": 3
 							}
 						},
 						"reserved": [
 							{
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 4
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 4
 									}
 								},
 								"fieldNames": [
@@ -271,7 +271,7 @@ func TestConvert(t *testing.T) {
 				"options": [],
 				"package": "",
 				"services": {
-					"_kics_lines": {}
+					"_dd_lines": {}
 				},
 				"syntax": "proto3"
 			}`,
@@ -305,27 +305,27 @@ func TestConvert(t *testing.T) {
 			}`),
 			wantIgnoreLines: []int(nil),
 			want: `{
-				"_kics_lines": {
-					"_kics_package": {
-						"_kics_line": 7
+				"_dd_lines": {
+					"_dd_package": {
+						"_dd_line": 7
 					},
-					"_kics_syntax": {
-						"_kics_line": 1
+					"_dd_syntax": {
+						"_dd_line": 1
 					},
-					"kics__default": {
-						"_kics_line": 0
+					"_dd__default": {
+						"_dd_line": 0
 					}
 				},
 				"enum": {
-					"_kics_lines": {}
+					"_dd_lines": {}
 				},
 				"imports": {
-					"_kics_lines": {
-						"_kics_envoyproxy/protoc-gen-validate/validate/validate.proto": {
-							"_kics_line": 4
+					"_dd_lines": {
+						"_dd_envoyproxy/protoc-gen-validate/validate/validate.proto": {
+							"_dd_line": 4
 						},
-						"_kics_google/rpc/status.proto": {
-							"_kics_line": 5
+						"_dd_google/rpc/status.proto": {
+							"_dd_line": 5
 						}
 					},
 					"envoyproxy/protoc-gen-validate/validate/validate.proto": {},
@@ -333,31 +333,31 @@ func TestConvert(t *testing.T) {
 				},
 				"messages": {
 					"HelloReply": {
-						"_kics_lines": {
-							"_kics__default": {
-								"_kics_line": 22
+						"_dd_lines": {
+							"_dd__default": {
+								"_dd_line": 22
 							},
-							"_kics_message": {
-								"_kics_line": 23
+							"_dd_message": {
+								"_dd_line": 23
 							},
-							"_kics_status": {
-								"_kics_line": 24
+							"_dd_status": {
+								"_dd_line": 24
 							}
 						},
 						"field": {
 							"message": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 23
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 23
 									}
 								},
 								"sequence": 1,
 								"type": "string"
 							},
 							"status": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 24
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 24
 									}
 								},
 								"sequence": 2,
@@ -366,32 +366,32 @@ func TestConvert(t *testing.T) {
 						}
 					},
 					"HelloRequest": {
-						"_kics_lines": {
-							"_kics__default": {
-								"_kics_line": 18
+						"_dd_lines": {
+							"_dd__default": {
+								"_dd_line": 18
 							},
-							"_kics_name": {
-								"_kics_line": 19
+							"_dd_name": {
+								"_dd_line": 19
 							}
 						},
 						"field": {
 							"name": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 19
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 19
 									}
 								},
 								"options": [
 									{
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 19
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 19
 											}
 										},
 										"constant": {
-											"_kics_lines": {
-												"_kics__default": {
-													"_kics_line": 19
+											"_dd_lines": {
+												"_dd__default": {
+													"_dd_line": 19
 												}
 											},
 											"isString": true,
@@ -407,12 +407,12 @@ func TestConvert(t *testing.T) {
 							}
 						}
 					},
-					"_kics_lines": {
-						"_kics_HelloReply": {
-							"_kics_line": 22
+					"_dd_lines": {
+						"_dd_HelloReply": {
+							"_dd_line": 22
 						},
-						"_kics_HelloRequest": {
-							"_kics_line": 18
+						"_dd_HelloRequest": {
+							"_dd_line": 18
 						}
 					}
 				},
@@ -420,39 +420,39 @@ func TestConvert(t *testing.T) {
 				"package": "helloworld",
 				"services": {
 					"Greeter": {
-						"_kics_lines": {
-							"_kics_SayHello": {
-								"_kics_line": 10
+						"_dd_lines": {
+							"_dd_SayHello": {
+								"_dd_line": 10
 							},
-							"_kics__default": {
-								"_kics_line": 9
+							"_dd__default": {
+								"_dd_line": 9
 							}
 						},
 						"rpc": {
 							"SayHello": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 10
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 10
 									}
 								},
 								"options": [
 									{
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 11
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 11
 											}
 										},
 										"constant": {
-											"_kics_lines": {
-												"_kics__default": {
-													"_kics_line": 11
+											"_dd_lines": {
+												"_dd__default": {
+													"_dd_line": 11
 												}
 											},
 											"map": {
 												"body": {
-													"_kics_lines": {
-														"_kics__default": {
-															"_kics_line": 13
+													"_dd_lines": {
+														"_dd__default": {
+															"_dd_line": 13
 														}
 													},
 													"isString": true,
@@ -460,9 +460,9 @@ func TestConvert(t *testing.T) {
 													"source": "*"
 												},
 												"post": {
-													"_kics_lines": {
-														"_kics__default": {
-															"_kics_line": 12
+													"_dd_lines": {
+														"_dd__default": {
+															"_dd_line": 12
 														}
 													},
 													"isString": true,
@@ -472,9 +472,9 @@ func TestConvert(t *testing.T) {
 											},
 											"orderedMap": [
 												{
-													"_kics_lines": {
-														"_kics__default": {
-															"_kics_line": 12
+													"_dd_lines": {
+														"_dd__default": {
+															"_dd_line": 12
 														}
 													},
 													"isString": true,
@@ -483,9 +483,9 @@ func TestConvert(t *testing.T) {
 													"source": "/service/hello"
 												},
 												{
-													"_kics_lines": {
-														"_kics__default": {
-															"_kics_line": 13
+													"_dd_lines": {
+														"_dd__default": {
+															"_dd_line": 13
 														}
 													},
 													"isString": true,
@@ -503,9 +503,9 @@ func TestConvert(t *testing.T) {
 							}
 						}
 					},
-					"_kics_lines": {
-						"_kics_Greeter": {
-							"_kics_line": 9
+					"_dd_lines": {
+						"_dd_Greeter": {
+							"_dd_line": 9
 						}
 					}
 				},
@@ -535,60 +535,60 @@ func TestConvert(t *testing.T) {
 			}`),
 			wantIgnoreLines: []int(nil),
 			want: `{
-				"_kics_lines": {
-					"_kics_package": {
-						"_kics_line": 2
+				"_dd_lines": {
+					"_dd_package": {
+						"_dd_line": 2
 					},
-					"_kics_syntax": {
-						"_kics_line": 1
+					"_dd_syntax": {
+						"_dd_line": 1
 					},
-					"kics__default": {
-						"_kics_arr": [
+					"_dd__default": {
+						"_dd_arr": [
 							{
 								"java_package": {
-									"_kics_line": 4
+									"_dd_line": 4
 								}
 							}
 						],
-						"_kics_line": 0
+						"_dd_line": 0
 					}
 				},
 				"enum": {
 					"EnumAllowingAlias": {
-						"_kics_lines": {
-							"_kics_RUNNING": {
-								"_kics_line": 9
+						"_dd_lines": {
+							"_dd_RUNNING": {
+								"_dd_line": 9
 							},
-							"_kics_STARTED": {
-								"_kics_line": 8
+							"_dd_STARTED": {
+								"_dd_line": 8
 							},
-							"_kics_UNKNOWN": {
-								"_kics_line": 7
+							"_dd_UNKNOWN": {
+								"_dd_line": 7
 							},
-							"_kics__default": {
-								"_kics_line": 5
+							"_dd__default": {
+								"_dd_line": 5
 							},
-							"_kics_allow_alias": {
-								"_kics_line": 6
+							"_dd_allow_alias": {
+								"_dd_line": 6
 							}
 						},
 						"field": {
 							"RUNNING": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 9
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 9
 									}
 								},
 								"options": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 9
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 9
 										}
 									},
 									"constant": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 9
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 9
 											}
 										},
 										"isString": true,
@@ -601,9 +601,9 @@ func TestConvert(t *testing.T) {
 								"value": 2
 							},
 							"STARTED": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 8
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 8
 									}
 								},
 								"options": {
@@ -612,9 +612,9 @@ func TestConvert(t *testing.T) {
 								"value": 1
 							},
 							"UNKNOWN": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 7
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 7
 									}
 								},
 								"options": {
@@ -624,15 +624,15 @@ func TestConvert(t *testing.T) {
 						},
 						"options": {
 							"allow_alias": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 6
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 6
 									}
 								},
 								"constant": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 6
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 6
 										}
 									},
 									"source": "true"
@@ -641,16 +641,16 @@ func TestConvert(t *testing.T) {
 							}
 						}
 					},
-					"_kics_lines": {
-						"_kics_EnumAllowingAlias": {
-							"_kics_line": 5
+					"_dd_lines": {
+						"_dd_EnumAllowingAlias": {
+							"_dd_line": 5
 						}
 					}
 				},
 				"imports": {
-					"_kics_lines": {
-						"_kics_other.proto": {
-							"_kics_line": 3
+					"_dd_lines": {
+						"_dd_other.proto": {
+							"_dd_line": 3
 						}
 					},
 					"other.proto": {
@@ -659,40 +659,40 @@ func TestConvert(t *testing.T) {
 				},
 				"messages": {
 					"Outer": {
-						"_kics_lines": {
-							"_kics_(my_option).a": {
-								"_kics_line": 12
+						"_dd_lines": {
+							"_dd_(my_option).a": {
+								"_dd_line": 12
 							},
-							"_kics_Inner": {
-								"_kics_line": 13
+							"_dd_Inner": {
+								"_dd_line": 13
 							},
-							"_kics__default": {
-								"_kics_line": 11
+							"_dd__default": {
+								"_dd_line": 11
 							},
-							"_kics_enum_field": {
-								"_kics_line": 17
+							"_dd_enum_field": {
+								"_dd_line": 17
 							},
-							"_kics_inner_message": {
-								"_kics_line": 16
+							"_dd_inner_message": {
+								"_dd_line": 16
 							},
-							"_kics_my_map": {
-								"_kics_line": 18
+							"_dd_my_map": {
+								"_dd_line": 18
 							}
 						},
 						"field": {
 							"enum_field": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 17
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 17
 									}
 								},
 								"sequence": 3,
 								"type": "EnumAllowingAlias"
 							},
 							"inner_message": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 16
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 16
 									}
 								},
 								"repeated": true,
@@ -702,19 +702,19 @@ func TestConvert(t *testing.T) {
 						},
 						"inner_message": {
 							"Inner": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 13
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 13
 									},
-									"_kics_ival": {
-										"_kics_line": 14
+									"_dd_ival": {
+										"_dd_line": 14
 									}
 								},
 								"field": {
 									"ival": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 14
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 14
 											}
 										},
 										"sequence": 1,
@@ -726,9 +726,9 @@ func TestConvert(t *testing.T) {
 						"map": {
 							"my_map": {
 								"field": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 18
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 18
 										}
 									},
 									"sequence": 4,
@@ -739,15 +739,15 @@ func TestConvert(t *testing.T) {
 						},
 						"options": {
 							"(my_option).a": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 12
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 12
 									}
 								},
 								"constant": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 12
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 12
 										}
 									},
 									"source": "true"
@@ -756,23 +756,23 @@ func TestConvert(t *testing.T) {
 							}
 						}
 					},
-					"_kics_lines": {
-						"_kics_Outer": {
-							"_kics_line": 11
+					"_dd_lines": {
+						"_dd_Outer": {
+							"_dd_line": 11
 						}
 					}
 				},
 				"options": [
 					{
-						"_kics_lines": {
-							"_kics__default": {
-								"_kics_line": 4
+						"_dd_lines": {
+							"_dd__default": {
+								"_dd_line": 4
 							}
 						},
 						"constant": {
-							"_kics_lines": {
-								"_kics__default": {
-									"_kics_line": 4
+							"_dd_lines": {
+								"_dd__default": {
+									"_dd_line": 4
 								}
 							},
 							"isString": true,
@@ -784,7 +784,7 @@ func TestConvert(t *testing.T) {
 				],
 				"package": "Cx",
 				"services": {
-					"_kics_lines": {}
+					"_dd_lines": {}
 				},
 				"syntax": "proto3"
 			}`,

--- a/pkg/parser/grpc/parser_test.go
+++ b/pkg/parser/grpc/parser_test.go
@@ -41,27 +41,27 @@ func TestParser_Parse(t *testing.T) {
 			want: `[
 				{
 					"options": [],
-					"_kics_lines": {
-						"_kics_syntax": {
-							"_kics_line": 2
+					"_dd_lines": {
+						"_dd_syntax": {
+							"_dd_line": 2
 						},
-						"kics__default": {
-							"_kics_line": 0
+						"_dd__default": {
+							"_dd_line": 0
 						}
 					},
 					"syntax": "proto3",
 					"package": "",
 					"messages": {
-						"_kics_lines": {}
+						"_dd_lines": {}
 					},
 					"enum": {
-						"_kics_lines": {}
+						"_dd_lines": {}
 					},
 					"services": {
-						"_kics_lines": {}
+						"_dd_lines": {}
 					},
 					"imports": {
-						"_kics_lines": {}
+						"_dd_lines": {}
 					}
 				}
 			]`,
@@ -100,40 +100,40 @@ func TestParser_Parse(t *testing.T) {
 				{
 					"enum": {
 						"EnumAllowingAlias": {
-							"_kics_lines": {
-								"_kics_RUNNING": {
-									"_kics_line": 10
+							"_dd_lines": {
+								"_dd_RUNNING": {
+									"_dd_line": 10
 								},
-								"_kics_STARTED": {
-									"_kics_line": 9
+								"_dd_STARTED": {
+									"_dd_line": 9
 								},
-								"_kics_UNKNOWN": {
-									"_kics_line": 8
+								"_dd_UNKNOWN": {
+									"_dd_line": 8
 								},
-								"_kics__default": {
-									"_kics_line": 6
+								"_dd__default": {
+									"_dd_line": 6
 								},
-								"_kics_allow_alias": {
-									"_kics_line": 7
+								"_dd_allow_alias": {
+									"_dd_line": 7
 								}
 							},
 							"field": {
 								"RUNNING": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 10
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 10
 										}
 									},
 									"options": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 10
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 10
 											}
 										},
 										"constant": {
-											"_kics_lines": {
-												"_kics__default": {
-													"_kics_line": 10
+											"_dd_lines": {
+												"_dd__default": {
+													"_dd_line": 10
 												}
 											},
 											"isString": true,
@@ -146,9 +146,9 @@ func TestParser_Parse(t *testing.T) {
 									"value": 2
 								},
 								"STARTED": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 9
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 9
 										}
 									},
 									"options": {
@@ -157,9 +157,9 @@ func TestParser_Parse(t *testing.T) {
 									"value": 1
 								},
 								"UNKNOWN": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 8
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 8
 										}
 									},
 									"options": {
@@ -169,15 +169,15 @@ func TestParser_Parse(t *testing.T) {
 							},
 							"options": {
 								"allow_alias": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 7
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 7
 										}
 									},
 									"constant": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 7
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 7
 											}
 										},
 										"source": "true"
@@ -186,19 +186,19 @@ func TestParser_Parse(t *testing.T) {
 								}
 							}
 						},
-						"_kics_lines": {
-							"_kics_EnumAllowingAlias": {
-								"_kics_line": 6
+						"_dd_lines": {
+							"_dd_EnumAllowingAlias": {
+								"_dd_line": 6
 							}
 						}
 					},
 					"services": {
-						"_kics_lines": {}
+						"_dd_lines": {}
 					},
 					"imports": {
-						"_kics_lines": {
-							"_kics_other.proto": {
-								"_kics_line": 3
+						"_dd_lines": {
+							"_dd_other.proto": {
+								"_dd_line": 3
 							}
 						},
 						"other.proto": {
@@ -207,15 +207,15 @@ func TestParser_Parse(t *testing.T) {
 					},
 					"options": [
 						{
-							"_kics_lines": {
-								"_kics__default": {
-									"_kics_line": 4
+							"_dd_lines": {
+								"_dd__default": {
+									"_dd_line": 4
 								}
 							},
 							"constant": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 4
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 4
 									}
 								},
 								"isString": true,
@@ -225,62 +225,62 @@ func TestParser_Parse(t *testing.T) {
 							"name": "java_package"
 						}
 					],
-					"_kics_lines": {
-						"_kics_package": {
-							"_kics_line": 2
+					"_dd_lines": {
+						"_dd_package": {
+							"_dd_line": 2
 						},
-						"_kics_syntax": {
-							"_kics_line": 1
+						"_dd_syntax": {
+							"_dd_line": 1
 						},
-						"kics__default": {
-							"_kics_arr": [
+						"_dd__default": {
+							"_dd_arr": [
 								{
 									"java_package": {
-										"_kics_line": 4
+										"_dd_line": 4
 									}
 								}
 							],
-							"_kics_line": 0
+							"_dd_line": 0
 						}
 					},
 					"syntax": "proto3",
 					"package": "Cx",
 					"messages": {
 						"Outer": {
-							"_kics_lines": {
-								"_kics_(my_option).a": {
-									"_kics_line": 14
+							"_dd_lines": {
+								"_dd_(my_option).a": {
+									"_dd_line": 14
 								},
-								"_kics_Inner": {
-									"_kics_line": 15
+								"_dd_Inner": {
+									"_dd_line": 15
 								},
-								"_kics__default": {
-									"_kics_line": 12
+								"_dd__default": {
+									"_dd_line": 12
 								},
-								"_kics_enum_field": {
-									"_kics_line": 19
+								"_dd_enum_field": {
+									"_dd_line": 19
 								},
-								"_kics_inner_message": {
-									"_kics_line": 18
+								"_dd_inner_message": {
+									"_dd_line": 18
 								},
-								"_kics_my_map": {
-									"_kics_line": 21
+								"_dd_my_map": {
+									"_dd_line": 21
 								}
 							},
 							"field": {
 								"enum_field": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 19
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 19
 										}
 									},
 									"sequence": 3,
 									"type": "EnumAllowingAlias"
 								},
 								"inner_message": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 18
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 18
 										}
 									},
 									"repeated": true,
@@ -290,19 +290,19 @@ func TestParser_Parse(t *testing.T) {
 							},
 							"inner_message": {
 								"Inner": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 15
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 15
 										},
-										"_kics_ival": {
-											"_kics_line": 16
+										"_dd_ival": {
+											"_dd_line": 16
 										}
 									},
 									"field": {
 										"ival": {
-											"_kics_lines": {
-												"_kics__default": {
-													"_kics_line": 16
+											"_dd_lines": {
+												"_dd__default": {
+													"_dd_line": 16
 												}
 											},
 											"sequence": 1,
@@ -314,9 +314,9 @@ func TestParser_Parse(t *testing.T) {
 							"map": {
 								"my_map": {
 									"field": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 21
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 21
 											}
 										},
 										"sequence": 4,
@@ -327,15 +327,15 @@ func TestParser_Parse(t *testing.T) {
 							},
 							"options": {
 								"(my_option).a": {
-									"_kics_lines": {
-										"_kics__default": {
-											"_kics_line": 14
+									"_dd_lines": {
+										"_dd__default": {
+											"_dd_line": 14
 										}
 									},
 									"constant": {
-										"_kics_lines": {
-											"_kics__default": {
-												"_kics_line": 14
+										"_dd_lines": {
+											"_dd__default": {
+												"_dd_line": 14
 											}
 										},
 										"source": "true"
@@ -344,9 +344,9 @@ func TestParser_Parse(t *testing.T) {
 								}
 							}
 						},
-						"_kics_lines": {
-							"_kics_Outer": {
-								"_kics_line": 12
+						"_dd_lines": {
+							"_dd_Outer": {
+								"_dd_line": 12
 							}
 						}
 					}

--- a/pkg/parser/json/json_line.go
+++ b/pkg/parser/json/json_line.go
@@ -182,7 +182,7 @@ func (j *jsonLineStruct) closeBrackets(lenPathArr int) {
 // setLineInfo will set the line information of keys in json based on the line Information map
 func (j *jsonLine) setLineInfo(doc map[string]interface{}) map[string]interface{} {
 	// set the line info for keys in root level
-	doc["_kics_lines"] = j.setLine(doc, 0, "", false)
+	doc["_dd_lines"] = j.setLine(doc, 0, "", false)
 	return doc
 }
 
@@ -193,7 +193,7 @@ func (j *jsonLine) setLineInfo(doc map[string]interface{}) map[string]interface{
 func (j *jsonLine) setLine(val map[string]interface{}, def int, father string, pop bool) map[string]*model.LineObject {
 	lineMap := make(map[string]*model.LineObject)
 	// set the line information of val
-	lineMap["_kics__default"] = &model.LineObject{
+	lineMap["_dd__default"] = &model.LineObject{
 		Line: def,
 		Arr:  []map[string]*model.LineObject{},
 	}
@@ -223,10 +223,10 @@ func (j *jsonLine) setLine(val map[string]interface{}, def int, father string, p
 			lineArr = j.setSeqLines(v, lineNr, father, key, lineArr)
 		// value is an object and must setLines for each element of the object
 		case map[string]interface{}:
-			v["_kics_lines"] = j.setLine(v, lineNr, fmt.Sprintf("%s.%s", father, key), pop)
+			v["_dd_lines"] = j.setLine(v, lineNr, fmt.Sprintf("%s.%s", father, key), pop)
 		default:
 			// value as no childs
-			lineMap[fmt.Sprintf("_kics_%s", key)] = &model.LineObject{
+			lineMap[fmt.Sprintf("_dd_%s", key)] = &model.LineObject{
 				Line: lineNr,
 				Arr:  lineArr,
 			}
@@ -235,7 +235,7 @@ func (j *jsonLine) setLine(val map[string]interface{}, def int, father string, p
 
 		// set line information of value with its default line and
 		// if present array elements line informations
-		lineMap[fmt.Sprintf("_kics_%s", key)] = &model.LineObject{
+		lineMap[fmt.Sprintf("_dd_%s", key)] = &model.LineObject{
 			Line: lineNr,
 			Arr:  lineArr,
 		}
@@ -268,7 +268,7 @@ func (j *jsonLine) setSeqLines(v []interface{}, def int, father, key string,
 					continue
 				}
 				lineArr = append(lineArr, map[string]*model.LineObject{
-					"_kics__default": {
+					"_dd__default": {
 						Line: lineStr.(*fifo).pop(),
 					},
 				})

--- a/pkg/parser/json/json_line_test.go
+++ b/pkg/parser/json/json_line_test.go
@@ -20,7 +20,7 @@ var testsinitiateJSONLine = []struct {
 	name         string
 	args         args
 	want         string
-	wantKicsLine string
+	wantLine string
 }{
 	{
 		name: "test array of ints",
@@ -84,44 +84,44 @@ var testsinitiateJSONLine = []struct {
 				}
 			  }
 			  `,
-		wantKicsLine: `{
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 0
+		wantLine: `{
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 0
 				  },
-				  "_kics_father": {
-					"_kics_line": 2
+				  "_dd_father": {
+					"_dd_line": 2
 				  }
 				},
 				"father": {
-				  "_kics_lines": {
-					"_kics__default": {
-					  "_kics_line": 2
+				  "_dd_lines": {
+					"_dd__default": {
+					  "_dd_line": 2
 					},
-					"_kics_son": {
-					  "_kics_arr": [
+					"_dd_son": {
+					  "_dd_arr": [
 						{
-						  "_kics__default": {
-							"_kics_line": 4
+						  "_dd__default": {
+							"_dd_line": 4
 						  }
 						},
 						{
-						  "_kics__default": {
-							"_kics_line": 5
+						  "_dd__default": {
+							"_dd_line": 5
 						  }
 						},
 						{
-						  "_kics__default": {
-							"_kics_line": 6
+						  "_dd__default": {
+							"_dd_line": 6
 						  }
 						},
 						{
-						  "_kics__default": {
-							"_kics_line": 7
+						  "_dd__default": {
+							"_dd_line": 7
 						  }
 						}
 					  ],
-					  "_kics_line": 3
+					  "_dd_line": 3
 					}
 				  },
 				  "son": [
@@ -145,24 +145,24 @@ var testsinitiateJSONLine = []struct {
 				}
 				`),
 		},
-		wantKicsLine: `
+		wantLine: `
 			{
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 0
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 0
 				  },
-				  "_kics_father": {
-					"_kics_arr": [
+				  "_dd_father": {
+					"_dd_arr": [
 					  {
-						"_kics__default": {
-						  "_kics_line": 4
+						"_dd__default": {
+						  "_dd_line": 4
 						},
-						"_kics_key": {
-						  "_kics_line": 4
+						"_dd_key": {
+						  "_dd_line": 4
 						}
 					  }
 					],
-					"_kics_line": 2
+					"_dd_line": 2
 				  }
 				},
 				"father": [
@@ -208,14 +208,14 @@ var testsinitiateJSONLine = []struct {
 				}
 				`),
 		},
-		wantKicsLine: `
+		wantLine: `
 			{
-				"_kics_lines": {
-					"_kics__default": {
-						"_kics_line": 0
+				"_dd_lines": {
+					"_dd__default": {
+						"_dd_line": 0
 					},
-					"_kics_parameters": {
-						"_kics_line": 2
+					"_dd_parameters": {
+						"_dd_line": 2
 					}
 				},
 				"parameters":"simple test"
@@ -253,30 +253,30 @@ var testsinitiateJSONLine = []struct {
 				}
 				`),
 		},
-		wantKicsLine: `
+		wantLine: `
 			{
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 0
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 0
 				  },
-				  "_kics_father": {
-					"_kics_line": 2
+				  "_dd_father": {
+					"_dd_line": 2
 				  }
 				},
 				"father": {
-				  "_kics_lines": {
-					"_kics__default": {
-					  "_kics_line": 2
+				  "_dd_lines": {
+					"_dd__default": {
+					  "_dd_line": 2
 					},
-					"_kics_close": {
-					  "_kics_arr": [
+					"_dd_close": {
+					  "_dd_arr": [
 						{
-						  "_kics__default": {
-							"_kics_line": 4
+						  "_dd__default": {
+							"_dd_line": 4
 						  }
 						}
 					  ],
-					  "_kics_line": 3
+					  "_dd_line": 3
 					}
 				  },
 				  "close": [
@@ -326,36 +326,36 @@ var testsinitiateJSONLine = []struct {
 				}
 				`),
 		},
-		wantKicsLine: `{
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 0
+		wantLine: `{
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 0
 				  },
-				  "_kics_father1": {
-					"_kics_line": 2
+				  "_dd_father1": {
+					"_dd_line": 2
 				  },
-				  "_kics_father2": {
-					"_kics_line": 5
+				  "_dd_father2": {
+					"_dd_line": 5
 				  }
 				},
 				"father1": {
-				  "_kics_lines": {
-					"_kics__default": {
-					  "_kics_line": 2
+				  "_dd_lines": {
+					"_dd__default": {
+					  "_dd_line": 2
 					},
-					"_kics_key": {
-					  "_kics_line": 3
+					"_dd_key": {
+					  "_dd_line": 3
 					}
 				  },
 				  "key": "value"
 				},
 				"father2": {
-				  "_kics_lines": {
-					"_kics__default": {
-					  "_kics_line": 5
+				  "_dd_lines": {
+					"_dd__default": {
+					  "_dd_line": 5
 					},
-					"_kics_key": {
-					  "_kics_line": 6
+					"_dd_key": {
+					  "_dd_line": 6
 					}
 				  },
 				  "key": "value"
@@ -415,23 +415,23 @@ var testsinitiateJSONLine = []struct {
 			}
 			`),
 		},
-		wantKicsLine: `
+		wantLine: `
 			{
-				"_kics_lines": {
-					"_kics__default": {
-						"_kics_line": 0
+				"_dd_lines": {
+					"_dd__default": {
+						"_dd_line": 0
 					},
-					"_kics_father":{
-						"_kics_line": 2
+					"_dd_father":{
+						"_dd_line": 2
 					}
 				},
 				"father": {
-					"_kics_lines": {
-						"_kics__default": {
-							"_kics_line": 2
+					"_dd_lines": {
+						"_dd__default": {
+							"_dd_line": 2
 						},
-						"_kics_son": {
-							"_kics_line": 3
+						"_dd_son": {
+							"_dd_line": 3
 						}
 					},
 					"son": "this is a son"
@@ -475,26 +475,26 @@ var testsinitiateJSONLine = []struct {
 				}
 				`),
 		},
-		wantKicsLine: `
+		wantLine: `
 			{
-				"_kics_lines": {
-					"_kics__default": {
-						"_kics_line": 0
+				"_dd_lines": {
+					"_dd__default": {
+						"_dd_line": 0
 					},
-					"_kics_father": {
-						"_kics_arr": [
+					"_dd_father": {
+						"_dd_arr": [
 							{
-								"_kics__default": {
-									"_kics_line": 3
+								"_dd__default": {
+									"_dd_line": 3
 								}
 							},
 							{
-								"_kics__default": {
-									"_kics_line": 4
+								"_dd__default": {
+									"_dd_line": 4
 								}
 							}
 						],
-						"_kics_line":2
+						"_dd_line":2
 					}
 				},
 				"father": [
@@ -541,26 +541,26 @@ var testsinitiateJSONLine = []struct {
 				}
 				`),
 		},
-		wantKicsLine: `
+		wantLine: `
 			{
-				"_kics_lines": {
-					"_kics__default": {
-						"_kics_line": 0
+				"_dd_lines": {
+					"_dd__default": {
+						"_dd_line": 0
 					},
-					"_kics_father": {
-						"_kics_arr":[
+					"_dd_father": {
+						"_dd_arr":[
 							{
-								"_kics__default": {
-									"_kics_line": 3
+								"_dd__default": {
+									"_dd_line": 3
 								}
 							},
 							{
-								"_kics__default": {
-									"_kics_line": 4
+								"_dd__default": {
+									"_dd_line": 4
 								}
 							}
 						],
-						"_kics_line": 2
+						"_dd_line": 2
 					}
 				},
 				"father":[
@@ -609,29 +609,29 @@ var testsinitiateJSONLine = []struct {
 			}
 			`),
 		},
-		wantKicsLine: `
+		wantLine: `
 			{
-				"_kics_lines":{
-					"_kics__default":{
-						"_kics_line":0
+				"_dd_lines":{
+					"_dd__default":{
+						"_dd_line":0
 					},
-					"_kics_resources":{
-						"_kics_line":2,
-					"_kics_arr":[
+					"_dd_resources":{
+						"_dd_line":2,
+					"_dd_arr":[
 						{
-							"_kics__default":{
-								"_kics_line":4
+							"_dd__default":{
+								"_dd_line":4
 							},
-							"_kics_properties":{
-								"_kics_line":4
+							"_dd_properties":{
+								"_dd_line":4
 							}
 						},
 						{
-							"_kics__default":{
-								"_kics_line":9
+							"_dd__default":{
+								"_dd_line":9
 							},
-							"_kics_properties":{
-								"_kics_line":9
+							"_dd_properties":{
+								"_dd_line":9
 							}
 						}
 					]
@@ -640,12 +640,12 @@ var testsinitiateJSONLine = []struct {
 			"resources":[
 				{
 					"properties":{
-						"_kics_lines":{
-							"_kics__default":{
-								"_kics_line":4
+						"_dd_lines":{
+							"_dd__default":{
+								"_dd_line":4
 							},
-							"_kics_httpsOnly":{
-								"_kics_line":5
+							"_dd_httpsOnly":{
+								"_dd_line":5
 							}
 						},
 						"httpsOnly":false
@@ -653,12 +653,12 @@ var testsinitiateJSONLine = []struct {
 				},
 				{
 					"properties":{
-						"_kics_lines":{
-							"_kics__default":{
-								"_kics_line":9
+						"_dd_lines":{
+							"_dd__default":{
+								"_dd_line":9
 							},
-							"_kics_httpsOnly":{
-								"_kics_line":10
+							"_dd_httpsOnly":{
+								"_dd_line":10
 							}
 						},
 						"httpsOnly":false
@@ -729,7 +729,7 @@ func Test_jsonLine_setLineInfo(t *testing.T) {
 		require.NoError(t, err)
 		j := initializeJSONLine(tt.args.doc)
 		got := j.setLineInfo(unmarshaledJSON)
-		compareJSONLine(t, got, tt.wantKicsLine)
+		compareJSONLine(t, got, tt.wantLine)
 		//})
 	}
 }

--- a/pkg/parser/jsonfilter/json_filter_test.go
+++ b/pkg/parser/jsonfilter/json_filter_test.go
@@ -707,9 +707,9 @@ func TestJSONFilterExpressions(t *testing.T) {
 				visitor := parser.NewJSONFilterPrinterVisitor()
 				got := visitor.VisitAll(tree)
 
-				if !reflect.DeepEqual(tc.expected, got) {
-					t.Errorf("test[%s]:\ninput    %v\nexpected %v\ngot      %v", tc.name, tc.input, tc.expected, got)
-				}
+			if !reflect.DeepEqual(tc.expected.FilterExpression, got.FilterExpression) {
+				t.Errorf("test[%s]:\ninput    %v\nexpected %v\ngot      %v", tc.name, tc.input, tc.expected.FilterExpression, got.FilterExpression)
+			}
 			} else {
 				require.True(t, errorListener.HasErrors(), "test[%s] Expected error but got none", tc.name)
 			}
@@ -726,19 +726,19 @@ func TestMarshallJSONFilterExpressions(t *testing.T) {
 		{
 			name:  "expr_single_selector",
 			input: `{$.eventName = CreateDeliveryChannel}`,
-			want: `{"_kics_filter_expr":{"_selector":"$.eventName","_op":"=","_value":"CreateDeliveryChannel"}}
+			want: `{"_dd_filter_expr":{"_selector":"$.eventName","_op":"=","_value":"CreateDeliveryChannel"}}
 `,
 		},
 		{
 			name:  "expr_two_selectors_and_with_parenthesis_unquoted_quoted_strings",
 			input: `{ ($.eventName = ConsoleLogin) && ($.errorMessage = "Failed authentication") }`,
-			want: `{"_kics_filter_expr":{"_op":"&&","_left":{"_selector":"$.eventName","_op":"=","_value":"ConsoleLogin"},"_right":{"_selector":"$.errorMessage","_op":"=","_value":"\"Failed authentication\""}}}
+			want: `{"_dd_filter_expr":{"_op":"&&","_left":{"_selector":"$.eventName","_op":"=","_value":"ConsoleLogin"},"_right":{"_selector":"$.errorMessage","_op":"=","_value":"\"Failed authentication\""}}}
 `,
 		},
 		{
 			name:  "expr_three_selectors_and_without_parenthesis",
 			input: `{ $.userIdentity.type = "Root" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != "AwsServiceEvent" }`,
-			want: `{"_kics_filter_expr":{"_op":"&&","_left":{"_op":"&&","_left":{"_selector":"$.userIdentity.type","_op":"=","_value":"\"Root\""},"_right":{"_selector":"$.userIdentity.invokedBy","_op":"NOT","_value":"EXISTS"}},"_right":{"_selector":"$.eventType","_op":"!=","_value":"\"AwsServiceEvent\""}}}
+			want: `{"_dd_filter_expr":{"_op":"&&","_left":{"_op":"&&","_left":{"_selector":"$.userIdentity.type","_op":"=","_value":"\"Root\""},"_right":{"_selector":"$.userIdentity.invokedBy","_op":"NOT","_value":"EXISTS"}},"_right":{"_selector":"$.eventType","_op":"!=","_value":"\"AwsServiceEvent\""}}}
 `,
 		},
 		{
@@ -746,7 +746,7 @@ func TestMarshallJSONFilterExpressions(t *testing.T) {
 			input: `{ ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) ||` +
 				`($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) ||` +
 				`($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup)}`,
-			want: `{"_kics_filter_expr":{"_op":"||","_left":{"_op":"||","_left":{"_op":"||","_left":{"_op":"||","_left":{"_op":"||","_left":{"_selector":"$.eventName","_op":"=","_value":"AuthorizeSecurityGroupIngress"},"_right":{"_selector":"$.eventName","_op":"=","_value":"AuthorizeSecurityGroupEgress"}},"_right":{"_selector":"$.eventName","_op":"=","_value":"RevokeSecurityGroupIngress"}},"_right":{"_selector":"$.eventName","_op":"=","_value":"RevokeSecurityGroupEgress"}},"_right":{"_selector":"$.eventName","_op":"=","_value":"CreateSecurityGroup"}},"_right":{"_selector":"$.eventName","_op":"=","_value":"DeleteSecurityGroup"}}}
+			want: `{"_dd_filter_expr":{"_op":"||","_left":{"_op":"||","_left":{"_op":"||","_left":{"_op":"||","_left":{"_op":"||","_left":{"_selector":"$.eventName","_op":"=","_value":"AuthorizeSecurityGroupIngress"},"_right":{"_selector":"$.eventName","_op":"=","_value":"AuthorizeSecurityGroupEgress"}},"_right":{"_selector":"$.eventName","_op":"=","_value":"RevokeSecurityGroupIngress"}},"_right":{"_selector":"$.eventName","_op":"=","_value":"RevokeSecurityGroupEgress"}},"_right":{"_selector":"$.eventName","_op":"=","_value":"CreateSecurityGroup"}},"_right":{"_selector":"$.eventName","_op":"=","_value":"DeleteSecurityGroup"}}}
 `,
 		},
 	}
@@ -767,10 +767,16 @@ func TestMarshallJSONFilterExpressions(t *testing.T) {
 		visitor := parser.NewJSONFilterPrinterVisitor()
 		expTree := visitor.VisitAll(tree)
 
+		// Marshal only the canonical FilterExpression field so the test is
+		// independent of legacy _kics_filter_expr being present alongside it.
+		wrapper := struct {
+			FilterExpression any `json:"_dd_filter_expr"`
+		}{FilterExpression: expTree.FilterExpression}
+
 		buf := new(bytes.Buffer)
 		encoder := json.NewEncoder(buf)
 		encoder.SetEscapeHTML(false)
-		err := encoder.Encode(expTree)
+		err := encoder.Encode(wrapper)
 		require.NoError(t, err)
 
 		got := buf.String()

--- a/pkg/parser/jsonfilter/parser/jsonfilter_tree_visitor.go
+++ b/pkg/parser/jsonfilter/parser/jsonfilter_tree_visitor.go
@@ -15,7 +15,8 @@ const (
 )
 
 type AWSJSONFilter struct {
-	FilterExpression interface{} `json:"_kics_filter_expr"`
+	FilterExpression     interface{} `json:"_dd_filter_expr"`
+	KicsFilterExpression interface{} `json:"_kics_filter_expr"` // legacy compat; drop once all rules use _dd_filter_expr
 }
 
 type FilterExp struct {
@@ -41,8 +42,10 @@ func NewJSONFilterPrinterVisitor() *JSONFilterTreeVisitor {
 }
 
 func (v *JSONFilterTreeVisitor) VisitAll(tree antlr.ParseTree) AWSJSONFilter {
+	expr := v.Visit(tree)
 	return AWSJSONFilter{
-		FilterExpression: v.Visit(tree),
+		FilterExpression:     expr,
+		KicsFilterExpression: expr,
 	}
 }
 

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -51,7 +51,7 @@ type converter struct {
 }
 
 const (
-	kicsLinesKey          = "_kics_"
+	ddLinesKey            = "_dd_"
 	ctyFriendlyNameString = "string"
 )
 
@@ -87,17 +87,17 @@ func (c *converter) convertBody(ctx context.Context, body *hclsyntax.Body, defLi
 	}
 
 	out := make(model.Document)
-	kicsS := make(map[string]model.LineObject)
-	// set kics line for the body
-	kicsS["_kics__default"] = model.LineObject{
+	ddLines := make(map[string]model.LineObject)
+	// set line info for the body
+	ddLines["_dd__default"] = model.LineObject{
 		Line: defLine,
 	}
 
 	if body.Attributes != nil {
 		for key, value := range body.Attributes {
 			out[key], err = c.convertExpression(value.Expr)
-			// set kics line for the body value
-			kicsS[kicsLinesKey+key] = model.LineObject{
+			// set line info for the body value
+			ddLines["_dd_"+key] = model.LineObject{
 				Line: value.SrcRange.Start.Line,
 				Arr:  c.getArrLines(value.Expr),
 			}
@@ -108,8 +108,8 @@ func (c *converter) convertBody(ctx context.Context, body *hclsyntax.Body, defLi
 	}
 
 	for _, block := range body.Blocks {
-		// set kics line for block
-		kicsS[kicsLinesKey+block.Type] = model.LineObject{
+		// set line info for block
+		ddLines["_dd_"+block.Type] = model.LineObject{
 			Line: block.TypeRange.Start.Line,
 		}
 		err = c.convertBlock(ctx, block, out, block.TypeRange.Start.Line)
@@ -118,7 +118,7 @@ func (c *converter) convertBody(ctx context.Context, body *hclsyntax.Body, defLi
 		}
 	}
 
-	out["_kics_lines"] = kicsS
+	out["_dd_lines"] = ddLines
 
 	return out, nil
 }
@@ -130,12 +130,12 @@ func (c *converter) getArrLines(expr hclsyntax.Expression) []map[string]*model.L
 		for _, ex := range v.Exprs {
 			arrEx := make(map[string]*model.LineObject)
 			// set default line of array
-			arrEx["_kics__default"] = &model.LineObject{
+			arrEx["_dd__default"] = &model.LineObject{
 				Line: ex.Range().Start.Line,
 			}
 			switch valType := ex.(type) {
 			case *hclsyntax.ObjectConsExpr:
-				arrEx["_kics__default"] = &model.LineObject{
+				arrEx["_dd__default"] = &model.LineObject{
 					Line: ex.Range().Start.Line + 1,
 				}
 				// set lines for array elements
@@ -144,13 +144,13 @@ func (c *converter) getArrLines(expr hclsyntax.Expression) []map[string]*model.L
 					if err != nil {
 						return nil
 					}
-					arrEx[kicsLinesKey+key] = &model.LineObject{
+					arrEx["_dd_"+key] = &model.LineObject{
 						Line: item.KeyExpr.Range().Start.Line,
 					}
 				}
 			case *hclsyntax.TupleConsExpr:
 				// set lines for array elements if type is different than array, map/object
-				arrEx["_kics__default"] = &model.LineObject{
+				arrEx["_dd__default"] = &model.LineObject{
 					Arr: c.getArrLines(valType),
 				}
 			}

--- a/pkg/parser/terraform/converter/default_test.go
+++ b/pkg/parser/terraform/converter/default_test.go
@@ -30,30 +30,30 @@ block "label_one" "label_two" {
 	"block": {
 		"label_one": {
 			"label_two": {
-				"_kics_lines": {
-					"_kics__default": {
-						"_kics_line": 2
+				"_dd_lines": {
+					"_dd__default": {
+						"_dd_line": 2
 					},
-					"_kics_nested_block": {
-						"_kics_line": 3
+					"_dd_nested_block": {
+						"_dd_line": 3
 					}
 				},
 				"nested_block": {
-					"_kics_lines": {
-						"_kics__default": {
-							"_kics_line": 3
+					"_dd_lines": {
+						"_dd__default": {
+							"_dd_line": 3
 						}
 					}
 				}
 			}
 		}
 	},
-	"_kics_lines": {
-		"_kics__default": {
-			"_kics_line": 0
+	"_dd_lines": {
+		"_dd__default": {
+			"_dd_line": 0
 		},
-		"_kics_block": {
-			"_kics_line": 2
+		"_dd_block": {
+			"_dd_line": 2
 		}
 	}
 }`
@@ -86,58 +86,58 @@ block "label_one" "label_two" {
 }`
 
 	expected := `{
-		"_kics_lines": {
-			"_kics__default": {
-				"_kics_line": 0
+		"_dd_lines": {
+			"_dd__default": {
+				"_dd_line": 0
 			},
-			"_kics_block": {
-				"_kics_line": 2
+			"_dd_block": {
+				"_dd_line": 2
 			}
 		},
 		"block": {
 			"label_one": {
 				"label_two": {
-					"_kics_lines": {
-						"_kics__default": {
-							"_kics_line": 2
+					"_dd_lines": {
+						"_dd__default": {
+							"_dd_line": 2
 						},
-						"_kics_default": {
-							"_kics_arr": [
+						"_dd_default": {
+							"_dd_arr": [
 								{
-									"_kics__default": {
-										"_kics_line": 5
+									"_dd__default": {
+										"_dd_line": 5
 									},
-									"_kics_attribute": {
-										"_kics_line": 6
+									"_dd_attribute": {
+										"_dd_line": 6
 									},
-									"_kics_id": {
-										"_kics_line": 5
+									"_dd_id": {
+										"_dd_line": 5
 									}
 								},
 								{
-									"_kics__default": {
-										"_kics_line": 9
+									"_dd__default": {
+										"_dd_line": 9
 									},
-									"_kics_attribute": {
-										"_kics_line": 10
+									"_dd_attribute": {
+										"_dd_line": 10
 									},
-									"_kics_id": {
-										"_kics_line": 9
+									"_dd_id": {
+										"_dd_line": 9
 									}
 								},
 								{
-									"_kics__default": {
-										"_kics_line": 13
+									"_dd__default": {
+										"_dd_line": 13
 									},
-									"_kics_attribute": {
-										"_kics_line": 14
+									"_dd_attribute": {
+										"_dd_line": 14
 									},
-									"_kics_id": {
-										"_kics_line": 13
+									"_dd_id": {
+										"_dd_line": 13
 									}
 								}
 							],
-							"_kics_line": 3
+							"_dd_line": 3
 						}
 					},
 					"default": [
@@ -185,22 +185,22 @@ block "label_one" {
 		"block": {
 			"label_one": {
 				"attribute": "value",
-				"_kics_lines": {
-					"_kics__default": {
-						"_kics_line": 2
+				"_dd_lines": {
+					"_dd__default": {
+						"_dd_line": 2
 					},
-					"_kics_attribute": {
-						"_kics_line": 3
+					"_dd_attribute": {
+						"_dd_line": 3
 					}
 				}
 			}
 		},
-		"_kics_lines": {
-			"_kics__default": {
-				"_kics_line": 0
+		"_dd_lines": {
+			"_dd__default": {
+				"_dd_line": 0
 			},
-			"_kics_block": {
-				"_kics_line": 2
+			"_dd_block": {
+				"_dd_line": 2
 			}
 		}
 	}`
@@ -228,35 +228,35 @@ block "label_one" {
 		"block": {
 			"label_one": [
 				{
-					"_kics_lines": {
-						"_kics__default": {
-							"_kics_line": 2
+					"_dd_lines": {
+						"_dd__default": {
+							"_dd_line": 2
 						},
-						"_kics_attribute": {
-							"_kics_line": 3
+						"_dd_attribute": {
+							"_dd_line": 3
 						}
 					},
 					"attribute": "value"
 				},
 				{
 					"attribute": "value_two",
-					"_kics_lines": {
-						"_kics__default": {
-							"_kics_line": 5
+					"_dd_lines": {
+						"_dd__default": {
+							"_dd_line": 5
 						},
-						"_kics_attribute": {
-							"_kics_line": 6
+						"_dd_attribute": {
+							"_dd_line": 6
 						}
 					}
 				}
 			]
 		},
-		"_kics_lines": {
-			"_kics__default": {
-				"_kics_line": 0
+		"_dd_lines": {
+			"_dd__default": {
+				"_dd_line": 0
 			},
-			"_kics_block": {
-				"_kics_line": 5
+			"_dd_block": {
+				"_dd_line": 5
 			}
 		}
 	}`
@@ -492,25 +492,25 @@ block "label_one" {
 }
 `,
 			want: `{
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 0
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 0
 				  },
-				  "_kics_block": {
-					"_kics_line": 2
+				  "_dd_block": {
+					"_dd_line": 2
 				  }
 				},
 				"block": {
 				  "label_one": {
-					"_kics_lines": {
-					  "_kics__default": {
-						"_kics_line": 2
+					"_dd_lines": {
+					  "_dd__default": {
+						"_dd_line": 2
 					  },
-					  "_kics_policy": {
-						"_kics_line": 3
+					  "_dd_policy": {
+						"_dd_line": 3
 					  },
-					  "_kics_some_number": {
-						"_kics_line": 6
+					  "_dd_some_number": {
+						"_dd_line": 6
 					  }
 					},
 					"policy": "{\"Id\":\"id\"}",
@@ -532,25 +532,25 @@ block "label_one" {
 }
 `,
 			want: `{
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 0
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 0
 				  },
-				  "_kics_block": {
-					"_kics_line": 2
+				  "_dd_block": {
+					"_dd_line": 2
 				  }
 				},
 				"block": {
 				  "label_one": {
-					"_kics_lines": {
-					  "_kics__default": {
-						"_kics_line": 2
+					"_dd_lines": {
+					  "_dd__default": {
+						"_dd_line": 2
 					  },
-					  "_kics_policy": {
-						"_kics_line": 3
+					  "_dd_policy": {
+						"_dd_line": 3
 					  },
-					  "_kics_some_number": {
-						"_kics_line": 6
+					  "_dd_some_number": {
+						"_dd_line": 6
 					  }
 					},
 					"policy": "{\"Id\":\"aws.meuId\"}",
@@ -587,42 +587,42 @@ block "label_one" {
 						"actions": [
 						  "secretsmanager:GetSecretValue"
 						],
-						"_kics_lines": {
-						  "_kics__default": {
-							"_kics_line": 2
+						"_dd_lines": {
+						  "_dd__default": {
+							"_dd_line": 2
 						  },
-						  "_kics_actions": {
-							"_kics_line": 3,
-							"_kics_arr": [
+						  "_dd_actions": {
+							"_dd_line": 3,
+							"_dd_arr": [
 							  {
-								"_kics__default": {
-								  "_kics_line": 4
+								"_dd__default": {
+								  "_dd_line": 4
 								}
 							  }
 							]
 						  },
-						  "_kics_resources": {
-							"_kics_line": 6
+						  "_dd_resources": {
+							"_dd_line": 6
 						  }
 						}
 					  },
-					  "_kics_lines": {
-						"_kics__default": {
-						  "_kics_line": 1
+					  "_dd_lines": {
+						"_dd__default": {
+						  "_dd_line": 1
 						},
-						"_kics_statement": {
-						  "_kics_line": 2
+						"_dd_statement": {
+						  "_dd_line": 2
 						}
 					  }
 					}
 				  }
 				},
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 0
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 0
 				  },
-				  "_kics_data": {
-					"_kics_line": 1
+				  "_dd_data": {
+					"_dd_line": 1
 				  }
 				}
 			  }
@@ -644,21 +644,21 @@ block "label_one" {
 			{
   "locals": {
     "namespace_secrets": "${{ for n in [\"string1\", \"string2\", \"string3\"] : \"${n}_default\" => {\n    \"roles/secretmanager.secretAccessor\" = [\n      \"serviceAccount:${module.test[local.name].email}\",\n    ]\n    }\n  }}",
-    "_kics_lines": {
-      "_kics__default": {
-        "_kics_line": 1
+    "_dd_lines": {
+      "_dd__default": {
+        "_dd_line": 1
       },
-      "_kics_namespace_secrets": {
-        "_kics_line": 2
+      "_dd_namespace_secrets": {
+        "_dd_line": 2
       }
     }
   },
-  "_kics_lines": {
-    "_kics__default": {
-      "_kics_line": 0
+  "_dd_lines": {
+    "_dd__default": {
+      "_dd_line": 0
     },
-    "_kics_locals": {
-      "_kics_line": 1
+    "_dd_locals": {
+      "_dd_line": 1
     }
   }
 }
@@ -759,67 +759,67 @@ variable "region" {
 				"x": -10,
 				"squoted": "'quoted'",
 				"hyphen-test": 3,
-				"_kics_lines": {
-					"_kics__default": {
-						"_kics_line": 2
+				"_dd_lines": {
+					"_dd__default": {
+						"_dd_line": 2
 					},
-					"_kics_arr": {
-						"_kics_line": 6,
-						"_kics_arr": [
+					"_dd_arr": {
+						"_dd_line": 6,
+						"_dd_arr": [
 							{
-								"_kics__default": {
-									"_kics_line": 6
+								"_dd__default": {
+									"_dd_line": 6
 								}
 							},
 							{
-								"_kics__default": {
-									"_kics_line": 6
+								"_dd__default": {
+									"_dd_line": 6
 								}
 							},
 							{
-								"_kics__default": {
-									"_kics_line": 6
+								"_dd__default": {
+									"_dd_line": 6
 								}
 							},
 							{
-								"_kics__default": {
-									"_kics_line": 6
+								"_dd__default": {
+									"_dd_line": 6
 								}
 							}
 						]
 					},
-					"_kics_hyphen-test": {
-						"_kics_line": 7
+					"_dd_hyphen-test": {
+						"_dd_line": 7
 					},
-					"_kics_quoted": {
-						"_kics_line": 10
+					"_dd_quoted": {
+						"_dd_line": 10
 					},
-					"_kics_squoted": {
-						"_kics_line": 11
+					"_dd_squoted": {
+						"_dd_line": 11
 					},
-					"_kics_temp": {
-						"_kics_line": 8
+					"_dd_temp": {
+						"_dd_line": 8
 					},
-					"_kics_temp2": {
-						"_kics_line": 9
+					"_dd_temp2": {
+						"_dd_line": 9
 					},
-					"_kics_test1": {
-						"_kics_line": 4
+					"_dd_test1": {
+						"_dd_line": 4
 					},
-					"_kics_test2": {
-						"_kics_line": 5
+					"_dd_test2": {
+						"_dd_line": 5
 					},
-					"_kics_test3": {
-						"_kics_line": 3
+					"_dd_test3": {
+						"_dd_line": 3
 					},
-					"_kics_x": {
-						"_kics_line": 12
+					"_dd_x": {
+						"_dd_line": 12
 					},
-					"_kics_y": {
-						"_kics_line": 13
+					"_dd_y": {
+						"_dd_line": 13
 					},
-					"_kics_z": {
-						"_kics_line": 14
+					"_dd_z": {
+						"_dd_line": 14
 					}
 				},
 				"quoted": "\"quoted\"",
@@ -841,32 +841,32 @@ variable "region" {
 					"a.b.c[\"hi\"][3].*": 3,
 					"loop": "This has a for loop: %{for x in local.arr}x,%{endfor}"
 				},
-				"_kics_lines": {
-					"_kics__default": {
-						"_kics_line": 16
+				"_dd_lines": {
+					"_dd__default": {
+						"_dd_line": 16
 					},
-					"_kics_other": {
-						"_kics_line": 17
+					"_dd_other": {
+						"_dd_line": 17
 					}
 				}
 			},
 			{
 				"heredoc2": "\t\tAnother heredoc, that\n\t\tdoesn't remove indentation\n\t\t${local.other.3}\n\t\t%{if true ? false : true}\"gotcha\"\\n%{else}4%{endif}\n",` + //nolint
-		`"_kics_lines": {
-					"_kics__default": {
-						"_kics_line": 28
+		`"_dd_lines": {
+					"_dd__default": {
+						"_dd_line": 28
 					},
-					"_kics_cond": {
-						"_kics_line": 34
+					"_dd_cond": {
+						"_dd_line": 34
 					},
-					"_kics_heredoc": {
-						"_kics_line": 29
+					"_dd_heredoc": {
+						"_dd_line": 29
 					},
-					"_kics_heredoc2": {
-						"_kics_line": 35
+					"_dd_heredoc2": {
+						"_dd_line": 35
 					},
-					"_kics_simple": {
-						"_kics_line": 33
+					"_dd_simple": {
+						"_dd_line": 33
 					}
 				},
 				"heredoc": "This is a heredoc template.\nIt references ${local.other.3}\n",
@@ -878,21 +878,21 @@ variable "region" {
 			"terraform_remote_state": {
 				"remote": {
 					"some_number": 3,
-					"_kics_lines": {
-						"_kics__default": {
-							"_kics_line": 42
+					"_dd_lines": {
+						"_dd__default": {
+							"_dd_line": 42
 						},
-						"_kics_backend": {
-							"_kics_line": 43
+						"_dd_backend": {
+							"_dd_line": 43
 						},
-						"_kics_config": {
-							"_kics_line": 44
+						"_dd_config": {
+							"_dd_line": 44
 						},
-						"_kics_policy": {
-							"_kics_line": 50
+						"_dd_policy": {
+							"_dd_line": 50
 						},
-						"_kics_some_number": {
-							"_kics_line": 53
+						"_dd_some_number": {
+							"_dd_line": 53
 						}
 					},
 					"backend": "s3",
@@ -908,36 +908,36 @@ variable "region" {
 		},
 		"variable": {
 			"profile": {
-				"_kics_lines": {
-					"_kics__default": {
-						"_kics_line": 55
+				"_dd_lines": {
+					"_dd__default": {
+						"_dd_line": 55
 					}
 				}
 			},
 			"region": {
 				"default": "us-east-1",
-				"_kics_lines": {
-					"_kics__default": {
-						"_kics_line": 56
+				"_dd_lines": {
+					"_dd__default": {
+						"_dd_line": 56
 					},
-					"_kics_default": {
-						"_kics_line": 57
+					"_dd_default": {
+						"_dd_line": 57
 					}
 				}
 			}
 		},
-		"_kics_lines": {
-			"_kics__default": {
-				"_kics_line": 0
+		"_dd_lines": {
+			"_dd__default": {
+				"_dd_line": 0
 			},
-			"_kics_data": {
-				"_kics_line": 42
+			"_dd_data": {
+				"_dd_line": 42
 			},
-			"_kics_locals": {
-				"_kics_line": 28
+			"_dd_locals": {
+				"_dd_line": 28
 			},
-			"_kics_variable": {
-				"_kics_line": 56
+			"_dd_variable": {
+				"_dd_line": 56
 			}
 		}
 	}`

--- a/pkg/parser/yaml/cicd/parser_test.go
+++ b/pkg/parser/yaml/cicd/parser_test.go
@@ -99,21 +99,21 @@ resources:
 		{
 			want: `[
 			{
-			  "_kics_lines": {
-				"_kics__default": {
-				  "_kics_line": 0
+			  "_dd_lines": {
+				"_dd__default": {
+				  "_dd_line": 0
 				},
-				"_kics_martin": {
-				  "_kics_line": 3
+				"_dd_martin": {
+				  "_dd_line": 3
 				}
 			  },
 			  "martin": {
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 3
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 3
 				  },
-				  "_kics_name": {
-					"_kics_line": 4
+				  "_dd_name": {
+					"_dd_line": 4
 				  }
 				},
 				"name": "test"
@@ -121,21 +121,21 @@ resources:
 			  "_path":"test.yaml"
 			},
 			{
-			  "_kics_lines": {
-				"_kics__default": {
-				  "_kics_line": 0
+			  "_dd_lines": {
+				"_dd__default": {
+				  "_dd_line": 0
 				},
-				"_kics_martin2": {
-				  "_kics_line": 6
+				"_dd_martin2": {
+				  "_dd_line": 6
 				}
 			  },
 			  "martin2": {
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 6
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 6
 				  },
-				  "_kics_name": {
-					"_kics_line": 7
+				  "_dd_name": {
+					"_dd_line": 7
 				  }
 				},
 				"name": "test2"
@@ -150,39 +150,39 @@ resources:
 		{
 			want: `[
 			{
-			  "_kics_lines": {
-				"_kics__default": {
-				  "_kics_arr": [
+			  "_dd_lines": {
+				"_dd__default": {
+				  "_dd_arr": [
 					{
-					  "_kics__default": {
-						"_kics_line": 4
+					  "_dd__default": {
+						"_dd_line": 4
 					  },
-					  "_kics_amazon.aws.aws_s3": {
-						"_kics_line": 5
+					  "_dd_amazon.aws.aws_s3": {
+						"_dd_line": 5
 					  },
-					  "_kics_name": {
-						"_kics_line": 4
+					  "_dd_name": {
+						"_dd_line": 4
 					  }
 					}
 				  ],
-				  "_kics_line": 0
+				  "_dd_line": 0
 				}
 			  },
 			  "playbooks": [
 				{
 				  "amazon.aws.aws_s3": {
-					"_kics_lines": {
-					  "_kics__default": {
-						"_kics_line": 5
+					"_dd_lines": {
+					  "_dd__default": {
+						"_dd_line": 5
 					  },
-					  "_kics_bucket": {
-						"_kics_line": 6
+					  "_dd_bucket": {
+						"_dd_line": 6
 					  },
-					  "_kics_mode": {
-						"_kics_line": 7
+					  "_dd_mode": {
+						"_dd_line": 7
 					  },
-					  "_kics_permission": {
-						"_kics_line": 8
+					  "_dd_permission": {
+						"_dd_line": 8
 					  }
 					},
 					"bucket": "mybucket",
@@ -202,36 +202,36 @@ resources:
 		{
 			want: `[
 			{
-			  "_kics_lines": {
-				"_kics__default": {
-				  "_kics_line": 0
+			  "_dd_lines": {
+				"_dd__default": {
+				  "_dd_line": 0
 				},
-				"_kics_test": {
-				  "_kics_arr": [
+				"_dd_test": {
+				  "_dd_arr": [
 					{
-					  "_kics__default": {
-						"_kics_line": 4
+					  "_dd__default": {
+						"_dd_line": 4
 					  },
-					  "_kics_group": {
-						"_kics_line": 4
+					  "_dd_group": {
+						"_dd_line": 4
 					  }
 					}
 				  ],
-				  "_kics_line": 2
+				  "_dd_line": 2
 				},
-				"_kics_test_2": {
-				  "_kics_line": 7
+				"_dd_test_2": {
+				  "_dd_line": 7
 				}
 			  },
 			  "test": [
 				{
 				  "group": {
-					"_kics_lines": {
-					  "_kics__default": {
-						"_kics_line": 4
+					"_dd_lines": {
+					  "_dd__default": {
+						"_dd_line": 4
 					  },
-					  "_kics_name": {
-						"_kics_line": 6
+					  "_dd_name": {
+						"_dd_line": 6
 					  }
 					},
 					"name": "cx"
@@ -239,38 +239,38 @@ resources:
 				}
 			  ],
 			  "test_2": {
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 7
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 7
 				  },
-				  "_kics_perm": {
-					"_kics_arr": [
+				  "_dd_perm": {
+					"_dd_arr": [
 					  {
-						"_kics_<<": {
-						  "_kics_line": 9
+						"_dd_<<": {
+						  "_dd_line": 9
 						},
-						"_kics__default": {
-						  "_kics_line": 9
+						"_dd__default": {
+						  "_dd_line": 9
 						}
 					  }
 					],
-					"_kics_line": 8
+					"_dd_line": 8
 				  }
 				},
 				"perm": [
 					{
-						"_kics_lines": {
-							"_kics__default": {
-								"_kics_line": 9
+						"_dd_lines": {
+							"_dd__default": {
+								"_dd_line": 9
 							}
 						},
 						"group": {
-							"_kics_lines": {
-								"_kics__default": {
-									"_kics_line": 4
+							"_dd_lines": {
+								"_dd__default": {
+									"_dd_line": 4
 								},
-								"_kics_name": {
-									"_kics_line": 6
+								"_dd_name": {
+									"_dd_line": 6
 								}
 							},
 							"name": "cx"
@@ -293,39 +293,39 @@ resources:
 		{
 			want: `[
 				{
-					"_kics_lines": {
-						"_kics__default": {
-							"_kics_line": 0
+					"_dd_lines": {
+						"_dd__default": {
+							"_dd_line": 0
 						},
-						"_kics_resources": {
-							"_kics_arr": [
+						"_dd_resources": {
+							"_dd_arr": [
 								{
-									"_kics__default": {
-										"_kics_line": 3
+									"_dd__default": {
+										"_dd_line": 3
 									},
-									"_kics_name": {
-										"_kics_line": 3
+									"_dd_name": {
+										"_dd_line": 3
 									},
-									"_kics_type": {
-										"_kics_line": 4
+									"_dd_type": {
+										"_dd_line": 4
 									}
 								},
 								{
-									"_kics__default": {
-										"_kics_line": 5
+									"_dd__default": {
+										"_dd_line": 5
 									},
-									"_kics_name": {
-										"_kics_line": 5
+									"_dd_name": {
+										"_dd_line": 5
 									},
-									"_kics_properties": {
-										"_kics_line": 7
+									"_dd_properties": {
+										"_dd_line": 7
 									},
-									"_kics_type": {
-										"_kics_line": 6
+									"_dd_type": {
+										"_dd_line": 6
 									}
 								}
 							],
-							"_kics_line": 2
+							"_dd_line": 2
 						}
 					},
 					"resources": [
@@ -336,12 +336,12 @@ resources:
 						{
 							"name": "my-vm",
 							"properties": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 7
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 7
 									},
-									"_kics_serviceAccountId": {
-										"_kics_line": 8
+									"_dd_serviceAccountId": {
+										"_dd_line": 8
 									}
 								},
 								"serviceAccountId": "my-vm-access"

--- a/pkg/parser/yaml/default/parser_test.go
+++ b/pkg/parser/yaml/default/parser_test.go
@@ -107,21 +107,21 @@ resources:
 		{
 			want: `[
 			{
-			  "_kics_lines": {
-				"_kics__default": {
-				  "_kics_line": 0
+			  "_dd_lines": {
+				"_dd__default": {
+				  "_dd_line": 0
 				},
-				"_kics_martin": {
-				  "_kics_line": 3
+				"_dd_martin": {
+				  "_dd_line": 3
 				}
 			  },
 			  "martin": {
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 3
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 3
 				  },
-				  "_kics_name": {
-					"_kics_line": 4
+				  "_dd_name": {
+					"_dd_line": 4
 				  }
 				},
 				"name": "test"
@@ -129,21 +129,21 @@ resources:
 			  "_path":"test.yaml"
 			},
 			{
-			  "_kics_lines": {
-				"_kics__default": {
-				  "_kics_line": 0
+			  "_dd_lines": {
+				"_dd__default": {
+				  "_dd_line": 0
 				},
-				"_kics_martin2": {
-				  "_kics_line": 6
+				"_dd_martin2": {
+				  "_dd_line": 6
 				}
 			  },
 			  "martin2": {
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 6
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 6
 				  },
-				  "_kics_name": {
-					"_kics_line": 7
+				  "_dd_name": {
+					"_dd_line": 7
 				  }
 				},
 				"name": "test2"
@@ -158,39 +158,39 @@ resources:
 		{
 			want: `[
 			{
-			  "_kics_lines": {
-				"_kics__default": {
-				  "_kics_arr": [
+			  "_dd_lines": {
+				"_dd__default": {
+				  "_dd_arr": [
 					{
-					  "_kics__default": {
-						"_kics_line": 4
+					  "_dd__default": {
+						"_dd_line": 4
 					  },
-					  "_kics_amazon.aws.aws_s3": {
-						"_kics_line": 5
+					  "_dd_amazon.aws.aws_s3": {
+						"_dd_line": 5
 					  },
-					  "_kics_name": {
-						"_kics_line": 4
+					  "_dd_name": {
+						"_dd_line": 4
 					  }
 					}
 				  ],
-				  "_kics_line": 0
+				  "_dd_line": 0
 				}
 			  },
 			  "playbooks": [
 				{
 				  "amazon.aws.aws_s3": {
-					"_kics_lines": {
-					  "_kics__default": {
-						"_kics_line": 5
+					"_dd_lines": {
+					  "_dd__default": {
+						"_dd_line": 5
 					  },
-					  "_kics_bucket": {
-						"_kics_line": 6
+					  "_dd_bucket": {
+						"_dd_line": 6
 					  },
-					  "_kics_mode": {
-						"_kics_line": 7
+					  "_dd_mode": {
+						"_dd_line": 7
 					  },
-					  "_kics_permission": {
-						"_kics_line": 8
+					  "_dd_permission": {
+						"_dd_line": 8
 					  }
 					},
 					"bucket": "mybucket",
@@ -210,36 +210,36 @@ resources:
 		{
 			want: `[
 			{
-			  "_kics_lines": {
-				"_kics__default": {
-				  "_kics_line": 0
+			  "_dd_lines": {
+				"_dd__default": {
+				  "_dd_line": 0
 				},
-				"_kics_test": {
-				  "_kics_arr": [
+				"_dd_test": {
+				  "_dd_arr": [
 					{
-					  "_kics__default": {
-						"_kics_line": 4
+					  "_dd__default": {
+						"_dd_line": 4
 					  },
-					  "_kics_group": {
-						"_kics_line": 4
+					  "_dd_group": {
+						"_dd_line": 4
 					  }
 					}
 				  ],
-				  "_kics_line": 2
+				  "_dd_line": 2
 				},
-				"_kics_test_2": {
-				  "_kics_line": 7
+				"_dd_test_2": {
+				  "_dd_line": 7
 				}
 			  },
 			  "test": [
 				{
 				  "group": {
-					"_kics_lines": {
-					  "_kics__default": {
-						"_kics_line": 4
+					"_dd_lines": {
+					  "_dd__default": {
+						"_dd_line": 4
 					  },
-					  "_kics_name": {
-						"_kics_line": 6
+					  "_dd_name": {
+						"_dd_line": 6
 					  }
 					},
 					"name": "cx"
@@ -247,38 +247,38 @@ resources:
 				}
 			  ],
 			  "test_2": {
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 7
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 7
 				  },
-				  "_kics_perm": {
-					"_kics_arr": [
+				  "_dd_perm": {
+					"_dd_arr": [
 					  {
-						"_kics_<<": {
-						  "_kics_line": 9
+						"_dd_<<": {
+						  "_dd_line": 9
 						},
-						"_kics__default": {
-						  "_kics_line": 9
+						"_dd__default": {
+						  "_dd_line": 9
 						}
 					  }
 					],
-					"_kics_line": 8
+					"_dd_line": 8
 				  }
 				},
 				"perm": [
 					{
-						"_kics_lines": {
-							"_kics__default": {
-								"_kics_line": 9
+						"_dd_lines": {
+							"_dd__default": {
+								"_dd_line": 9
 							}
 						},
 						"group": {
-							"_kics_lines": {
-								"_kics__default": {
-									"_kics_line": 4
+							"_dd_lines": {
+								"_dd__default": {
+									"_dd_line": 4
 								},
-								"_kics_name": {
-									"_kics_line": 6
+								"_dd_name": {
+									"_dd_line": 6
 								}
 							},
 							"name": "cx"
@@ -301,39 +301,39 @@ resources:
 		{
 			want: `[
 				{
-					"_kics_lines": {
-						"_kics__default": {
-							"_kics_line": 0
+					"_dd_lines": {
+						"_dd__default": {
+							"_dd_line": 0
 						},
-						"_kics_resources": {
-							"_kics_arr": [
+						"_dd_resources": {
+							"_dd_arr": [
 								{
-									"_kics__default": {
-										"_kics_line": 3
+									"_dd__default": {
+										"_dd_line": 3
 									},
-									"_kics_name": {
-										"_kics_line": 3
+									"_dd_name": {
+										"_dd_line": 3
 									},
-									"_kics_type": {
-										"_kics_line": 4
+									"_dd_type": {
+										"_dd_line": 4
 									}
 								},
 								{
-									"_kics__default": {
-										"_kics_line": 5
+									"_dd__default": {
+										"_dd_line": 5
 									},
-									"_kics_name": {
-										"_kics_line": 5
+									"_dd_name": {
+										"_dd_line": 5
 									},
-									"_kics_properties": {
-										"_kics_line": 7
+									"_dd_properties": {
+										"_dd_line": 7
 									},
-									"_kics_type": {
-										"_kics_line": 6
+									"_dd_type": {
+										"_dd_line": 6
 									}
 								}
 							],
-							"_kics_line": 2
+							"_dd_line": 2
 						}
 					},
 					"resources": [
@@ -344,12 +344,12 @@ resources:
 						{
 							"name": "my-vm",
 							"properties": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 7
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 7
 									},
-									"_kics_serviceAccountId": {
-										"_kics_line": 8
+									"_dd_serviceAccountId": {
+										"_dd_line": 8
 									}
 								},
 								"serviceAccountId": "my-vm-access"

--- a/pkg/parser/yaml/parser_test.go
+++ b/pkg/parser/yaml/parser_test.go
@@ -78,21 +78,21 @@ resources:
 		{
 			want: `[
 			{
-			  "_kics_lines": {
-				"_kics__default": {
-				  "_kics_line": 0
+			  "_dd_lines": {
+				"_dd__default": {
+				  "_dd_line": 0
 				},
-				"_kics_martin": {
-				  "_kics_line": 3
+				"_dd_martin": {
+				  "_dd_line": 3
 				}
 			  },
 			  "martin": {
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 3
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 3
 				  },
-				  "_kics_name": {
-					"_kics_line": 4
+				  "_dd_name": {
+					"_dd_line": 4
 				  }
 				},
 				"name": "test"
@@ -100,21 +100,21 @@ resources:
 			  "_path":"test.yaml"
 			},
 			{
-			  "_kics_lines": {
-				"_kics__default": {
-				  "_kics_line": 0
+			  "_dd_lines": {
+				"_dd__default": {
+				  "_dd_line": 0
 				},
-				"_kics_martin2": {
-				  "_kics_line": 6
+				"_dd_martin2": {
+				  "_dd_line": 6
 				}
 			  },
 			  "martin2": {
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 6
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 6
 				  },
-				  "_kics_name": {
-					"_kics_line": 7
+				  "_dd_name": {
+					"_dd_line": 7
 				  }
 				},
 				"name": "test2"
@@ -129,39 +129,39 @@ resources:
 		{
 			want: `[
 			{
-			  "_kics_lines": {
-				"_kics__default": {
-				  "_kics_arr": [
+			  "_dd_lines": {
+				"_dd__default": {
+				  "_dd_arr": [
 					{
-					  "_kics__default": {
-						"_kics_line": 4
+					  "_dd__default": {
+						"_dd_line": 4
 					  },
-					  "_kics_amazon.aws.aws_s3": {
-						"_kics_line": 5
+					  "_dd_amazon.aws.aws_s3": {
+						"_dd_line": 5
 					  },
-					  "_kics_name": {
-						"_kics_line": 4
+					  "_dd_name": {
+						"_dd_line": 4
 					  }
 					}
 				  ],
-				  "_kics_line": 0
+				  "_dd_line": 0
 				}
 			  },
 			  "playbooks": [
 				{
 				  "amazon.aws.aws_s3": {
-					"_kics_lines": {
-					  "_kics__default": {
-						"_kics_line": 5
+					"_dd_lines": {
+					  "_dd__default": {
+						"_dd_line": 5
 					  },
-					  "_kics_bucket": {
-						"_kics_line": 6
+					  "_dd_bucket": {
+						"_dd_line": 6
 					  },
-					  "_kics_mode": {
-						"_kics_line": 7
+					  "_dd_mode": {
+						"_dd_line": 7
 					  },
-					  "_kics_permission": {
-						"_kics_line": 8
+					  "_dd_permission": {
+						"_dd_line": 8
 					  }
 					},
 					"bucket": "mybucket",
@@ -181,36 +181,36 @@ resources:
 		{
 			want: `[
 			{
-			  "_kics_lines": {
-				"_kics__default": {
-				  "_kics_line": 0
+			  "_dd_lines": {
+				"_dd__default": {
+				  "_dd_line": 0
 				},
-				"_kics_test": {
-				  "_kics_arr": [
+				"_dd_test": {
+				  "_dd_arr": [
 					{
-					  "_kics__default": {
-						"_kics_line": 4
+					  "_dd__default": {
+						"_dd_line": 4
 					  },
-					  "_kics_group": {
-						"_kics_line": 4
+					  "_dd_group": {
+						"_dd_line": 4
 					  }
 					}
 				  ],
-				  "_kics_line": 2
+				  "_dd_line": 2
 				},
-				"_kics_test_2": {
-				  "_kics_line": 7
+				"_dd_test_2": {
+				  "_dd_line": 7
 				}
 			  },
 			  "test": [
 				{
 				  "group": {
-					"_kics_lines": {
-					  "_kics__default": {
-						"_kics_line": 4
+					"_dd_lines": {
+					  "_dd__default": {
+						"_dd_line": 4
 					  },
-					  "_kics_name": {
-						"_kics_line": 6
+					  "_dd_name": {
+						"_dd_line": 6
 					  }
 					},
 					"name": "cx"
@@ -218,38 +218,38 @@ resources:
 				}
 			  ],
 			  "test_2": {
-				"_kics_lines": {
-				  "_kics__default": {
-					"_kics_line": 7
+				"_dd_lines": {
+				  "_dd__default": {
+					"_dd_line": 7
 				  },
-				  "_kics_perm": {
-					"_kics_arr": [
+				  "_dd_perm": {
+					"_dd_arr": [
 					  {
-						"_kics_<<": {
-						  "_kics_line": 9
+						"_dd_<<": {
+						  "_dd_line": 9
 						},
-						"_kics__default": {
-						  "_kics_line": 9
+						"_dd__default": {
+						  "_dd_line": 9
 						}
 					  }
 					],
-					"_kics_line": 8
+					"_dd_line": 8
 				  }
 				},
 				"perm": [
 					{
-						"_kics_lines": {
-							"_kics__default": {
-								"_kics_line": 9
+						"_dd_lines": {
+							"_dd__default": {
+								"_dd_line": 9
 							}
 						},
 						"group": {
-							"_kics_lines": {
-								"_kics__default": {
-									"_kics_line": 4
+							"_dd_lines": {
+								"_dd__default": {
+									"_dd_line": 4
 								},
-								"_kics_name": {
-									"_kics_line": 6
+								"_dd_name": {
+									"_dd_line": 6
 								}
 							},
 							"name": "cx"
@@ -272,39 +272,39 @@ resources:
 		{
 			want: `[
 				{
-					"_kics_lines": {
-						"_kics__default": {
-							"_kics_line": 0
+					"_dd_lines": {
+						"_dd__default": {
+							"_dd_line": 0
 						},
-						"_kics_resources": {
-							"_kics_arr": [
+						"_dd_resources": {
+							"_dd_arr": [
 								{
-									"_kics__default": {
-										"_kics_line": 3
+									"_dd__default": {
+										"_dd_line": 3
 									},
-									"_kics_name": {
-										"_kics_line": 3
+									"_dd_name": {
+										"_dd_line": 3
 									},
-									"_kics_type": {
-										"_kics_line": 4
+									"_dd_type": {
+										"_dd_line": 4
 									}
 								},
 								{
-									"_kics__default": {
-										"_kics_line": 5
+									"_dd__default": {
+										"_dd_line": 5
 									},
-									"_kics_name": {
-										"_kics_line": 5
+									"_dd_name": {
+										"_dd_line": 5
 									},
-									"_kics_properties": {
-										"_kics_line": 7
+									"_dd_properties": {
+										"_dd_line": 7
 									},
-									"_kics_type": {
-										"_kics_line": 6
+									"_dd_type": {
+										"_dd_line": 6
 									}
 								}
 							],
-							"_kics_line": 2
+							"_dd_line": 2
 						}
 					},
 					"resources": [
@@ -315,12 +315,12 @@ resources:
 						{
 							"name": "my-vm",
 							"properties": {
-								"_kics_lines": {
-									"_kics__default": {
-										"_kics_line": 7
+								"_dd_lines": {
+									"_dd__default": {
+										"_dd_line": 7
 									},
-									"_kics_serviceAccountId": {
-										"_kics_line": 8
+									"_dd_serviceAccountId": {
+										"_dd_line": 8
 									}
 								},
 								"serviceAccountId": "my-vm-access"


### PR DESCRIPTION
## Motivation

The parsed document AST uses `_kics_line`, `_kics_lines`, `_kics_filter_expr` etc. as field names, inherited from KICS. Nine rules in `datadog-iac-scanner-default-rules` reference these keys directly in Rego. This renames them to `_dd_*` while keeping both old and new fields emitted during migration so the two repos can be deployed independently.

## Changes

**Parsers (retrocompat — both keys emitted)**

`docker.Command` and `buildah.Command` now emit both `_kics_line` (legacy) and `_dd_line`. `jsonfilter.AWSJSONFilter` emits both `_kics_filter_expr` (legacy) and `_dd_filter_expr`. Old rules using the legacy keys continue to produce findings.

**Parsers (direct rename — internal keys, no rego visibility)**

`_kics_lines` → `_dd_lines`, `_kics__default` → `_dd__default`, `_kics_arr` → `_dd_arr` across all converters (Terraform, gRPC, JSON, YAML, Bicep) and `model.LineObject` JSON tags.

**Detector**

All `_kics_*` path strings in `pkg/detector/search_line_detector.go` updated to `_dd_*`.

**Tests**

Test fixtures and inline assertions updated to reflect both old and new keys where retrocompat applies; struct and marshal tests updated to compare only the canonical new field.

## QA Instruction

1. `go test ./pkg/parser/... ./pkg/detector/... ./pkg/model/... ./pkg/kics/...`
2. Run a full scan against a Terraform + Dockerfile fixture and confirm line numbers are reported correctly.
3. To verify backward compat: temporarily revert one Dockerfile rego rule to `_kics_line` and confirm findings still appear.

## Impact

Affects every parser's document output. No change in scan findings — both field names are present in the document during migration. The companion rules PR updates the 9 rego rules that reference these keys directly.