### PR TITLE
Rename KICSCommentRgxp identifiers to DDCommentRgxp and clean up kics comments

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -1,6 +1,6 @@
 package assets
 
-import "embed" // used for embedding KICS libraries
+import "embed" // used for embedding scanner libraries
 
 //go:embed libraries/*.rego
 var embeddedLibraries embed.FS

--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -102,7 +102,7 @@ func GenerateReport(ctx context.Context, path, filename string, body interface{}
 	return err
 }
 
-// GetExecutableDirectory - returns the path to the directory containing KICS executable
+// GetExecutableDirectory - returns the path to the directory containing the scanner executable
 func GetExecutableDirectory() string {
 	log.Debug().Msg("helpers.GetExecutableDirectory()")
 	path, err := os.Executable()

--- a/internal/console/pre_scan.go
+++ b/internal/console/pre_scan.go
@@ -6,7 +6,7 @@
 package console
 
 import (
-	_ "embed" // Embed kics CLI img and scan-flags
+	_ "embed" // Embed scanner CLI img and scan-flags
 	"fmt"
 	"runtime"
 	"strings"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	// Version - current KICS version
+	// Version - current scanner version
 	Version = "development"
 	// SCMCommit - Source control management commit identifier
 	SCMCommit = "NOCOMMIT"
@@ -93,7 +93,7 @@ var (
 )
 
 const (
-	// Fullname - KICS fullname
+	// Fullname - scanner fullname
 	Fullname = "DataDog IaC Scanner"
 
 	// URL - DD Docs url

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -96,7 +96,7 @@ type Inspector struct {
 	queryExecTimeout     time.Duration
 	useOldSeverities     bool
 	numWorkers           int
-	computeNewSimID  bool
+	computeNewSimID      bool
 	flagEvaluator        featureflags.FlagEvaluator
 }
 

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -71,7 +71,7 @@ type QueryLoader struct {
 
 // VulnerabilityBuilder represents a function that will build a vulnerability
 type VulnerabilityBuilder func(ctx context.Context, qCtx *QueryContext, tracker Tracker, v interface{},
-	detector *detector.DetectLine, useOldSeverities bool, kicsComputeNewSimID bool, queryDuration time.Duration) (*model.Vulnerability, error)
+	detector *detector.DetectLine, useOldSeverities bool, computeNewSimID bool, queryDuration time.Duration) (*model.Vulnerability, error)
 
 // PreparedQuery includes the opaQuery and its metadata
 type PreparedQuery struct {
@@ -96,7 +96,7 @@ type Inspector struct {
 	queryExecTimeout     time.Duration
 	useOldSeverities     bool
 	numWorkers           int
-	kicsComputeNewSimID  bool
+	computeNewSimID  bool
 	flagEvaluator        featureflags.FlagEvaluator
 }
 
@@ -133,7 +133,7 @@ func NewInspector(
 	useOldSeverities bool,
 	needsLog bool,
 	numWorkers int,
-	kicsComputeNewSimID bool,
+	computeNewSimID bool,
 	flagEvaluator featureflags.FlagEvaluator,
 ) (*Inspector, error) {
 	contextLogger := logger.FromContext(ctx)
@@ -184,7 +184,7 @@ func NewInspector(
 		queryExecTimeout:    queryExecTimeout,
 		useOldSeverities:    useOldSeverities,
 		numWorkers:          utils.AdjustNumWorkers(numWorkers),
-		kicsComputeNewSimID: kicsComputeNewSimID,
+		computeNewSimID: computeNewSimID,
 		flagEvaluator:       flagEvaluator,
 	}, nil
 }
@@ -576,7 +576,7 @@ func (c *Inspector) DecodeQueryResults(
 func getVulnerabilitiesFromQuery(ctx context.Context, qCtx *QueryContext, c *Inspector,
 	queryResultItem interface{}, queryDuration time.Duration) (*model.Vulnerability, bool) {
 	contextLogger := logger.FromContext(ctx)
-	vulnerability, err := c.vb(ctx, qCtx, c.tracker, queryResultItem, c.detector, c.useOldSeverities, c.kicsComputeNewSimID, queryDuration)
+	vulnerability, err := c.vb(ctx, qCtx, c.tracker, queryResultItem, c.detector, c.useOldSeverities, c.computeNewSimID, queryDuration)
 	if err != nil && err.Error() == ErrNoResult.Error() {
 		// Ignoring bad results
 		return nil, false

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -173,19 +173,19 @@ func NewInspector(
 	}
 
 	return &Inspector{
-		QueryLoader:         &queryLoader,
-		vb:                  vb,
-		tracker:             tracker,
-		failedQueries:       failedQueries,
-		excludeResults:      excludeResults,
-		ruleConfigs:         ruleConfigs,
-		detector:            lineDetector,
-		repoPath:            repoPath,
-		queryExecTimeout:    queryExecTimeout,
-		useOldSeverities:    useOldSeverities,
-		numWorkers:          utils.AdjustNumWorkers(numWorkers),
-		computeNewSimID: computeNewSimID,
-		flagEvaluator:       flagEvaluator,
+		QueryLoader:      &queryLoader,
+		vb:               vb,
+		tracker:          tracker,
+		failedQueries:    failedQueries,
+		excludeResults:   excludeResults,
+		ruleConfigs:      ruleConfigs,
+		detector:         lineDetector,
+		repoPath:         repoPath,
+		queryExecTimeout: queryExecTimeout,
+		useOldSeverities: useOldSeverities,
+		numWorkers:       utils.AdjustNumWorkers(numWorkers),
+		computeNewSimID:  computeNewSimID,
+		flagEvaluator:    flagEvaluator,
 	}, nil
 }
 

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -60,7 +60,7 @@ type inspectorOpts struct {
 	useOldSeverities    bool
 	needsLog            bool
 	numWorkers          int
-	kicsComputeNewSimID bool
+	computeNewSimID bool
 	vb                  VulnerabilityBuilder
 	tracker             Tracker
 }
@@ -112,7 +112,7 @@ func newTestInspector(t *testing.T, opts inspectorOpts) *Inspector {
 		opts.useOldSeverities,
 		opts.needsLog,
 		opts.numWorkers,
-		opts.kicsComputeNewSimID,
+		opts.computeNewSimID,
 		featureflags.NewLocalEvaluator(),
 	)
 	require.NoError(t, err)
@@ -239,7 +239,7 @@ func TestNewInspector(t *testing.T) {
 		queries:             queries,
 		tracker:             track,
 		needsLog:            true,
-		kicsComputeNewSimID: true,
+		computeNewSimID: true,
 	})
 
 	require.NotNil(t, ins.vb, "vulnerability builder should be wired")
@@ -307,7 +307,7 @@ func TestEngine_LenQueriesByPlat(t *testing.T) {
 		{Query: "tf_rule_b", Content: "package tf_rule_b\n", InputData: "{}", Platform: "terraform", Aggregation: 1},
 		{Query: "k8s_rule", Content: "package k8s_rule\n", InputData: "{}", Platform: "kubernetes", Aggregation: 1},
 	}
-	ins := newTestInspector(t, inspectorOpts{queries: queries, kicsComputeNewSimID: true})
+	ins := newTestInspector(t, inspectorOpts{queries: queries, computeNewSimID: true})
 
 	require.Equal(t, 2, ins.LenQueriesByPlat([]string{"terraform"}))
 	require.Equal(t, 1, ins.LenQueriesByPlat([]string{"kubernetes"}))
@@ -316,7 +316,7 @@ func TestEngine_LenQueriesByPlat(t *testing.T) {
 }
 
 func TestEngine_GetFailedQueries(t *testing.T) {
-	ins := newTestInspector(t, inspectorOpts{kicsComputeNewSimID: true})
+	ins := newTestInspector(t, inspectorOpts{computeNewSimID: true})
 	const nrFailedQueries = 5
 	for idx := 0; idx < nrFailedQueries; idx++ {
 		ins.failedQueries[fmt.Sprint(idx)] = nil
@@ -614,7 +614,7 @@ func TestGetVulnerabilitiesFromQuery_FirstJustificationWins(t *testing.T) {
 
 func TestInspector_DecodeQueryResults(t *testing.T) {
 	ctx := context.Background()
-	c := newTestInspector(t, inspectorOpts{kicsComputeNewSimID: true})
+	c := newTestInspector(t, inspectorOpts{computeNewSimID: true})
 
 	queryContext := newQueryContext(ctx)
 

--- a/pkg/engine/provider/extract.go
+++ b/pkg/engine/provider/extract.go
@@ -26,7 +26,7 @@ type ExtractedPath struct {
 }
 
 // GetKuberneterSources uses Kubernetes API to download runtime resources
-// After Downloaded files kics scan the files as normal local files
+// After downloading, scan the files as normal local files
 func GetKuberneterSources(ctx context.Context, source []string, destinationPath string) (ExtractedPath, error) {
 	contextLogger := logger.FromContext(ctx)
 	extrStruct := ExtractedPath{

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -39,7 +39,7 @@ const (
 
 var (
 	queryRegexExcludeTerraCache = regexp.MustCompile(fmt.Sprintf(`^(.*?%s)?\.terra.*`, regexp.QuoteMeta(string(os.PathSeparator))))
-	// ErrNotSupportedFile - error representing when a file format is not supported by KICS
+	// ErrNotSupportedFile - error representing when a file format is not supported by the scanner
 	ErrNotSupportedFile = errors.New("invalid file format")
 )
 

--- a/pkg/engine/similarity_id_test.go
+++ b/pkg/engine/similarity_id_test.go
@@ -102,7 +102,7 @@ func inspectSimIDs(t *testing.T, q model.QueryMetadata, filePath string, content
 	ins := newTestInspector(t, inspectorOpts{
 		queries:             []model.QueryMetadata{q},
 		vb:                  DefaultVulnerabilityBuilder,
-		kicsComputeNewSimID: true,
+		computeNewSimID: true,
 		repoPath:            "testdata/simid",
 	})
 

--- a/pkg/engine/source/filesystem.go
+++ b/pkg/engine/source/filesystem.go
@@ -219,32 +219,32 @@ func checkQueryFeatureFlagDisabled(ctx context.Context, metadata map[string]any,
 		return false
 	}
 
-	// Extract KICS ID from query metadata
-	kicsID, exists := metadata["id"]
+	// Extract rule ID from query metadata
+	ruleID, exists := metadata["id"]
 	if !exists {
 		return false
 	}
 
-	kicsIDStr, ok := kicsID.(string)
+	ruleIDStr, ok := ruleID.(string)
 	if !ok {
 		return false
 	}
 
-	// Extract KICS PLATFORM from query metadata
-	kicsPlatform, exists := metadata["platform"]
+	// Extract platform from query metadata
+	rulePlatformVal, exists := metadata["platform"]
 	if !exists {
 		return false
 	}
 
-	kicsPlatformStr, ok := kicsPlatform.(string)
+	rulePlatformStr, ok := rulePlatformVal.(string)
 	if !ok {
 		return false
 	}
 
-	// Create custom variables with the KICS ID
+	// Create custom variables with the rule ID and platform for feature flag evaluation
 	customVariables := map[string]any{
-		"KICS_RULE_ID":       kicsIDStr,
-		"KICS_RULE_PLATFORM": kicsPlatformStr,
+		"KICS_RULE_ID":       ruleIDStr,
+		"KICS_RULE_PLATFORM": rulePlatformStr,
 	}
 
 	contextLogger := logger.FromContext(ctx)
@@ -254,29 +254,29 @@ func checkQueryFeatureFlagDisabled(ctx context.Context, metadata map[string]any,
 	if err != nil {
 		// If feature flag evaluation fails, log and continue (fail open)
 		contextLogger.Warn().
-			Err(err).Str("kics_id", kicsIDStr).
+			Err(err).Str("rule_id", ruleIDStr).
 			Str("feature_flag", featureflags.IacDisableKicsRule).
-			Msg("Failed to evaluate feature flag for KICS rule")
+			Msg("Failed to evaluate feature flag for rule")
 	}
 
 	if ruleIdDisabled {
-		contextLogger.Info().Str("kics_id", kicsIDStr).Str("feature_flag", featureflags.IacDisableKicsRule).
-			Msg("KICS rule disabled by feature flag")
+		contextLogger.Info().Str("rule_id", ruleIDStr).Str("feature_flag", featureflags.IacDisableKicsRule).
+			Msg("Rule disabled by feature flag")
 		return true
 	}
 
-	// Check if the rule is enabled via feature flag
+	// Check if the rule's platform is enabled via feature flag
 	rulePlatformEnabled, err := queryParameters.FlagEvaluator.EvaluateWithOrgAndEnvAndCustomVariables(featureflags.IacEnableKicsPlatform,
 		customVariables)
 	if err != nil {
 		// If feature flag evaluation fails, log and continue (fail open)
-		contextLogger.Warn().Err(err).Str("kics_id", kicsIDStr).Str("feature_flag", featureflags.IacEnableKicsPlatform).
-			Msg("Failed to evaluate feature flag for KICS rule")
+		contextLogger.Warn().Err(err).Str("rule_id", ruleIDStr).Str("feature_flag", featureflags.IacEnableKicsPlatform).
+			Msg("Failed to evaluate feature flag for rule platform")
 	}
 
 	if !rulePlatformEnabled {
-		contextLogger.Info().Str("kics_id", kicsIDStr).Str("feature_flag", featureflags.IacEnableKicsPlatform).
-			Msg("KICS rule disabled by feature flag")
+		contextLogger.Info().Str("rule_id", ruleIDStr).Str("feature_flag", featureflags.IacEnableKicsPlatform).
+			Msg("Rule platform disabled by feature flag")
 		return true
 	}
 
@@ -343,7 +343,7 @@ func (s *FilesystemSource) iterateQueryDirs(ctx context.Context, queryDirs []str
 	return queries
 }
 
-// validateMetadata prevents panics when KICS queries metadata fields are missing
+// validateMetadata prevents panics when query metadata fields are missing
 func validateMetadata(metadata map[string]any) (exist bool, field string) {
 	fields := []string{
 		"id",

--- a/pkg/engine/source/filesystem.go
+++ b/pkg/engine/source/filesystem.go
@@ -43,7 +43,7 @@ const (
 
 	common = "Common"
 
-	kicsDefault = "default"
+	defaultLibrary = "default"
 )
 
 // NewFilesystemSource initializes a NewFilesystemSource with source to queries and types of queries to load
@@ -98,7 +98,7 @@ func isDefaultLibrary(libraryPath string) bool {
 // GetPathToCustomLibrary - returns the libraries path for a given platform
 func GetPathToCustomLibrary(ctx context.Context, platform, libraryPathFlag string) string {
 	contextLogger := logger.FromContext(ctx)
-	libraryFilePath := kicsDefault
+	libraryFilePath := defaultLibrary
 
 	if !isDefaultLibrary(libraryPathFlag) {
 		contextLogger.Debug().Msgf("Trying to load custom libraries from %s", libraryPathFlag)

--- a/pkg/engine/source/source.go
+++ b/pkg/engine/source/source.go
@@ -49,7 +49,7 @@ type QueriesSource interface {
 	GetQueryLibrary(ctx context.Context, platform string) (RegoLibraries, error)
 }
 
-// MergeInputData merges KICS input data with custom input data user defined
+// MergeInputData merges default input data with custom input data user defined
 func MergeInputData(defaultInputData, customInputData string) (string, error) {
 	if checkEmptyInputdata(customInputData) && checkEmptyInputdata(defaultInputData) {
 		return emptyInputData, nil

--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -68,7 +68,7 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 	v interface{},
 	detector *dec.DetectLine,
 	useOldSeverities bool,
-	kicsComputeNewSimID bool,
+	computeNewSimID bool,
 	queryDuration time.Duration) (*model.Vulnerability, error) {
 	contextLogger := logger.FromContext(ctx)
 	vObj, ok := v.(map[string]interface{})
@@ -186,7 +186,7 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 	}
 
 	similarityID, oldSimilarityID := generateSimilaritiesID(ctx, qCtx, linesVulne.ResolvedFile, queryID, legacyQueryID,
-		similarityIDLineInfo, searchValue, searchKey, similarityIDLineInfoOld, kicsComputeNewSimID, &logWithFields, tracker)
+		similarityIDLineInfo, searchValue, searchKey, similarityIDLineInfoOld, computeNewSimID, &logWithFields, tracker)
 
 	return &model.Vulnerability{
 		ID:              0,
@@ -312,11 +312,11 @@ func getString(m map[string]interface{}, key string) string {
 func generateSimilaritiesID(
 	ctx context.Context, qCtx *QueryContext,
 	resolvedFile, queryID, legacyQueryID, similarityIDLineInfo, searchValue, searchKey, similarityIDLineInfoOld string,
-	kicsComputeNewSimID bool,
+	computeNewSimID bool,
 	logWithFields *zerolog.Logger,
 	tracker Tracker) (similarityID, oldSimilarityID *string) {
 	usedID := utils.ChooseQueryID(queryID, legacyQueryID)
-	if kicsComputeNewSimID {
+	if computeNewSimID {
 		similarityID, err := buildSimilarityID(ctx, qCtx, resolvedFile, usedID, similarityIDLineInfo, searchValue)
 		if err != nil {
 			logWithFields.Err(err).Send()

--- a/pkg/engine/vulnerability_builder_test.go
+++ b/pkg/engine/vulnerability_builder_test.go
@@ -34,7 +34,7 @@ var vbTests = []struct {
 	want                model.Vulnerability
 	useNewVulnerability bool
 	wantErr             bool
-	kicsComputeNewSimID bool
+	computeNewSimID bool
 }{
 	{
 		name: "DefaultVulnerabilityBuilderWithOldSimId",
@@ -91,7 +91,7 @@ var vbTests = []struct {
 			QueryDuration:    testQueryDuration,
 		},
 		wantErr:             false,
-		kicsComputeNewSimID: true,
+		computeNewSimID: true,
 	},
 	{
 		name: "DefaultVulnerabilityBuilderWithoutOldSimId",
@@ -148,7 +148,7 @@ var vbTests = []struct {
 			QueryDuration:    testQueryDuration,
 		},
 		wantErr:             false,
-		kicsComputeNewSimID: false,
+		computeNewSimID: false,
 	},
 	{
 		name: "DefaultVulnerabilityBuilder with override for severity and old sim id",
@@ -210,7 +210,7 @@ var vbTests = []struct {
 			QueryDuration:    testQueryDuration, //nolint
 		},
 		wantErr:             false,
-		kicsComputeNewSimID: true,
+		computeNewSimID: true,
 	},
 	{
 		name: "DefaultVulnerabilityBuilder with override for severity and without old sim id",
@@ -272,7 +272,7 @@ var vbTests = []struct {
 			QueryDuration:    testQueryDuration, //nolint
 		},
 		wantErr:             false,
-		kicsComputeNewSimID: false,
+		computeNewSimID: false,
 	},
 	{
 		name: "DefaultVulnerabilityBuilder with override for name",
@@ -335,7 +335,7 @@ var vbTests = []struct {
 			QueryDuration:    testQueryDuration, //nolint
 		},
 		wantErr:             false,
-		kicsComputeNewSimID: true,
+		computeNewSimID: true,
 	},
 	{
 		name: "DefaultVulnerabilityBuilder with new Severity",
@@ -394,7 +394,7 @@ var vbTests = []struct {
 			QueryDuration:    testQueryDuration, //nolint
 		},
 		wantErr:             false,
-		kicsComputeNewSimID: true,
+		computeNewSimID: true,
 	},
 	{
 		name: "DefaultVulnerabilityBuilder with override for platform and cloud provider",
@@ -455,7 +455,7 @@ var vbTests = []struct {
 			QueryDuration:    testQueryDuration,
 		},
 		wantErr:             false,
-		kicsComputeNewSimID: true,
+		computeNewSimID: true,
 	},
 }
 
@@ -465,7 +465,7 @@ func TestDefaultVulnerabilityBuilder(t *testing.T) {
 	for _, tt := range vbTests {
 		insDetector := detector.NewDetectLine(3)
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := DefaultVulnerabilityBuilder(ctx, tt.args.ctx, tt.args.tracker, tt.args.v, insDetector, tt.useNewVulnerability, tt.kicsComputeNewSimID, testQueryDuration)
+			got, err := DefaultVulnerabilityBuilder(ctx, tt.args.ctx, tt.args.tracker, tt.args.v, insDetector, tt.useNewVulnerability, tt.computeNewSimID, testQueryDuration)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("test[%s] DefaultVulnerabilityBuilder() error %v, wantErr %v", tt.name, err, tt.wantErr)
 				return

--- a/pkg/kuberneter/kuberneter_test.go
+++ b/pkg/kuberneter/kuberneter_test.go
@@ -42,7 +42,7 @@ func TestImport(t *testing.T) {
 			args: args{
 				kuberneterPath: "*:*:*",
 			},
-			want:    "kics-extract-kuberneter",
+			want:    "dd-extract-kuberneter",
 			wantErr: true,
 		},
 		{

--- a/pkg/kuberneter/utils.go
+++ b/pkg/kuberneter/utils.go
@@ -186,7 +186,7 @@ func getDestinationFolder(destinationPath string) (string, error) {
 			return "", errors.Wrap(err, "failed to get working directory")
 		}
 	}
-	destFolderName := fmt.Sprintf("kics-extract-kuberneter-%s", time.Now().Format("01-02-2006"))
+	destFolderName := fmt.Sprintf("dd-extract-kuberneter-%s", time.Now().Format("01-02-2006"))
 	destination := filepath.Join(destinationPath, destFolderName)
 
 	if err := os.MkdirAll(destination, dirPerms); err != nil {

--- a/pkg/model/comment_yaml.go
+++ b/pkg/model/comment_yaml.go
@@ -193,7 +193,7 @@ func (c *comment) value() (value CommentCommand) {
 			comment = res
 		}
 	}
-	// check if we are working with kics command
+	// check if we are working with a dd-iac-scan command
 	if DDCommentRgxp.MatchString(comment) {
 		comment = DDCommentRgxp.ReplaceAllString(comment, "")
 		comment = strings.Trim(comment, "\n")

--- a/pkg/model/comment_yaml.go
+++ b/pkg/model/comment_yaml.go
@@ -122,7 +122,7 @@ func processRegularLine(comment string, content *yaml.Node, position int, isFoot
 
 	// comment is not a foot comment
 
-	if KICSCommentRgxpYaml.MatchString(comment) {
+	if DDCommentRgxpYaml.MatchString(comment) {
 		// has dd-iac-scan ignore at the end of the comment
 		linesIgnore = append(linesIgnore, line)
 	}
@@ -188,14 +188,14 @@ func getNodeLastLine(node *yaml.Node) (lastLine int) {
 func (c *comment) value() (value CommentCommand) {
 	comment := strings.ToLower(string(*c))
 	if isHelm(comment) {
-		res := KICSGetContentCommentRgxp.FindString(comment)
+		res := DDGetContentCommentRgxp.FindString(comment)
 		if res != "" {
 			comment = res
 		}
 	}
 	// check if we are working with kics command
-	if KICSCommentRgxp.MatchString(comment) {
-		comment = KICSCommentRgxp.ReplaceAllString(comment, "")
+	if DDCommentRgxp.MatchString(comment) {
+		comment = DDCommentRgxp.ReplaceAllString(comment, "")
 		comment = strings.Trim(comment, "\n")
 		commands := strings.Split(strings.Trim(comment, "\r"), " ")
 		value = ProcessCommands(commands)

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -90,12 +90,12 @@ var (
 )
 
 var (
-	// KICSCommentRgxp is the regexp to identify if a comment is a KICS comment
-	KICSCommentRgxp = regexp.MustCompile(`(^|\n)((/{2})|#|;)*\s*dd-iac-scan\s*`)
-	// KICSGetContentCommentRgxp to gets the kics comment on the hel case
-	KICSGetContentCommentRgxp = regexp.MustCompile(`(^|\n)((/{2})|#|;)*\s*dd-iac-scan([^\n]*)\n`)
-	// KICSCommentRgxpYaml is the regexp to identify if the comment has KICS comment at the end of the comment in YAML
-	KICSCommentRgxpYaml = regexp.MustCompile(`((/{2})|#)*\s*dd-iac-scan\s*(ignore-line|ignore-block)\s*\n*$`)
+	// DDCommentRgxp identifies dd-iac-scan inline suppression comments
+	DDCommentRgxp = regexp.MustCompile(`(^|\n)((/{2})|#|;)*\s*dd-iac-scan\s*`)
+	// DDGetContentCommentRgxp extracts the dd-iac-scan comment content
+	DDGetContentCommentRgxp = regexp.MustCompile(`(^|\n)((/{2})|#|;)*\s*dd-iac-scan([^\n]*)\n`)
+	// DDCommentRgxpYaml identifies dd-iac-scan suppression comments in YAML
+	DDCommentRgxpYaml = regexp.MustCompile(`((/{2})|#)*\s*dd-iac-scan\s*(ignore-line|ignore-block)\s*\n*$`)
 )
 
 // VulnerabilityLines is the representation of the found line for issue

--- a/pkg/parser/ansible/ini/comments/comments.go
+++ b/pkg/parser/ansible/ini/comments/comments.go
@@ -13,7 +13,7 @@ import (
 )
 
 func getKicsIgnore(comment string) string {
-	commentLower := model.KICSCommentRgxp.ReplaceAllString(strings.ToLower(comment), "")
+	commentLower := model.DDCommentRgxp.ReplaceAllString(strings.ToLower(comment), "")
 	commentLower = strings.Trim(commentLower, "\r")
 	commentLower = strings.Trim(commentLower, "\n")
 	return commentLower
@@ -48,7 +48,7 @@ func GetIgnoreLines(lines []string) []int {
 	comment := regexp.MustCompile(`^[#;]`)
 
 	for i, line := range lines {
-		if model.KICSCommentRgxp.MatchString(line) {
+		if model.DDCommentRgxp.MatchString(line) {
 			kicsIgnore := getKicsIgnore(line)
 
 			switch model.CommentCommand(kicsIgnore) {

--- a/pkg/parser/ansible/ini/comments/comments.go
+++ b/pkg/parser/ansible/ini/comments/comments.go
@@ -12,7 +12,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 )
 
-func getKicsIgnore(comment string) string {
+func getIgnoreCommand(comment string) string {
 	commentLower := model.DDCommentRgxp.ReplaceAllString(strings.ToLower(comment), "")
 	commentLower = strings.Trim(commentLower, "\r")
 	commentLower = strings.Trim(commentLower, "\n")
@@ -49,9 +49,9 @@ func GetIgnoreLines(lines []string) []int {
 
 	for i, line := range lines {
 		if model.DDCommentRgxp.MatchString(line) {
-			kicsIgnore := getKicsIgnore(line)
+			ignoreCmd := getIgnoreCommand(line)
 
-			switch model.CommentCommand(kicsIgnore) {
+			switch model.CommentCommand(ignoreCmd) {
 			case model.IgnoreLine:
 				if i+1 < len(lines) {
 					ignoreLines = append(ignoreLines, i, i+1)

--- a/pkg/parser/ansible/ini/comments/comments_test.go
+++ b/pkg/parser/ansible/ini/comments/comments_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func Test_getKicsIgnore(t *testing.T) {
+func Test_getIgnoreCommand(t *testing.T) {
 	tests := []struct {
 		comment string
 		want    string

--- a/pkg/parser/ansible/ini/comments/comments_test.go
+++ b/pkg/parser/ansible/ini/comments/comments_test.go
@@ -27,7 +27,7 @@ func Test_getKicsIgnore(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.comment, func(t *testing.T) {
-			if got := getKicsIgnore(tt.comment); !reflect.DeepEqual(got, tt.want) {
+			if got := getIgnoreCommand(tt.comment); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("got = %s, want %s", got, tt.want)
 			}
 		})

--- a/pkg/parser/buildah/comments.go
+++ b/pkg/parser/buildah/comments.go
@@ -13,7 +13,7 @@ import (
 )
 
 func getKicsIgnore(comment string) string {
-	commentLower := model.KICSCommentRgxp.ReplaceAllString(strings.ToLower(comment), "")
+	commentLower := model.DDCommentRgxp.ReplaceAllString(strings.ToLower(comment), "")
 	commentLower = strings.Trim(commentLower, "\r")
 	commentLower = strings.Trim(commentLower, "\n")
 
@@ -24,7 +24,7 @@ func (i *Info) getIgnoreLines(comment *syntax.Comment) {
 	// get normal comments
 	i.IgnoreLines = append(i.IgnoreLines, int(comment.Hash.Line()))
 
-	if model.KICSCommentRgxp.MatchString(comment.Text) {
+	if model.DDCommentRgxp.MatchString(comment.Text) {
 		kicsIgnore := getKicsIgnore(comment.Text)
 
 		switch model.CommentCommand(kicsIgnore) {
@@ -43,7 +43,7 @@ func (i *Info) getIgnoreBlockLines(comments []syntax.Comment, start, end int) {
 		comment := comments[c]
 
 		// get dd-iac-scan ignore-block related to command
-		if model.KICSCommentRgxp.MatchString(comment.Text) {
+		if model.DDCommentRgxp.MatchString(comment.Text) {
 			kicsIgnore := getKicsIgnore(comment.Text)
 
 			if model.CommentCommand(kicsIgnore) == model.IgnoreBlock {

--- a/pkg/parser/buildah/comments.go
+++ b/pkg/parser/buildah/comments.go
@@ -12,7 +12,7 @@ import (
 	"mvdan.cc/sh/v3/syntax"
 )
 
-func getKicsIgnore(comment string) string {
+func getIgnoreCommand(comment string) string {
 	commentLower := model.DDCommentRgxp.ReplaceAllString(strings.ToLower(comment), "")
 	commentLower = strings.Trim(commentLower, "\r")
 	commentLower = strings.Trim(commentLower, "\n")
@@ -25,9 +25,9 @@ func (i *Info) getIgnoreLines(comment *syntax.Comment) {
 	i.IgnoreLines = append(i.IgnoreLines, int(comment.Hash.Line()))
 
 	if model.DDCommentRgxp.MatchString(comment.Text) {
-		kicsIgnore := getKicsIgnore(comment.Text)
+		ignoreCmd := getIgnoreCommand(comment.Text)
 
-		switch model.CommentCommand(kicsIgnore) {
+		switch model.CommentCommand(ignoreCmd) {
 		case model.IgnoreLine:
 			// get dd-iac-scan ignore-line
 			i.IgnoreLines = append(i.IgnoreLines, int(comment.Hash.Line())+1)
@@ -44,9 +44,9 @@ func (i *Info) getIgnoreBlockLines(comments []syntax.Comment, start, end int) {
 
 		// get dd-iac-scan ignore-block related to command
 		if model.DDCommentRgxp.MatchString(comment.Text) {
-			kicsIgnore := getKicsIgnore(comment.Text)
+			ignoreCmd := getIgnoreCommand(comment.Text)
 
-			if model.CommentCommand(kicsIgnore) == model.IgnoreBlock {
+			if model.CommentCommand(ignoreCmd) == model.IgnoreBlock {
 				if int(comment.Hash.Line()) == start-1 {
 					i.IgnoreLines = append(i.IgnoreLines, model.Range(start, end)...)
 					i.IgnoreBlockLines = append(i.IgnoreBlockLines, model.Range(start, end)...)

--- a/pkg/parser/docker/comments.go
+++ b/pkg/parser/docker/comments.go
@@ -63,8 +63,8 @@ func (i *ignore) getIgnoreComments(node *parser.Node) (ignore bool) {
 func processComment(comment string) (value model.CommentCommand) {
 	commentLower := strings.ToLower(comment)
 
-	if model.KICSCommentRgxp.MatchString(commentLower) {
-		commentLower = model.KICSCommentRgxp.ReplaceAllString(commentLower, "")
+	if model.DDCommentRgxp.MatchString(commentLower) {
+		commentLower = model.DDCommentRgxp.ReplaceAllString(commentLower, "")
 		commands := strings.Split(strings.Trim(commentLower, "\n"), " ")
 		value = model.ProcessCommands(commands)
 		return

--- a/pkg/parser/grpc/converter/converter.go
+++ b/pkg/parser/grpc/converter/converter.go
@@ -582,8 +582,8 @@ func (j *JSONProto) processCommentProto(comment *proto.Comment, lineStart int, e
 	var value model.CommentCommand
 	for _, line := range comment.Lines {
 		comment := strings.ToLower(line)
-		if model.KICSCommentRgxp.MatchString(comment) {
-			comment = model.KICSCommentRgxp.ReplaceAllString(comment, "")
+		if model.DDCommentRgxp.MatchString(comment) {
+			comment = model.DDCommentRgxp.ReplaceAllString(comment, "")
 			comment = strings.Trim(comment, "\n")
 			commands := strings.Split(strings.Trim(comment, "\r"), " ")
 			value = model.ProcessCommands(commands)

--- a/pkg/parser/json/parser.go
+++ b/pkg/parser/json/parser.go
@@ -58,20 +58,20 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	}
 
 	jLine := initializeJSONLine(resolved)
-	kicsJSON := jLine.setLineInfo(r)
+	jsonDoc := jLine.setLineInfo(r)
 
 	// Try to parse JSON as Terraform plan
-	kicsPlan, err := parseTFPlan(kicsJSON)
+	tfPlan, err := parseTFPlan(jsonDoc)
 	if err != nil {
 		// JSON is not a tf plan
-		return resolved, []model.Document{kicsJSON}, nil, resolvedFiles, nil
+		return resolved, []model.Document{jsonDoc}, nil, resolvedFiles, nil
 	}
 
 	p.shouldIdentMu.Lock()
 	p.shouldIdent = true
 	p.shouldIdentMu.Unlock()
 
-	return resolved, []model.Document{kicsPlan}, nil, resolvedFiles, nil
+	return resolved, []model.Document{tfPlan}, nil, resolvedFiles, nil
 }
 
 // SupportedExtensions returns extensions supported by this parser, which is json extension

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -12,16 +12,16 @@ import (
 	hcl_plan "github.com/hashicorp/terraform-json"
 )
 
-// KicsPlan is an auxiliary structure for parsing tfplans as a KICS Document
-type KicsPlan struct {
-	Resource map[string]KicsPlanResource `json:"resource"`
+// TFPlan is an auxiliary structure for parsing tfplans as a scanner Document
+type TFPlan struct {
+	Resource map[string]TFPlanResource `json:"resource"`
 }
 
-// KicsPlanResource is an auxiliary structure for parsing tfplans as a KICS Document
-type KicsPlanResource map[string]KicsPlanNamedResource
+// TFPlanResource is an auxiliary structure for parsing tfplans as a scanner Document
+type TFPlanResource map[string]TFPlanNamedResource
 
-// KicsPlanNamedResource is an auxiliary structure for parsing tfplans as a KICS Document
-type KicsPlanNamedResource map[string]interface{}
+// TFPlanNamedResource is an auxiliary structure for parsing tfplans as a scanner Document
+type TFPlanNamedResource map[string]interface{}
 
 // parseTFPlan unmarshals Document as a plan so it can be rebuilt with only
 // the required information
@@ -43,10 +43,10 @@ func parseTFPlan(doc model.Document) (model.Document, error) {
 	return parsedPlan, nil
 }
 
-// readPlan will get the information needed and parse it in a way KICS understands it
+// readPlan extracts the information needed from a Terraform plan and converts it to a scanner Document
 func readPlan(plan *hcl_plan.Plan) model.Document {
-	kp := KicsPlan{
-		Resource: make(map[string]KicsPlanResource),
+	kp := TFPlan{
+		Resource: make(map[string]TFPlanResource),
 	}
 
 	kp.readModule(plan.PlannedValues.RootModule)
@@ -66,10 +66,10 @@ func readPlan(plan *hcl_plan.Plan) model.Document {
 }
 
 // readModule will iterate over all planned_value getting the information required
-func (kp *KicsPlan) readModule(module *hcl_plan.StateModule) {
+func (kp *TFPlan) readModule(module *hcl_plan.StateModule) {
 	// initialize all the types interfaces
 	for _, resource := range module.Resources {
-		convNamedRes := make(map[string]KicsPlanNamedResource)
+		convNamedRes := make(map[string]TFPlanNamedResource)
 		kp.Resource[resource.Type] = convNamedRes
 	}
 	// fill in all the types interfaces

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -70,7 +70,7 @@ func (b *Builder) Build(types, cloudProviders []string) ([]*Parser, error) {
 	return parserSlice, nil
 }
 
-// ErrNotSupportedFile represents an error when a file is not supported by KICS
+// ErrNotSupportedFile represents an error when a file is not supported by the scanner
 var ErrNotSupportedFile = errors.New("unsupported file to parse")
 
 // Parser is a struct that associates a parser to its supported extensions
@@ -170,7 +170,7 @@ func (c *Parser) Parse(
 	}, ErrNotSupportedFile
 }
 
-// SupportedExtensions returns extensions supported by KICS
+// SupportedExtensions returns extensions supported by the scanner
 func (c *Parser) SupportedExtensions() model.Extensions {
 	return c.extensions
 }

--- a/pkg/parser/terraform/comment/comment.go
+++ b/pkg/parser/terraform/comment/comment.go
@@ -24,9 +24,9 @@ func (c *comment) position() hcl.Pos {
 // value returns the value of a comment
 func (c *comment) value() (value model.CommentCommand) {
 	comment := strings.ToLower(string(c.Bytes))
-	// check if we are working with kics command
-	if model.KICSCommentRgxp.MatchString(comment) {
-		comment = model.KICSCommentRgxp.ReplaceAllString(comment, "")
+	// check if we are working with a dd-iac-scan inline suppression comment
+	if model.DDCommentRgxp.MatchString(comment) {
+		comment = model.DDCommentRgxp.ReplaceAllString(comment, "")
 		comment = strings.Trim(comment, "\n")
 		commands := strings.Split(strings.Trim(comment, "\r"), " ")
 		value = model.ProcessCommands(commands)
@@ -118,7 +118,7 @@ func checkBlockRange(block *hcl.Block, position hcl.Pos) bool {
 //     COMMENT PARSER       //
 // ///////////////////////////
 
-// ParseComments parses the comments and returns the kics commands
+// ParseComments parses the comments and returns the dd-iac-scan commands
 func ParseComments(src []byte, filename string) (Ignore, error) {
 	comments, diags := hclsyntax.LexConfig(src, filename, hcl.Pos{Line: 0, Column: 0})
 	if diags != nil && diags.HasErrors() {
@@ -130,7 +130,7 @@ func ParseComments(src []byte, filename string) (Ignore, error) {
 	return ig, nil
 }
 
-// processTokens goes over the tokens and returns the kics commands
+// processTokens goes over the tokens and returns the dd-iac-scan commands
 func processTokens(tokens hclsyntax.Tokens) (ig Ignore) {
 	ignoreLines := make([]hcl.Pos, 0)
 	ignoreBlocks := make([]hcl.Pos, 0)
@@ -152,7 +152,7 @@ func processTokens(tokens hclsyntax.Tokens) (ig Ignore) {
 	return ig
 }
 
-// processComment analyzes the comment to determine which type of kics command the comment is
+// processComment analyzes the comment to determine which type of dd-iac-scan command it is
 func processComment(comment *comment, tokenToIgnore *comment,
 	ignoreLine, ignoreBlock, ignoreComments []hcl.Pos) (ignoreLineR, ignoreBlockR, ignoreCommentsR []hcl.Pos) {
 	ignoreLineR = ignoreLine
@@ -161,13 +161,13 @@ func processComment(comment *comment, tokenToIgnore *comment,
 
 	switch comment.value() {
 	case model.IgnoreLine:
-		// comment is of type kics ignore-line
+		// comment is of type dd-iac-scan ignore-line
 		ignoreLineR = append(ignoreLineR, tokenToIgnore.position(), hcl.Pos{Line: comment.position().Line - 1})
 	case model.IgnoreBlock:
-		// comment is of type kics ignore-block
+		// comment is of type dd-iac-scan ignore-block
 		ignoreBlockR = append(ignoreBlockR, tokenToIgnore.position(), hcl.Pos{Line: comment.position().Line - 1})
 	default:
-		// comment is not of type kics ignore
+		// comment is not of type dd-iac-scan ignore
 		ignoreCommentsR = append(ignoreCommentsR, hcl.Pos{Line: comment.position().Line - 1})
 		return
 	}

--- a/pkg/parser/terraform/functions/default.go
+++ b/pkg/parser/terraform/functions/default.go
@@ -43,7 +43,7 @@ var Base64EncodeFunc = function.New(&function.Spec{
 	},
 })
 
-// TerraformFuncs contains all functions, if KICS has to override a function
+// TerraformFuncs contains all functions, overriding any conflicting built-ins
 // it should create a file in this package and add/change this function key here
 var TerraformFuncs = map[string]function.Function{
 	"abs":             stdlib.AbsoluteFunc,

--- a/pkg/report/model/asff.go
+++ b/pkg/report/model/asff.go
@@ -58,7 +58,7 @@ type Resource struct {
 	Type string
 }
 
-// Severity contains the original severity (KICS severity) and the label severity (ASFF severity)
+// Severity contains the original severity and the label severity (ASFF severity)
 type Severity struct {
 	Original string
 	Label    string

--- a/pkg/report/model/junit.go
+++ b/pkg/report/model/junit.go
@@ -61,7 +61,7 @@ func NewJUnitReport(time string) JUnitReport {
 	}
 }
 
-// GenerateTestEntry generates a new test entry for failed tests on KICS scan
+// GenerateTestEntry generates a new test entry for failed tests on a scan
 func (jUnit *junitTestSuites) GenerateTestEntry(query *model.QueryResult) {
 	queryDescription := query.Description
 	if query.CISDescriptionTextFormatted != "" {

--- a/pkg/report/model/sonarqube.go
+++ b/pkg/report/model/sonarqube.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 )
 
-// severitySonarQubeEquivalence maps the severity of the KICS to the SonarQube equivalent
+// severitySonarQubeEquivalence maps the scanner severity to the SonarQube equivalent
 var severitySonarQubeEquivalence = map[model.Severity]string{
 	"INFO":     "INFO",
 	"LOW":      "MINOR",

--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -149,7 +149,7 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 	}
 	contextLogger.Debug().Msg("Chart installability check passed")
 
-	client.Namespace = "kics-namespace"
+	client.Namespace = "dd-namespace"
 	contextLogger.Debug().Msgf("Running helm chart with namespace: '%s', release name: '%s'", client.Namespace, client.ReleaseName)
 	helmRelease, err := client.Run(chartRequested, vals)
 	if err != nil {
@@ -181,7 +181,7 @@ func newClient(ctx context.Context) *action.Install {
 	cfg := new(action.Configuration)
 	client := action.NewInstall(cfg)
 	client.DryRun = true
-	client.ReleaseName = "kics-helm"
+	client.ReleaseName = "dd-helm"
 	client.Replace = true // Skip the name check
 	client.ClientOnly = true
 	client.APIVersions = chartutil.VersionSet([]string{})

--- a/pkg/resolver/helm/resolver_test.go
+++ b/pkg/resolver/helm/resolver_test.go
@@ -50,11 +50,11 @@ func TestHelm_Resolve(t *testing.T) { //nolint
 apiVersion: v1
 kind: Service
 metadata:
-  name: kics-helm-test_helm
+  name: dd-helm-test_helm
   labels:
     helm.sh/chart: test_helm-0.1.0
     app.kubernetes.io/name: test_helm
-    app.kubernetes.io/instance: kics-helm
+    app.kubernetes.io/instance: dd-helm
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -66,7 +66,7 @@ spec:
       name: http
   selector:
     app.kubernetes.io/name: test_helm
-    app.kubernetes.io/instance: kics-helm
+    app.kubernetes.io/instance: dd-helm
 `),
 						OriginalData: []byte(`# KICS_HELM_ID_0:
 apiVersion: v1
@@ -116,11 +116,11 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kics-helm-test_helm_subchart
+  name: dd-helm-test_helm_subchart
   labels:
     helm.sh/chart: test_helm_subchart-0.1.0
     app.kubernetes.io/name: test_helm_subchart
-    app.kubernetes.io/instance: kics-helm
+    app.kubernetes.io/instance: dd-helm
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
 `),
@@ -150,11 +150,11 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kics-helm-subchart
+  name: dd-helm-subchart
   labels:
     helm.sh/chart: subchart-0.1.0
     app.kubernetes.io/name: subchart
-    app.kubernetes.io/instance: kics-helm
+    app.kubernetes.io/instance: dd-helm
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -166,7 +166,7 @@ spec:
       name: http
   selector:
     app.kubernetes.io/name: subchart
-    app.kubernetes.io/instance: kics-helm
+    app.kubernetes.io/instance: dd-helm
 `),
 						OriginalData: []byte(`# KICS_HELM_ID_0:
 apiVersion: v1

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -215,11 +215,11 @@ func PrepareScanDocument(ctx context.Context, body map[string]interface{}, kind 
 	var bodyMap map[string]interface{}
 	j, err := json.Marshal(body)
 	if err != nil {
-		contextLogger.Error().Msgf("failed to remove kics line information")
+		contextLogger.Error().Msgf("failed to remove dd line information")
 		return body
 	}
 	if err := json.Unmarshal(j, &bodyMap); err != nil {
-		contextLogger.Error().Msgf("failed to remove kics line information: '%s'", err)
+		contextLogger.Error().Msgf("failed to remove dd line information: '%s'", err)
 		return body
 	}
 	prepareScanDocumentRoot(bodyMap, kind)

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -7,7 +7,7 @@ package scan
 
 import (
 	"context"
-	_ "embed" // Embed kics CLI img and scan-flags
+	_ "embed" // Embed scanner CLI img and scan-flags
 	"os"
 	"path/filepath"
 	"sort"

--- a/pkg/scan/utils_test.go
+++ b/pkg/scan/utils_test.go
@@ -17,7 +17,7 @@ import (
 
 func contributionAppeal(customPrint *consolePrinter.Printer, queriesPath []string) {
 	if usingCustomQueries(queriesPath) {
-		msg := "\nAre you using a custom query? If so, feel free to contribute to KICS!\n"
+		msg := "\nAre you using a custom query? If so, feel free to contribute!\n"
 		contributionPage := "Check out how to do it: https://github.com/DataDog/datadog-iac-scanner/blob/master/docs/CONTRIBUTING.md\n"
 
 		output := customPrint.ContributionMessage.Sprintf("%s", msg+contributionPage)
@@ -88,7 +88,7 @@ func Test_ContributionAppeal(t *testing.T) {
 			name:           "test custom query",
 			consolePrinter: consolePrinter.NewPrinter(),
 			queriesPath:    []string{filepath.Join("custom", "query", "path")},
-			expectedOutput: "\nAre you using a custom query? If so, feel free to contribute to KICS!\nCheck out how to do it: https://github.com/DataDog/datadog-iac-scanner/blob/master/docs/CONTRIBUTING.md",
+			expectedOutput: "\nAre you using a custom query? If so, feel free to contribute!\nCheck out how to do it: https://github.com/DataDog/datadog-iac-scanner/blob/master/docs/CONTRIBUTING.md",
 		},
 		{
 			name:           "test non custom query",

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -480,7 +480,7 @@ var SummaryMockCriticalFullPathASFF = model.Summary{
 	},
 }
 
-// SummaryMock a summary to be used without running kics scan
+// SummaryMock a summary to be used without running a scan
 var SummaryMock = model.Summary{
 	Counters: model.Counters{
 		ScannedFiles:           1,
@@ -585,7 +585,7 @@ var SimpleSummaryMockAsff = model.Summary{
 	},
 }
 
-// ComplexSummaryMock a summary with more results to be used without running kics scan
+// ComplexSummaryMock a summary with more results to be used without running a scan
 var ComplexSummaryMock = model.Summary{
 	Counters: model.Counters{
 		ScannedFiles:           2,


### PR DESCRIPTION
## Motivation

Final cleanup of KICS/Checkmarx naming in internal Go identifiers and code comments. No behavior change.

## Changes

**model package**

`KICSCommentRgxp`, `KICSGetContentCommentRgxp`, `KICSCommentRgxpYaml` renamed to `DDCommentRgxp`, `DDGetContentCommentRgxp`, `DDCommentRgxpYaml` respectively. All 6 call sites updated.

**Comments**

Remaining `// kics ...` and `// KICS ...` doc strings in `comment.go`, `functions/default.go`, `provider/extract.go`, and `test/helpers.go` reworded to remove the KICS reference.

## QA Instruction

1. `go build ./...`
2. `go test ./pkg/model/... ./pkg/parser/terraform/comment/... ./pkg/parser/docker/... ./pkg/parser/buildah/...`

## Impact

Internal rename only. No exported API, no CLI flags, no rule format affected.