### PR TITLE
Default rule engine to Rego v1

### DIFF
--- a/.github/workflows/test-rego-libraries.yml
+++ b/.github/workflows/test-rego-libraries.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Download and install OPA
         run: |
-          OPA_VERSION="0.49.2"
+          OPA_VERSION="1.13.2"
           curl -L -o opa "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_amd64_static"
           chmod +x opa
           sudo mv opa /usr/local/bin/

--- a/assets/libraries/ansible.rego
+++ b/assets/libraries/ansible.rego
@@ -1,23 +1,25 @@
 package generic.ansible
 
+import rego.v1
+
 # Global variable with all tasks in input
 tasks := TasksPerDocument
 
 # Builds an object that stores all tasks for each document id
-TasksPerDocument[id] = result {
+TasksPerDocument[id] := result if {
 	document := input.document[i]
 	id := document.id
 	result := getTasks(document)
 }
 
 # Function used to get all tasks from a document
-getTasks(document) = result {
+getTasks(document) := result if {
 	document.playbooks[0].tasks
 	result := [task |
 		playbook := document.playbooks[0].tasks[_]
 		task := getTasksFromBlocks(playbook)[_]
 	]
-} else = result {
+} else := result if {
 	result := [task |
 		playbook := document.playbooks[_]
 		task := getTasksFromBlocks(playbook)[_]
@@ -25,7 +27,7 @@ getTasks(document) = result {
 }
 
 # Function used to get all nested tasks inside a block task ("block", "always", "rescue")
-getTasksFromBlocks(playbook) = result {
+getTasksFromBlocks(playbook) := result if {
 	playbook.block
 	result := [task |
 		walk(playbook, [path, task])
@@ -33,58 +35,56 @@ getTasksFromBlocks(playbook) = result {
 		not task.block
 		validPath(path)
 	]
-} else = [playbook] {
-	true
-}
+} else := [playbook]
 
 # Validates the path of a nested element inside a block task to assure it's a task
-validPath(path) {
+validPath(path) if {
 	count(path) > 1
-	validGroup(path[minus(count(path), 2)])
+	validGroup(path[count(path) - 2])
 }
 
 # Identifies a block task
-validGroup("block") = true
+validGroup("block") := true
 
-validGroup("always") = true
+validGroup("always") := true
 
-validGroup("rescue") = true
+validGroup("rescue") := true
 
 # Checks if a task is not an absent task
-checkState(task) {
+checkState(task) if {
 	state := object.get(task, "state", "undefined")
 	state != "absent"
 }
 
 # Checks if a variable has 'true' value in Ansible
-isAnsibleTrue(answer) {
+isAnsibleTrue(answer) if {
 	lower(answer) == "yes"
-} else {
+} else if {
 	lower(answer) == "true"
-} else {
+} else if {
 	answer == true
 }
 
 # Checks if a variable has 'false' value in Ansible
-isAnsibleFalse(answer) {
+isAnsibleFalse(answer) if {
 	lower(answer) == "no"
-} else {
+} else if {
 	lower(answer) == "false"
-} else {
+} else if {
 	answer == false
 }
 
-check_database_flags_content(database_flags, flagName, flagValue) {
+check_database_flags_content(database_flags, flagName, flagValue) if {
 	database_flags[x].name == flagName
 	database_flags[x].value != flagValue
 }
 
-check_database_flags_content(database_flags, flagName, flagValue) {
+check_database_flags_content(database_flags, flagName, flagValue) if {
 	database_flags.name == flagName
 	database_flags.value != flagValue
 }
 
-allowsPort(allowed, port) {
+allowsPort(allowed, port) if {
 	portNumber := to_number(port)
 	some i
 	contains(allowed.ports[i], "-")
@@ -94,55 +94,53 @@ allowsPort(allowed, port) {
 
 	low <= portNumber
 	high >= portNumber
-} else {
+} else if {
 	allowed.ports[_] == port
-} else = false {
-	true
-}
+} else := false
 
 # Checks if a given port is included in a network rule
-isPortInRule(rule, portNumber) {
+isPortInRule(rule, portNumber) if {
 	rule.from_port != -1
 	rule.from_port <= portNumber
 	rule.to_port >= portNumber
 }
 
-isPortInRule(rule, portNumber) {
+isPortInRule(rule, portNumber) if {
 	rule.ports == portNumber
 }
 
-isPortInRule(rule, portNumber) {
+isPortInRule(rule, portNumber) if {
 	rule.ports[_] == portNumber
 }
 
-isPortInRule(rule, portNumber) {
+isPortInRule(rule, portNumber) if {
 	mports := split(rule.ports, "-")
 	to_number(mports[0]) <= portNumber
 	to_number(mports[1]) >= portNumber
 }
 
-isPortInRule(rule, portNumber) {
+isPortInRule(rule, portNumber) if {
 	mports := split(rule.ports[_], "-")
 	to_number(mports[0]) <= portNumber
 	to_number(mports[1]) >= portNumber
 }
 
-isPortInRule(rule, portNumber) {
+isPortInRule(rule, portNumber) if {
 	rule.from_port == -1
 }
 
-isPortInRule(rule, portNumber) {
+isPortInRule(rule, portNumber) if {
 	rule.to_port == -1
 }
 
 # Checks if CIDR represents entire network
-isEntireNetwork(cidr) {
+isEntireNetwork(cidr) if {
 	is_array(cidr)
 	cidrs = {"0.0.0.0/0", "::/0"}
 	count({x | cidr[x]; cidr[x] == cidrs[j]}) != 0
 }
 
-isEntireNetwork(cidr) {
+isEntireNetwork(cidr) if {
 	is_string(cidr)
 	cidrs = {"0.0.0.0/0", "::/0"}
 	cidr == cidrs[j]
@@ -198,18 +196,18 @@ ansible_modules := {
 	"config_rule": {"variants": {"community.aws.config_rule", "config_rule", "community.aws.aws_config_rule", "aws_config_rule"}, "name_key": "name"},
 	"copy": {"variants": {"ansible.builtin.copy", "copy"}, "name_key": "dest"},
 	"dnf": {"variants": {"ansible.builtin.dnf", "dnf"}, "name_key": "name"},
-    "easy_install": {"variants": {"community.general.easy_install", "easy_install"}, "name_key": "name"},
-    "ec2_ami": {"variants": {"amazon.aws.ec2_ami", "ec2_ami"}, "name_key": "name"},
-    "ec2_group": {"variants": {"amazon.aws.ec2_security_group", "amazon.aws.ec2_group", "ec2_group"}, "name_key": "name"},
-    "ec2_instance": {"variants": {"amazon.aws.ec2_instance", "community.aws.ec2_instance", "ec2_instance"}, "name_key": "name"},
-    "ec2_launch_template": {"variants": {"amazon.aws.ec2_launch_template", "community.aws.ec2_launch_template", "ec2_launch_template"}, "name_key": "name"},
-    "ec2_vol": {"variants": {"amazon.aws.ec2_vol", "ec2_vol"}, "name_key": "name"},
-    "ec2_vpc_subnet": {"variants": {"amazon.aws.ec2_vpc_subnet", "ec2_vpc_subnet"}, "name_key": "cidr"},
-    "ecs_ecr": {"variants": {"community.aws.ecs_ecr", "ecs_ecr"}, "name_key": "name"},
-    "ecs_service": {"variants": {"community.aws.ecs_service", "ecs_service"}, "name_key": "name"},
-    "ecs_taskdefinition": {"variants": {"community.aws.ecs_taskdefinition", "ecs_taskdefinition"}, "name_key": "family"},
-    "efs": {"variants": {"community.aws.efs", "efs"}, "name_key": "name"},
-    "elasticache": {"variants": {"community.aws.elasticache", "elasticache"}, "name_key": "name"},
+	"easy_install": {"variants": {"community.general.easy_install", "easy_install"}, "name_key": "name"},
+	"ec2_ami": {"variants": {"amazon.aws.ec2_ami", "ec2_ami"}, "name_key": "name"},
+	"ec2_group": {"variants": {"amazon.aws.ec2_security_group", "amazon.aws.ec2_group", "ec2_group"}, "name_key": "name"},
+	"ec2_instance": {"variants": {"amazon.aws.ec2_instance", "community.aws.ec2_instance", "ec2_instance"}, "name_key": "name"},
+	"ec2_launch_template": {"variants": {"amazon.aws.ec2_launch_template", "community.aws.ec2_launch_template", "ec2_launch_template"}, "name_key": "name"},
+	"ec2_vol": {"variants": {"amazon.aws.ec2_vol", "ec2_vol"}, "name_key": "name"},
+	"ec2_vpc_subnet": {"variants": {"amazon.aws.ec2_vpc_subnet", "ec2_vpc_subnet"}, "name_key": "cidr"},
+	"ecs_ecr": {"variants": {"community.aws.ecs_ecr", "ecs_ecr"}, "name_key": "name"},
+	"ecs_service": {"variants": {"community.aws.ecs_service", "ecs_service"}, "name_key": "name"},
+	"ecs_taskdefinition": {"variants": {"community.aws.ecs_taskdefinition", "ecs_taskdefinition"}, "name_key": "family"},
+	"efs": {"variants": {"community.aws.efs", "efs"}, "name_key": "name"},
+	"elasticache": {"variants": {"community.aws.elasticache", "elasticache"}, "name_key": "name"},
 	"elb_application_lb": {"variants": {"amazon.aws.elb_application_lb", "community.aws.elb_application_lb", "elb_application_lb"}, "name_key": "name"},
 	"elb_network_lb": {"variants": {"community.aws.elb_network_lb", "elb_network_lb"}, "name_key": "name"},
 	"file": {"variants": {"ansible.builtin.file", "file"}, "name_key": "path"},
@@ -261,30 +259,30 @@ ansible_modules := {
 	"route53": {"variants": {"amazon.aws.route53", "community.aws.route53", "route53"}, "name_key": "record"},
 	"s3_bucket": {"variants": {"amazon.aws.s3_bucket", "s3_bucket"}, "name_key": "name"},
 	"s3_cors": {"variants": {"community.aws.s3_cors", "s3_cors", "community.aws.aws_s3_cors", "aws_s3_cors"}, "name_key": "name"},
-    "s3_object": {"variants": {"amazon.aws.s3_object", "s3_object", "amazon.aws.aws_s3", "aws_s3"}, "name_key": "object"},
-    "ses_identity_policy": {"variants": {"community.aws.ses_identity_policy", "ses_identity_policy", "community.aws.aws_ses_identity_policy", "aws_ses_identity_policy"}, "name_key": "identity"},
-    "slackpkg": {"variants": {"community.general.slackpkg", "slackpkg"}, "name_key": "name"},
-    "sns_topic": {"variants": {"community.aws.sns_topic", "sns_topic"}, "name_key": "name"},
-    "sorcery": {"variants": {"community.general.sorcery", "sorcery"}, "name_key": "name"},
-    "sqs_queue": {"variants": {"community.aws.sqs_queue", "sqs_queue"}, "name_key": "name"},
-    "sts_assume_role": {"variants": {"amazon.aws.sts_assume_role", "community.aws.sts_assume_role", "sts_assume_role"}, "name_key": "role_arn"},
-    "swdepot": {"variants": {"community.general.swdepot", "swdepot"}, "name_key": "name"},
-    "template": {"variants": {"ansible.builtin.template", "template"}, "name_key": "dest"},
+	"s3_object": {"variants": {"amazon.aws.s3_object", "s3_object", "amazon.aws.aws_s3", "aws_s3"}, "name_key": "object"},
+	"ses_identity_policy": {"variants": {"community.aws.ses_identity_policy", "ses_identity_policy", "community.aws.aws_ses_identity_policy", "aws_ses_identity_policy"}, "name_key": "identity"},
+	"slackpkg": {"variants": {"community.general.slackpkg", "slackpkg"}, "name_key": "name"},
+	"sns_topic": {"variants": {"community.aws.sns_topic", "sns_topic"}, "name_key": "name"},
+	"sorcery": {"variants": {"community.general.sorcery", "sorcery"}, "name_key": "name"},
+	"sqs_queue": {"variants": {"community.aws.sqs_queue", "sqs_queue"}, "name_key": "name"},
+	"sts_assume_role": {"variants": {"amazon.aws.sts_assume_role", "community.aws.sts_assume_role", "sts_assume_role"}, "name_key": "role_arn"},
+	"swdepot": {"variants": {"community.general.swdepot", "swdepot"}, "name_key": "name"},
+	"template": {"variants": {"ansible.builtin.template", "template"}, "name_key": "dest"},
 	"uri": {"variants": {"ansible.builtin.uri", "uri"}, "name_key": "url"},
 	"win_copy": {"variants": {"ansible.windows.win_copy", "win_copy"}, "name_key": "dest"},
 	"win_template": {"variants": {"ansible.windows.win_template", "win_template"}, "name_key": "dest"},
-    "user": {"variants": {"ansible.builtin.user", "user"}, "name_key": "name"},
-    "win_chocolatey": {"variants": {"chocolatey.chocolatey.win_chocolatey", "win_chocolatey"}, "name_key": "name"},
-    "yarn": {"variants": {"community.general.yarn", "yarn"}, "name_key": "name"},
-    "yum": {"variants": {"ansible.builtin.yum", "yum"}, "name_key": "name"},
-    "zypper": {"variants": {"community.general.zypper", "zypper"}, "name_key": "name"}
+	"user": {"variants": {"ansible.builtin.user", "user"}, "name_key": "name"},
+	"win_chocolatey": {"variants": {"chocolatey.chocolatey.win_chocolatey", "win_chocolatey"}, "name_key": "name"},
+	"yarn": {"variants": {"community.general.yarn", "yarn"}, "name_key": "name"},
+	"yum": {"variants": {"ansible.builtin.yum", "yum"}, "name_key": "name"},
+	"zypper": {"variants": {"community.general.zypper", "zypper"}, "name_key": "name"},
 }
 
 # Set of variant keys (FQCNs/short names) for a canonical; iterate with get_variants(canonical)[_]
-get_variants(canonical) = ansible_modules[canonical].variants
+get_variants(canonical) := ansible_modules[canonical].variants
 
 # Resource name from task: module_args[name_key] or fallback to task.name
-get_resource_name(module_args, canonical, task) = name {
+get_resource_name(module_args, canonical, task) := name if {
 	key := ansible_modules[canonical].name_key
 	name := object.get(module_args, key, task.name)
 }

--- a/assets/libraries/azureresourcemanager.rego
+++ b/assets/libraries/azureresourcemanager.rego
@@ -1,64 +1,66 @@
 package generic.azureresourcemanager
 
+import rego.v1
+
 # gets the network security group properties for two types of resource ('Microsoft.Network/networkSecurityGroups' and 'Microsoft.Network/networkSecurityGroups/securityRules')
-get_sg_info(value) = typeInfo {
-    value.type == "Microsoft.Network/networkSecurityGroups/securityRules"
+get_sg_info(value) := typeInfo if {
+	value.type == "Microsoft.Network/networkSecurityGroups/securityRules"
 	typeInfo := {
-		"type": value.type, 
-		"properties": value.properties, 
+		"type": value.type,
+		"properties": value.properties,
 		"path": "resources.type={{Microsoft.Network/networkSecurityGroups/securityRules}}.properties",
-		"sl": ["properties"]
-   }   
-} else = typeInfo {
+		"sl": ["properties"],
+	}
+} else := typeInfo if {
 	value.type == "securityRules"
 	typeInfo := {
-		"type": value.type, 
-		"properties": value.properties, 
+		"type": value.type,
+		"properties": value.properties,
 		"path": "resources.type={{securityRules}}.properties",
-		"sl": ["properties"]
+		"sl": ["properties"],
 	}
 }
 
 # checks if source address prefix is open to the Internet
 relevantSourceAddPrefix := {"*", "0.0.0.0", "internet", "any"}
 
-source_address_prefix_is_open(properties) {
+source_address_prefix_is_open(properties) if {
 	properties.sourceAddressPrefix == relevantSourceAddPrefix[p]
-} else {
+} else if {
 	endswith(properties.sourceAddressPrefix, "/0")
-} else {
+} else if {
 	properties.sourceAddressPrefixes[x] == relevantSourceAddPrefix[p]
-} else {
+} else if {
 	endswith(properties.sourceAddressPrefixes[x], "/0")
 }
 
-contains_target_port(targetPort, port) {
+contains_target_port(targetPort, port) if {
 	regex.match(sprintf("(^|\\s|,)%d(-|,|$|\\s)", [targetPort]), port)
-} else {
+} else if {
 	ports = split(port, ",")
 	sublist = split(ports[var], "-")
 	to_number(trim(sublist[0], " ")) <= targetPort
 	to_number(trim(sublist[1], " ")) >= targetPort
-} else {
+} else if {
 	port == "*"
 }
 
-contains_port(properties, targetPort) {
+contains_port(properties, targetPort) if {
 	contains_target_port(targetPort, properties.destinationPortRange)
-} else {
+} else if {
 	contains_target_port(targetPort, properties.destinationPortRanges[d])
 }
 
 # get_children returns an Array of all children of the resource
 # doc is input.document[i]
 # parent is the parent resource
-get_children(doc, parent, path) = childArr {
+get_children(doc, parent, path) := childArr if {
 	resourceArr := [x | x := {"value": parent.resources[_], "path": array.concat(path, ["resources"])}]
 	outerArr := get_outer_children(doc, parent.name)
 	childArr := array.concat(resourceArr, outerArr)
 }
 
-get_outer_children(doc, nameParent) = outerArr {
+get_outer_children(doc, nameParent) := outerArr if {
 	outerArr := [x |
 		[path, value] := walk(doc)
 		startswith(value.name, nameParent)
@@ -67,28 +69,27 @@ get_outer_children(doc, nameParent) = outerArr {
 	]
 }
 
-getDefaultValueFromParametersIfPresent(doc, valueToCheck) = [value, propertyType] {
+getDefaultValueFromParametersIfPresent(doc, valueToCheck) := [value, propertyType] if {
 	parameterName := isParameterReference(valueToCheck)
 	parameter := doc.parameters[parameterName].defaultValue
 	value := parameter
 	propertyType := "parameter default value"
-} else = [value, propertyType] {
+} else := [value, propertyType] if {
 	not isParameterReference(valueToCheck)
 	value := valueToCheck
 	propertyType := "property value"
 }
 
-isParameterReference(valueToCheck) = parameterName {
+isParameterReference(valueToCheck) := parameterName if {
 	startswith(valueToCheck, "[parameters('")
 	endswith(valueToCheck, "')]")
 	parameterName := trim_right(trim_left(trim_left(valueToCheck, "[parameters"), "('"), "')]")
 }
 
-
-isDisabledOrUndefined(doc, resource, parametersPath){
+isDisabledOrUndefined(doc, resource, parametersPath) if {
 	object.get(resource, split(parametersPath, "."), "not defined") == "not defined"
-} else {
-	value := object.get(resource, split(parametersPath, "."),"")
+} else if {
+	value := object.get(resource, split(parametersPath, "."), "")
 	[check, _] := getDefaultValueFromParametersIfPresent(doc, value)
 	check == false
 }

--- a/assets/libraries/buildah.rego
+++ b/assets/libraries/buildah.rego
@@ -1,1 +1,3 @@
 package generic.buildah
+
+import rego.v1

--- a/assets/libraries/cicd.rego
+++ b/assets/libraries/cicd.rego
@@ -1,19 +1,21 @@
 package generic.cicd
 
-dangerous_triggers = ["pull_request_target", "workflow_run"]
+import rego.v1
+
+dangerous_triggers := ["pull_request_target", "workflow_run"]
 
 # Check if workflow has dangerous triggers
-has_dangerous_trigger(doc) {
+has_dangerous_trigger(doc) if {
 	trigger := doc.on
 	trigger == dangerous_triggers[_]
 }
 
-has_dangerous_trigger(doc) {
+has_dangerous_trigger(doc) if {
 	trigger := doc.on[_]
 	trigger == dangerous_triggers[_]
 }
 
-has_dangerous_trigger(doc) {
+has_dangerous_trigger(doc) if {
 	doc.on[trigger]
 	trigger == dangerous_triggers[_]
 }
@@ -22,46 +24,44 @@ has_dangerous_trigger(doc) {
 # carry steps under `doc.runs.steps[*]` rather than `doc.jobs[*].steps[*]`. They
 # inherit the trigger context from the calling workflow, so step-level rules
 # cannot use `doc.on` for them.
-is_composite_action(doc) {
+is_composite_action(doc) if {
 	doc.runs.using == "composite"
 }
 
 # True when the raw text of a parsed GitHub Actions expression references a
 # directly attacker-influenced context: `inputs.*`, `github.event.*`,
 # `github.head_ref`, or `github.pull_request.*`.
-references_untrusted_context(raw) {
+references_untrusted_context(raw) if {
 	contains(raw, "inputs.")
 }
 
-references_untrusted_context(raw) {
+references_untrusted_context(raw) if {
 	contains(raw, "github.event.")
 }
 
-references_untrusted_context(raw) {
+references_untrusted_context(raw) if {
 	contains(raw, "github.head_ref")
 }
 
-references_untrusted_context(raw) {
+references_untrusted_context(raw) if {
 	contains(raw, "github.pull_request.")
 }
 
 # True for AST dereferences rooted at the `inputs` context (`inputs.<X>`),
 # but not for `github.event.inputs.<X>`, whose root is `github`.
-is_bare_inputs_dereference(node) {
+is_bare_inputs_dereference(node) if {
 	node.type == "dereference_expression"
 	object := node.children[0]
 	object.type == "identifier"
 	lower(object.value) == "inputs"
 }
 
-check_provider(doc) := "github" {
+check_provider(doc) := "github" if {
 	contains(doc._path, "/.github/")
-} else := "github" {
+} else := "github" if {
 	regex.match("/action\\.ya?ml", doc._path)
-} else := "github" {
+} else := "github" if {
 	contains(doc._path, "\\.github\\")
-} else := "github" {
+} else := "github" if {
 	regex.match("\\\\action\\.ya?ml", doc._path)
-} else := "other" {
-	true
-}
+} else := "other"

--- a/assets/libraries/cloudformation.rego
+++ b/assets/libraries/cloudformation.rego
@@ -1,61 +1,62 @@
 package generic.cloudformation
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-
-normalize_cloudFormation_boolean(boolOrString) = string {
+normalize_cloudFormation_boolean(boolOrString) := string if {
 	boolOrString == true
 	string = "true"
-} else = string {
+} else := string if {
 	lower(boolOrString) == "true"
 	string = "true"
-} else = string {
+} else := string if {
 	lower(boolOrString) == "on"
 	string = "true"
-} else = string {
+} else := string if {
 	lower(boolOrString) == "yes"
 	string = "true"
-} else = string {
+} else := string if {
 	string = "false"
 }
 
 # Find out if the document has a resource type equals to 'AWS::SecretsManager::Secret'
-hasSecretManager(str, document) {
+hasSecretManager(str, document) if {
 	selectedSecret := strings.replace_n({"${": "", "}": ""}, regex.find_n(`\${\w+}`, str, 1)[0])
 	document[selectedSecret].Type == "AWS::SecretsManager::Secret"
 }
 
 # Check if the type is ELB
-isLoadBalancer(resource) {
+isLoadBalancer(resource) if {
 	resource.Type == "AWS::ElasticLoadBalancing::LoadBalancer"
 }
 
 # Check if the type is ELB
-isLoadBalancer(resource) {
+isLoadBalancer(resource) if {
 	resource.Type == "AWS::ElasticLoadBalancingV2::LoadBalancer"
 }
 
 # Check if there is an action inside an array
-checkAction(currentAction, actionToCompare) {
+checkAction(currentAction, actionToCompare) if {
 	is_string(currentAction)
 	currentAction == "*"
 	currentAction == actionToCompare
-} else {
+} else if {
 	is_string(currentAction)
 	contains(lower(currentAction), actionToCompare)
-} else {
+} else if {
 	is_array(currentAction)
 	action := currentAction[_]
 	action == "*"
 	action == actionToCompare
-} else {
+} else if {
 	is_array(currentAction)
 	action := currentAction[_]
 	contains(lower(action), actionToCompare)
 }
 
 # Dictionary of UDP ports
-udpPortsMap = {
+udpPortsMap := {
 	53: "DNS",
 	137: "NetBIOS Name Service",
 	138: "NetBIOS Datagram Service",
@@ -72,37 +73,37 @@ udpPortsMap = {
 }
 
 # Get content of the resource(s) based on the type
-getResourcesByType(resources, type) = list {
+getResourcesByType(resources, type) := list if {
 	list = [resource | resources[i].Type == type; resource := resources[i]]
 }
 
-getBucketName(resource) = name {
+getBucketName(resource) := name if {
 	name := resource.Properties.Bucket
 	not common_lib.valid_key(name, "Ref")
-} else = name {
+} else := name if {
 	name := resource.Properties.Bucket.Ref
 }
 
-get_encryption(resource) = encryption {
+get_encryption(resource) := encryption if {
 	resource.Properties.Encrypted == true
 	encryption := "encrypted"
-} else = encryption {
+} else := encryption if {
 	fields := {"EncryptionSpecification", "KmsMasterKeyId", "EncryptionInfo", "EncryptionOptions", "BucketEncryption", "StreamEncryption"}
 	common_lib.valid_key(resource.Properties, fields[_])
 	encryption := "encrypted"
-} else = encryption {
+} else := encryption if {
 	encryption := "unencrypted"
 }
 
-get_name(targetName) = name {
+get_name(targetName) := name if {
 	common_lib.valid_key(targetName, "Ref")
 	name := targetName.Ref
-} else = name {
+} else := name if {
 	not common_lib.valid_key(targetName, "Ref")
 	name := targetName
 }
 
-get_resource_accessibility(nameRef, type, key) = info {
+get_resource_accessibility(nameRef, type, key) := info if {
 	document := input.document
 	policy := document[_].Resources[_]
 	policy.Type == type
@@ -116,7 +117,7 @@ get_resource_accessibility(nameRef, type, key) = info {
 	common_lib.is_allow_effect(statement)
 
 	info := {"accessibility": "public", "policy": policy.Properties.PolicyDocument}
-} else = info {
+} else := info if {
 	document := input.document
 	policy := document[_].Resources[_]
 	policy.Type == type
@@ -130,7 +131,7 @@ get_resource_accessibility(nameRef, type, key) = info {
 	common_lib.is_allow_effect(statement)
 
 	info := {"accessibility": "public", "policy": policy.Properties.PolicyDocument}
-} else = info {
+} else := info if {
 	document := input.document
 	policy := document[_].Resources[_]
 	policy.Type == type
@@ -140,7 +141,7 @@ get_resource_accessibility(nameRef, type, key) = info {
 	get_name(keys) == nameRef
 
 	info := {"accessibility": "hasPolicy", "policy": policy.Properties.PolicyDocument}
-} else = info {
+} else := info if {
 	document := input.document
 	policy := document[_].Resources[_]
 	policy.Type == type
@@ -150,11 +151,11 @@ get_resource_accessibility(nameRef, type, key) = info {
 	get_name(keys[_]) == nameRef
 
 	info := {"accessibility": "hasPolicy", "policy": policy.Properties.PolicyDocument}
-} else = info {
+} else := info if {
 	info := {"accessibility": "unknown", "policy": ""}
 }
 
-resourceFieldName = {
+resourceFieldName := {
 	"AWS::Config::ConfigRule": "ConfigRuleName",
 	"AWS::ElasticLoadBalancing::LoadBalancer": "LoadBalancerName",
 	"AWS::ElasticLoadBalancingV2::LoadBalancer": "Name",
@@ -249,18 +250,18 @@ resourceFieldName = {
 	"AWS::Serverless::Function": "FunctionName",
 }
 
-pseudo_parameter_default_replacements = {
-	"${AWS::AccountId}":   "aws-account-id",
+pseudo_parameter_default_replacements := {
+	"${AWS::AccountId}": "aws-account-id",
 	"${AWS::NotificationARNs}": "aws-notification-arns",
-	"${AWS::NoValue}":     "aws-no-value",
-	"${AWS::Partition}":   "aws",
-	"${AWS::Region}":      "aws-region",
-	"${AWS::StackId}":     "aws-stack-id",
-	"${AWS::StackName}":   "aws-stack-name",
-	"${AWS::URLSuffix}":   "amazonaws.com",
+	"${AWS::NoValue}": "aws-no-value",
+	"${AWS::Partition}": "aws",
+	"${AWS::Region}": "aws-region",
+	"${AWS::StackId}": "aws-stack-id",
+	"${AWS::StackName}": "aws-stack-name",
+	"${AWS::URLSuffix}": "amazonaws.com",
 }
 
-parameter_default_replacements = replacements {
+parameter_default_replacements := replacements if {
 	params := input.document[_].Parameters
 	replacements := {old: new |
 		some param_name
@@ -269,7 +270,7 @@ parameter_default_replacements = replacements {
 		old := sprintf("${%s}", [param_name])
 		new := sprintf("%v", [param.Default])
 	}
-} else = replacements {
+} else := replacements if {
 	replacements := {}
 }
 
@@ -281,32 +282,32 @@ parameter_default_replacements = replacements {
 # of explicit variable bindings. When the template head is itself an intrinsic
 # (e.g. {"Fn::If": [...]}) it is not a string, so no template is produced and
 # callers fall back to the logical id.
-sub_template(sub_expr) = template {
+sub_template(sub_expr) := template if {
 	is_string(sub_expr)
 	template := sub_expr
-} else = template {
+} else := template if {
 	is_array(sub_expr)
 	count(sub_expr) > 0
 	is_string(sub_expr[0])
 	template := sub_expr[0]
 }
 
-intrinsic_value_to_string(v) = stringified {
+intrinsic_value_to_string(v) := stringified if {
 	is_string(v)
 	stringified := v
-} else = stringified {
+} else := stringified if {
 	is_number(v)
 	stringified := sprintf("%v", [v])
-} else = stringified {
+} else := stringified if {
 	is_boolean(v)
 	stringified := sprintf("%v", [v])
-} else = stringified {
+} else := stringified if {
 	common_lib.valid_key(v, "Ref")
 	ref_name := v.Ref
 	default_val := input.document[_].Parameters[ref_name].Default
 	default_val != null
 	stringified := sprintf("%v", [default_val])
-} else = stringified {
+} else := stringified if {
 	common_lib.valid_key(v, "Ref")
 	ref_name := v.Ref
 	old := sprintf("${%s}", [ref_name])
@@ -317,7 +318,7 @@ intrinsic_value_to_string(v) = stringified {
 # the explicit variable bindings of a sequence-form Fn::Sub, i.e. the second
 # element of ["template", {"Var": value}]. Values may be literals or a Ref to a
 # parameter/pseudo-parameter, resolved via intrinsic_value_to_string.
-sequence_sub_replacements(sub_expr) = replacements {
+sequence_sub_replacements(sub_expr) := replacements if {
 	is_array(sub_expr)
 	count(sub_expr) > 1
 	vars := sub_expr[1]
@@ -328,7 +329,7 @@ sequence_sub_replacements(sub_expr) = replacements {
 		new := intrinsic_value_to_string(raw)
 		old := sprintf("${%s}", [var_name])
 	}
-} else = replacements {
+} else := replacements if {
 	replacements := {}
 }
 
@@ -337,7 +338,7 @@ sequence_sub_replacements(sub_expr) = replacements {
 # the sequence form win over template Parameters, which win over pseudo
 # parameters. If any placeholder remains unresolved the rule fails so callers
 # fall back to the logical id rather than leaking a "${...}" string.
-resolve_sub_name(sub_expr) = resolved {
+resolve_sub_name(sub_expr) := resolved if {
 	template := sub_template(sub_expr)
 	step1 := strings.replace_n(sequence_sub_replacements(sub_expr), template)
 	step2 := strings.replace_n(parameter_default_replacements, step1)
@@ -346,53 +347,53 @@ resolve_sub_name(sub_expr) = resolved {
 	resolved != ""
 }
 
-get_resource_name(resource, resourceDefinitionName) = name {
+get_resource_name(resource, resourceDefinitionName) := name if {
 	field := resourceFieldName[resource.Type]
 	fieldValue := resource.Properties[field]
 	is_string(fieldValue)
 	fieldValue != ""
 	name := fieldValue
-} else = name {
+} else := name if {
 	field := resourceFieldName[resource.Type]
 	fieldValue := resource.Properties[field]
 	is_string(fieldValue)
 	fieldValue != ""
 	name := fieldValue[_]
-} else = name {
+} else := name if {
 	field := resourceFieldName[resource.Type]
 	sub_expr := resource.Properties[field]["Fn::Sub"]
 	name := resolve_sub_name(sub_expr)
-} else = name {
+} else := name if {
 	field := resourceFieldName[resource.Type]
 	ref_name := resource.Properties[field].Ref
 	name := input.document[_].Parameters[ref_name].Default
 	name != null
 	name != ""
-} else = name {
+} else := name if {
 	field := resourceFieldName[resource.Type]
 	ref_name := resource.Properties[field].Ref
 	old := sprintf("${%s}", [ref_name])
 	name := pseudo_parameter_default_replacements[old]
-} else = name {
+} else := name if {
 	name := common_lib.get_tag_name_if_exists(resource)
-} else = name {
+} else := name if {
 	name := resourceDefinitionName
 }
 
-getPath(path) = result {
+getPath(path) := result if {
 	count(path) > 0
 	path_string := common_lib.concat_path(path)
 	out := array.concat([path_string], ["."])
 	result := concat("", out)
-} else = result {
+} else := result if {
 	count(path) == 0
 	result := ""
 }
 
-createSearchKey(elem) = search {
+createSearchKey(elem) := search if {
 	not elem.Name.Ref
 	search := sprintf("=%s", [elem.Name])
-} else = search {
+} else := search if {
 	elem.Name.Ref
 	search := sprintf(".Ref=%s", [elem.Name.Ref])
 }

--- a/assets/libraries/common.rego
+++ b/assets/libraries/common.rego
@@ -1,6 +1,6 @@
 package generic.common
 
-import future.keywords.in
+import rego.v1
 
 # build_search_line will convert all values to string, and build path with given values
 # values need to be in the correct order
@@ -12,71 +12,70 @@ import future.keywords.in
 # [path, value] := walk(doc)
 # build_search_line(path, ["grandson"])
 
-build_search_line(path, obj) = resolvedPath {
+build_search_line(path, obj) := resolvedPath if {
 	resolveArray := [x | pathItem := path[n]; x := convert_path_item(pathItem)]
 	resolvedObj := [x | objItem := obj[n]; x := convert_path_item(objItem)]
 	resolvedPath = array.concat(resolveArray, resolvedObj)
 }
 
-convert_path_item(pathItem) = convertedPath {
+convert_path_item(pathItem) := convertedPath if {
 	is_number(pathItem)
 	convertedPath := sprintf("%d", [pathItem])
-} else = convertedPath {
+} else := convertedPath if {
 	convertedPath := sprintf("%s", [pathItem])
 }
 
-concat_path(path) = concatenated {
+concat_path(path) := concatenated if {
 	concatenated := concat(".", [x | x := resolve_path(path[_]); x != ""])
 }
 
-resolve_path(pathItem) = resolved {
-	any([contains(pathItem, "."), contains(pathItem, "="), contains(pathItem, "/")])
+resolve_path(pathItem) := resolved if {
+	checks := [contains(pathItem, "."), contains(pathItem, "="), contains(pathItem, "/")]
+	checks[_] == true
 	resolved := sprintf("{{%s}}", [pathItem])
-} else = resolved {
+} else := resolved if {
 	is_number(pathItem)
 	resolved := ""
-} else = pathItem {
-	true
+} else := pathItem
+
+json_unmarshal(s) := s if {
+	is_object(s)
 }
 
-json_unmarshal(s) = s {
-  is_object(s)
+json_unmarshal(s) := s if {
+	is_array(s)
 }
 
-json_unmarshal(s) = s {
-  is_array(s)
+json_unmarshal(s) := result if {
+	s == null
+	result := json.unmarshal("{}")
 }
 
-json_unmarshal(s) = result {
-  s == null
-  result := json.unmarshal("{}")
+json_unmarshal(s) := result if {
+	s != null
+	is_string(s)
+	startswith(s, "jsonencode(")
+	endswith(s, ")")
+
+	raw := substring(s, count("jsonencode("), (count(s) - count("jsonencode(")) - 1)
+	json_text := terraform_to_json(raw)
+	result := json.unmarshal(json_text)
 }
 
-json_unmarshal(s) = result {
-  s != null
-  is_string(s)
-  startswith(s, "jsonencode(")
-  endswith(s, ")")
-
-  raw := substring(s, count("jsonencode("), count(s) - count("jsonencode(") - 1)
-  json_text := terraform_to_json(raw)
-  result := json.unmarshal(json_text)
+json_unmarshal(s) := result if {
+	s != null
+	is_string(s)
+	not startswith(s, "jsonencode(")
+	result := json.unmarshal(s)
 }
 
-json_unmarshal(s) = result {
-  s != null
-  is_string(s)
-  not startswith(s, "jsonencode(")
-  result := json.unmarshal(s)
+terraform_to_json(s) := out if {
+	step1 := regex.replace(s, "(\\b\\w+\\b)\\s*=", "\"${1}\":")
+	step2 := regex.replace(step1, "#.*", "") # Remove inline comments
+	out := regex.replace(step2, ",\\s*]", "]") # Remove trailing commas
 }
 
-terraform_to_json(s) = out {
-  step1 := regex.replace(s, "(\\b\\w+\\b)\\s*=", "\"${1}\":")
-  step2 := regex.replace(step1, "#.*", "") # Remove inline comments
-  out := regex.replace(step2, ",\\s*]", "]") # Remove trailing commas
-}
-
-calc_IP_value(ip) = result {
+calc_IP_value(ip) := result if {
 	ips := split(ip, ".")
 
 	#calculate the value of an ip
@@ -86,54 +85,54 @@ calc_IP_value(ip) = result {
 }
 
 # Checks if a value is within a range
-between(value, min, max) {
+between(value, min, max) if {
 	value >= min
 	value <= max
 }
 
 # Checks if a list contains an item
-inArray(list, item) {
+inArray(list, item) if {
 	some i
 	list[i] == item
 }
 
 # Checks if a value is empty ("") or null
-emptyOrNull("") = true
+emptyOrNull("") := true
 
-emptyOrNull(null) = true
+emptyOrNull(null) := true
 
 # Checks if an IP is private
-isPrivateIP(ipVal) {
+isPrivateIP(ipVal) if {
 	private_ips := ["10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12"]
 	some i
 	net.cidr_contains(private_ips[i], ipVal)
 }
 
 # Check if field equals to value or if any element from field equals to value
-equalsOrInArray(field, value) {
+equalsOrInArray(field, value) if {
 	is_string(field)
 	lower(field) == value
 }
 
-equalsOrInArray(field, value) {
+equalsOrInArray(field, value) if {
 	is_array(field)
 	some i
 	lower(field[i]) == value
 }
 
 # Check if field contains value or if any element from field contains value
-containsOrInArrayContains(field, value) {
+containsOrInArrayContains(field, value) if {
 	is_string(value)
 	contains(lower(field), value)
 }
 
-containsOrInArrayContains(field, value) {
+containsOrInArrayContains(field, value) if {
 	is_array(field)
 	some i
 	contains(lower(field[i]), value)
 }
 
-isCommonKey(p) {
+isCommonKey(p) if {
 	bl = {
 		"namespace",
 		"bypass",
@@ -207,7 +206,7 @@ isCommonKey(p) {
 }
 
 # Dictionary of TCP ports
-tcpPortsMap = {
+tcpPortsMap := {
 	20: "FTP",
 	21: "FTP",
 	22: "SSH",
@@ -274,48 +273,44 @@ tcpPortsMap = {
 }
 
 # verifies if the resource(statement.Principal.AWS) contains an ARN that points to a specific IAM user
-allowsAllPrincipalsToAssume(resource, statement) {
+allowsAllPrincipalsToAssume(resource, statement) if {
 	is_string(resource) == true
 	contains(resource, "arn:aws:iam::")
 	contains(resource, ":root")
 	not contains(statement.Effect, "Deny")
 }
 
-allowsAllPrincipalsToAssume(resource, statement) {
+allowsAllPrincipalsToAssume(resource, statement) if {
 	is_array(resource) == true
 	contains(resource[x], "arn:aws:iam::")
 	contains(resource[x], ":root")
 	not contains(statement.Effect, "Deny")
 }
 
-compareArrays(arrayOne, arrayTwo) {
+compareArrays(arrayOne, arrayTwo) if {
 	upper(arrayOne[_]) == upper(arrayTwo[_])
-} else = false {
-	true
-}
+} else := false
 
-valid_key(obj, key) {
+valid_key(obj, key) if {
 	_ = obj[key]
 	not is_null(obj[key])
-} else = false {
-	true
-}
+} else := false
 
-getDays(date, daysInMonth) = days {
+getDays(date, daysInMonth) := days if {
 	index := date[1] - 2
 	index >= 0
 
 	days = ((date[0] * 365) + daysInMonth[index]) + date[2]
 }
 
-getDays(date, daysInMonth) = days {
+getDays(date, daysInMonth) := days if {
 	index := date[1] - 2
 	index < 0
 
 	days = (date[0] * 365) + date[2]
 }
 
-expired(expirationDate) {
+expired(expirationDate) if {
 	currentDate := time.date(time.now_ns())
 	daysInMonth := [31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365]
 
@@ -325,89 +320,86 @@ expired(expirationDate) {
 	daysInExpirationDate < daysInCurrentDate
 }
 
-unsecured_cors_rule(methods, headers, origins) {
+unsecured_cors_rule(methods, headers, origins) if {
 	# allows all methods
 	availableMethods := {"GET", "PUT", "POST", "DELETE", "HEAD"}
 	count({x | method := methods[x]; method == availableMethods[_]}) == count(availableMethods)
-} else {
+} else if {
 	# allows all headers
 	contains(headers[_], "*")
-} else {
+} else if {
 	# allows several origins
 	contains(origins[_], "*")
 }
 
-get_module_equivalent_key(provider, moduleName, resource, key) = keyInResource {
+get_module_equivalent_key(provider, moduleName, resource, key) := keyInResource if {
 	providers := data.common_lib.modules[provider]
 	module := providers[moduleName]
 	inArray(module.resources, resource)
 	keyInResource := module.inputs[key]
 }
 
-check_selector(filter, value, op, name) {
+check_selector(filter, value, op, name) if {
 	selector := find_selector_by_value(filter, value)
 	selector._op == op
 	selector._selector == name
-} else = false {
-	true
-}
+} else := false
 
-find_selector_by_value(filter, str) = rtn {
+find_selector_by_value(filter, str) := rtn if {
 	[_, fvalue] := walk(filter)
 	trim(fvalue._value, "\"") == str
 	rtn := fvalue
-} else {
+} else if {
 	[_, fvalue] := walk(filter)
 	trim(fvalue._value, "'") == str
 	rtn = fvalue
 }
 
-get_tag_name_if_exists(resource) = name {
+get_tag_name_if_exists(resource) := name if {
 	name := resource.tags.Name
-} else = name {
+} else := name if {
 	tag := resource.Properties.Tags[_]
 	tag.Key == "Name"
 	is_string(tag.Value)
 	name := tag.Value
-} else = name {
+} else := name if {
 	tag := resource.Properties.FileSystemTags[_]
 	tag.Key == "Name"
 	is_string(tag.Value)
 	name := tag.Value
-} else = name {
+} else := name if {
 	tag := resource.Properties.Tags[key]
 	is_string(tag)
 	key == "Name"
 	name := tag
-} else = name {
+} else := name if {
 	tag := resource.spec.forProvider.tags[_]
 	tag.key == "Name"
 	is_string(tag.value)
 	name := tag.value
-} else = name {
+} else := name if {
 	tag := resource.properties.tags[key]
 	is_string(tag)
 	key == "Name"
 	name := tag
 }
 
-
-get_encryption_if_exists(resource) = encryption {
+get_encryption_if_exists(resource) := encryption if {
 	resource.encrypted == true
 	encryption := "encrypted"
-} else = encryption {
+} else := encryption if {
 	options := {"encryption_at_rest_kms_key_arn", "encryption_in_transit"}
 	valid_key(resource.encryption_info, options[_])
 	encryption := "encrypted"
-} else = encryption {
+} else := encryption if {
 	fields := {"sqs_managed_sse_enabled", "kms_master_key_id", "encryption_options", "server_side_encryption_configuration"}
 	valid_key(resource, fields[_])
 	encryption := "encrypted"
-} else = encryption {
+} else := encryption if {
 	encryption := "unencrypted"
 }
 
-engines = {
+engines := {
 	"aurora": 3306,
 	"aurora-mysql": 3306,
 	"aurora-postgresql": 3306,
@@ -424,36 +416,36 @@ engines = {
 	"sqlserver-web": 1433,
 }
 
-is_ingress(firewall) {
+is_ingress(firewall) if {
 	not valid_key(firewall, "direction")
-} else {
+} else if {
 	firewall.direction == "INGRESS"
 }
 
-get_statement(policy) = st {
+get_statement(policy) := st if {
 	is_object(policy.Statement)
 	st = [policy.Statement]
-} else = st {
+} else := st if {
 	is_array(policy.Statement)
 	st = policy.Statement
 }
 
-is_allow_effect(statement) {
+is_allow_effect(statement) if {
 	not valid_key(statement, "Effect")
 	not valid_key(statement, "effect")
-} else {
+} else if {
 	statement.Effect == "Allow"
-} else {
-    statement.effect == "Allow"
+} else if {
+	statement.effect == "Allow"
 }
 
-get_policy(p) = policy {
+get_policy(p) := policy if {
 	policy = json_unmarshal(p)
-} else = policy {
+} else := policy if {
 	policy = p
 }
 
-condition_keys_limiting_access_to_account_id = {
+condition_keys_limiting_access_to_account_id := {
 	"aws:SourceOwner",
 	"aws:SourceAccount",
 	"aws:ResourceAccount",
@@ -461,88 +453,98 @@ condition_keys_limiting_access_to_account_id = {
 	"aws:VpceAccount",
 }
 
-conditions = {
+conditions := {
 	"Condition",
 	"condition",
 }
 
-is_access_limited_to_an_account_id(statement) {
+is_access_limited_to_an_account_id(statement) if {
 	valid_key(statement, conditions[idx])
 	condition_operator := statement[conditions[idx]][op][key]
 	lower(key) == lower(condition_keys_limiting_access_to_account_id[_])
 }
 
-is_cross_account(statement) {
+is_cross_account(statement) if {
 	is_string(statement.Principal.AWS)
 	regex.match("(^[0-9]{12}$)|(^arn:aws:(iam|sts)::[0-9]{12})", statement.Principal.AWS)
-} else {
+} else if {
 	is_array(statement.Principal.AWS)
 	regex.match("(^[0-9]{12}$)|(^arn:aws:(iam|sts)::[0-9]{12})", statement.Principal.AWS[_])
 }
 
-is_assume_role(statement) {
+is_assume_role(statement) if {
 	statement.Action == "sts:AssumeRole"
-} else {
+} else if {
 	statement.Action[_] == "sts:AssumeRole"
 }
 
-has_external_id(statement) {
+has_external_id(statement) if {
 	count(statement.Condition.StringEquals["sts:ExternalId"]) > 0
 }
 
-has_mfa(statement) {
+has_mfa(statement) if {
 	statement.Condition.BoolIfExists["aws:MultiFactorAuthPresent"] == "true"
-} else {
+} else if {
 	statement.Condition.Bool["aws:MultiFactorAuthPresent"] == "true"
 }
 
-any_principal(statement) {
+any_principal(statement) if {
 	contains(statement.Principal, "*")
-} else {
+} else if {
 	is_string(statement.Principal.AWS)
 	contains(statement.Principal.AWS, "*")
-} else {
+} else if {
 	is_array(statement.Principal.AWS)
 	contains(statement.Principal.AWS[_], "*")
-} else {
+} else if {
 	not valid_key(statement, "Principal")
 }
 
-is_recommended_tls(field) {
+is_recommended_tls(field) if {
 	inArray({"TLSv1.2_2018", "TLSv1.2_2019", "TLSv1.2_2021"}, field)
 }
 
-is_unrestricted(sourceRange) {
+is_unrestricted(sourceRange) if {
 	cidrs := {"0.0.0.0/0", "::/0"}
 	sourceRange == cidrs[_]
 }
 
-check_principals(statement) {
+check_principals(statement) if {
 	statement.principals.identifiers[_] == "*"
 	statement.principals.type == "AWS"
-} else {
+} else if {
 	is_object(statement.Principal) == true
 	statement.Principal.AWS == "*"
-} else {
+} else if {
 	is_string(statement.Principal) == true
 	statement.Principal == "*"
 }
 
-check_actions(statement, typeAction) {
-	any([statement.actions[_] == typeAction, statement.actions[_] == "*"])
-} else {
-	any([statement.Actions[_] == typeAction, statement.Actions[_] == "*"])
-} else {
+check_actions(statement, typeAction) if {
+	statement.actions[_] == typeAction
+} else if {
+	statement.actions[_] == "*"
+} else if {
+	statement.Actions[_] == typeAction
+} else if {
+	statement.Actions[_] == "*"
+} else if {
 	is_array(statement.Action) == true
-	any([statement.Action[_] == typeAction, statement.Action[_] == "*"])
-} else {
+	statement.Action[_] == typeAction
+} else if {
+	is_array(statement.Action) == true
+	statement.Action[_] == "*"
+} else if {
 	is_string(statement.Action) == true
-	any([statement.Action == typeAction, statement.Action == "*"])
+	statement.Action == typeAction
+} else if {
+	is_string(statement.Action) == true
+	statement.Action == "*"
 }
 
-has_wildcard(statement, typeAction) {
+has_wildcard(statement, typeAction) if {
 	check_principals(statement)
-} else {
+} else if {
 	check_actions(statement, typeAction)
 }
 
@@ -553,7 +555,7 @@ has_wildcard(statement, typeAction) {
 # array_vals := ["elem1", "elem2", "elem4"]
 #
 # return_value := {"valid": false, "searchKey": "elem1.elem2"}
-get_nested_values_info(object, array_vals) = return_value {
+get_nested_values_info(object, array_vals) := return_value if {
 	arr := [x |
 		some i, _ in array_vals
 		path := array.slice(array_vals, 0, i + 1)
@@ -567,11 +569,11 @@ get_nested_values_info(object, array_vals) = return_value {
 	}
 }
 
-remove_last_point(searchKey) = sk {
+remove_last_point(searchKey) := sk if {
 	sk := trim_right(searchKey, ".")
 }
 
-isOSDir(mountPath) = result {
+isOSDir(mountPath) := result if {
 	hostSensitiveDir = {
 		"/bin", "/sbin", "/boot", "/cdrom",
 		"/dev", "/etc", "/home", "/lib",
@@ -581,31 +583,31 @@ isOSDir(mountPath) = result {
 	}
 
 	result = list_contains(hostSensitiveDir, mountPath)
-} else = result {
+} else := result if {
 	result = mountPath == "/"
 }
 
-list_contains(dirs, elem) {
+list_contains(dirs, elem) if {
 	startswith(elem, dirs[_])
 }
 
 # if accessibility is "hasPolicy", bom_output should also display the policy content
-get_bom_output(bom_output, policy) = output {
+get_bom_output(bom_output, policy) := output if {
 	bom_output.resource_accessibility == "hasPolicy"
 	out := {"policy": policy}
 
 	output := object.union(bom_output, out)
-} else = output {
+} else := output if {
 	output := bom_output
 }
 
 # This function is based on these docs: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.html#describe-ebs-optimization
-is_aws_ebs_optimized_by_default(instanceType) {
+is_aws_ebs_optimized_by_default(instanceType) if {
 	inArray(data.common_lib.aws_ebs_optimized_by_default, instanceType)
 }
 
 # IANA
-weakCipher(aux) {
+weakCipher(aux) if {
 	weak_ciphers_IANA_Format = {
 		"TLS_NULL_WITH_NULL_NULL", "TLS_RSA_WITH_NULL_MD5", "TLS_RSA_WITH_NULL_SHA", "TLS_RSA_EXPORT_WITH_RC4_40_MD5", "TLS_RSA_WITH_RC4_128_MD5", "TLS_RSA_WITH_RC4_128_SHA", "TLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5", "TLS_RSA_WITH_IDEA_CBC_SHA", "TLS_RSA_EXPORT_WITH_DES40_CBC_SHA", "TLS_RSA_WITH_DES_CBC_SHA", "TLS_RSA_WITH_3DES_EDE_CBC_SHA", "TLS_DH_DSS_EXPORT_WITH_DES40_CBC_SHA", "TLS_DH_DSS_WITH_DES_CBC_SHA", "TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA", "TLS_DH_RSA_EXPORT_WITH_DES40_CBC_SHA", "TLS_DH_RSA_WITH_DES_CBC_SHA", "TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA", "TLS_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA", "TLS_DHE_DSS_WITH_DES_CBC_SHA", "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA", "TLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA", "TLS_DHE_RSA_WITH_DES_CBC_SHA", "TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA", "TLS_DH_anon_EXPORT_WITH_RC4_40_MD5", "TLS_DH_anon_WITH_RC4_128_MD5", "TLS_DH_anon_EXPORT_WITH_DES40_CBC_SHA", "TLS_DH_anon_WITH_DES_CBC_SHA", "TLS_DH_anon_WITH_3DES_EDE_CBC_SHA", "TLS_KRB5_WITH_DES_CBC_SHA", "TLS_KRB5_WITH_3DES_EDE_CBC_SHA", "TLS_KRB5_WITH_RC4_128_SHA", "TLS_KRB5_WITH_IDEA_CBC_SHA", "TLS_KRB5_WITH_DES_CBC_MD5", "TLS_KRB5_WITH_3DES_EDE_CBC_MD5", "TLS_KRB5_WITH_RC4_128_MD5", "TLS_KRB5_WITH_IDEA_CBC_MD5", "TLS_KRB5_EXPORT_WITH_DES_CBC_40_SHA", "TLS_KRB5_EXPORT_WITH_RC2_CBC_40_SHA", "TLS_KRB5_EXPORT_WITH_RC4_40_SHA", "TLS_KRB5_EXPORT_WITH_DES_CBC_40_MD5", "TLS_KRB5_EXPORT_WITH_RC2_CBC_40_MD5", "TLS_KRB5_EXPORT_WITH_RC4_40_MD5", "TLS_PSK_WITH_NULL_SHA", "TLS_DHE_PSK_WITH_NULL_SHA", "TLS_RSA_PSK_WITH_NULL_SHA", "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_DH_DSS_WITH_AES_128_CBC_SHA", "TLS_DH_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_DSS_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DH_anon_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA", "TLS_DH_DSS_WITH_AES_256_CBC_SHA", "TLS_DH_RSA_WITH_AES_256_CBC_SHA", "TLS_DHE_DSS_WITH_AES_256_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA", "TLS_DH_anon_WITH_AES_256_CBC_SHA", "TLS_RSA_WITH_NULL_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA256", "TLS_RSA_WITH_AES_256_CBC_SHA256", "TLS_DH_DSS_WITH_AES_128_CBC_SHA256", "TLS_DH_RSA_WITH_AES_128_CBC_SHA256", "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256", "TLS_RSA_WITH_CAMELLIA_128_CBC_SHA", "TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA", "TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA", "TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA", "TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA", "TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256", "TLS_DH_DSS_WITH_AES_256_CBC_SHA256", "TLS_DH_RSA_WITH_AES_256_CBC_SHA256", "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256", "TLS_DH_anon_WITH_AES_128_CBC_SHA256", "TLS_DH_anon_WITH_AES_256_CBC_SHA256", "TLS_RSA_WITH_CAMELLIA_256_CBC_SHA", "TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA", "TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA", "TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA", "TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA", "TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA", "TLS_PSK_WITH_RC4_128_SHA", "TLS_PSK_WITH_3DES_EDE_CBC_SHA", "TLS_PSK_WITH_AES_128_CBC_SHA", "TLS_PSK_WITH_AES_256_CBC_SHA", "TLS_DHE_PSK_WITH_RC4_128_SHA", "TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA", "TLS_DHE_PSK_WITH_AES_128_CBC_SHA", "TLS_DHE_PSK_WITH_AES_256_CBC_SHA", "TLS_RSA_PSK_WITH_RC4_128_SHA", "TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA", "TLS_RSA_PSK_WITH_AES_128_CBC_SHA", "TLS_RSA_PSK_WITH_AES_256_CBC_SHA", "TLS_RSA_WITH_SEED_CBC_SHA", "TLS_DH_DSS_WITH_SEED_CBC_SHA", "TLS_DH_RSA_WITH_SEED_CBC_SHA", "TLS_DHE_DSS_WITH_SEED_CBC_SHA", "TLS_DHE_RSA_WITH_SEED_CBC_SHA", "TLS_DH_anon_WITH_SEED_CBC_SHA", "TLS_RSA_WITH_AES_128_GCM_SHA256", "TLS_RSA_WITH_AES_256_GCM_SHA384", "TLS_DH_RSA_WITH_AES_128_GCM_SHA256", "TLS_DH_RSA_WITH_AES_256_GCM_SHA384", "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256", "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384", "TLS_DH_DSS_WITH_AES_128_GCM_SHA256", "TLS_DH_DSS_WITH_AES_256_GCM_SHA384", "TLS_DH_anon_WITH_AES_128_GCM_SHA256", "TLS_DH_anon_WITH_AES_256_GCM_SHA384", "TLS_PSK_WITH_AES_128_GCM_SHA256", "TLS_PSK_WITH_AES_256_GCM_SHA384", "TLS_RSA_PSK_WITH_AES_128_GCM_SHA256", "TLS_RSA_PSK_WITH_AES_256_GCM_SHA384", "TLS_PSK_WITH_AES_128_CBC_SHA256", "TLS_PSK_WITH_AES_256_CBC_SHA384", "TLS_PSK_WITH_NULL_SHA256", "TLS_PSK_WITH_NULL_SHA384", "TLS_DHE_PSK_WITH_AES_128_CBC_SHA256",
 		"TLS_DHE_PSK_WITH_AES_256_CBC_SHA384", "TLS_DHE_PSK_WITH_NULL_SHA256", "TLS_DHE_PSK_WITH_NULL_SHA384", "TLS_RSA_PSK_WITH_AES_128_CBC_SHA256", "TLS_RSA_PSK_WITH_AES_256_CBC_SHA384", "TLS_RSA_PSK_WITH_NULL_SHA256", "TLS_RSA_PSK_WITH_NULL_SHA384", "TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256", "TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA256", "TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA256", "TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA256", "TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256", "TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA256", "TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256", "TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA256", "TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA256", "TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA256", "TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256", "TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA256", "TLS_SM4_GCM_SM3", "TLS_SM4_CCM_SM3", "TLS_EMPTY_RENEGOTIATION_INFO_SCSV", "TLS_AES_128_CCM_8_SHA256", "TLS_ECDH_ECDSA_WITH_NULL_SHA", "TLS_ECDH_ECDSA_WITH_RC4_128_SHA", "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA", "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA", "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_ECDSA_WITH_NULL_SHA", "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA", "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", "TLS_ECDH_RSA_WITH_NULL_SHA", "TLS_ECDH_RSA_WITH_RC4_128_SHA", "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA", "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_RSA_WITH_NULL_SHA", "TLS_ECDHE_RSA_WITH_RC4_128_SHA", "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", "TLS_ECDH_anon_WITH_NULL_SHA", "TLS_ECDH_anon_WITH_RC4_128_SHA", "TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA", "TLS_ECDH_anon_WITH_AES_128_CBC_SHA", "TLS_ECDH_anon_WITH_AES_256_CBC_SHA", "TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA", "TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA", "TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA", "TLS_SRP_SHA_WITH_AES_128_CBC_SHA", "TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA", "TLS_SRP_SHA_DSS_WITH_AES_128_CBC_SHA", "TLS_SRP_SHA_WITH_AES_256_CBC_SHA", "TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA", "TLS_SRP_SHA_DSS_WITH_AES_256_CBC_SHA", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384", "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256", "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384", "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384", "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256", "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_PSK_WITH_RC4_128_SHA", "TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA", "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA", "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA", "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384", "TLS_ECDHE_PSK_WITH_NULL_SHA", "TLS_ECDHE_PSK_WITH_NULL_SHA256", "TLS_ECDHE_PSK_WITH_NULL_SHA384", "TLS_RSA_WITH_ARIA_128_CBC_SHA256", "TLS_RSA_WITH_ARIA_256_CBC_SHA384", "TLS_DH_DSS_WITH_ARIA_128_CBC_SHA256", "TLS_DH_DSS_WITH_ARIA_256_CBC_SHA384", "TLS_DH_RSA_WITH_ARIA_128_CBC_SHA256", "TLS_DH_RSA_WITH_ARIA_256_CBC_SHA384", "TLS_DHE_DSS_WITH_ARIA_128_CBC_SHA256", "TLS_DHE_DSS_WITH_ARIA_256_CBC_SHA384", "TLS_DHE_RSA_WITH_ARIA_128_CBC_SHA256", "TLS_DHE_RSA_WITH_ARIA_256_CBC_SHA384", "TLS_DH_anon_WITH_ARIA_128_CBC_SHA256", "TLS_DH_anon_WITH_ARIA_256_CBC_SHA384", "TLS_ECDHE_ECDSA_WITH_ARIA_128_CBC_SHA256", "TLS_ECDHE_ECDSA_WITH_ARIA_256_CBC_SHA384", "TLS_ECDH_ECDSA_WITH_ARIA_128_CBC_SHA256", "TLS_ECDH_ECDSA_WITH_ARIA_256_CBC_SHA384", "TLS_ECDHE_RSA_WITH_ARIA_128_CBC_SHA256", "TLS_ECDHE_RSA_WITH_ARIA_256_CBC_SHA384", "TLS_ECDH_RSA_WITH_ARIA_128_CBC_SHA256", "TLS_ECDH_RSA_WITH_ARIA_256_CBC_SHA384", "TLS_RSA_WITH_ARIA_128_GCM_SHA256", "TLS_RSA_WITH_ARIA_256_GCM_SHA384", "TLS_DHE_RSA_WITH_ARIA_128_GCM_SHA256", "TLS_DHE_RSA_WITH_ARIA_256_GCM_SHA384", "TLS_DH_RSA_WITH_ARIA_128_GCM_SHA256", "TLS_DH_RSA_WITH_ARIA_256_GCM_SHA384", "TLS_DHE_DSS_WITH_ARIA_128_GCM_SHA256", "TLS_DHE_DSS_WITH_ARIA_256_GCM_SHA384", "TLS_DH_DSS_WITH_ARIA_128_GCM_SHA256", "TLS_DH_DSS_WITH_ARIA_256_GCM_SHA384", "TLS_DH_anon_WITH_ARIA_128_GCM_SHA256",
@@ -615,58 +617,57 @@ weakCipher(aux) {
 }
 
 # OpenSSL
-weakCipher(aux) {
+weakCipher(aux) if {
 	weak_ciphers_OpenSSL_Format = {"NULL-MD5", "NULL-SHA", "IDEA-CBC-SHA", "DES-CBC3-SHA", "DHE-DSS-DES-CBC3-SHA", "DHE-RSA-DES-CBC3-SHA", "ADH-DES-CBC3-SHA", "PSK-NULL-SHA", "DHE-PSK-NULL-SHA", "RSA-PSK-NULL-SHA", "AES128-SHA", "DHE-DSS-AES128-SHA", "DHE-RSA-AES128-SHA", "ADH-AES128-SHA", "AES256-SHA", "DHE-DSS-AES256-SHA", "DHE-RSA-AES256-SHA", "ADH-AES256-SHA", "NULL-SHA256", "AES128-SHA256", "AES256-SHA256", "DHE-DSS-AES128-SHA256", "CAMELLIA128-SHA", "DHE-DSS-CAMELLIA128-SHA", "DHE-RSA-CAMELLIA128-SHA", "ADH-CAMELLIA128-SHA", "DHE-RSA-AES128-SHA256", "DHE-DSS-AES256-SHA256", "DHE-RSA-AES256-SHA256", "ADH-AES128-SHA256", "ADH-AES256-SHA256", "CAMELLIA256-SHA", "DHE-DSS-CAMELLIA256-SHA", "DHE-RSA-CAMELLIA256-SHA", "ADH-CAMELLIA256-SHA", "PSK-3DES-EDE-CBC-SHA", "PSK-AES128-CBC-SHA", "PSK-AES256-CBC-SHA", "DHE-PSK-3DES-EDE-CBC-SHA", "DHE-PSK-AES128-CBC-SHA", "DHE-PSK-AES256-CBC-SHA", "RSA-PSK-3DES-EDE-CBC-SHA", "RSA-PSK-AES128-CBC-SHA", "RSA-PSK-AES256-CBC-SHA", "SEED-SHA", "DHE-DSS-SEED-SHA", "DHE-RSA-SEED-SHA", "ADH-SEED-SHA", "AES128-GCM-SHA256", "AES256-GCM-SHA384", "DHE-DSS-AES128-GCM-SHA256", "DHE-DSS-AES256-GCM-SHA384", "ADH-AES128-GCM-SHA256", "ADH-AES256-GCM-SHA384", "PSK-AES128-GCM-SHA256", "PSK-AES256-GCM-SHA384", "RSA-PSK-AES128-GCM-SHA256", "RSA-PSK-AES256-GCM-SHA384", "PSK-AES128-CBC-SHA256", "PSK-AES256-CBC-SHA384", "PSK-NULL-SHA256", "PSK-NULL-SHA384", "DHE-PSK-AES128-CBC-SHA256", "DHE-PSK-AES256-CBC-SHA384", "DHE-PSK-NULL-SHA256", "DHE-PSK-NULL-SHA384", "RSA-PSK-AES128-CBC-SHA256", "RSA-PSK-AES256-CBC-SHA384", "RSA-PSK-NULL-SHA256", "RSA-PSK-NULL-SHA384", "CAMELLIA128-SHA256", "DHE-DSS-CAMELLIA128-SHA256", "DHE-RSA-CAMELLIA128-SHA256", "ADH-CAMELLIA128-SHA256", "CAMELLIA256-SHA256", "DHE-DSS-CAMELLIA256-SHA256", "DHE-RSA-CAMELLIA256-SHA256", "ADH-CAMELLIA256-SHA256", "ECDHE-ECDSA-NULL-SHA", "ECDHE-ECDSA-DES-CBC3-SHA", "ECDHE-ECDSA-AES128-SHA", "ECDHE-ECDSA-AES256-SHA", "ECDHE-RSA-NULL-SHA", "ECDHE-RSA-DES-CBC3-SHA", "ECDHE-RSA-AES128-SHA", "ECDHE-RSA-AES256-SHA", "AECDH-NULL-SHA", "AECDH-DES-CBC3-SHA", "AECDH-AES128-SHA", "AECDH-AES256-SHA", "SRP-3DES-EDE-CBC-SHA", "SRP-RSA-3DES-EDE-CBC-SHA", "SRP-DSS-3DES-EDE-CBC-SHA", "SRP-AES-128-CBC-SHA", "SRP-RSA-AES-128-CBC-SHA", "SRP-DSS-AES-128-CBC-SHA", "SRP-AES-256-CBC-SHA", "SRP-RSA-AES-256-CBC-SHA", "SRP-DSS-AES-256-CBC-SHA", "ECDHE-ECDSA-AES128-SHA256", "ECDHE-ECDSA-AES256-SHA384", "ECDHE-RSA-AES128-SHA256", "ECDHE-RSA-AES256-SHA384", "ECDHE-PSK-3DES-EDE-CBC-SHA", "ECDHE-PSK-AES128-CBC-SHA", "ECDHE-PSK-AES256-CBC-SHA", "ECDHE-PSK-AES128-CBC-SHA256", "ECDHE-PSK-AES256-CBC-SHA384", "ECDHE-PSK-NULL-SHA", "ECDHE-PSK-NULL-SHA256", "ECDHE-PSK-NULL-SHA384", "ECDHE-ECDSA-CAMELLIA128-SHA256", "ECDHE-ECDSA-CAMELLIA256-SHA384", "ECDHE-RSA-CAMELLIA128-SHA256", "ECDHE-RSA-CAMELLIA256-SHA384", "PSK-CAMELLIA128-SHA256", "PSK-CAMELLIA256-SHA384", "DHE-PSK-CAMELLIA128-SHA256", "DHE-PSK-CAMELLIA256-SHA384", "RSA-PSK-CAMELLIA128-SHA256", "RSA-PSK-CAMELLIA256-SHA384", "ECDHE-PSK-CAMELLIA128-SHA256", "ECDHE-PSK-CAMELLIA256-SHA384", "AES128-CCM", "AES256-CCM", "AES128-CCM8", "AES256-CCM8", "DHE-RSA-AES128-CCM8", "DHE-RSA-AES256-CCM8", "PSK-AES128-CCM", "PSK-AES256-CCM", "PSK-AES128-CCM8", "PSK-AES256-CCM8", "DHE-PSK-AES128-CCM8", "DHE-PSK-AES256-CCM8", "ECDHE-ECDSA-AES128-CCM", "ECDHE-ECDSA-AES256-CCM", "ECDHE-ECDSA-AES128-CCM8", "ECDHE-ECDSA-AES256-CCM8", "PSK-CHACHA20-POLY1305", "RSA-PSK-CHACHA20-POLY1305"}
 	weak_ciphers_OpenSSL_Format[_] == aux
 }
 
 # GnuTLS
-weakCipher(aux) {
+weakCipher(aux) if {
 	weak_ciphers_GnuTLS_Format = {"TLS_RSA_NULL_MD5", "TLS_RSA_NULL_SHA1", "TLS_RSA_ARCFOUR_128_MD5", "TLS_RSA_ARCFOUR_128_SHA1", "TLS_RSA_3DES_EDE_CBC_SHA1", "TLS_DHE_DSS_3DES_EDE_CBC_SHA1", "TLS_DHE_RSA_3DES_EDE_CBC_SHA1", "TLS_DH_ANON_ARCFOUR_128_MD5", "TLS_DH_ANON_3DES_EDE_CBC_SHA1", "TLS_PSK_NULL_SHA1", "TLS_DHE_PSK_NULL_SHA1", "TLS_RSA_PSK_NULL_SHA1", "TLS_RSA_AES_128_CBC_SHA1", "TLS_DHE_DSS_AES_128_CBC_SHA1", "TLS_DHE_RSA_AES_128_CBC_SHA1", "TLS_DH_ANON_AES_128_CBC_SHA1", "TLS_RSA_AES_256_CBC_SHA1", "TLS_DHE_DSS_AES_256_CBC_SHA1", "TLS_DHE_RSA_AES_256_CBC_SHA1", "TLS_DH_ANON_AES_256_CBC_SHA1", "TLS_RSA_NULL_SHA256", "TLS_RSA_AES_128_CBC_SHA256", "TLS_RSA_AES_256_CBC_SHA256", "TLS_DHE_DSS_AES_128_CBC_SHA256", "TLS_RSA_CAMELLIA_128_CBC_SHA1", "TLS_DHE_DSS_CAMELLIA_128_CBC_SHA1", "TLS_DHE_RSA_CAMELLIA_128_CBC_SHA1", "TLS_DH_ANON_CAMELLIA_128_CBC_SHA1", "TLS_DHE_RSA_AES_128_CBC_SHA256", "TLS_DHE_DSS_AES_256_CBC_SHA256", "TLS_DHE_RSA_AES_256_CBC_SHA256", "TLS_DH_ANON_AES_128_CBC_SHA256", "TLS_DH_ANON_AES_256_CBC_SHA256", "TLS_RSA_CAMELLIA_256_CBC_SHA1", "TLS_DHE_DSS_CAMELLIA_256_CBC_SHA1", "TLS_DHE_RSA_CAMELLIA_256_CBC_SHA1", "TLS_DH_ANON_CAMELLIA_256_CBC_SHA1", "TLS_PSK_ARCFOUR_128_SHA1", "TLS_PSK_3DES_EDE_CBC_SHA1", "TLS_PSK_AES_128_CBC_SHA1", "TLS_PSK_AES_256_CBC_SHA1", "TLS_DHE_PSK_ARCFOUR_128_SHA1", "TLS_DHE_PSK_3DES_EDE_CBC_SHA1", "TLS_DHE_PSK_AES_128_CBC_SHA1", "TLS_DHE_PSK_AES_256_CBC_SHA1", "TLS_RSA_PSK_ARCFOUR_128_SHA1", "TLS_RSA_PSK_3DES_EDE_CBC_SHA1", "TLS_RSA_PSK_AES_128_CBC_SHA1", "TLS_RSA_PSK_AES_256_CBC_SHA1", "TLS_RSA_AES_128_GCM_SHA256", "TLS_RSA_AES_256_GCM_SHA384", "TLS_DHE_DSS_AES_128_GCM_SHA256", "TLS_DHE_DSS_AES_256_GCM_SHA384", "TLS_DH_ANON_AES_128_GCM_SHA256", "TLS_DH_ANON_AES_256_GCM_SHA384", "TLS_PSK_AES_128_GCM_SHA256", "TLS_PSK_AES_256_GCM_SHA384", "TLS_RSA_PSK_AES_128_GCM_SHA256", "TLS_RSA_PSK_AES_256_GCM_SHA384", "TLS_PSK_AES_128_CBC_SHA256", "TLS_PSK_AES_256_CBC_SHA384", "TLS_PSK_NULL_SHA256", "TLS_PSK_NULL_SHA384", "TLS_DHE_PSK_AES_128_CBC_SHA256", "TLS_DHE_PSK_AES_256_CBC_SHA384", "TLS_DHE_PSK_NULL_SHA256", "TLS_DHE_PSK_NULL_SHA384", "TLS_RSA_PSK_AES_128_CBC_SHA256", "TLS_RSA_PSK_AES_256_CBC_SHA384", "TLS_RSA_PSK_NULL_SHA256", "TLS_RSA_PSK_NULL_SHA384", "TLS_RSA_CAMELLIA_128_CBC_SHA256", "TLS_DHE_DSS_CAMELLIA_128_CBC_SHA256", "TLS_DHE_RSA_CAMELLIA_128_CBC_SHA256", "TLS_DH_ANON_CAMELLIA_128_CBC_SHA256", "TLS_RSA_CAMELLIA_256_CBC_SHA256", "TLS_DHE_DSS_CAMELLIA_256_CBC_SHA256", "TLS_DHE_RSA_CAMELLIA_256_CBC_SHA256", "TLS_DH_ANON_CAMELLIA_256_CBC_SHA256", "TLS_ECDHE_ECDSA_NULL_SHA1", "TLS_ECDHE_ECDSA_ARCFOUR_128_SHA1", "TLS_ECDHE_ECDSA_3DES_EDE_CBC_SHA1", "TLS_ECDHE_ECDSA_AES_128_CBC_SHA1", "TLS_ECDHE_ECDSA_AES_256_CBC_SHA1", "TLS_ECDHE_RSA_NULL_SHA1", "TLS_ECDHE_RSA_ARCFOUR_128_SHA1", "TLS_ECDHE_RSA_3DES_EDE_CBC_SHA1", "TLS_ECDHE_RSA_AES_128_CBC_SHA1", "TLS_ECDHE_RSA_AES_256_CBC_SHA1", "TLS_ECDH_ANON_NULL_SHA1", "TLS_ECDH_ANON_ARCFOUR_128_SHA1", "TLS_ECDH_ANON_3DES_EDE_CBC_SHA1", "TLS_ECDH_ANON_AES_128_CBC_SHA1", "TLS_ECDH_ANON_AES_256_CBC_SHA1", "TLS_SRP_SHA_3DES_EDE_CBC_SHA1", "TLS_SRP_SHA_RSA_3DES_EDE_CBC_SHA1", "TLS_SRP_SHA_DSS_3DES_EDE_CBC_SHA1", "TLS_SRP_SHA_AES_128_CBC_SHA1", "TLS_SRP_SHA_RSA_AES_128_CBC_SHA1", "TLS_SRP_SHA_DSS_AES_128_CBC_SHA1", "TLS_SRP_SHA_AES_256_CBC_SHA1", "TLS_SRP_SHA_RSA_AES_256_CBC_SHA1", "TLS_SRP_SHA_DSS_AES_256_CBC_SHA1", "TLS_ECDHE_ECDSA_AES_128_CBC_SHA256", "TLS_ECDHE_ECDSA_AES_256_CBC_SHA384", "TLS_ECDHE_RSA_AES_128_CBC_SHA256", "TLS_ECDHE_RSA_AES_256_CBC_SHA384", "TLS_ECDHE_PSK_ARCFOUR_128_SHA1", "TLS_ECDHE_PSK_3DES_EDE_CBC_SHA1", "TLS_ECDHE_PSK_AES_128_CBC_SHA1", "TLS_ECDHE_PSK_AES_256_CBC_SHA1", "TLS_ECDHE_PSK_AES_128_CBC_SHA256", "TLS_ECDHE_PSK_AES_256_CBC_SHA384", "TLS_ECDHE_PSK_NULL_SHA1", "TLS_ECDHE_PSK_NULL_SHA256", "TLS_ECDHE_PSK_NULL_SHA384", "TLS_ECDHE_ECDSA_CAMELLIA_128_CBC_SHA256", "TLS_ECDHE_ECDSA_CAMELLIA_256_CBC_SHA384", "TLS_ECDHE_RSA_CAMELLIA_128_CBC_SHA256", "TLS_ECDHE_RSA_CAMELLIA_256_CBC_SHA384", "TLS_RSA_CAMELLIA_128_GCM_SHA256", "TLS_RSA_CAMELLIA_256_GCM_SHA384", "TLS_DHE_RSA_CAMELLIA_128_GCM_SHA256", "TLS_DHE_RSA_CAMELLIA_256_GCM_SHA384", "TLS_DHE_DSS_CAMELLIA_128_GCM_SHA256", "TLS_DHE_DSS_CAMELLIA_256_GCM_SHA384", "TLS_DH_ANON_CAMELLIA_128_GCM_SHA256", "TLS_DH_ANON_CAMELLIA_256_GCM_SHA384", "TLS_ECDHE_ECDSA_CAMELLIA_128_GCM_SHA256", "TLS_ECDHE_ECDSA_CAMELLIA_256_GCM_SHA384", "TLS_ECDHE_RSA_CAMELLIA_128_GCM_SHA256", "TLS_ECDHE_RSA_CAMELLIA_256_GCM_SHA384", "TLS_PSK_CAMELLIA_128_GCM_SHA256", "TLS_PSK_CAMELLIA_256_GCM_SHA384", "TLS_DHE_PSK_CAMELLIA_128_GCM_SHA256", "TLS_DHE_PSK_CAMELLIA_256_GCM_SHA384", "TLS_RSA_PSK_CAMELLIA_128_GCM_SHA256", "TLS_RSA_PSK_CAMELLIA_256_GCM_SHA384", "TLS_PSK_CAMELLIA_128_CBC_SHA256", "TLS_PSK_CAMELLIA_256_CBC_SHA384", "TLS_DHE_PSK_CAMELLIA_128_CBC_SHA256", "TLS_DHE_PSK_CAMELLIA_256_CBC_SHA384", "TLS_RSA_PSK_CAMELLIA_128_CBC_SHA256", "TLS_RSA_PSK_CAMELLIA_256_CBC_SHA384", "TLS_ECDHE_PSK_CAMELLIA_128_CBC_SHA256", "TLS_ECDHE_PSK_CAMELLIA_256_CBC_SHA384", "TLS_RSA_AES_128_CCM", "TLS_RSA_AES_256_CCM", "TLS_RSA_AES_128_CCM_8", "TLS_RSA_AES_256_CCM_8", "TLS_DHE_RSA_AES_128_CCM_8", "TLS_DHE_RSA_AES_256_CCM_8", "TLS_PSK_AES_128_CCM", "TLS_PSK_AES_256_CCM", "TLS_PSK_AES_128_CCM_8", "TLS_PSK_AES_256_CCM_8", "TLS_DHE_PSK_AES_128_CCM_8", "TLS_DHE_PSK_AES_256_CCM_8", "TLS_ECDHE_ECDSA_AES_128_CCM", "TLS_ECDHE_ECDSA_AES_256_CCM", "TLS_ECDHE_ECDSA_AES_128_CCM_8", "TLS_ECDHE_ECDSA_AES_256_CCM_8", "TLS_PSK_CHACHA20_POLY1305", "TLS_RSA_PSK_CHACHA20_POLY1305"}
 	weak_ciphers_GnuTLS_Format[_] == aux
 }
 
-
 #aurora is equivelent to mysql 5.6 https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html#UsingWithRDS.IAMDBAuth.Availability
 #all aurora-postgresql versions that do not support IAM auth are deprecated Source:console.aws (launch rds instance)
-valid_for_iam_engine_and_version_check(resource, engineVar, engineVersionVar, instanceClassVar) {
+valid_for_iam_engine_and_version_check(resource, engineVar, engineVersionVar, instanceClassVar) if {
 	key_list := [engineVar, engineVersionVar]
 	contains(lower(resource[engineVar]), "mariadb")
 	version_check := {x | x := resource[key_list[_]]; contains(x, "10.6")}
 	count(version_check) > 0
-} else {
+} else if {
 	engines_that_supports_iam := ["aurora-postgresql", "postgres", "mysql", "mariadb"]
 	contains(lower(resource[engineVar]), engines_that_supports_iam[_])
 	not valid_key(resource, engineVersionVar)
-} else {
+} else if {
 	engines_that_supports_iam := ["aurora-postgresql", "postgres", "mysql"]
 	contains(lower(resource[engineVar]), engines_that_supports_iam[_])
-} else {
+} else if {
 	aurora_mysql_engines := ["aurora", "aurora-mysql"]
 	contains(lower(resource[engineVar]), aurora_mysql_engines[_])
 	invalid_classes := ["db.t2.small", "db.t3.small"]
 	not inArray(invalid_classes, resource[instanceClassVar])
 }
 
-get_group_from_policy_attachment(attachment) = group {
+get_group_from_policy_attachment(attachment) := group if {
 	group := split(attachment.groups[_], ".")[1]
-} else = group {
+} else := group if {
 	group := split(attachment.group, ".")[1]
 }
 
-get_role_from_policy_attachment(attachment) = role {
+get_role_from_policy_attachment(attachment) := role if {
 	role := split(attachment.roles[_], ".")[1]
-} else = role {
+} else := role if {
 	role := split(attachment.role, ".")[1]
 }
 
-get_user_from_policy_attachment(attachment) = user {
+get_user_from_policy_attachment(attachment) := user if {
 	user := split(attachment.users[_], ".")[1]
-} else = user {
+} else := user if {
 	user := split(attachment.user, ".")[1]
 }
 
-unrecommended_permission_policy(resourcePolicy, permission) {
+unrecommended_permission_policy(resourcePolicy, permission) if {
 	policy := json_unmarshal(resourcePolicy.policy)
 
 	st := get_statement(policy)
@@ -678,7 +679,7 @@ unrecommended_permission_policy(resourcePolicy, permission) {
 	equalsOrInArray(statement.Action, lower(permission))
 }
 
-group_unrecommended_permission_policy_scenarios(targetGroup, permission) {
+group_unrecommended_permission_policy_scenarios(targetGroup, permission) if {
 	# get the IAM group policy
 	groupPolicy := input.document[_].resource.aws_iam_group_policy[_]
 
@@ -688,7 +689,7 @@ group_unrecommended_permission_policy_scenarios(targetGroup, permission) {
 
 	# verify that the policy is unrecommended
 	unrecommended_permission_policy(groupPolicy, permission)
-} else {
+} else if {
 	# find attachment
 	attachments := {"aws_iam_policy_attachment", "aws_iam_group_policy_attachment"}
 	attachment := input.document[_].resource[attachments[_]][_]
@@ -707,7 +708,7 @@ group_unrecommended_permission_policy_scenarios(targetGroup, permission) {
 	unrecommended_permission_policy(resourcePolicy, permission)
 }
 
-role_unrecommended_permission_policy_scenarios(targetRole, permission) {
+role_unrecommended_permission_policy_scenarios(targetRole, permission) if {
 	# get the IAM role policy
 	rolePolicy := input.document[_].resource.aws_iam_role_policy[_]
 
@@ -717,7 +718,7 @@ role_unrecommended_permission_policy_scenarios(targetRole, permission) {
 
 	# verify that the policy is unrecommended
 	unrecommended_permission_policy(rolePolicy, permission)
-} else {
+} else if {
 	# find attachment
 	attachments := {"aws_iam_policy_attachment", "aws_iam_role_policy_attachment"}
 	attachment := input.document[_].resource[attachments[_]][_]
@@ -736,7 +737,7 @@ role_unrecommended_permission_policy_scenarios(targetRole, permission) {
 	unrecommended_permission_policy(resourcePolicy, permission)
 }
 
-user_unrecommended_permission_policy_scenarios(targetUser, permission) {
+user_unrecommended_permission_policy_scenarios(targetUser, permission) if {
 	# get the IAM user policy
 	userPolicy := input.document[_].resource.aws_iam_user_policy[_]
 
@@ -746,7 +747,7 @@ user_unrecommended_permission_policy_scenarios(targetUser, permission) {
 
 	# verify that the policy is unrecommended
 	unrecommended_permission_policy(userPolicy, permission)
-} else {
+} else if {
 	# find attachment
 	attachments := {"aws_iam_policy_attachment", "aws_iam_user_policy_attachment"}
 	attachment := input.document[_].resource[attachments[_]][_]
@@ -765,46 +766,46 @@ user_unrecommended_permission_policy_scenarios(targetUser, permission) {
 	unrecommended_permission_policy(resourcePolicy, permission)
 }
 
-get_latest_software_version(name) = version {
+get_latest_software_version(name) := version if {
 	software_info := data.version_numbers_to_check
 	software_info[i].name == name
 	version := software_info[i].version
 }
 
-get_version(name) = version {
+get_version(name) := version if {
 	val := get_latest_software_version(name)
 	splited := split(val, ".")
-	version := concat(".", [splited[0],splited[1]])
+	version := concat(".", [splited[0], splited[1]])
 }
 
-contains_element(arr, element) {
-    element == arr[_]
+contains_element(arr, element) if {
+	element == arr[_]
 }
 
-contains_with_size(arr, element){
-	count(arr)>0
-    test := arr[j]
+contains_with_size(arr, element) if {
+	count(arr) > 0
+	test := arr[j]
 	contains(test, element)
 }
 
-valid_non_empty_key(field, key) = output {
+valid_non_empty_key(field, key) := output if {
 	not valid_key(field, key)
 	output = ""
-} else = output {
+} else := output if {
 	keyObj := field[key]
 	is_object(keyObj)
 	count(keyObj) == 0
 	output := concat(".", ["", key])
-} else = output {
+} else := output if {
 	keyObj := field[key]
 	keyObj == ""
 	output := concat(".", ["", key])
 }
 
 # Helper to ensure that a value is always treated as an array.
-as_array(x) = y {
-    is_array(x)
-    y = x
-} else = [x] {
-    not is_array(x)
+as_array(x) := y if {
+	is_array(x)
+	y = x
+} else := [x] if {
+	not is_array(x)
 }

--- a/assets/libraries/crossplane.rego
+++ b/assets/libraries/crossplane.rego
@@ -1,28 +1,30 @@
 package generic.crossplane
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-getPath(path) = result {
+getPath(path) := result if {
 	count(path) > 0
 	path_string := common_lib.concat_path(path)
 	out := array.concat([path_string], ["."])
 	result := concat("", out)
-} else = result {
+} else := result if {
 	count(path) == 0
 	result := ""
 }
 
-getResourceName(resource) = name {
+getResourceName(resource) := name if {
 	resourceNameAtt := crossplaneResourcesWithName[resource.Kind]
 	forProvider := resource.spec.forProvider
 	name := forProvider[resourceNameAtt]
-} else = name {
+} else := name if {
 	name := common_lib.get_tag_name_if_exists(resource)
-} else = name {
+} else := name if {
 	name := resource.metadata.name
 }
 
-crossplaneResourcesWithName = {
+crossplaneResourcesWithName := {
 	"Redis": "resourceGroupName",
 	"AKSCluster": "resourceGroupName",
 	"DBCluster": "databaseName",

--- a/assets/libraries/dockercompose.rego
+++ b/assets/libraries/dockercompose.rego
@@ -1,1 +1,3 @@
 package generic.dockercompose
+
+import rego.v1

--- a/assets/libraries/dockerfile.rego
+++ b/assets/libraries/dockerfile.rego
@@ -1,19 +1,21 @@
 package generic.dockerfile
 
-getPackages(commands, command) = output {
+import rego.v1
+
+getPackages(commands, command) := output if {
 	index := indexof(commands, command[0])
 	len := count(command[0])
 
 	commandWithAll := substring(commands, len + index, count(commands))
 
 	contains(commandWithAll, ";")
-	commandWithAllNoTabs:= replace(commandWithAll, "\t", "")
+	commandWithAllNoTabs := replace(commandWithAll, "\t", "")
 	commandWithAllSplit := split(commandWithAllNoTabs, ";")
 
 	packages := split(trim_space(commandWithAllSplit[0]), " ")
 
 	output = packages
-}else = output {
+} else := output if {
 	index := indexof(commands, command[0])
 	len := count(command[0])
 
@@ -25,48 +27,48 @@ getPackages(commands, command) = output {
 	packages := split(commandWithAllSplit[0], " ")
 
 	output = packages
-}else = output {
+} else := output if {
 	index := indexof(commands, command[0])
 	len := count(command[0])
 
 	commandWithAll := substring(commands, len + index, count(commands))
 
 	not contains(commandWithAll, ";")
-    not contains(commandWithAll, "&&")
+	not contains(commandWithAll, "&&")
 
 	packages := split(commandWithAll, " ")
 
 	output = packages
 }
 
-getCommands(commands) = output{
+getCommands(commands) := output if {
 	output := split(commands, "&&")
-} else = output{
+} else := output if {
 	output := split(commands, "; ")
 }
 
-withVersion(pack) {
+withVersion(pack) if {
 	regex.match("[A-Za-z0-9_\\+-]+[-:][$](.+)", pack)
 }
 
-withVersion(pack) {
+withVersion(pack) if {
 	regex.match("[A-Za-z0-9_\\+-]+[:-]([0-9]+.)+[0-9]+", pack)
 }
 
-withVersion(pack) {
+withVersion(pack) if {
 	regex.match("[A-Za-z0-9_\\+-]+~?=(.+)", pack)
 }
 
-arrayContains(array, list) {
+arrayContains(array, list) if {
 	contains(array[_], list[_])
 }
 
-check_multi_stage(imageName, images) {
-    unsortedIndex := {x |
-        images[name][i].Cmd == "from"
-        x := {"Name": name, "Line": images[name][i].EndLine}
-    }
+check_multi_stage(imageName, images) if {
+	unsortedIndex := {x |
+		images[name][i].Cmd == "from"
+		x := {"Name": name, "Line": images[name][i].EndLine}
+	}
 
-    sortedIndex := sort(unsortedIndex)
-    imageName == sortedIndex[minus(count(sortedIndex), 1)].Name
-} 
+	sortedIndex := sort(unsortedIndex)
+	imageName == sortedIndex[count(sortedIndex) - 1].Name
+}

--- a/assets/libraries/googledeploymentmanager.rego
+++ b/assets/libraries/googledeploymentmanager.rego
@@ -1,1 +1,3 @@
 package generic.googledeploymentmanager
+
+import rego.v1

--- a/assets/libraries/grpc.rego
+++ b/assets/libraries/grpc.rego
@@ -1,1 +1,3 @@
 package generic.grpc
+
+import rego.v1

--- a/assets/libraries/k8s.rego
+++ b/assets/libraries/k8s.rego
@@ -1,107 +1,108 @@
 package generic.k8s
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-getSpecInfo(document) = specInfo { # this one can be also used for the result
+getSpecInfo(document) := specInfo if { # this one can be also used for the result
 	templates := {"job_template", "jobTemplate"}
 	spec := document.spec[templates[t]].spec.template.spec
 	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
-} else = specInfo {
+} else := specInfo if {
 	spec := document.spec.template.spec
 	specInfo := {"spec": spec, "path": "spec.template.spec"}
-} else = specInfo {
+} else := specInfo if {
 	spec := document.spec
 	specInfo := {"spec": spec, "path": "spec"}
 }
 
-checkKind(currentKind, listKinds) {
+checkKind(currentKind, listKinds) if {
 	currentKind == listKinds[i]
 }
 
-checkKindWithKnative(doc, listKinds, knativeKinds) {
+checkKindWithKnative(doc, listKinds, knativeKinds) if {
 	doc.kind == listKinds[i]
-} else {
+} else if {
 	contains(doc.apiVersion, "knative")
 	doc.kind == knativeKinds[i]
 }
 
-
-hasFlag(container, flag) {
+hasFlag(container, flag) if {
 	common_lib.inArray(container.command, flag)
-} else {
+} else if {
 	common_lib.inArray(container.args, flag)
 }
 
-startWithFlag(container, flag) {
+startWithFlag(container, flag) if {
 	startsWithArray(container.command, flag)
-} else {
+} else if {
 	startsWithArray(container.args, flag)
 }
 
-startsWithArray(arr, item) {
+startsWithArray(arr, item) if {
 	startswith(arr[_], item)
 }
 
-hasFlagWithValue(container, flag, value) {
+hasFlagWithValue(container, flag, value) if {
 	command := container.command
 	startswith(command[a], flag)
 	values := split(command[a], "=")[1]
 	hasValue(values, value)
-} else {
+} else if {
 	args := container.args
 	startswith(args[a], flag)
 	values := split(args[a], "=")[1]
 	hasValue(values, value)
 }
 
-hasValue(values, value) {
+hasValue(values, value) if {
 	splittedValues := split(values, ",")
 	splittedValues[_] == value
 }
 
-startAndEndWithFlag(container, flag, ext) {
+startAndEndWithFlag(container, flag, ext) if {
 	startWithAndEndWithArray(container.command, flag, ext)
-} else {
+} else if {
 	startWithAndEndWithArray(container.args, flag, ext)
 }
 
-startWithAndEndWithArray(arr, item, ext) {
+startWithAndEndWithArray(arr, item, ext) if {
 	startswith(arr[_], item)
 	endswith(arr[_], ext)
 }
 
-hasFlagEqualOrGreaterThanValue(container, flag, value) {
+hasFlagEqualOrGreaterThanValue(container, flag, value) if {
 	command := container.command
 	startswith(command[a], flag)
 	flag_value := split(command[a], "=")[1]
 	to_number(flag_value) >= value
-} else {
+} else if {
 	args := container.args
 	startswith(args[a], flag)
 	flag_value := split(args[a], "=")[1]
 	to_number(flag_value) >= value
 }
 
-hasFlagBetweenValues(container, flag, higher, lower) {
+hasFlagBetweenValues(container, flag, higher, lower) if {
 	command := container.command
 	startswith(command[a], flag)
 	value := split(command[a], "=")[1]
 	betweenValues(value, higher, lower)
-} else {
+} else if {
 	args := container.args
 	startswith(args[a], flag)
 	value := split(args[a], "=")[1]
 	betweenValues(value, higher, lower)
 }
 
-betweenValues(value, higher, lower) {
+betweenValues(value, higher, lower) if {
 	to_number(value) > higher
 	to_number(value) < lower
 }
 
 # Valid K8s/Knative Kinds that support podSpec or PodSpecTemplate
 # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podspec-v1-core
-valid_pod_spec_kind_list = [
+valid_pod_spec_kind_list := [
 	"Pod",
 	"Configuration",
 	"Service",

--- a/assets/libraries/knative.rego
+++ b/assets/libraries/knative.rego
@@ -1,3 +1,5 @@
 package generic.knative
 
+import rego.v1
+
 import data.generic.common as common_lib

--- a/assets/libraries/openapi.rego
+++ b/assets/libraries/openapi.rego
@@ -1,26 +1,28 @@
 package generic.openapi
 
-check_openapi(doc) = version {
+import rego.v1
+
+check_openapi(doc) := version if {
 	object.get(doc, "openapi", "undefined") != "undefined"
 	regex.match("^3\\.0\\.\\d+$", doc.openapi)
 	version = "3.0"
-} else = version {
+} else := version if {
 	object.get(doc, "swagger", "undefined") != "undefined"
 	version = "2.0"
-} else = version {
+} else := version if {
 	version = "undefined"
 }
 
-is_valid_url(url) {
+is_valid_url(url) if {
 	regex.match(`^(https?):\/\/(-\.)?([^\s\/?\.#-]+([-\.\/])?)+(\/[^\s]*)?$`, url)
 }
 
-improperly_defined(params, value) {
+improperly_defined(params, value) if {
 	params.in == "header"
 	params.name == value
 }
 
-incorrect_ref(ref, object) {
+incorrect_ref(ref, object) if {
 	references := {
 		"schemas": "#/components/schemas/",
 		"responses": "#/components/responses/",
@@ -35,7 +37,7 @@ incorrect_ref(ref, object) {
 	not startswith(ref, references[object])
 }
 
-incorrect_ref_swagger(ref, object) {
+incorrect_ref_swagger(ref, object) if {
 	references := {
 		"parameters": "#/parameters/",
 		"responses": "#/responses/",
@@ -45,65 +47,65 @@ incorrect_ref_swagger(ref, object) {
 	not startswith(ref, references[object])
 }
 
-content_allowed(operation, code) {
+content_allowed(operation, code) if {
 	operation != "head"
-	all([code != "204", code != "304"])
+	code != "204"
+	code != "304"
 }
 
 # It verifies if there is some schema in 'key' equal to the input with the 'field' undefined
-check_content(s, field, key) {
+check_content(s, field, key) if {
 	object.get(key[s], field, "undefined") == "undefined"
 }
 
 # It verifies if the 'schema_ref' refers to a schema with the 'field' undefined
-undefined_field_in_json_object(doc, schema_ref, field, version) {
+undefined_field_in_json_object(doc, schema_ref, field, version) if {
 	version == "3.0"
 	r := split(schema_ref, "/")
 	count(r) == 4
 	check_content(r[3], field, doc.components.schemas)
-} else {
+} else if {
 	version == "2.0"
 	r := split(schema_ref, "/")
 	count(r) == 3
 	check_content(r[2], field, doc.definitions)
 }
 
-check_unused_reference(doc, referenceName, type) {
+check_unused_reference(doc, referenceName, type) if {
 	ref := sprintf("#/components/%s/%s", [type, referenceName])
 
 	count({ref | [_, value] := walk(doc); ref == value["$ref"]}) == 0
 }
 
-check_reference_unexisting(doc, reference, type) = checkComponents {
+check_reference_unexisting(doc, reference, type) := checkComponents if {
 	refString := sprintf("#/components/%s/", [type])
 	startswith(reference, refString)
 	checkComponents := trim_prefix(reference, refString)
 	object.get(doc.components[type], checkComponents, "undefined") == "undefined"
 }
 
-check_reference_unexisting_swagger(doc, reference, type) = checkRef {
+check_reference_unexisting_swagger(doc, reference, type) := checkRef if {
 	refString := sprintf("#/%s/", [type])
 	startswith(reference, refString)
 	checkRef := trim_prefix(reference, refString)
 	object.get(doc[type], checkRef, "undefined") == "undefined"
 }
 
-concat_path(path) = concatenated {
+concat_path(path) := concatenated if {
 	concatenated := concat(".", [x | x := resolve_path(path[_]); x != ""])
 }
 
-resolve_path(pathItem) = resolved {
-	any([contains(pathItem, "."), contains(pathItem, "="), contains(pathItem, "/")])
+resolve_path(pathItem) := resolved if {
+	checks := [contains(pathItem, "."), contains(pathItem, "="), contains(pathItem, "/")]
+	checks[_] == true
 	resolved := sprintf("{{%s}}", [pathItem])
-} else = resolved {
+} else := resolved if {
 	is_number(pathItem)
 	resolved := ""
-} else = pathItem {
-	true
-}
+} else := pathItem
 
 # It verifies if the path contains an operation. If true, keeps the operation type and the response code related to it
-is_operation(path) = info {
+is_operation(path) := info if {
 	path[0] == "paths"
 	operations := {"get", "post", "put", "delete", "options", "head", "patch", "trace"}
 	operations[z] == path[2]
@@ -112,45 +114,45 @@ is_operation(path) = info {
 	code := path[idx]
 	op := operations[z]
 	info := {"code": code, "operation": op}
-} else = info {
+} else := info if {
 	info := {}
 }
 
-is_numeric_type(type) {
+is_numeric_type(type) if {
 	numeric := {"integer", "number"}
 	type == numeric[_]
 }
 
 # It verifies if the string schema does not have the 'field' defined
-undefined_field_in_string_type(value, field) {
+undefined_field_in_string_type(value, field) if {
 	value.type == "string"
 	object.get(value, field, "undefined") == "undefined"
 }
 
 # It verifies if the numeric schema does not have the 'field' defined
-undefined_field_in_numeric_schema(value, field) {
+undefined_field_in_numeric_schema(value, field) if {
 	is_numeric_type(value.type)
 	object.get(value, field, "undefined") == "undefined"
 }
 
-is_path_template(path) = matches {
+is_path_template(path) := matches if {
 	matches := regex.find_n(`\{([A-Za-z]+[A-Za-z-_]*[A-Za-z]+)\}`, path, -1)
 }
 
 # It verifies if the 'field' is consistent with the 'type'
-invalid_field(field, type) {
+invalid_field(field, type) if {
 	is_numeric_type(type)
 	not is_number(field)
-} else {
+} else if {
 	type == "string"
 	not is_string(field)
-} else {
+} else if {
 	type == "boolean"
 	not is_boolean(field)
-} else {
+} else if {
 	type == "object"
 	not is_object(field)
-} else {
+} else if {
 	type == "array"
 	not is_array(field)
 }
@@ -215,35 +217,35 @@ require_objects_v2 := {
 }
 
 # get schema info (object and path) according to the openAPI version
-get_schema_info(doc, version) = schemaInfo {
+get_schema_info(doc, version) := schemaInfo if {
 	version == "3.0"
 	schemaInfo := {"obj": doc.components.schemas, "path": "components.schemas"}
-} else = schemaInfo {
+} else := schemaInfo if {
 	version == "2.0"
 	schemaInfo := {"obj": doc.definitions, "path": "definitions"}
 }
 
-api_key_exposed(doc, version, s) {
+api_key_exposed(doc, version, s) if {
 	version == "3.0"
 	doc.components.securitySchemes[s].type == "apiKey"
 	server := doc.servers[_]
 	startswith(server.url, "http://")
-} else {
+} else if {
 	version == "3.0"
 	doc.components.securitySchemes[s].type == "apiKey"
 	not valid_key(doc, "servers")
-} else {
+} else if {
 	version == "2.0"
 	doc.securityDefinitions[s].type == "apiKey"
 	scheme := doc.schemes[_]
-    scheme == "http"
-} else {
+	scheme == "http"
+} else if {
 	version == "2.0"
 	doc.securityDefinitions[s].type == "apiKey"
 	not valid_key(doc, "schemes")
 }
 
-check_scheme(doc, schemeKey, scope, version) {
+check_scheme(doc, schemeKey, scope, version) if {
 	version == "3.0"
 	secScheme := doc.components.securitySchemes[schemeKey]
 	secScheme.type == "oauth2"
@@ -251,7 +253,7 @@ check_scheme(doc, schemeKey, scope, version) {
 	arr := [x | _ := secScheme.flows[flowKey].scopes[scopeName]; scopeName == scope; x := scope]
 
 	count(arr) == 0
-} else {
+} else if {
 	version == "2.0"
 	secScheme := doc.securityDefinitions[schemeKey]
 	secScheme.type == "oauth2"
@@ -262,47 +264,47 @@ check_scheme(doc, schemeKey, scope, version) {
 }
 
 # It verifies if the path is empty. If so, it refers to a global object. If not, joins it with the defaultValue.
-concat_default_value(path, defaultValue) = searchKey {
+concat_default_value(path, defaultValue) := searchKey if {
 	count(path) == 0
 	searchKey := defaultValue
-} else = searchKey {
+} else := searchKey if {
 	searchKey := concat(".", [path, defaultValue])
 }
 
-get_name(p, name) = sk {
-	p[minus(count(p), 1)] == "components"
+get_name(p, name) := sk if {
+	p[count(p) - 1] == "components"
 	sk := name
-} else = sk {
+} else := sk if {
 	sk := concat("", ["name=", name])
 }
 
-get_complete_search_key(n, parcialSk, property) = sk {
+get_complete_search_key(n, parcialSk, property) := sk if {
 	is_string(n)
 	sk := sprintf("%s.%s.%s", [parcialSk, n, property])
-} else = sk {
+} else := sk if {
 	sk := sprintf("%s.%s", [parcialSk, property])
 }
 
-is_mimetype_valid(content) {
+is_mimetype_valid(content) if {
 	known_prefixs := {"application", "audio", "font", "example", "image", "message", "model", "multipart", "text", "video"}
 	count({x | prefix := known_prefixs[x]; startswith(content, prefix)}) > 0
 }
 
-get_discriminator(schema, version) = discriminator {
+get_discriminator(schema, version) := discriminator if {
 	version == "3.0"
 	discriminator := {"obj": schema.discriminator.propertyName, "path": "discriminator.propertyName"}
-} else = discriminator {
+} else := discriminator if {
 	version == "2.0"
 	discriminator := {"obj": schema.discriminator, "path": "discriminator"}
 }
 
-check_definitions(doc, object, name) {
+check_definitions(doc, object, name) if {
 	[path, value] := walk(doc)
 	ref := value["$ref"]
 	count({x | ref == sprintf("#/%s/%s", [object, name]); x := ref}) == 0
 }
 
-is_valid_mime(mime) {
+is_valid_mime(mime) if {
 	type := "[A-Za-z0-9][A-Za-z0-9!#$&\\-^_]{0,126}"
 	subtype := "[A-Za-z0-9][A-Za-z0-9!#$&\\-^_.+]{0,126}"
 	token := "([!#$%&'*+.^_`|~0-9A-Za-z-]+)"
@@ -315,12 +317,12 @@ is_valid_mime(mime) {
 	regex.match(mimeRegex, mime) == true
 }
 
-valid_key(obj, key) {
+valid_key(obj, key) if {
 	_ = obj[key]
 	not is_null(obj[key])
 }
 
-is_missing_attribute_and_ref(obj, attr) {
+is_missing_attribute_and_ref(obj, attr) if {
 	not valid_key(obj, attr)
 	not valid_key(obj, "$ref")
 }

--- a/assets/libraries/pulumi.rego
+++ b/assets/libraries/pulumi.rego
@@ -1,17 +1,19 @@
 package generic.pulumi
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-getResourceName(resource, logicName) = name {
+getResourceName(resource, logicName) := name if {
 	resourceNameAtt := pulumiResourcesWithName[resource.Type]
 	name := resource.Properties[resourceNameAtt]
-} else = name {
+} else := name if {
 	name := common_lib.get_tag_name_if_exists(resource)
-} else = name {
+} else := name if {
 	name := logicName
 }
 
-pulumiResourcesWithName = {
-	"gcp:storage:Bucket"    : "name",
-	"gcp:compute:SSLPolicy" : "name",
+pulumiResourcesWithName := {
+	"gcp:storage:Bucket": "name",
+	"gcp:compute:SSLPolicy": "name",
 }

--- a/assets/libraries/serverlessfw.rego
+++ b/assets/libraries/serverlessfw.rego
@@ -1,37 +1,39 @@
 package generic.serverlessfw
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-resourceTypeMapping(resourceType, provider)= resourceTypeVal{
-    resourceTypeVal :=resourcesMap[provider][resourceType]
+resourceTypeMapping(resourceType, provider) := resourceTypeVal if {
+	resourceTypeVal := resourcesMap[provider][resourceType]
 }
 
-resourcesMap = {
-    "aws": {
-        "function": "AWS::Lambda",
-        "api": "AWS::ApiGateway",
-        "iam": "AWS::IAM"        
-    },
-    "azure":{
-        "function": "Azure:Function",
-        "api": "Azure:APIManagement",
-        "iam": "Azure:Role"
-    },
-    "google":{
-        "function": "Google:Cloudfunctions",
-        "api": "Google:ApiGateway",
-        "iam": "Google:IAM"
-    },
-    "aliyun":{
-        "function": "Aliyun:FunctionCompute",
-        "api": "Aliyun:ApiGateway",
-        "iam": "Aliyun:RAM"
-    }
+resourcesMap := {
+	"aws": {
+		"function": "AWS::Lambda",
+		"api": "AWS::ApiGateway",
+		"iam": "AWS::IAM",
+	},
+	"azure": {
+		"function": "Azure:Function",
+		"api": "Azure:APIManagement",
+		"iam": "Azure:Role",
+	},
+	"google": {
+		"function": "Google:Cloudfunctions",
+		"api": "Google:ApiGateway",
+		"iam": "Google:IAM",
+	},
+	"aliyun": {
+		"function": "Aliyun:FunctionCompute",
+		"api": "Aliyun:ApiGateway",
+		"iam": "Aliyun:RAM",
+	},
 }
 
-get_service_name(document) = name{
-    name := document.service.name
-} else = name {
-    is_string(document.service)
-    name := document.service
+get_service_name(document) := name if {
+	name := document.service.name
+} else := name if {
+	is_string(document.service)
+	name := document.service
 }

--- a/assets/libraries/terraform.rego
+++ b/assets/libraries/terraform.rego
@@ -1,67 +1,69 @@
 package generic.terraform
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-check_cidr(rule) {
+check_cidr(rule) if {
 	rule.cidr_blocks[_] == "0.0.0.0/0"
-} else {
+} else if {
 	rule.cidr_block == "0.0.0.0/0"
 }
 
 # Checks if a TCP port is open in a rule
-portOpenToInternet(rule, port) {
-  rule.action != "deny"
+portOpenToInternet(rule, port) if {
+	rule.action != "deny"
 	check_cidr(rule)
 	rule.protocol == "tcp"
 	containsPort(rule, port)
 }
 
-portOpenToInternet(rule, port) {
-  rule.rule_action != "deny"
+portOpenToInternet(rule, port) if {
+	rule.rule_action != "deny"
 	check_cidr(rule)
 	rule.protocol == "tcp"
 	containsPort(rule, port)
 }
 
-portOpenToInternet(rule, port) {
-  not has_key(rule, "action")
-  not has_key(rule, "rule_action")
+portOpenToInternet(rule, port) if {
+	not has_key(rule, "action")
+	not has_key(rule, "rule_action")
 	check_cidr(rule)
 	rule.protocol == "tcp"
 	containsPort(rule, port)
 }
 
-portOpenToInternet(rules, port) {
+portOpenToInternet(rules, port) if {
 	rule := rules[_]
-  rule.action != "deny"
+	rule.action != "deny"
 	check_cidr(rule)
 	rule.protocol == "tcp"
 	containsPort(rule, port)
 }
 
-portOpenToInternet(rules, port) {
+portOpenToInternet(rules, port) if {
 	rule := rules[_]
-  not has_key(rule, "action")
+	not has_key(rule, "action")
 	check_cidr(rule)
 	rule.protocol == "tcp"
 	containsPort(rule, port)
 }
 
 # Checks if a port is included in a rule
-containsPort(rule, port) {
+containsPort(rule, port) if {
 	rule.from_port <= port
 	rule.to_port >= port
-} else {
+} else if {
 	rule.from_port == 0
 	rule.to_port == 0
-} else {
+} else if {
 	regex.match(sprintf("(^|\\s|,)%d(-|,|$|\\s)", [port]), rule.destination_port_range)
-} else {
+} else if {
 	ports := split(rule.destination_port_range, ",")
 	sublist := split(ports[var], "-")
 	to_number(trim(sublist[0], " ")) <= port
 	to_number(trim(sublist[1], " ")) >= port
-} else {
+} else if {
 	ports := split(rule.port_range, ",")
 	sublist := split(ports[var], "/")
 	to_number(trim(sublist[0], " ")) <= port
@@ -69,58 +71,58 @@ containsPort(rule, port) {
 }
 
 # Gets the list of protocols
-getProtocolList("-1") = protocols {
+getProtocolList("-1") := protocols if {
 	protocols := ["TCP", "UDP", "ICMP"]
 }
 
-getProtocolList("*") = protocols {
+getProtocolList("*") := protocols if {
 	protocols := ["TCP", "UDP", "ICMP"]
 }
 
-getProtocolList(protocol) = protocols {
+getProtocolList(protocol) := protocols if {
 	upper(protocol) == "TCP"
 	protocols := ["TCP"]
 }
 
-getProtocolList(protocol) = protocols {
+getProtocolList(protocol) := protocols if {
 	upper(protocol) == "UDP"
 	protocols := ["UDP"]
 }
 
 # Checks if any principal are allowed in a policy
-anyPrincipal(statement) {
-  # Case: Principal = "*"
-  statement.Principal == "*"
+anyPrincipal(statement) if {
+	# Case: Principal = "*"
+	statement.Principal == "*"
 }
 
-anyPrincipal(statement) {
-  # Case: Principal = ["*"]
-  is_array(statement.Principal)
-  "*" == statement.Principal[_]
+anyPrincipal(statement) if {
+	# Case: Principal = ["*"]
+	is_array(statement.Principal)
+	"*" == statement.Principal[_]
 }
 
-anyPrincipal(statement) {
-  # Case: Principal = {"AWS": "*"}
-  is_string(statement.Principal.AWS)
-  statement.Principal.AWS == "*"
+anyPrincipal(statement) if {
+	# Case: Principal = {"AWS": "*"}
+	is_string(statement.Principal.AWS)
+	statement.Principal.AWS == "*"
 }
 
-anyPrincipal(statement) {
-  # Case: Principal = {"AWS": ["*"]}
-  is_array(statement.Principal.AWS)
-  "*" == statement.Principal.AWS[_]
+anyPrincipal(statement) if {
+	# Case: Principal = {"AWS": ["*"]}
+	is_array(statement.Principal.AWS)
+	"*" == statement.Principal.AWS[_]
 }
 
-anyPrincipal(statement) {
-  # Case: Principal = {"Service": "*"}  (uncommon, but valid)
-  is_string(statement.Principal.Service)
-  statement.Principal.Service == "*"
+anyPrincipal(statement) if {
+	# Case: Principal = {"Service": "*"}  (uncommon, but valid)
+	is_string(statement.Principal.Service)
+	statement.Principal.Service == "*"
 }
 
-anyPrincipal(statement) {
-  # Case: Principal = {"Service": ["*"]}
-  is_array(statement.Principal.Service)
-  "*" == statement.Principal.Service[_]
+anyPrincipal(statement) if {
+	# Case: Principal = {"Service": ["*"]}
+	is_array(statement.Principal.Service)
+	"*" == statement.Principal.Service[_]
 }
 
 # wildcard_principal_sub_path returns the path segments *under* `Principal` that
@@ -134,37 +136,37 @@ anyPrincipal(statement) {
 #
 # Priority: explicit sub-keys (AWS, Service) take precedence over the flat form
 # so a statement with both still produces a single, deterministic finding.
-wildcard_principal_sub_path(statement) = ["AWS"] {
-  is_string(statement.Principal.AWS)
-  statement.Principal.AWS == "*"
-} else = ["AWS"] {
-  is_array(statement.Principal.AWS)
-  statement.Principal.AWS[_] == "*"
-} else = ["Service"] {
-  is_string(statement.Principal.Service)
-  statement.Principal.Service == "*"
-} else = ["Service"] {
-  is_array(statement.Principal.Service)
-  statement.Principal.Service[_] == "*"
-} else = [] {
-  statement.Principal == "*"
-} else = [] {
-  is_array(statement.Principal)
-  statement.Principal[_] == "*"
+wildcard_principal_sub_path(statement) := ["AWS"] if {
+	is_string(statement.Principal.AWS)
+	statement.Principal.AWS == "*"
+} else := ["AWS"] if {
+	is_array(statement.Principal.AWS)
+	statement.Principal.AWS[_] == "*"
+} else := ["Service"] if {
+	is_string(statement.Principal.Service)
+	statement.Principal.Service == "*"
+} else := ["Service"] if {
+	is_array(statement.Principal.Service)
+	statement.Principal.Service[_] == "*"
+} else := [] if {
+	statement.Principal == "*"
+} else := [] if {
+	is_array(statement.Principal)
+	statement.Principal[_] == "*"
 }
 
-getSpecInfo(resource) = specInfo { # this one can be also used for the result
+getSpecInfo(resource) := specInfo if { # this one can be also used for the result
 	spec := resource.spec.job_template.spec.template.spec
 	specInfo := {"spec": spec, "path": "spec.job_template.spec.template.spec"}
-} else = specInfo {
+} else := specInfo if {
 	spec := resource.spec.template.spec
 	specInfo := {"spec": spec, "path": "spec.template.spec"}
-} else = specInfo {
+} else := specInfo if {
 	spec := resource.spec
 	specInfo := {"spec": spec, "path": "spec"}
 }
 
-check_aws_resource_supports_tags(p) {
+check_aws_resource_supports_tags(p) if {
 	resource = {
 		"aws_acm_certificate": "",
 		"aws_acmpca_certificate_authority": "",
@@ -494,45 +496,45 @@ check_aws_resource_supports_tags(p) {
 	resource[p]
 }
 
-empty_array(arr) {
+empty_array(arr) if {
 	arr == []
-} else {
+} else if {
 	arr == null
-} else {
+} else if {
 	false
 }
 
-uses_aws_managed_key(key, awsManagedKey) {
+uses_aws_managed_key(key, awsManagedKey) if {
 	key == awsManagedKey
-} else {
+} else if {
 	keyName := split(key, ".")[2]
 	kms := input.document[z].data.aws_kms_key[keyName]
 	kms.key_id == awsManagedKey
 }
 
-getStatement(policy) = st {
+getStatement(policy) := st if {
 	is_array(policy.Statement)
 	st = policy.Statement
-} else = st {
+} else := st if {
 	st := [policy.Statement]
 }
 
-is_publicly_accessible(policy) {
+is_publicly_accessible(policy) if {
 	statements := getStatement(policy)
-	statement:= statements[_]
+	statement := statements[_]
 	statement.Effect == "Allow"
 	anyPrincipal(statement)
 }
 
-get_accessibility(resource, name, resourcePolicyName, resourceTarget) = info {
+get_accessibility(resource, name, resourcePolicyName, resourceTarget) := info if {
 	policy := common_lib.json_unmarshal(resource.policy)
 	is_publicly_accessible(policy)
 	info = {"accessibility": "public", "policy": policy}
-} else = info {
+} else := info if {
 	policy := common_lib.json_unmarshal(resource.policy)
 	not is_publicly_accessible(policy)
 	info = {"accessibility": "hasPolicy", "policy": policy}
-} else = info {
+} else := info if {
 	not common_lib.valid_key(resource, "policy")
 
 	resourcePolicy := input.document[_].resource[resourcePolicyName][_]
@@ -541,7 +543,7 @@ get_accessibility(resource, name, resourcePolicyName, resourceTarget) = info {
 	policy := common_lib.json_unmarshal(resourcePolicy.policy)
 	is_publicly_accessible(policy)
 	info = {"accessibility": "public", "policy": policy}
-} else = info {
+} else := info if {
 	not common_lib.valid_key(resource, "policy")
 
 	resourcePolicy := input.document[_].resource[resourcePolicyName][_]
@@ -550,69 +552,68 @@ get_accessibility(resource, name, resourcePolicyName, resourceTarget) = info {
 	policy := common_lib.json_unmarshal(resourcePolicy.policy)
 	not is_publicly_accessible(policy)
 	info = {"accessibility": "hasPolicy", "policy": policy}
-} else = info {
+} else := info if {
 	info = {"accessibility": "unknown", "policy": ""}
 }
 
-is_default_password(password) = output {
-   contains(password, data.common_lib.default_passwords[_])
-   output = true
-} else = output {
+is_default_password(password) := output if {
+	contains(password, data.common_lib.default_passwords[_])
+	output = true
+} else := output if {
 	# repetition of the same number more than three times
 	regex.match(`(0{3,}|1{3,}|2{3,}|3{3,}|4{3,}|5{3,}|6{3,}|7{3,}|8{3,}|9{3,})`, password) == true
 	output = true
-} else = output {
+} else := output if {
 	output = false
 }
 
-matches(target, name) {
+matches(target, name) if {
 	split(target, ".")[1] == name
-} else {
+} else if {
 	target == name
 }
 
-check_member(attribute, search) {
+check_member(attribute, search) if {
 	startswith(attribute.members[_], search)
-} else {
+} else if {
 	startswith(attribute.member, search)
 }
 
-check_member(attribute, search) {
+check_member(attribute, search) if {
 	startswith(attribute.members[_], search)
-} else {
+} else if {
 	startswith(attribute.member, search)
 }
 
-matches(target, name) {
+matches(target, name) if {
 	split(target, ".")[1] == name
-} else {
+} else if {
 	target == name
 }
 
-matches(target, name) {
+matches(target, name) if {
 	split(target, ".")[1] == name
-} else {
+} else if {
 	target == name
 }
 
-
-has_target_resource(bucketName, resourceName) {
+has_target_resource(bucketName, resourceName) if {
 	resource := input.document[i].resource[resourceName][_]
 
 	split(resource.bucket, ".")[1] == bucketName
 }
 
 #Checks if an action is allowed for all principals
-allows_action_from_all_principals(json_policy, action) {
- 	policy := common_lib.json_unmarshal(json_policy)
+allows_action_from_all_principals(json_policy, action) if {
+	policy := common_lib.json_unmarshal(json_policy)
 	st := common_lib.get_statement(policy)
 	statement := st[_]
 	statement.Effect == "Allow"
-    anyPrincipal(statement)
-    common_lib.containsOrInArrayContains(statement.Action, action)
+	anyPrincipal(statement)
+	common_lib.containsOrInArrayContains(statement.Action, action)
 }
 
-resourceFieldName = {
+resourceFieldName := {
 	"google_bigquery_dataset": "friendly_name",
 	"alicloud_actiontrail_trail": "trail_name",
 	"alicloud_ros_stack": "stack_name",
@@ -623,45 +624,45 @@ resourceFieldName = {
 	"aws_elasticache_cluster": "cluster_id",
 }
 
-compute_raw_resource_name(resource, resourceDefinitionName) = name {
-	name := resource["name"]
-} else = name {
-	name := resource["display_name"]
-}  else = name {
+compute_raw_resource_name(resource, resourceDefinitionName) := name if {
+	name := resource.name
+} else := name if {
+	name := resource.display_name
+} else := name if {
 	name := resource.metadata.name
-} else = name {
+} else := name if {
 	prefix := resource.name_prefix
 	name := sprintf("%s<unknown-sufix>", [prefix])
-} else = name {
+} else := name if {
 	name := common_lib.get_tag_name_if_exists(resource)
-} else = name {
+} else := name if {
 	name := resourceDefinitionName
 }
 
-get_resource_name(resource, resourceDefinitionName) = final_name {
-    final_name := resourceDefinitionName
+get_resource_name(resource, resourceDefinitionName) := final_name if {
+	final_name := resourceDefinitionName
 }
 
 # String safe to use as resourceName: no "${" interpolation fragments.
-is_literal_string(s) {
+is_literal_string(s) if {
 	is_string(s)
 	not contains(s, "${")
 }
 
-get_specific_resource_name(resource, resourceType, resourceDefinitionName) = name {
+get_specific_resource_name(resource, resourceType, resourceDefinitionName) := name if {
 	field := resourceFieldName[resourceType]
 	name := resource[field]
 	is_literal_string(name)
-} else = name {
+} else := name if {
 	name := get_resource_name(resource, resourceDefinitionName)
 }
 
 # Literal attr value, or `${parent_type}.<name>.*` resolved via input.document + resourceFieldName; else fallback (never `${...}`).
-resolve_reference_name(resource, attr, parent_type, fallback) = out {
+resolve_reference_name(resource, attr, parent_type, fallback) := out if {
 	val := resource[attr]
 	is_literal_string(val)
 	out := val
-} else = out {
+} else := out if {
 	ref := resource[attr]
 	is_string(ref)
 	startswith(ref, sprintf("${%s.", [parent_type]))
@@ -672,523 +673,523 @@ resolve_reference_name(resource, attr, parent_type, fallback) = out {
 	candidate := get_specific_resource_name(target, parent_type, parts[1])
 	is_literal_string(candidate)
 	out := candidate
-} else = out {
+} else := out if {
 	out := fallback
 }
 
 # S3 `bucket` -> resolved name (same-scan aws_s3_bucket refs); else fallback.
-resolve_s3_bucket_name(resource, fallback) = name {
+resolve_s3_bucket_name(resource, fallback) := name if {
 	name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", fallback)
 }
 
-check_key_empty(disk_encryption_key) = key {
+check_key_empty(disk_encryption_key) := key if {
 	common_lib.valid_key(disk_encryption_key, "raw_key")
 	common_lib.emptyOrNull(disk_encryption_key.raw_key)
 	key := "raw_key"
-} else = key {
+} else := key if {
 	common_lib.valid_key(disk_encryption_key, "kms_key_self_link")
 	common_lib.emptyOrNull(disk_encryption_key.kms_key_self_link)
 	key := "kms_key_self_link"
 }
 
-check_gcp_resource_supports_labels(p) {
+check_gcp_resource_supports_labels(p) if {
 	resource = {
-        "google_active_directory_domain": "",
-        "google_alloydb_backup": "",
-        "google_alloydb_cluster": "",
-        "google_alloydb_instance": "",
-        "google_artifact_registry_repository": "",
-        "google_assured_workloads_workload": "",
-        "google_beyondcorp_app_connection": "",
-        "google_beyondcorp_app_connector": "",
-        "google_beyondcorp_app_gateway": "",
-        "google_bigquery_dataset": "",
-        "google_bigquery_job": "",
-        "google_bigquery_table": "",
-        "google_bigtable_instance": "",
-        "google_certificate_manager_certificate": "",
-        "google_certificate_manager_certificate_issuance_config": "",
-        "google_certificate_manager_certificate_map": "",
-        "google_certificate_manager_certificate_map_entry": "",
-        "google_certificate_manager_dns_authorization": "",
-        "google_certificate_manager_trust_config": "",
-        "google_cloud_identity_group": "",
-        "google_cloud_run_v2_job": "",
-        "google_cloud_run_v2_service": "",
-        "google_clouddeploy_delivery_pipeline": "",
-        "google_clouddeploy_target": "",
-        "google_cloudfunctions2_function": "",
-        "google_cloudfunctions_function": "",
-        "google_composer_environment": "",
-        "google_compute_address": "",
-        "google_compute_disk": "",
-        "google_compute_external_vpn_gateway": "",
-        "google_compute_forwarding_rule": "",
-        "google_compute_global_forwarding_rule": "",
-        "google_compute_image": "",
-        "google_compute_instance": "",
-        "google_compute_instance_from_template": "",
-        "google_compute_instance_template": "",
-        "google_compute_region_disk": "",
-        "google_compute_region_instance_template": "",
-        "google_compute_snapshot": "",
-        "google_compute_vpn_tunnel": "",
-        "google_data_fusion_instance": "",
-        "google_database_migration_service_connection_profile": "",
-        "google_database_migration_service_private_connection": "",
-        "google_dataflow_job": "",
-        "google_dataplex_asset": "",
-        "google_dataplex_datascan": "",
-        "google_dataplex_lake": "",
-        "google_dataplex_task": "",
-        "google_dataplex_zone": "",
-        "google_dataproc_cluster": "",
-        "google_dataproc_job": "",
-        "google_dataproc_metastore_service": "",
-        "google_dataproc_workflow_template": "",
-        "google_datastream_connection_profile": "",
-        "google_datastream_private_connection": "",
-        "google_datastream_stream": "",
-        "google_dialogflow_cx_intent": "",
-        "google_dns_managed_zone": "",
-        "google_edgecontainer_cluster": "",
-        "google_edgecontainer_node_pool": "",
-        "google_edgecontainer_vpn_connection": "",
-        "google_edgenetwork_network": "",
-        "google_edgenetwork_subnet": "",
-        "google_eventarc_trigger": "",
-        "google_filestore_backup": "",
-        "google_filestore_instance": "",
-        "google_filestore_snapshot": "",
-        "google_gke_backup_backup_plan": "",
-        "google_gke_backup_restore_plan": "",
-        "google_gke_hub_feature": "",
-        "google_gke_hub_membership": "",
-        "google_gke_hub_membership_binding": "",
-        "google_gke_hub_namespace": "",
-        "google_gke_hub_scope": "",
-        "google_gke_hub_scope_rbac_role_binding": "",
-        "google_healthcare_consent_store": "",
-        "google_healthcare_dicom_store": "",
-        "google_healthcare_fhir_store": "",
-        "google_healthcare_hl7_v2_store": "",
-        "google_integration_connectors_connection": "",
-        "google_kms_crypto_key": "",
-        "google_memcache_instance": "",
-        "google_ml_engine_model": "",
-        "google_monitoring_notification_channel": "",
-        "google_network_connectivity_hub": "",
-        "google_network_connectivity_policy_based_route": "",
-        "google_network_connectivity_service_connection_policy": "",
-        "google_network_connectivity_spoke": "",
-        "google_network_management_connectivity_test": "",
-        "google_network_security_address_group": "",
-        "google_network_services_edge_cache_keyset": "",
-        "google_network_services_edge_cache_origin": "",
-        "google_network_services_edge_cache_service": "",
-        "google_network_services_gateway": "",
-        "google_notebooks_instance": "",
-        "google_privateca_ca_pool": "",
-        "google_privateca_certificate": "",
-        "google_privateca_certificate_authority": "",
-        "google_privateca_certificate_template": "",
-        "google_project": "",
-        "google_pubsub_subscription": "",
-        "google_pubsub_topic": "",
-        "google_recaptcha_enterprise_key": "",
-        "google_redis_instance": "",
-        "google_secret_manager_secret": "",
-        "google_spanner_instance": "",
-        "google_storage_bucket": "",
-        "google_tpu_node": "",
-        "google_vertex_ai_dataset": "",
-        "google_vertex_ai_endpoint": "",
-        "google_vertex_ai_featurestore": "",
-        "google_vertex_ai_featurestore_entitytype": "",
-        "google_vertex_ai_featurestore_entitytype_feature": "",
-        "google_vertex_ai_index": "",
-        "google_vertex_ai_index_endpoint": "",
-        "google_vertex_ai_tensorboard": "",
-        "google_workflows_workflow": ""
-    }
+		"google_active_directory_domain": "",
+		"google_alloydb_backup": "",
+		"google_alloydb_cluster": "",
+		"google_alloydb_instance": "",
+		"google_artifact_registry_repository": "",
+		"google_assured_workloads_workload": "",
+		"google_beyondcorp_app_connection": "",
+		"google_beyondcorp_app_connector": "",
+		"google_beyondcorp_app_gateway": "",
+		"google_bigquery_dataset": "",
+		"google_bigquery_job": "",
+		"google_bigquery_table": "",
+		"google_bigtable_instance": "",
+		"google_certificate_manager_certificate": "",
+		"google_certificate_manager_certificate_issuance_config": "",
+		"google_certificate_manager_certificate_map": "",
+		"google_certificate_manager_certificate_map_entry": "",
+		"google_certificate_manager_dns_authorization": "",
+		"google_certificate_manager_trust_config": "",
+		"google_cloud_identity_group": "",
+		"google_cloud_run_v2_job": "",
+		"google_cloud_run_v2_service": "",
+		"google_clouddeploy_delivery_pipeline": "",
+		"google_clouddeploy_target": "",
+		"google_cloudfunctions2_function": "",
+		"google_cloudfunctions_function": "",
+		"google_composer_environment": "",
+		"google_compute_address": "",
+		"google_compute_disk": "",
+		"google_compute_external_vpn_gateway": "",
+		"google_compute_forwarding_rule": "",
+		"google_compute_global_forwarding_rule": "",
+		"google_compute_image": "",
+		"google_compute_instance": "",
+		"google_compute_instance_from_template": "",
+		"google_compute_instance_template": "",
+		"google_compute_region_disk": "",
+		"google_compute_region_instance_template": "",
+		"google_compute_snapshot": "",
+		"google_compute_vpn_tunnel": "",
+		"google_data_fusion_instance": "",
+		"google_database_migration_service_connection_profile": "",
+		"google_database_migration_service_private_connection": "",
+		"google_dataflow_job": "",
+		"google_dataplex_asset": "",
+		"google_dataplex_datascan": "",
+		"google_dataplex_lake": "",
+		"google_dataplex_task": "",
+		"google_dataplex_zone": "",
+		"google_dataproc_cluster": "",
+		"google_dataproc_job": "",
+		"google_dataproc_metastore_service": "",
+		"google_dataproc_workflow_template": "",
+		"google_datastream_connection_profile": "",
+		"google_datastream_private_connection": "",
+		"google_datastream_stream": "",
+		"google_dialogflow_cx_intent": "",
+		"google_dns_managed_zone": "",
+		"google_edgecontainer_cluster": "",
+		"google_edgecontainer_node_pool": "",
+		"google_edgecontainer_vpn_connection": "",
+		"google_edgenetwork_network": "",
+		"google_edgenetwork_subnet": "",
+		"google_eventarc_trigger": "",
+		"google_filestore_backup": "",
+		"google_filestore_instance": "",
+		"google_filestore_snapshot": "",
+		"google_gke_backup_backup_plan": "",
+		"google_gke_backup_restore_plan": "",
+		"google_gke_hub_feature": "",
+		"google_gke_hub_membership": "",
+		"google_gke_hub_membership_binding": "",
+		"google_gke_hub_namespace": "",
+		"google_gke_hub_scope": "",
+		"google_gke_hub_scope_rbac_role_binding": "",
+		"google_healthcare_consent_store": "",
+		"google_healthcare_dicom_store": "",
+		"google_healthcare_fhir_store": "",
+		"google_healthcare_hl7_v2_store": "",
+		"google_integration_connectors_connection": "",
+		"google_kms_crypto_key": "",
+		"google_memcache_instance": "",
+		"google_ml_engine_model": "",
+		"google_monitoring_notification_channel": "",
+		"google_network_connectivity_hub": "",
+		"google_network_connectivity_policy_based_route": "",
+		"google_network_connectivity_service_connection_policy": "",
+		"google_network_connectivity_spoke": "",
+		"google_network_management_connectivity_test": "",
+		"google_network_security_address_group": "",
+		"google_network_services_edge_cache_keyset": "",
+		"google_network_services_edge_cache_origin": "",
+		"google_network_services_edge_cache_service": "",
+		"google_network_services_gateway": "",
+		"google_notebooks_instance": "",
+		"google_privateca_ca_pool": "",
+		"google_privateca_certificate": "",
+		"google_privateca_certificate_authority": "",
+		"google_privateca_certificate_template": "",
+		"google_project": "",
+		"google_pubsub_subscription": "",
+		"google_pubsub_topic": "",
+		"google_recaptcha_enterprise_key": "",
+		"google_redis_instance": "",
+		"google_secret_manager_secret": "",
+		"google_spanner_instance": "",
+		"google_storage_bucket": "",
+		"google_tpu_node": "",
+		"google_vertex_ai_dataset": "",
+		"google_vertex_ai_endpoint": "",
+		"google_vertex_ai_featurestore": "",
+		"google_vertex_ai_featurestore_entitytype": "",
+		"google_vertex_ai_featurestore_entitytype_feature": "",
+		"google_vertex_ai_index": "",
+		"google_vertex_ai_index_endpoint": "",
+		"google_vertex_ai_tensorboard": "",
+		"google_workflows_workflow": "",
+	}
 	resource[p]
 }
 
-check_azure_resource_supports_tags(p) {
+check_azure_resource_supports_tags(p) if {
 	resource = {
-        "azurerm_aadb2c_directory": "",
-        "azurerm_active_directory_domain_service": "",
-        "azurerm_analysis_services_server": "",
-        "azurerm_api_connection": "",
-        "azurerm_api_management": "",
-        "azurerm_api_management_named_value": "",
-        "azurerm_app_configuration": "",
-        "azurerm_app_configuration_feature": "",
-        "azurerm_app_configuration_key": "",
-        "azurerm_app_service": "",
-        "azurerm_app_service_certificate": "",
-        "azurerm_app_service_certificate_order": "",
-        "azurerm_app_service_environment": "",
-        "azurerm_app_service_environment_v3": "",
-        "azurerm_app_service_managed_certificate": "",
-        "azurerm_app_service_plan": "",
-        "azurerm_app_service_slot": "",
-        "azurerm_application_gateway": "",
-        "azurerm_application_insights": "",
-        "azurerm_application_insights_standard_web_test": "",
-        "azurerm_application_insights_web_test": "",
-        "azurerm_application_insights_workbook": "",
-        "azurerm_application_insights_workbook_template": "",
-        "azurerm_application_load_balancer": "",
-        "azurerm_application_load_balancer_frontend": "",
-        "azurerm_application_load_balancer_subnet_association": "",
-        "azurerm_application_security_group": "",
-        "azurerm_arc_kubernetes_cluster": "",
-        "azurerm_arc_machine_extension": "",
-        "azurerm_arc_private_link_scope": "",
-        "azurerm_arc_resource_bridge_appliance": "",
-        "azurerm_attestation_provider": "",
-        "azurerm_automanage_configuration": "",
-        "azurerm_automation_account": "",
-        "azurerm_automation_dsc_configuration": "",
-        "azurerm_automation_python3_package": "",
-        "azurerm_automation_runbook": "",
-        "azurerm_automation_watcher": "",
-        "azurerm_availability_set": "",
-        "azurerm_bastion_host": "",
-        "azurerm_batch_account": "",
-        "azurerm_bot_channels_registration": "",
-        "azurerm_bot_connection": "",
-        "azurerm_bot_service_azure_bot": "",
-        "azurerm_bot_web_app": "",
-        "azurerm_capacity_reservation": "",
-        "azurerm_capacity_reservation_group": "",
-        "azurerm_cdn_endpoint": "",
-        "azurerm_cdn_frontdoor_endpoint": "",
-        "azurerm_cdn_frontdoor_firewall_policy": "",
-        "azurerm_cdn_frontdoor_profile": "",
-        "azurerm_cdn_profile": "",
-        "azurerm_cognitive_account": "",
-        "azurerm_communication_service": "",
-        "azurerm_confidential_ledger": "",
-        "azurerm_container_app": "",
-        "azurerm_container_app_environment": "",
-        "azurerm_container_app_environment_certificate": "",
-        "azurerm_container_group": "",
-        "azurerm_container_registry": "",
-        "azurerm_container_registry_agent_pool": "",
-        "azurerm_container_registry_task": "",
-        "azurerm_container_registry_webhook": "",
-        "azurerm_cosmosdb_account": "",
-        "azurerm_cosmosdb_cassandra_cluster": "",
-        "azurerm_cosmosdb_postgresql_cluster": "",
-        "azurerm_custom_ip_prefix": "",
-        "azurerm_custom_provider": "",
-        "azurerm_dashboard": "",
-        "azurerm_dashboard_grafana": "",
-        "azurerm_data_factory": "",
-        "azurerm_data_protection_backup_vault": "",
-        "azurerm_data_protection_resource_guard": "",
-        "azurerm_data_share_account": "",
-        "azurerm_database_migration_project": "",
-        "azurerm_database_migration_service": "",
-        "azurerm_databox_edge_device": "",
-        "azurerm_databricks_access_connector": "",
-        "azurerm_databricks_workspace": "",
-        "azurerm_datadog_monitor": "",
-        "azurerm_dedicated_hardware_security_module": "",
-        "azurerm_dedicated_host": "",
-        "azurerm_dedicated_host_group": "",
-        "azurerm_dev_center": "",
-        "azurerm_dev_center_project": "",
-        "azurerm_dev_test_global_vm_shutdown_schedule": "",
-        "azurerm_dev_test_lab": "",
-        "azurerm_dev_test_linux_virtual_machine": "",
-        "azurerm_dev_test_policy": "",
-        "azurerm_dev_test_schedule": "",
-        "azurerm_dev_test_virtual_network": "",
-        "azurerm_dev_test_windows_virtual_machine": "",
-        "azurerm_digital_twins_instance": "",
-        "azurerm_disk_access": "",
-        "azurerm_disk_encryption_set": "",
-        "azurerm_disk_pool": "",
-        "azurerm_dns_a_record": "",
-        "azurerm_dns_aaaa_record": "",
-        "azurerm_dns_caa_record": "",
-        "azurerm_dns_cname_record": "",
-        "azurerm_dns_mx_record": "",
-        "azurerm_dns_ns_record": "",
-        "azurerm_dns_ptr_record": "",
-        "azurerm_dns_srv_record": "",
-        "azurerm_dns_txt_record": "",
-        "azurerm_dns_zone": "",
-        "azurerm_elastic_cloud_elasticsearch": "",
-        "azurerm_email_communication_service": "",
-        "azurerm_eventgrid_domain": "",
-        "azurerm_eventgrid_system_topic": "",
-        "azurerm_eventgrid_topic": "",
-        "azurerm_eventhub_cluster": "",
-        "azurerm_eventhub_namespace": "",
-        "azurerm_express_route_circuit": "",
-        "azurerm_express_route_gateway": "",
-        "azurerm_express_route_port": "",
-        "azurerm_firewall": "",
-        "azurerm_firewall_policy": "",
-        "azurerm_fluid_relay_server": "",
-        "azurerm_frontdoor": "",
-        "azurerm_frontdoor_firewall_policy": "",
-        "azurerm_function_app": "",
-        "azurerm_function_app_slot": "",
-        "azurerm_gallery_application": "",
-        "azurerm_gallery_application_version": "",
-        "azurerm_graph_account": "",
-        "azurerm_graph_services_account": "",
-        "azurerm_hdinsight_hadoop_cluster": "",
-        "azurerm_hdinsight_hbase_cluster": "",
-        "azurerm_hdinsight_interactive_query_cluster": "",
-        "azurerm_hdinsight_kafka_cluster": "",
-        "azurerm_hdinsight_spark_cluster": "",
-        "azurerm_healthbot": "",
-        "azurerm_healthcare_dicom_service": "",
-        "azurerm_healthcare_fhir_service": "",
-        "azurerm_healthcare_medtech_service": "",
-        "azurerm_healthcare_service": "",
-        "azurerm_healthcare_workspace": "",
-        "azurerm_hpc_cache": "",
-        "azurerm_image": "",
-        "azurerm_integration_service_environment": "",
-        "azurerm_iot_security_solution": "",
-        "azurerm_iot_time_series_insights_event_source_eventhub": "",
-        "azurerm_iot_time_series_insights_event_source_iothub": "",
-        "azurerm_iot_time_series_insights_gen2_environment": "",
-        "azurerm_iot_time_series_insights_reference_data_set": "",
-        "azurerm_iot_time_series_insights_standard_environment": "",
-        "azurerm_iotcentral_application": "",
-        "azurerm_iothub": "",
-        "azurerm_iothub_device_update_account": "",
-        "azurerm_iothub_device_update_instance": "",
-        "azurerm_iothub_dps": "",
-        "azurerm_ip_group": "",
-        "azurerm_key_vault": "",
-        "azurerm_key_vault_certificate": "",
-        "azurerm_key_vault_key": "",
-        "azurerm_key_vault_managed_hardware_security_module": "",
-        "azurerm_key_vault_managed_storage_account": "",
-        "azurerm_key_vault_managed_storage_account_sas_token_definition": "",
-        "azurerm_key_vault_secret": "",
-        "azurerm_kubernetes_cluster": "",
-        "azurerm_kubernetes_cluster_node_pool": "",
-        "azurerm_kubernetes_fleet_manager": "",
-        "azurerm_kusto_cluster": "",
-        "azurerm_lab_service_lab": "",
-        "azurerm_lab_service_plan": "",
-        "azurerm_lb": "",
-        "azurerm_linux_function_app": "",
-        "azurerm_linux_function_app_slot": "",
-        "azurerm_linux_virtual_machine": "",
-        "azurerm_linux_virtual_machine_scale_set": "",
-        "azurerm_linux_web_app": "",
-        "azurerm_linux_web_app_slot": "",
-        "azurerm_load_test": "",
-        "azurerm_local_network_gateway": "",
-        "azurerm_log_analytics_cluster": "",
-        "azurerm_log_analytics_query_pack": "",
-        "azurerm_log_analytics_query_pack_query": "",
-        "azurerm_log_analytics_saved_search": "",
-        "azurerm_log_analytics_solution": "",
-        "azurerm_log_analytics_workspace": "",
-        "azurerm_logic_app_integration_account": "",
-        "azurerm_logic_app_standard": "",
-        "azurerm_logic_app_workflow": "",
-        "azurerm_logz_monitor": "",
-        "azurerm_logz_sub_account": "",
-        "azurerm_machine_learning_compute_cluster": "",
-        "azurerm_machine_learning_compute_instance": "",
-        "azurerm_machine_learning_datastore_blobstorage": "",
-        "azurerm_machine_learning_datastore_datalake_gen2": "",
-        "azurerm_machine_learning_datastore_fileshare": "",
-        "azurerm_machine_learning_inference_cluster": "",
-        "azurerm_machine_learning_synapse_spark": "",
-        "azurerm_machine_learning_workspace": "",
-        "azurerm_maintenance_configuration": "",
-        "azurerm_managed_application": "",
-        "azurerm_managed_application_definition": "",
-        "azurerm_managed_disk": "",
-        "azurerm_managed_lustre_file_system": "",
-        "azurerm_management_group_template_deployment": "",
-        "azurerm_maps_account": "",
-        "azurerm_maps_creator": "",
-        "azurerm_mariadb_server": "",
-        "azurerm_media_live_event": "",
-        "azurerm_media_services_account": "",
-        "azurerm_media_streaming_endpoint": "",
-        "azurerm_mobile_network": "",
-        "azurerm_mobile_network_attached_data_network": "",
-        "azurerm_mobile_network_data_network": "",
-        "azurerm_mobile_network_packet_core_control_plane": "",
-        "azurerm_mobile_network_packet_core_data_plane": "",
-        "azurerm_mobile_network_service": "",
-        "azurerm_mobile_network_sim_group": "",
-        "azurerm_mobile_network_sim_policy": "",
-        "azurerm_mobile_network_site": "",
-        "azurerm_mobile_network_slice": "",
-        "azurerm_monitor_action_group": "",
-        "azurerm_monitor_action_rule_action_group": "",
-        "azurerm_monitor_action_rule_suppression": "",
-        "azurerm_monitor_activity_log_alert": "",
-        "azurerm_monitor_alert_processing_rule_action_group": "",
-        "azurerm_monitor_alert_processing_rule_suppression": "",
-        "azurerm_monitor_alert_prometheus_rule_group": "",
-        "azurerm_monitor_autoscale_setting": "",
-        "azurerm_monitor_data_collection_endpoint": "",
-        "azurerm_monitor_data_collection_rule": "",
-        "azurerm_monitor_metric_alert": "",
-        "azurerm_monitor_private_link_scope": "",
-        "azurerm_monitor_scheduled_query_rules_alert": "",
-        "azurerm_monitor_scheduled_query_rules_alert_v2": "",
-        "azurerm_monitor_scheduled_query_rules_log": "",
-        "azurerm_monitor_smart_detector_alert_rule": "",
-        "azurerm_monitor_workspace": "",
-        "azurerm_mssql_database": "",
-        "azurerm_mssql_elasticpool": "",
-        "azurerm_mssql_failover_group": "",
-        "azurerm_mssql_job_agent": "",
-        "azurerm_mssql_managed_instance": "",
-        "azurerm_mssql_server": "",
-        "azurerm_mssql_virtual_machine": "",
-        "azurerm_mssql_virtual_machine_group": "",
-        "azurerm_mysql_flexible_server": "",
-        "azurerm_mysql_server": "",
-        "azurerm_nat_gateway": "",
-        "azurerm_netapp_account": "",
-        "azurerm_netapp_pool": "",
-        "azurerm_netapp_snapshot_policy": "",
-        "azurerm_netapp_volume": "",
-        "azurerm_network_connection_monitor": "",
-        "azurerm_network_ddos_protection_plan": "",
-        "azurerm_network_function_azure_traffic_collector": "",
-        "azurerm_network_function_collector_policy": "",
-        "azurerm_network_interface": "",
-        "azurerm_network_manager": "",
-        "azurerm_network_profile": "",
-        "azurerm_network_security_group": "",
-        "azurerm_network_watcher": "",
-        "azurerm_network_watcher_flow_log": "",
-        "azurerm_nginx_deployment": "",
-        "azurerm_notification_hub": "",
-        "azurerm_notification_hub_namespace": "",
-        "azurerm_orbital_contact_profile": "",
-        "azurerm_orbital_spacecraft": "",
-        "azurerm_orchestrated_virtual_machine_scale_set": "",
-        "azurerm_palo_alto_local_rulestack_rule": "",
-        "azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack": "",
-        "azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama": "",
-        "azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack": "",
-        "azurerm_palo_alto_next_generation_firewall_virtual_network_panorama": "",
-        "azurerm_point_to_site_vpn_gateway": "",
-        "azurerm_portal_dashboard": "",
-        "azurerm_postgresql_flexible_server": "",
-        "azurerm_postgresql_server": "",
-        "azurerm_powerbi_embedded": "",
-        "azurerm_private_dns_a_record": "",
-        "azurerm_private_dns_aaaa_record": "",
-        "azurerm_private_dns_cname_record": "",
-        "azurerm_private_dns_mx_record": "",
-        "azurerm_private_dns_ptr_record": "",
-        "azurerm_private_dns_resolver": "",
-        "azurerm_private_dns_resolver_dns_forwarding_ruleset": "",
-        "azurerm_private_dns_resolver_inbound_endpoint": "",
-        "azurerm_private_dns_resolver_outbound_endpoint": "",
-        "azurerm_private_dns_srv_record": "",
-        "azurerm_private_dns_txt_record": "",
-        "azurerm_private_dns_zone": "",
-        "azurerm_private_dns_zone_virtual_network_link": "",
-        "azurerm_private_endpoint": "",
-        "azurerm_private_link_service": "",
-        "azurerm_proximity_placement_group": "",
-        "azurerm_public_ip": "",
-        "azurerm_public_ip_prefix": "",
-        "azurerm_purview_account": "",
-        "azurerm_recovery_services_vault": "",
-        "azurerm_redis_cache": "",
-        "azurerm_redis_enterprise_cluster": "",
-        "azurerm_relay_namespace": "",
-        "azurerm_resource_deployment_script_azure_cli": "",
-        "azurerm_resource_deployment_script_azure_power_shell": "",
-        "azurerm_resource_group": "",
-        "azurerm_resource_group_template_deployment": "",
-        "azurerm_route_filter": "",
-        "azurerm_route_server": "",
-        "azurerm_route_table": "",
-        "azurerm_search_service": "",
-        "azurerm_security_center_automation": "",
-        "azurerm_sentinel_threat_intelligence_indicator": "",
-        "azurerm_service_fabric_cluster": "",
-        "azurerm_service_fabric_managed_cluster": "",
-        "azurerm_service_plan": "",
-        "azurerm_servicebus_namespace": "",
-        "azurerm_shared_image": "",
-        "azurerm_shared_image_gallery": "",
-        "azurerm_shared_image_version": "",
-        "azurerm_signalr_service": "",
-        "azurerm_snapshot": "",
-        "azurerm_spatial_anchors_account": "",
-        "azurerm_spring_cloud_service": "",
-        "azurerm_sql_database": "",
-        "azurerm_sql_elasticpool": "",
-        "azurerm_sql_failover_group": "",
-        "azurerm_sql_managed_instance": "",
-        "azurerm_sql_server": "",
-        "azurerm_ssh_public_key": "",
-        "azurerm_stack_hci_cluster": "",
-        "azurerm_static_site": "",
-        "azurerm_storage_account": "",
-        "azurerm_storage_mover": "",
-        "azurerm_storage_sync": "",
-        "azurerm_stream_analytics_cluster": "",
-        "azurerm_stream_analytics_job": "",
-        "azurerm_subnet_service_endpoint_storage_policy": "",
-        "azurerm_subscription": "",
-        "azurerm_subscription_template_deployment": "",
-        "azurerm_synapse_private_link_hub": "",
-        "azurerm_synapse_spark_pool": "",
-        "azurerm_synapse_sql_pool": "",
-        "azurerm_synapse_workspace": "",
-        "azurerm_tenant_template_deployment": "",
-        "azurerm_traffic_manager_profile": "",
-        "azurerm_user_assigned_identity": "",
-        "azurerm_video_analyzer": "",
-        "azurerm_virtual_desktop_application_group": "",
-        "azurerm_virtual_desktop_host_pool": "",
-        "azurerm_virtual_desktop_scaling_plan": "",
-        "azurerm_virtual_desktop_workspace": "",
-        "azurerm_virtual_hub": "",
-        "azurerm_virtual_hub_security_partner_provider": "",
-        "azurerm_virtual_machine": "",
-        "azurerm_virtual_machine_extension": "",
-        "azurerm_virtual_machine_scale_set": "",
-        "azurerm_virtual_network": "",
-        "azurerm_virtual_network_gateway": "",
-        "azurerm_virtual_network_gateway_connection": "",
-        "azurerm_virtual_wan": "",
-        "azurerm_vmware_private_cloud": "",
-        "azurerm_voice_services_communications_gateway": "",
-        "azurerm_voice_services_communications_gateway_test_line": "",
-        "azurerm_vpn_gateway": "",
-        "azurerm_vpn_server_configuration": "",
-        "azurerm_vpn_site": "",
-        "azurerm_web_application_firewall_policy": "",
-        "azurerm_web_pubsub": "",
-        "azurerm_windows_function_app": "",
-        "azurerm_windows_function_app_slot": "",
-        "azurerm_windows_virtual_machine": "",
-        "azurerm_windows_virtual_machine_scale_set": "",
-        "azurerm_windows_web_app": "",
-        "azurerm_windows_web_app_slot": ""
-    }
+		"azurerm_aadb2c_directory": "",
+		"azurerm_active_directory_domain_service": "",
+		"azurerm_analysis_services_server": "",
+		"azurerm_api_connection": "",
+		"azurerm_api_management": "",
+		"azurerm_api_management_named_value": "",
+		"azurerm_app_configuration": "",
+		"azurerm_app_configuration_feature": "",
+		"azurerm_app_configuration_key": "",
+		"azurerm_app_service": "",
+		"azurerm_app_service_certificate": "",
+		"azurerm_app_service_certificate_order": "",
+		"azurerm_app_service_environment": "",
+		"azurerm_app_service_environment_v3": "",
+		"azurerm_app_service_managed_certificate": "",
+		"azurerm_app_service_plan": "",
+		"azurerm_app_service_slot": "",
+		"azurerm_application_gateway": "",
+		"azurerm_application_insights": "",
+		"azurerm_application_insights_standard_web_test": "",
+		"azurerm_application_insights_web_test": "",
+		"azurerm_application_insights_workbook": "",
+		"azurerm_application_insights_workbook_template": "",
+		"azurerm_application_load_balancer": "",
+		"azurerm_application_load_balancer_frontend": "",
+		"azurerm_application_load_balancer_subnet_association": "",
+		"azurerm_application_security_group": "",
+		"azurerm_arc_kubernetes_cluster": "",
+		"azurerm_arc_machine_extension": "",
+		"azurerm_arc_private_link_scope": "",
+		"azurerm_arc_resource_bridge_appliance": "",
+		"azurerm_attestation_provider": "",
+		"azurerm_automanage_configuration": "",
+		"azurerm_automation_account": "",
+		"azurerm_automation_dsc_configuration": "",
+		"azurerm_automation_python3_package": "",
+		"azurerm_automation_runbook": "",
+		"azurerm_automation_watcher": "",
+		"azurerm_availability_set": "",
+		"azurerm_bastion_host": "",
+		"azurerm_batch_account": "",
+		"azurerm_bot_channels_registration": "",
+		"azurerm_bot_connection": "",
+		"azurerm_bot_service_azure_bot": "",
+		"azurerm_bot_web_app": "",
+		"azurerm_capacity_reservation": "",
+		"azurerm_capacity_reservation_group": "",
+		"azurerm_cdn_endpoint": "",
+		"azurerm_cdn_frontdoor_endpoint": "",
+		"azurerm_cdn_frontdoor_firewall_policy": "",
+		"azurerm_cdn_frontdoor_profile": "",
+		"azurerm_cdn_profile": "",
+		"azurerm_cognitive_account": "",
+		"azurerm_communication_service": "",
+		"azurerm_confidential_ledger": "",
+		"azurerm_container_app": "",
+		"azurerm_container_app_environment": "",
+		"azurerm_container_app_environment_certificate": "",
+		"azurerm_container_group": "",
+		"azurerm_container_registry": "",
+		"azurerm_container_registry_agent_pool": "",
+		"azurerm_container_registry_task": "",
+		"azurerm_container_registry_webhook": "",
+		"azurerm_cosmosdb_account": "",
+		"azurerm_cosmosdb_cassandra_cluster": "",
+		"azurerm_cosmosdb_postgresql_cluster": "",
+		"azurerm_custom_ip_prefix": "",
+		"azurerm_custom_provider": "",
+		"azurerm_dashboard": "",
+		"azurerm_dashboard_grafana": "",
+		"azurerm_data_factory": "",
+		"azurerm_data_protection_backup_vault": "",
+		"azurerm_data_protection_resource_guard": "",
+		"azurerm_data_share_account": "",
+		"azurerm_database_migration_project": "",
+		"azurerm_database_migration_service": "",
+		"azurerm_databox_edge_device": "",
+		"azurerm_databricks_access_connector": "",
+		"azurerm_databricks_workspace": "",
+		"azurerm_datadog_monitor": "",
+		"azurerm_dedicated_hardware_security_module": "",
+		"azurerm_dedicated_host": "",
+		"azurerm_dedicated_host_group": "",
+		"azurerm_dev_center": "",
+		"azurerm_dev_center_project": "",
+		"azurerm_dev_test_global_vm_shutdown_schedule": "",
+		"azurerm_dev_test_lab": "",
+		"azurerm_dev_test_linux_virtual_machine": "",
+		"azurerm_dev_test_policy": "",
+		"azurerm_dev_test_schedule": "",
+		"azurerm_dev_test_virtual_network": "",
+		"azurerm_dev_test_windows_virtual_machine": "",
+		"azurerm_digital_twins_instance": "",
+		"azurerm_disk_access": "",
+		"azurerm_disk_encryption_set": "",
+		"azurerm_disk_pool": "",
+		"azurerm_dns_a_record": "",
+		"azurerm_dns_aaaa_record": "",
+		"azurerm_dns_caa_record": "",
+		"azurerm_dns_cname_record": "",
+		"azurerm_dns_mx_record": "",
+		"azurerm_dns_ns_record": "",
+		"azurerm_dns_ptr_record": "",
+		"azurerm_dns_srv_record": "",
+		"azurerm_dns_txt_record": "",
+		"azurerm_dns_zone": "",
+		"azurerm_elastic_cloud_elasticsearch": "",
+		"azurerm_email_communication_service": "",
+		"azurerm_eventgrid_domain": "",
+		"azurerm_eventgrid_system_topic": "",
+		"azurerm_eventgrid_topic": "",
+		"azurerm_eventhub_cluster": "",
+		"azurerm_eventhub_namespace": "",
+		"azurerm_express_route_circuit": "",
+		"azurerm_express_route_gateway": "",
+		"azurerm_express_route_port": "",
+		"azurerm_firewall": "",
+		"azurerm_firewall_policy": "",
+		"azurerm_fluid_relay_server": "",
+		"azurerm_frontdoor": "",
+		"azurerm_frontdoor_firewall_policy": "",
+		"azurerm_function_app": "",
+		"azurerm_function_app_slot": "",
+		"azurerm_gallery_application": "",
+		"azurerm_gallery_application_version": "",
+		"azurerm_graph_account": "",
+		"azurerm_graph_services_account": "",
+		"azurerm_hdinsight_hadoop_cluster": "",
+		"azurerm_hdinsight_hbase_cluster": "",
+		"azurerm_hdinsight_interactive_query_cluster": "",
+		"azurerm_hdinsight_kafka_cluster": "",
+		"azurerm_hdinsight_spark_cluster": "",
+		"azurerm_healthbot": "",
+		"azurerm_healthcare_dicom_service": "",
+		"azurerm_healthcare_fhir_service": "",
+		"azurerm_healthcare_medtech_service": "",
+		"azurerm_healthcare_service": "",
+		"azurerm_healthcare_workspace": "",
+		"azurerm_hpc_cache": "",
+		"azurerm_image": "",
+		"azurerm_integration_service_environment": "",
+		"azurerm_iot_security_solution": "",
+		"azurerm_iot_time_series_insights_event_source_eventhub": "",
+		"azurerm_iot_time_series_insights_event_source_iothub": "",
+		"azurerm_iot_time_series_insights_gen2_environment": "",
+		"azurerm_iot_time_series_insights_reference_data_set": "",
+		"azurerm_iot_time_series_insights_standard_environment": "",
+		"azurerm_iotcentral_application": "",
+		"azurerm_iothub": "",
+		"azurerm_iothub_device_update_account": "",
+		"azurerm_iothub_device_update_instance": "",
+		"azurerm_iothub_dps": "",
+		"azurerm_ip_group": "",
+		"azurerm_key_vault": "",
+		"azurerm_key_vault_certificate": "",
+		"azurerm_key_vault_key": "",
+		"azurerm_key_vault_managed_hardware_security_module": "",
+		"azurerm_key_vault_managed_storage_account": "",
+		"azurerm_key_vault_managed_storage_account_sas_token_definition": "",
+		"azurerm_key_vault_secret": "",
+		"azurerm_kubernetes_cluster": "",
+		"azurerm_kubernetes_cluster_node_pool": "",
+		"azurerm_kubernetes_fleet_manager": "",
+		"azurerm_kusto_cluster": "",
+		"azurerm_lab_service_lab": "",
+		"azurerm_lab_service_plan": "",
+		"azurerm_lb": "",
+		"azurerm_linux_function_app": "",
+		"azurerm_linux_function_app_slot": "",
+		"azurerm_linux_virtual_machine": "",
+		"azurerm_linux_virtual_machine_scale_set": "",
+		"azurerm_linux_web_app": "",
+		"azurerm_linux_web_app_slot": "",
+		"azurerm_load_test": "",
+		"azurerm_local_network_gateway": "",
+		"azurerm_log_analytics_cluster": "",
+		"azurerm_log_analytics_query_pack": "",
+		"azurerm_log_analytics_query_pack_query": "",
+		"azurerm_log_analytics_saved_search": "",
+		"azurerm_log_analytics_solution": "",
+		"azurerm_log_analytics_workspace": "",
+		"azurerm_logic_app_integration_account": "",
+		"azurerm_logic_app_standard": "",
+		"azurerm_logic_app_workflow": "",
+		"azurerm_logz_monitor": "",
+		"azurerm_logz_sub_account": "",
+		"azurerm_machine_learning_compute_cluster": "",
+		"azurerm_machine_learning_compute_instance": "",
+		"azurerm_machine_learning_datastore_blobstorage": "",
+		"azurerm_machine_learning_datastore_datalake_gen2": "",
+		"azurerm_machine_learning_datastore_fileshare": "",
+		"azurerm_machine_learning_inference_cluster": "",
+		"azurerm_machine_learning_synapse_spark": "",
+		"azurerm_machine_learning_workspace": "",
+		"azurerm_maintenance_configuration": "",
+		"azurerm_managed_application": "",
+		"azurerm_managed_application_definition": "",
+		"azurerm_managed_disk": "",
+		"azurerm_managed_lustre_file_system": "",
+		"azurerm_management_group_template_deployment": "",
+		"azurerm_maps_account": "",
+		"azurerm_maps_creator": "",
+		"azurerm_mariadb_server": "",
+		"azurerm_media_live_event": "",
+		"azurerm_media_services_account": "",
+		"azurerm_media_streaming_endpoint": "",
+		"azurerm_mobile_network": "",
+		"azurerm_mobile_network_attached_data_network": "",
+		"azurerm_mobile_network_data_network": "",
+		"azurerm_mobile_network_packet_core_control_plane": "",
+		"azurerm_mobile_network_packet_core_data_plane": "",
+		"azurerm_mobile_network_service": "",
+		"azurerm_mobile_network_sim_group": "",
+		"azurerm_mobile_network_sim_policy": "",
+		"azurerm_mobile_network_site": "",
+		"azurerm_mobile_network_slice": "",
+		"azurerm_monitor_action_group": "",
+		"azurerm_monitor_action_rule_action_group": "",
+		"azurerm_monitor_action_rule_suppression": "",
+		"azurerm_monitor_activity_log_alert": "",
+		"azurerm_monitor_alert_processing_rule_action_group": "",
+		"azurerm_monitor_alert_processing_rule_suppression": "",
+		"azurerm_monitor_alert_prometheus_rule_group": "",
+		"azurerm_monitor_autoscale_setting": "",
+		"azurerm_monitor_data_collection_endpoint": "",
+		"azurerm_monitor_data_collection_rule": "",
+		"azurerm_monitor_metric_alert": "",
+		"azurerm_monitor_private_link_scope": "",
+		"azurerm_monitor_scheduled_query_rules_alert": "",
+		"azurerm_monitor_scheduled_query_rules_alert_v2": "",
+		"azurerm_monitor_scheduled_query_rules_log": "",
+		"azurerm_monitor_smart_detector_alert_rule": "",
+		"azurerm_monitor_workspace": "",
+		"azurerm_mssql_database": "",
+		"azurerm_mssql_elasticpool": "",
+		"azurerm_mssql_failover_group": "",
+		"azurerm_mssql_job_agent": "",
+		"azurerm_mssql_managed_instance": "",
+		"azurerm_mssql_server": "",
+		"azurerm_mssql_virtual_machine": "",
+		"azurerm_mssql_virtual_machine_group": "",
+		"azurerm_mysql_flexible_server": "",
+		"azurerm_mysql_server": "",
+		"azurerm_nat_gateway": "",
+		"azurerm_netapp_account": "",
+		"azurerm_netapp_pool": "",
+		"azurerm_netapp_snapshot_policy": "",
+		"azurerm_netapp_volume": "",
+		"azurerm_network_connection_monitor": "",
+		"azurerm_network_ddos_protection_plan": "",
+		"azurerm_network_function_azure_traffic_collector": "",
+		"azurerm_network_function_collector_policy": "",
+		"azurerm_network_interface": "",
+		"azurerm_network_manager": "",
+		"azurerm_network_profile": "",
+		"azurerm_network_security_group": "",
+		"azurerm_network_watcher": "",
+		"azurerm_network_watcher_flow_log": "",
+		"azurerm_nginx_deployment": "",
+		"azurerm_notification_hub": "",
+		"azurerm_notification_hub_namespace": "",
+		"azurerm_orbital_contact_profile": "",
+		"azurerm_orbital_spacecraft": "",
+		"azurerm_orchestrated_virtual_machine_scale_set": "",
+		"azurerm_palo_alto_local_rulestack_rule": "",
+		"azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack": "",
+		"azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama": "",
+		"azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack": "",
+		"azurerm_palo_alto_next_generation_firewall_virtual_network_panorama": "",
+		"azurerm_point_to_site_vpn_gateway": "",
+		"azurerm_portal_dashboard": "",
+		"azurerm_postgresql_flexible_server": "",
+		"azurerm_postgresql_server": "",
+		"azurerm_powerbi_embedded": "",
+		"azurerm_private_dns_a_record": "",
+		"azurerm_private_dns_aaaa_record": "",
+		"azurerm_private_dns_cname_record": "",
+		"azurerm_private_dns_mx_record": "",
+		"azurerm_private_dns_ptr_record": "",
+		"azurerm_private_dns_resolver": "",
+		"azurerm_private_dns_resolver_dns_forwarding_ruleset": "",
+		"azurerm_private_dns_resolver_inbound_endpoint": "",
+		"azurerm_private_dns_resolver_outbound_endpoint": "",
+		"azurerm_private_dns_srv_record": "",
+		"azurerm_private_dns_txt_record": "",
+		"azurerm_private_dns_zone": "",
+		"azurerm_private_dns_zone_virtual_network_link": "",
+		"azurerm_private_endpoint": "",
+		"azurerm_private_link_service": "",
+		"azurerm_proximity_placement_group": "",
+		"azurerm_public_ip": "",
+		"azurerm_public_ip_prefix": "",
+		"azurerm_purview_account": "",
+		"azurerm_recovery_services_vault": "",
+		"azurerm_redis_cache": "",
+		"azurerm_redis_enterprise_cluster": "",
+		"azurerm_relay_namespace": "",
+		"azurerm_resource_deployment_script_azure_cli": "",
+		"azurerm_resource_deployment_script_azure_power_shell": "",
+		"azurerm_resource_group": "",
+		"azurerm_resource_group_template_deployment": "",
+		"azurerm_route_filter": "",
+		"azurerm_route_server": "",
+		"azurerm_route_table": "",
+		"azurerm_search_service": "",
+		"azurerm_security_center_automation": "",
+		"azurerm_sentinel_threat_intelligence_indicator": "",
+		"azurerm_service_fabric_cluster": "",
+		"azurerm_service_fabric_managed_cluster": "",
+		"azurerm_service_plan": "",
+		"azurerm_servicebus_namespace": "",
+		"azurerm_shared_image": "",
+		"azurerm_shared_image_gallery": "",
+		"azurerm_shared_image_version": "",
+		"azurerm_signalr_service": "",
+		"azurerm_snapshot": "",
+		"azurerm_spatial_anchors_account": "",
+		"azurerm_spring_cloud_service": "",
+		"azurerm_sql_database": "",
+		"azurerm_sql_elasticpool": "",
+		"azurerm_sql_failover_group": "",
+		"azurerm_sql_managed_instance": "",
+		"azurerm_sql_server": "",
+		"azurerm_ssh_public_key": "",
+		"azurerm_stack_hci_cluster": "",
+		"azurerm_static_site": "",
+		"azurerm_storage_account": "",
+		"azurerm_storage_mover": "",
+		"azurerm_storage_sync": "",
+		"azurerm_stream_analytics_cluster": "",
+		"azurerm_stream_analytics_job": "",
+		"azurerm_subnet_service_endpoint_storage_policy": "",
+		"azurerm_subscription": "",
+		"azurerm_subscription_template_deployment": "",
+		"azurerm_synapse_private_link_hub": "",
+		"azurerm_synapse_spark_pool": "",
+		"azurerm_synapse_sql_pool": "",
+		"azurerm_synapse_workspace": "",
+		"azurerm_tenant_template_deployment": "",
+		"azurerm_traffic_manager_profile": "",
+		"azurerm_user_assigned_identity": "",
+		"azurerm_video_analyzer": "",
+		"azurerm_virtual_desktop_application_group": "",
+		"azurerm_virtual_desktop_host_pool": "",
+		"azurerm_virtual_desktop_scaling_plan": "",
+		"azurerm_virtual_desktop_workspace": "",
+		"azurerm_virtual_hub": "",
+		"azurerm_virtual_hub_security_partner_provider": "",
+		"azurerm_virtual_machine": "",
+		"azurerm_virtual_machine_extension": "",
+		"azurerm_virtual_machine_scale_set": "",
+		"azurerm_virtual_network": "",
+		"azurerm_virtual_network_gateway": "",
+		"azurerm_virtual_network_gateway_connection": "",
+		"azurerm_virtual_wan": "",
+		"azurerm_vmware_private_cloud": "",
+		"azurerm_voice_services_communications_gateway": "",
+		"azurerm_voice_services_communications_gateway_test_line": "",
+		"azurerm_vpn_gateway": "",
+		"azurerm_vpn_server_configuration": "",
+		"azurerm_vpn_site": "",
+		"azurerm_web_application_firewall_policy": "",
+		"azurerm_web_pubsub": "",
+		"azurerm_windows_function_app": "",
+		"azurerm_windows_function_app_slot": "",
+		"azurerm_windows_virtual_machine": "",
+		"azurerm_windows_virtual_machine_scale_set": "",
+		"azurerm_windows_web_app": "",
+		"azurerm_windows_web_app_slot": "",
+	}
 	resource[p]
 }
 
-has_key(obj, key) {
+has_key(obj, key) if {
 	_ = obj[key]
 }

--- a/assets/libraries/test/cicd_test.rego
+++ b/assets/libraries/test/cicd_test.rego
@@ -3,159 +3,161 @@
 # Run from repo root using `opa test assets/libraries/ -v`
 package generic.cicd
 
+import rego.v1
+
 # Test dangerous_triggers constant
-test_dangerous_triggers_list {
+test_dangerous_triggers_list if {
 	count(dangerous_triggers) == 2
 	dangerous_triggers[0] == "pull_request_target"
 	dangerous_triggers[1] == "workflow_run"
 }
 
 # Test has_dangerous_trigger - variant 1: doc.on as string
-test_has_dangerous_trigger_string_match_pull_request_target {
+test_has_dangerous_trigger_string_match_pull_request_target if {
 	doc := {"on": "pull_request_target"}
 	has_dangerous_trigger(doc)
 }
 
-test_has_dangerous_trigger_string_match_workflow_run {
+test_has_dangerous_trigger_string_match_workflow_run if {
 	doc := {"on": "workflow_run"}
 	has_dangerous_trigger(doc)
 }
 
-test_has_dangerous_trigger_string_no_match {
+test_has_dangerous_trigger_string_no_match if {
 	doc := {"on": "push"}
 	not has_dangerous_trigger(doc)
 }
 
 # Test has_dangerous_trigger - variant 2: doc.on as array
-test_has_dangerous_trigger_array_single_dangerous {
+test_has_dangerous_trigger_array_single_dangerous if {
 	doc := {"on": ["pull_request_target"]}
 	has_dangerous_trigger(doc)
 }
 
-test_has_dangerous_trigger_array_multiple_with_dangerous {
+test_has_dangerous_trigger_array_multiple_with_dangerous if {
 	doc := {"on": ["push", "workflow_run"]}
 	has_dangerous_trigger(doc)
 }
 
-test_has_dangerous_trigger_array_no_dangerous {
+test_has_dangerous_trigger_array_no_dangerous if {
 	doc := {"on": ["push", "pull_request"]}
 	not has_dangerous_trigger(doc)
 }
 
 # Test has_dangerous_trigger - variant 3: doc.on as object
-test_has_dangerous_trigger_object_pull_request_target {
+test_has_dangerous_trigger_object_pull_request_target if {
 	doc := {"on": {"pull_request_target": {}}}
 	has_dangerous_trigger(doc)
 }
 
-test_has_dangerous_trigger_object_workflow_run {
+test_has_dangerous_trigger_object_workflow_run if {
 	doc := {"on": {"workflow_run": {"workflows": ["build"]}}}
 	has_dangerous_trigger(doc)
 }
 
-test_has_dangerous_trigger_object_multiple_with_dangerous {
+test_has_dangerous_trigger_object_multiple_with_dangerous if {
 	doc := {"on": {"push": {}, "pull_request_target": {}}}
 	has_dangerous_trigger(doc)
 }
 
-test_has_dangerous_trigger_object_no_dangerous {
+test_has_dangerous_trigger_object_no_dangerous if {
 	doc := {"on": {"push": {}, "pull_request": {}}}
 	not has_dangerous_trigger(doc)
 }
 
 # Test is_composite_action
-test_is_composite_action_true {
+test_is_composite_action_true if {
 	doc := {"runs": {"using": "composite"}}
 	is_composite_action(doc)
 }
 
-test_is_composite_action_false_node {
+test_is_composite_action_false_node if {
 	doc := {"runs": {"using": "node20"}}
 	not is_composite_action(doc)
 }
 
-test_is_composite_action_false_docker {
+test_is_composite_action_false_docker if {
 	doc := {"runs": {"using": "docker"}}
 	not is_composite_action(doc)
 }
 
-test_is_composite_action_no_runs {
+test_is_composite_action_no_runs if {
 	doc := {"jobs": {}}
 	not is_composite_action(doc)
 }
 
 # Test references_untrusted_context - inputs.*
-test_references_untrusted_context_inputs {
+test_references_untrusted_context_inputs if {
 	raw := "${{ inputs.branch }}"
 	references_untrusted_context(raw)
 }
 
-test_references_untrusted_context_inputs_multiple {
+test_references_untrusted_context_inputs_multiple if {
 	raw := "echo ${{ inputs.username }} ${{ inputs.password }}"
 	references_untrusted_context(raw)
 }
 
 # Test references_untrusted_context - github.event.*
-test_references_untrusted_context_github_event {
+test_references_untrusted_context_github_event if {
 	raw := "${{ github.event.issue.title }}"
 	references_untrusted_context(raw)
 }
 
-test_references_untrusted_context_github_event_pull_request {
+test_references_untrusted_context_github_event_pull_request if {
 	raw := "${{ github.event.pull_request.head.ref }}"
 	references_untrusted_context(raw)
 }
 
 # Test references_untrusted_context - github.head_ref
-test_references_untrusted_context_head_ref {
+test_references_untrusted_context_head_ref if {
 	raw := "${{ github.head_ref }}"
 	references_untrusted_context(raw)
 }
 
-test_references_untrusted_context_head_ref_in_command {
+test_references_untrusted_context_head_ref_in_command if {
 	raw := "git checkout ${{ github.head_ref }}"
 	references_untrusted_context(raw)
 }
 
 # Test references_untrusted_context - github.pull_request.*
-test_references_untrusted_context_pull_request {
+test_references_untrusted_context_pull_request if {
 	raw := "${{ github.pull_request.title }}"
 	references_untrusted_context(raw)
 }
 
-test_references_untrusted_context_pull_request_number {
+test_references_untrusted_context_pull_request_number if {
 	raw := "${{ github.pull_request.number }}"
 	references_untrusted_context(raw)
 }
 
 # Test references_untrusted_context - safe contexts
-test_references_untrusted_context_safe_github_sha {
+test_references_untrusted_context_safe_github_sha if {
 	raw := "${{ github.sha }}"
 	not references_untrusted_context(raw)
 }
 
-test_references_untrusted_context_safe_github_ref {
+test_references_untrusted_context_safe_github_ref if {
 	raw := "${{ github.ref }}"
 	not references_untrusted_context(raw)
 }
 
-test_references_untrusted_context_safe_github_actor {
+test_references_untrusted_context_safe_github_actor if {
 	raw := "${{ github.actor }}"
 	not references_untrusted_context(raw)
 }
 
-test_references_untrusted_context_safe_secrets {
+test_references_untrusted_context_safe_secrets if {
 	raw := "${{ secrets.TOKEN }}"
 	not references_untrusted_context(raw)
 }
 
-test_references_untrusted_context_plain_text {
+test_references_untrusted_context_plain_text if {
 	raw := "echo hello world"
 	not references_untrusted_context(raw)
 }
 
 # Test is_bare_inputs_dereference
-test_is_bare_inputs_dereference_true {
+test_is_bare_inputs_dereference_true if {
 	node := {
 		"type": "dereference_expression",
 		"children": [{
@@ -166,7 +168,7 @@ test_is_bare_inputs_dereference_true {
 	is_bare_inputs_dereference(node)
 }
 
-test_is_bare_inputs_dereference_case_insensitive {
+test_is_bare_inputs_dereference_case_insensitive if {
 	node := {
 		"type": "dereference_expression",
 		"children": [{
@@ -177,7 +179,7 @@ test_is_bare_inputs_dereference_case_insensitive {
 	is_bare_inputs_dereference(node)
 }
 
-test_is_bare_inputs_dereference_false_github_event {
+test_is_bare_inputs_dereference_false_github_event if {
 	node := {
 		"type": "dereference_expression",
 		"children": [{
@@ -188,7 +190,7 @@ test_is_bare_inputs_dereference_false_github_event {
 	not is_bare_inputs_dereference(node)
 }
 
-test_is_bare_inputs_dereference_false_wrong_type {
+test_is_bare_inputs_dereference_false_wrong_type if {
 	node := {
 		"type": "identifier",
 		"value": "inputs",
@@ -196,7 +198,7 @@ test_is_bare_inputs_dereference_false_wrong_type {
 	not is_bare_inputs_dereference(node)
 }
 
-test_is_bare_inputs_dereference_false_wrong_child_type {
+test_is_bare_inputs_dereference_false_wrong_child_type if {
 	node := {
 		"type": "dereference_expression",
 		"children": [{
@@ -208,64 +210,64 @@ test_is_bare_inputs_dereference_false_wrong_child_type {
 }
 
 # Test check_provider - github via .github/ path
-test_check_provider_github_workflows {
+test_check_provider_github_workflows if {
 	doc := {"_path": "/repo/.github/workflows/ci.yml"}
 	result := check_provider(doc)
 	result == "github"
 }
 
-test_check_provider_github_actions {
+test_check_provider_github_actions if {
 	doc := {"_path": "/repo/.github/actions/custom/action.yml"}
 	result := check_provider(doc)
 	result == "github"
 }
 
 # Test check_provider - github via action.yml/action.yaml
-test_check_provider_github_action_yml {
+test_check_provider_github_action_yml if {
 	doc := {"_path": "/repo/custom-action/action.yml"}
 	result := check_provider(doc)
 	result == "github"
 }
 
-test_check_provider_github_action_yaml {
+test_check_provider_github_action_yaml if {
 	doc := {"_path": "/repo/custom-action/action.yaml"}
 	result := check_provider(doc)
 	result == "github"
 }
 
-test_check_provider_github_root_action {
+test_check_provider_github_root_action if {
 	doc := {"_path": "/action.yml"}
 	result := check_provider(doc)
 	result == "github"
 }
 
 # Test check_provider - other providers
-test_check_provider_other_gitlab {
+test_check_provider_other_gitlab if {
 	doc := {"_path": "/repo/.gitlab-ci.yml"}
 	result := check_provider(doc)
 	result == "other"
 }
 
-test_check_provider_other_circleci {
+test_check_provider_other_circleci if {
 	doc := {"_path": "/repo/.circleci/config.yml"}
 	result := check_provider(doc)
 	result == "other"
 }
 
-test_check_provider_other_random_file {
+test_check_provider_other_random_file if {
 	doc := {"_path": "/repo/some/file.yml"}
 	result := check_provider(doc)
 	result == "other"
 }
 
-test_check_provider_other_no_path {
+test_check_provider_other_no_path if {
 	doc := {}
 	result := check_provider(doc)
 	result == "other"
 }
 
 # Test edge cases - complex nested structures
-test_has_dangerous_trigger_complex_workflow {
+test_has_dangerous_trigger_complex_workflow if {
 	doc := {
 		"on": {
 			"push": {"branches": ["main"]},
@@ -276,20 +278,18 @@ test_has_dangerous_trigger_complex_workflow {
 	has_dangerous_trigger(doc)
 }
 
-test_references_untrusted_context_multiple_types {
+test_references_untrusted_context_multiple_types if {
 	raw := "echo ${{ inputs.name }} from ${{ github.event.sender.login }}"
 	references_untrusted_context(raw)
 }
 
-test_composite_action_with_steps {
-	doc := {
-		"runs": {
-			"using": "composite",
-			"steps": [
-				{"run": "echo hello"},
-				{"uses": "actions/checkout@v2"},
-			],
-		},
-	}
+test_composite_action_with_steps if {
+	doc := {"runs": {
+		"using": "composite",
+		"steps": [
+			{"run": "echo hello"},
+			{"uses": "actions/checkout@v2"},
+		],
+	}}
 	is_composite_action(doc)
 }

--- a/assets/libraries/test/cloudformation_test.rego
+++ b/assets/libraries/test/cloudformation_test.rego
@@ -3,76 +3,78 @@
 # Run from repo root using `opa test assets/libraries/ -v`
 package generic.cloudformation
 
+import rego.v1
+
 # Test normalize_cloudFormation_boolean function
-test_normalize_cloudFormation_boolean_true_bool {
+test_normalize_cloudFormation_boolean_true_bool if {
 	result := normalize_cloudFormation_boolean(true)
 	result == "true"
 }
 
-test_normalize_cloudFormation_boolean_true_string {
+test_normalize_cloudFormation_boolean_true_string if {
 	result := normalize_cloudFormation_boolean("true")
 	result == "true"
 }
 
-test_normalize_cloudFormation_boolean_yes {
+test_normalize_cloudFormation_boolean_yes if {
 	result := normalize_cloudFormation_boolean("yes")
 	result == "true"
 }
 
-test_normalize_cloudFormation_boolean_on {
+test_normalize_cloudFormation_boolean_on if {
 	result := normalize_cloudFormation_boolean("on")
 	result == "true"
 }
 
-test_normalize_cloudFormation_boolean_false {
+test_normalize_cloudFormation_boolean_false if {
 	result := normalize_cloudFormation_boolean(false)
 	result == "false"
 }
 
-test_normalize_cloudFormation_boolean_other {
+test_normalize_cloudFormation_boolean_other if {
 	result := normalize_cloudFormation_boolean("random")
 	result == "false"
 }
 
 # Test isLoadBalancer function
-test_is_load_balancer_classic {
+test_is_load_balancer_classic if {
 	resource := {"Type": "AWS::ElasticLoadBalancing::LoadBalancer"}
 	isLoadBalancer(resource)
 }
 
-test_is_load_balancer_v2 {
+test_is_load_balancer_v2 if {
 	resource := {"Type": "AWS::ElasticLoadBalancingV2::LoadBalancer"}
 	isLoadBalancer(resource)
 }
 
-test_is_not_load_balancer {
+test_is_not_load_balancer if {
 	resource := {"Type": "AWS::EC2::Instance"}
 	not isLoadBalancer(resource)
 }
 
 # Test checkAction function
-test_check_action_wildcard_string {
+test_check_action_wildcard_string if {
 	checkAction("*", "*")
 }
 
-test_check_action_contains_string {
+test_check_action_contains_string if {
 	checkAction("s3:getobject", "getobject")
 }
 
-test_check_action_wildcard_array {
+test_check_action_wildcard_array if {
 	checkAction(["*"], "*")
 }
 
-test_check_action_contains_array {
+test_check_action_contains_array if {
 	checkAction(["s3:GetObject", "s3:PutObject"], "getobject")
 }
 
-test_check_action_no_match {
+test_check_action_no_match if {
 	not checkAction("s3:DeleteObject", "getobject")
 }
 
 # Test getResourcesByType function
-test_get_resources_by_type_found {
+test_get_resources_by_type_found if {
 	resources := [
 		{"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "bucket1"}},
 		{"Type": "AWS::EC2::Instance", "Properties": {"InstanceType": "t2.micro"}},
@@ -83,97 +85,95 @@ test_get_resources_by_type_found {
 	result[0].Properties.BucketName == "bucket1"
 }
 
-test_get_resources_by_type_not_found {
-	resources := [
-		{"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "bucket1"}},
-	]
+test_get_resources_by_type_not_found if {
+	resources := [{"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "bucket1"}}]
 	result := getResourcesByType(resources, "AWS::EC2::Instance")
 	count(result) == 0
 }
 
-test_get_resources_by_type_empty {
+test_get_resources_by_type_empty if {
 	resources := []
 	result := getResourcesByType(resources, "AWS::S3::Bucket")
 	count(result) == 0
 }
 
 # Test getBucketName function
-test_get_bucket_name_string {
+test_get_bucket_name_string if {
 	resource := {"Properties": {"Bucket": "my-bucket"}}
 	result := getBucketName(resource)
 	result == "my-bucket"
 }
 
-test_get_bucket_name_ref {
+test_get_bucket_name_ref if {
 	resource := {"Properties": {"Bucket": {"Ref": "MyBucketRef"}}}
 	result := getBucketName(resource)
 	result == "MyBucketRef"
 }
 
 # Test get_encryption function
-test_get_encryption_encrypted_true {
+test_get_encryption_encrypted_true if {
 	resource := {"Properties": {"Encrypted": true}}
 	result := get_encryption(resource)
 	result == "encrypted"
 }
 
-test_get_encryption_with_encryption_specification {
+test_get_encryption_with_encryption_specification if {
 	resource := {"Properties": {"EncryptionSpecification": {"SSEEnabled": true}}}
 	result := get_encryption(resource)
 	result == "encrypted"
 }
 
-test_get_encryption_with_kms_key {
+test_get_encryption_with_kms_key if {
 	resource := {"Properties": {"KmsMasterKeyId": "arn:aws:kms:..."}}
 	result := get_encryption(resource)
 	result == "encrypted"
 }
 
-test_get_encryption_with_encryption_info {
+test_get_encryption_with_encryption_info if {
 	resource := {"Properties": {"EncryptionInfo": {"EncryptionAtRest": {}}}}
 	result := get_encryption(resource)
 	result == "encrypted"
 }
 
-test_get_encryption_with_encryption_options {
+test_get_encryption_with_encryption_options if {
 	resource := {"Properties": {"EncryptionOptions": {"Enabled": true}}}
 	result := get_encryption(resource)
 	result == "encrypted"
 }
 
-test_get_encryption_with_bucket_encryption {
+test_get_encryption_with_bucket_encryption if {
 	resource := {"Properties": {"BucketEncryption": {"ServerSideEncryptionConfiguration": []}}}
 	result := get_encryption(resource)
 	result == "encrypted"
 }
 
-test_get_encryption_with_stream_encryption {
+test_get_encryption_with_stream_encryption if {
 	resource := {"Properties": {"StreamEncryption": {"StreamEncryptionType": "KMS"}}}
 	result := get_encryption(resource)
 	result == "encrypted"
 }
 
-test_get_encryption_unencrypted {
+test_get_encryption_unencrypted if {
 	resource := {"Properties": {"Name": "my-resource"}}
 	result := get_encryption(resource)
 	result == "unencrypted"
 }
 
 # Test get_name function
-test_get_name_with_ref {
+test_get_name_with_ref if {
 	targetName := {"Ref": "MyResource"}
 	result := get_name(targetName)
 	result == "MyResource"
 }
 
-test_get_name_without_ref {
+test_get_name_without_ref if {
 	targetName := "my-resource-name"
 	result := get_name(targetName)
 	result == "my-resource-name"
 }
 
 # Test get_resource_name function
-test_get_resource_name_with_field {
+test_get_resource_name_with_field if {
 	resource := {
 		"Type": "AWS::S3::Bucket",
 		"Properties": {"BucketName": "my-bucket"},
@@ -182,7 +182,7 @@ test_get_resource_name_with_field {
 	result == "my-bucket"
 }
 
-test_get_resource_name_with_tag {
+test_get_resource_name_with_tag if {
 	resource := {
 		"Type": "AWS::EC2::Instance",
 		"Properties": {"Tags": [
@@ -194,7 +194,7 @@ test_get_resource_name_with_tag {
 	result == "my-instance"
 }
 
-test_get_resource_name_fallback {
+test_get_resource_name_fallback if {
 	resource := {
 		"Type": "AWS::EC2::Instance",
 		"Properties": {},
@@ -203,7 +203,7 @@ test_get_resource_name_fallback {
 	result == "MyInstance"
 }
 
-test_get_resource_name_elb {
+test_get_resource_name_elb if {
 	resource := {
 		"Type": "AWS::ElasticLoadBalancing::LoadBalancer",
 		"Properties": {"LoadBalancerName": "my-elb"},
@@ -212,7 +212,7 @@ test_get_resource_name_elb {
 	result == "my-elb"
 }
 
-test_get_resource_name_elbv2 {
+test_get_resource_name_elbv2 if {
 	resource := {
 		"Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
 		"Properties": {"Name": "my-alb"},
@@ -221,7 +221,7 @@ test_get_resource_name_elbv2 {
 	result == "my-alb"
 }
 
-test_get_resource_name_lambda {
+test_get_resource_name_lambda if {
 	resource := {
 		"Type": "AWS::Lambda::Function",
 		"Properties": {"FunctionName": "my-function"},
@@ -230,7 +230,7 @@ test_get_resource_name_lambda {
 	result == "my-function"
 }
 
-test_get_resource_name_rds {
+test_get_resource_name_rds if {
 	resource := {
 		"Type": "AWS::RDS::DBInstance",
 		"Properties": {"DBName": "mydb"},
@@ -239,7 +239,7 @@ test_get_resource_name_rds {
 	result == "mydb"
 }
 
-test_get_resource_name_api_gateway {
+test_get_resource_name_api_gateway if {
 	resource := {
 		"Type": "AWS::ApiGateway::RestApi",
 		"Properties": {"Name": "my-api"},
@@ -248,7 +248,7 @@ test_get_resource_name_api_gateway {
 	result == "my-api"
 }
 
-test_get_resource_name_dynamodb {
+test_get_resource_name_dynamodb if {
 	resource := {
 		"Type": "AWS::DynamoDB::Table",
 		"Properties": {"TableName": "my-table"},
@@ -257,7 +257,7 @@ test_get_resource_name_dynamodb {
 	result == "my-table"
 }
 
-test_get_resource_name_cloudtrail {
+test_get_resource_name_cloudtrail if {
 	resource := {
 		"Type": "AWS::CloudTrail::Trail",
 		"Properties": {"TrailName": "my-trail"},
@@ -267,101 +267,101 @@ test_get_resource_name_cloudtrail {
 }
 
 # Test getPath function
-test_get_path_with_elements {
+test_get_path_with_elements if {
 	path := ["Resources", "MyBucket", "Properties"]
 	result := getPath(path)
 	result == "Resources.MyBucket.Properties."
 }
 
-test_get_path_empty {
+test_get_path_empty if {
 	path := []
 	result := getPath(path)
 	result == ""
 }
 
-test_get_path_single_element {
+test_get_path_single_element if {
 	path := ["Resources"]
 	result := getPath(path)
 	result == "Resources."
 }
 
 # Test createSearchKey function
-test_create_search_key_without_ref {
+test_create_search_key_without_ref if {
 	elem := {"Name": "my-resource"}
 	result := createSearchKey(elem)
 	result == "=my-resource"
 }
 
-test_create_search_key_with_ref {
+test_create_search_key_with_ref if {
 	elem := {"Name": {"Ref": "MyResourceRef"}}
 	result := createSearchKey(elem)
 	result == ".Ref=MyResourceRef"
 }
 
 # Test UDP ports map
-test_udp_ports_map_dns {
+test_udp_ports_map_dns if {
 	port := udpPortsMap[53]
 	port == "DNS"
 }
 
-test_udp_ports_map_snmp {
+test_udp_ports_map_snmp if {
 	port := udpPortsMap[161]
 	port == "SNMP"
 }
 
-test_udp_ports_map_postgresql {
+test_udp_ports_map_postgresql if {
 	port := udpPortsMap[5432]
 	port == "PostgreSQL"
 }
 
-test_udp_ports_map_memcached {
+test_udp_ports_map_memcached if {
 	port := udpPortsMap[11211]
 	port == "Memcached"
 }
 
 # Test resourceFieldName map
-test_resource_field_name_s3 {
+test_resource_field_name_s3 if {
 	field := resourceFieldName["AWS::S3::Bucket"]
 	field == "BucketName"
 }
 
-test_resource_field_name_lambda {
+test_resource_field_name_lambda if {
 	field := resourceFieldName["AWS::Lambda::Function"]
 	field == "FunctionName"
 }
 
-test_resource_field_name_ec2 {
+test_resource_field_name_ec2 if {
 	field := resourceFieldName["AWS::EC2::Instance"]
 	field == ""
 }
 
-test_resource_field_name_dynamodb {
+test_resource_field_name_dynamodb if {
 	field := resourceFieldName["AWS::DynamoDB::Table"]
 	field == "TableName"
 }
 
-test_resource_field_name_rds {
+test_resource_field_name_rds if {
 	field := resourceFieldName["AWS::RDS::DBInstance"]
 	field == "DBName"
 }
 
-test_resource_field_name_api_gateway_stage {
+test_resource_field_name_api_gateway_stage if {
 	field := resourceFieldName["AWS::ApiGateway::Stage"]
 	field == "StageName"
 }
 
-test_resource_field_name_iam_role {
+test_resource_field_name_iam_role if {
 	field := resourceFieldName["AWS::IAM::Role"]
 	field == "RoleName"
 }
 
-test_resource_field_name_kms {
+test_resource_field_name_kms if {
 	field := resourceFieldName["AWS::KMS::Key"]
 	field == ""
 }
 
 # Test hasSecretManager function
-test_has_secret_manager_found {
+test_has_secret_manager_found if {
 	str := "${MySecret}"
 	document := {
 		"MySecret": {"Type": "AWS::SecretsManager::Secret"},
@@ -370,7 +370,7 @@ test_has_secret_manager_found {
 	hasSecretManager(str, document)
 }
 
-test_has_secret_manager_not_found {
+test_has_secret_manager_not_found if {
 	str := "${MySecret}"
 	document := {
 		"MySecret": {"Type": "AWS::S3::Bucket"},
@@ -379,16 +379,14 @@ test_has_secret_manager_not_found {
 	not hasSecretManager(str, document)
 }
 
-test_has_secret_manager_missing_resource {
+test_has_secret_manager_missing_resource if {
 	str := "${NonExistentSecret}"
-	document := {
-		"MySecret": {"Type": "AWS::SecretsManager::Secret"},
-	}
+	document := {"MySecret": {"Type": "AWS::SecretsManager::Secret"}}
 	not hasSecretManager(str, document)
 }
 
 # Test get_resource_name: Fn::Sub resolved against parameter defaults
-test_get_resource_name_fn_sub_single_param {
+test_get_resource_name_fn_sub_single_param if {
 	resource := {
 		"Type": "AWS::S3::Bucket",
 		"Properties": {"BucketName": {"Fn::Sub": "my-app-${Env}"}},
@@ -397,7 +395,7 @@ test_get_resource_name_fn_sub_single_param {
 	result == "my-app-prod"
 }
 
-test_get_resource_name_fn_sub_multiple_params {
+test_get_resource_name_fn_sub_multiple_params if {
 	resource := {
 		"Type": "AWS::S3::Bucket",
 		"Properties": {"BucketName": {"Fn::Sub": "${AppName}-${Env}-bucket"}},
@@ -409,7 +407,7 @@ test_get_resource_name_fn_sub_multiple_params {
 	result == "myapp-prod-bucket"
 }
 
-test_get_resource_name_fn_sub_sequence_form {
+test_get_resource_name_fn_sub_sequence_form if {
 	resource := {
 		"Type": "AWS::S3::Bucket",
 		"Properties": {"BucketName": {"Fn::Sub": [
@@ -421,7 +419,7 @@ test_get_resource_name_fn_sub_sequence_form {
 	result == "myapp-prod-bucket"
 }
 
-test_get_resource_name_fn_sub_sequence_ref_var {
+test_get_resource_name_fn_sub_sequence_ref_var if {
 	resource := {
 		"Type": "AWS::S3::Bucket",
 		"Properties": {"BucketName": {"Fn::Sub": [
@@ -433,7 +431,7 @@ test_get_resource_name_fn_sub_sequence_ref_var {
 	result == "myapp-prod-bucket"
 }
 
-test_get_resource_name_fn_sub_with_pseudo_parameters {
+test_get_resource_name_fn_sub_with_pseudo_parameters if {
 	resource := {
 		"Type": "AWS::S3::Bucket",
 		"Properties": {"BucketName": {"Fn::Sub": "my-bucket-${AWS::Region}-${AWS::AccountId}"}},
@@ -442,7 +440,7 @@ test_get_resource_name_fn_sub_with_pseudo_parameters {
 	result == "my-bucket-aws-region-aws-account-id"
 }
 
-test_get_resource_name_fn_sub_unresolvable_falls_back {
+test_get_resource_name_fn_sub_unresolvable_falls_back if {
 	# ${UnknownVar} cannot be resolved — falls back to logical id
 	resource := {
 		"Type": "AWS::S3::Bucket",
@@ -452,7 +450,7 @@ test_get_resource_name_fn_sub_unresolvable_falls_back {
 	result == "MyBucket"
 }
 
-test_get_resource_name_ref_param_default {
+test_get_resource_name_ref_param_default if {
 	resource := {
 		"Type": "AWS::S3::Bucket",
 		"Properties": {"BucketName": {"Ref": "BucketNameParam"}},
@@ -461,7 +459,7 @@ test_get_resource_name_ref_param_default {
 	result == "my-ref-bucket"
 }
 
-test_get_resource_name_ref_no_default_falls_back {
+test_get_resource_name_ref_no_default_falls_back if {
 	resource := {
 		"Type": "AWS::S3::Bucket",
 		"Properties": {"BucketName": {"Ref": "BucketNameParam"}},
@@ -470,7 +468,7 @@ test_get_resource_name_ref_no_default_falls_back {
 	result == "MyBucket"
 }
 
-test_get_resource_name_ref_pseudo_parameter {
+test_get_resource_name_ref_pseudo_parameter if {
 	resource := {
 		"Type": "AWS::S3::Bucket",
 		"Properties": {"BucketName": {"Ref": "AWS::Region"}},
@@ -481,7 +479,7 @@ test_get_resource_name_ref_pseudo_parameter {
 
 # Explicit sequence-form variables take precedence over a same-named parameter
 # default, matching CloudFormation Fn::Sub semantics.
-test_get_resource_name_fn_sub_sequence_overrides_param_default {
+test_get_resource_name_fn_sub_sequence_overrides_param_default if {
 	resource := {
 		"Type": "AWS::S3::Bucket",
 		"Properties": {"BucketName": {"Fn::Sub": [
@@ -495,7 +493,7 @@ test_get_resource_name_fn_sub_sequence_overrides_param_default {
 
 # A non-string Fn::Sub template head (here a nested Fn::If) cannot be resolved,
 # so resolution fails and get_resource_name falls back to the logical id.
-test_get_resource_name_fn_sub_complex_head_falls_back {
+test_get_resource_name_fn_sub_complex_head_falls_back if {
 	resource := {
 		"Type": "AWS::S3::Bucket",
 		"Properties": {"BucketName": {"Fn::Sub": [
@@ -508,7 +506,7 @@ test_get_resource_name_fn_sub_complex_head_falls_back {
 }
 
 # Test get_resource_accessibility function (basic scenarios)
-test_get_resource_accessibility_unknown {
+test_get_resource_accessibility_unknown if {
 	# When no matching policy is found, accessibility should be unknown
 	test_document := [{"Resources": {}}]
 	result := get_resource_accessibility("my-bucket", "AWS::S3::BucketPolicy", "Bucket") with input.document as test_document

--- a/assets/libraries/test/common_test.rego
+++ b/assets/libraries/test/common_test.rego
@@ -3,8 +3,10 @@
 # Run from repo root using `opa test assets/libraries/ -v`
 package generic.common
 
+import rego.v1
+
 # Test build_search_line function
-test_build_search_line_with_path_only {
+test_build_search_line_with_path_only if {
 	result := build_search_line(["father", "son", "grandson"], [])
 	count(result) == 3
 	result[0] == "father"
@@ -12,7 +14,7 @@ test_build_search_line_with_path_only {
 	result[2] == "grandson"
 }
 
-test_build_search_line_with_path_and_obj {
+test_build_search_line_with_path_and_obj if {
 	result := build_search_line(["father", "son"], ["grandson"])
 	count(result) == 3
 	result[0] == "father"
@@ -20,7 +22,7 @@ test_build_search_line_with_path_and_obj {
 	result[2] == "grandson"
 }
 
-test_build_search_line_with_numbers {
+test_build_search_line_with_numbers if {
 	result := build_search_line(["array", 0, "field"], [])
 	count(result) == 3
 	result[0] == "array"
@@ -29,140 +31,138 @@ test_build_search_line_with_numbers {
 }
 
 # Test concat_path function
-test_concat_path_simple {
+test_concat_path_simple if {
 	result := concat_path(["Resources", "MyBucket", "Properties"])
 	result == "Resources.MyBucket.Properties"
 }
 
-test_concat_path_with_numbers {
+test_concat_path_with_numbers if {
 	result := concat_path(["items", 0, "name"])
 	result == "items.name"
 }
 
-test_concat_path_with_special_chars {
+test_concat_path_with_special_chars if {
 	result := concat_path(["field.with.dot", "another=field"])
 	result == "{{field.with.dot}}.{{another=field}}"
 }
 
 # Test calc_IP_value function
-test_calc_IP_value_basic {
+test_calc_IP_value_basic if {
 	result := calc_IP_value("192.168.1.1")
 	result == 3232235777
 }
 
-test_calc_IP_value_zero {
+test_calc_IP_value_zero if {
 	result := calc_IP_value("0.0.0.0")
 	result == 0
 }
 
-test_calc_IP_value_max {
+test_calc_IP_value_max if {
 	result := calc_IP_value("255.255.255.255")
 	result == 4294967295
 }
 
 # Test between function
-test_between_true {
+test_between_true if {
 	between(5, 1, 10)
 }
 
-test_between_boundaries {
+test_between_boundaries if {
 	between(10, 10, 10)
 }
 
-test_between_false {
+test_between_false if {
 	not between(15, 1, 10)
 }
 
 # Test inArray function
-test_in_array_found {
+test_in_array_found if {
 	list := ["a", "b", "c"]
 	inArray(list, "b")
 }
 
-test_in_array_not_found {
+test_in_array_not_found if {
 	list := ["a", "b", "c"]
 	not inArray(list, "d")
 }
 
-test_in_array_numbers {
+test_in_array_numbers if {
 	list := [1, 2, 3]
 	inArray(list, 2)
 }
 
 # Test emptyOrNull function
-test_empty_or_null_with_empty_string {
+test_empty_or_null_with_empty_string if {
 	emptyOrNull("")
 }
 
-test_empty_or_null_with_null {
+test_empty_or_null_with_null if {
 	emptyOrNull(null)
 }
 
-test_empty_or_null_with_value {
+test_empty_or_null_with_value if {
 	not emptyOrNull("value")
 }
 
 # Test isPrivateIP function
-test_is_private_ip_class_a {
+test_is_private_ip_class_a if {
 	isPrivateIP("10.0.0.1")
 }
 
-test_is_private_ip_class_b {
+test_is_private_ip_class_b if {
 	isPrivateIP("172.16.0.1")
 }
 
-test_is_private_ip_class_c {
+test_is_private_ip_class_c if {
 	isPrivateIP("192.168.1.1")
 }
 
-test_is_not_private_ip {
+test_is_not_private_ip if {
 	not isPrivateIP("8.8.8.8")
 }
 
 # Test equalsOrInArray function
-test_equals_or_in_array_string_match {
+test_equals_or_in_array_string_match if {
 	equalsOrInArray("allow", "allow")
 }
 
-test_equals_or_in_array_string_case_insensitive {
+test_equals_or_in_array_string_case_insensitive if {
 	equalsOrInArray("Allow", "allow")
 }
 
-test_equals_or_in_array_array_match {
+test_equals_or_in_array_array_match if {
 	equalsOrInArray(["Allow", "Deny"], "allow")
 }
 
-test_equals_or_in_array_no_match {
+test_equals_or_in_array_no_match if {
 	not equalsOrInArray("Deny", "allow")
 }
 
 # Test containsOrInArrayContains function
-test_contains_or_in_array_contains_string {
+test_contains_or_in_array_contains_string if {
 	containsOrInArrayContains("allow-all", "allow")
 }
 
-test_contains_or_in_array_contains_array {
+test_contains_or_in_array_contains_array if {
 	containsOrInArrayContains(["allow-all", "deny-some"], "allow")
 }
 
-test_contains_or_in_array_contains_no_match {
+test_contains_or_in_array_contains_no_match if {
 	not containsOrInArrayContains("deny", "allow")
 }
 
 # Test get_statement function
-test_get_statement_array {
-	policy := {
-		"Statement": [
-			{"Effect": "Allow"},
-			{"Effect": "Deny"},
-		],
-	}
+test_get_statement_array if {
+	policy := {"Statement": [
+		{"Effect": "Allow"},
+		{"Effect": "Deny"},
+	]}
 	result := get_statement(policy)
 	count(result) == 2
 	result[0].Effect == "Allow"
 }
 
-test_get_statement_object {
+test_get_statement_object if {
 	policy := {"Statement": {"Effect": "Allow"}}
 	result := get_statement(policy)
 	count(result) == 1
@@ -170,172 +170,166 @@ test_get_statement_object {
 }
 
 # Test is_allow_effect function
-test_is_allow_effect_with_allow {
+test_is_allow_effect_with_allow if {
 	statement := {"Effect": "Allow"}
 	is_allow_effect(statement)
 }
 
-test_is_allow_effect_lowercase {
+test_is_allow_effect_lowercase if {
 	statement := {"effect": "Allow"}
 	is_allow_effect(statement)
 }
 
-test_is_allow_effect_no_effect_field {
+test_is_allow_effect_no_effect_field if {
 	statement := {"Action": "*"}
 	is_allow_effect(statement)
 }
 
-test_is_not_allow_effect {
+test_is_not_allow_effect if {
 	statement := {"Effect": "Deny"}
 	not is_allow_effect(statement)
 }
 
 # Test is_cross_account function
-test_is_cross_account_string {
+test_is_cross_account_string if {
 	statement := {"Principal": {"AWS": "arn:aws:iam::123456789012:root"}}
 	is_cross_account(statement)
 }
 
-test_is_cross_account_array {
+test_is_cross_account_array if {
 	statement := {"Principal": {"AWS": ["arn:aws:sts::123456789012:assumed-role/test"]}}
 	is_cross_account(statement)
 }
 
-test_is_cross_account_account_id {
+test_is_cross_account_account_id if {
 	statement := {"Principal": {"AWS": "123456789012"}}
 	is_cross_account(statement)
 }
 
-test_is_not_cross_account {
+test_is_not_cross_account if {
 	statement := {"Principal": {"AWS": "arn:aws:ec2::123456789012:instance/i-123"}}
 	not is_cross_account(statement)
 }
 
 # Test is_assume_role function
-test_is_assume_role_string {
+test_is_assume_role_string if {
 	statement := {"Action": "sts:AssumeRole"}
 	is_assume_role(statement)
 }
 
-test_is_assume_role_array {
+test_is_assume_role_array if {
 	statement := {"Action": ["sts:AssumeRole", "sts:GetSessionToken"]}
 	is_assume_role(statement)
 }
 
-test_is_not_assume_role {
+test_is_not_assume_role if {
 	statement := {"Action": "s3:GetObject"}
 	not is_assume_role(statement)
 }
 
 # Test has_external_id function
-test_has_external_id_present {
-	statement := {
-		"Condition": {"StringEquals": {"sts:ExternalId": "external123"}},
-	}
+test_has_external_id_present if {
+	statement := {"Condition": {"StringEquals": {"sts:ExternalId": "external123"}}}
 	has_external_id(statement)
 }
 
-test_has_external_id_absent {
+test_has_external_id_absent if {
 	statement := {"Condition": {"StringEquals": {}}}
 	not has_external_id(statement)
 }
 
 # Test has_mfa function
-test_has_mfa_bool_if_exists {
-	statement := {
-		"Condition": {"BoolIfExists": {"aws:MultiFactorAuthPresent": "true"}},
-	}
+test_has_mfa_bool_if_exists if {
+	statement := {"Condition": {"BoolIfExists": {"aws:MultiFactorAuthPresent": "true"}}}
 	has_mfa(statement)
 }
 
-test_has_mfa_bool {
-	statement := {
-		"Condition": {"Bool": {"aws:MultiFactorAuthPresent": "true"}},
-	}
+test_has_mfa_bool if {
+	statement := {"Condition": {"Bool": {"aws:MultiFactorAuthPresent": "true"}}}
 	has_mfa(statement)
 }
 
-test_has_mfa_absent {
+test_has_mfa_absent if {
 	statement := {"Condition": {}}
 	not has_mfa(statement)
 }
 
 # Test any_principal function
-test_any_principal_wildcard_string {
+test_any_principal_wildcard_string if {
 	statement := {"Principal": "*"}
 	any_principal(statement)
 }
 
-test_any_principal_aws_wildcard_string {
+test_any_principal_aws_wildcard_string if {
 	statement := {"Principal": {"AWS": "*"}}
 	any_principal(statement)
 }
 
-test_any_principal_aws_wildcard_array {
+test_any_principal_aws_wildcard_array if {
 	statement := {"Principal": {"AWS": ["*"]}}
 	any_principal(statement)
 }
 
-test_any_principal_no_principal {
+test_any_principal_no_principal if {
 	statement := {"Effect": "Allow"}
 	any_principal(statement)
 }
 
-test_not_any_principal {
+test_not_any_principal if {
 	statement := {"Principal": {"AWS": "arn:aws:iam::123456789012:root"}}
 	not any_principal(statement)
 }
 
 # Test valid_key function
-test_valid_key_exists {
+test_valid_key_exists if {
 	obj := {"key1": "value1", "key2": "value2"}
 	valid_key(obj, "key1")
 }
 
-test_valid_key_not_exists {
+test_valid_key_not_exists if {
 	obj := {"key1": "value1"}
 	not valid_key(obj, "key2")
 }
 
-test_valid_key_null_value {
+test_valid_key_null_value if {
 	obj := {"key1": null}
 	not valid_key(obj, "key1")
 }
 
 # Test expired function
-test_expired_past_date {
+test_expired_past_date if {
 	# Date in the past: January 1, 2000
 	expired([2000, 1, 1])
 }
 
-test_not_expired_future_date {
+test_not_expired_future_date if {
 	# Date in the future: January 1, 2030
 	not expired([2030, 1, 1])
 }
 
 # Test unsecured_cors_rule function
-test_unsecured_cors_all_methods {
+test_unsecured_cors_all_methods if {
 	methods := ["GET", "PUT", "POST", "DELETE", "HEAD"]
 	headers := ["Content-Type"]
 	origins := ["https://example.com"]
 	unsecured_cors_rule(methods, headers, origins)
 }
 
-test_unsecured_cors_wildcard_headers {
+test_unsecured_cors_wildcard_headers if {
 	methods := ["GET"]
 	headers := ["*"]
 	origins := ["https://example.com"]
 	unsecured_cors_rule(methods, headers, origins)
 }
 
-test_unsecured_cors_wildcard_origins {
+test_unsecured_cors_wildcard_origins if {
 	methods := ["GET"]
 	headers := ["Content-Type"]
 	origins := ["*"]
 	unsecured_cors_rule(methods, headers, origins)
 }
 
-test_secured_cors_rule {
+test_secured_cors_rule if {
 	methods := ["GET", "POST"]
 	headers := ["Content-Type"]
 	origins := ["https://example.com"]
@@ -343,105 +337,103 @@ test_secured_cors_rule {
 }
 
 # Test is_ingress function
-test_is_ingress_no_direction {
+test_is_ingress_no_direction if {
 	firewall := {"protocol": "tcp"}
 	is_ingress(firewall)
 }
 
-test_is_ingress_explicit {
+test_is_ingress_explicit if {
 	firewall := {"direction": "INGRESS"}
 	is_ingress(firewall)
 }
 
-test_is_not_ingress {
+test_is_not_ingress if {
 	firewall := {"direction": "EGRESS"}
 	not is_ingress(firewall)
 }
 
 # Test is_recommended_tls function
-test_is_recommended_tls_2018 {
+test_is_recommended_tls_2018 if {
 	is_recommended_tls("TLSv1.2_2018")
 }
 
-test_is_recommended_tls_2019 {
+test_is_recommended_tls_2019 if {
 	is_recommended_tls("TLSv1.2_2019")
 }
 
-test_is_recommended_tls_2021 {
+test_is_recommended_tls_2021 if {
 	is_recommended_tls("TLSv1.2_2021")
 }
 
-test_is_not_recommended_tls {
+test_is_not_recommended_tls if {
 	not is_recommended_tls("TLSv1.0")
 }
 
 # Test is_unrestricted function
-test_is_unrestricted_ipv4 {
+test_is_unrestricted_ipv4 if {
 	is_unrestricted("0.0.0.0/0")
 }
 
-test_is_unrestricted_ipv6 {
+test_is_unrestricted_ipv6 if {
 	is_unrestricted("::/0")
 }
 
-test_is_not_unrestricted {
+test_is_not_unrestricted if {
 	not is_unrestricted("10.0.0.0/16")
 }
 
 # Test check_principals function
-test_check_principals_identifiers {
-	statement := {
-		"principals": {
-			"identifiers": ["*"],
-			"type": "AWS",
-		},
-	}
+test_check_principals_identifiers if {
+	statement := {"principals": {
+		"identifiers": ["*"],
+		"type": "AWS",
+	}}
 	check_principals(statement)
 }
 
-test_check_principals_object {
+test_check_principals_object if {
 	statement := {"Principal": {"AWS": "*"}}
 	check_principals(statement)
 }
 
-test_check_principals_string {
+test_check_principals_string if {
 	statement := {"Principal": "*"}
 	check_principals(statement)
 }
 
-test_check_principals_no_wildcard {
+test_check_principals_no_wildcard if {
 	statement := {"Principal": {"AWS": "arn:aws:iam::123456789012:root"}}
 	not check_principals(statement)
 }
 
 # Test check_actions function
-test_check_actions_lowercase_array {
+test_check_actions_lowercase_array if {
 	statement := {"actions": ["s3:GetObject", "s3:PutObject"]}
 	check_actions(statement, "s3:GetObject")
 }
 
-test_check_actions_uppercase_array {
+test_check_actions_uppercase_array if {
 	statement := {"Actions": ["s3:GetObject"]}
 	check_actions(statement, "s3:GetObject")
 }
 
-test_check_actions_wildcard {
+test_check_actions_wildcard if {
 	statement := {"Action": "*"}
 	check_actions(statement, "s3:GetObject")
 }
 
-test_check_actions_no_match {
+test_check_actions_no_match if {
 	statement := {"Action": ["s3:GetObject"]}
 	not check_actions(statement, "s3:PutObject")
 }
 
 # Test has_wildcard function
-test_has_wildcard_principals {
+test_has_wildcard_principals if {
 	statement := {"Principal": "*", "Action": "s3:GetObject"}
 	has_wildcard(statement, "s3:GetObject")
 }
 
-test_has_wildcard_actions {
+test_has_wildcard_actions if {
 	statement := {
 		"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
 		"Action": "*",
@@ -450,192 +442,188 @@ test_has_wildcard_actions {
 }
 
 # Test isOSDir function
-test_is_os_dir_root {
+test_is_os_dir_root if {
 	isOSDir("/")
 }
 
-test_is_os_dir_bin {
+test_is_os_dir_bin if {
 	isOSDir("/bin")
 }
 
-test_is_os_dir_etc {
+test_is_os_dir_etc if {
 	isOSDir("/etc")
 }
 
-test_is_os_dir_nested {
+test_is_os_dir_nested if {
 	isOSDir("/etc/config")
 }
 
-test_is_not_os_dir {
+test_is_not_os_dir if {
 	not isOSDir("/app")
 }
 
 # Test compareArrays function
-test_compare_arrays_match {
+test_compare_arrays_match if {
 	arrayOne := ["Allow", "Deny"]
 	arrayTwo := ["allow", "deny"]
 	compareArrays(arrayOne, arrayTwo)
 }
 
-test_compare_arrays_no_match {
+test_compare_arrays_no_match if {
 	arrayOne := ["Allow"]
 	arrayTwo := ["Deny"]
 	not compareArrays(arrayOne, arrayTwo)
 }
 
 # Test weakCipher function with IANA format
-test_weak_cipher_iana_null {
+test_weak_cipher_iana_null if {
 	weakCipher("TLS_NULL_WITH_NULL_NULL")
 }
 
-test_weak_cipher_iana_rc4 {
+test_weak_cipher_iana_rc4 if {
 	weakCipher("TLS_RSA_WITH_RC4_128_MD5")
 }
 
-test_weak_cipher_iana_des {
+test_weak_cipher_iana_des if {
 	weakCipher("TLS_RSA_WITH_DES_CBC_SHA")
 }
 
 # Test weakCipher function with OpenSSL format
-test_weak_cipher_openssl_null {
+test_weak_cipher_openssl_null if {
 	weakCipher("NULL-MD5")
 }
 
-test_weak_cipher_openssl_des {
+test_weak_cipher_openssl_des if {
 	weakCipher("DES-CBC3-SHA")
 }
 
-test_weak_cipher_openssl_rc4 {
+test_weak_cipher_openssl_rc4 if {
 	weakCipher("AES128-SHA")
 }
 
 # Test weakCipher function with GnuTLS format
-test_weak_cipher_gnutls_null {
+test_weak_cipher_gnutls_null if {
 	weakCipher("TLS_RSA_NULL_MD5")
 }
 
-test_weak_cipher_gnutls_arcfour {
+test_weak_cipher_gnutls_arcfour if {
 	weakCipher("TLS_RSA_ARCFOUR_128_MD5")
 }
 
-test_weak_cipher_gnutls_des {
+test_weak_cipher_gnutls_des if {
 	weakCipher("TLS_RSA_3DES_EDE_CBC_SHA1")
 }
 
 # Test as_array function
-test_as_array_with_array {
-	input := ["a", "b", "c"]
-	result := as_array(input)
+test_as_array_with_array if {
+	arr := ["a", "b", "c"]
+	result := as_array(arr)
 	count(result) == 3
 	result[0] == "a"
 }
 
-test_as_array_with_single_value {
+test_as_array_with_single_value if {
 	result := as_array("value")
 	count(result) == 1
 	result[0] == "value"
 }
 
-test_as_array_with_number {
+test_as_array_with_number if {
 	result := as_array(42)
 	count(result) == 1
 	result[0] == 42
 }
 
 # Test contains_element function
-test_contains_element_found {
+test_contains_element_found if {
 	arr := ["a", "b", "c"]
 	contains_element(arr, "b")
 }
 
-test_contains_element_not_found {
+test_contains_element_not_found if {
 	arr := ["a", "b", "c"]
 	not contains_element(arr, "d")
 }
 
 # Test contains_with_size function
-test_contains_with_size_found {
+test_contains_with_size_found if {
 	arr := ["allow-all", "deny-some"]
 	contains_with_size(arr, "allow")
 }
 
-test_contains_with_size_not_found {
+test_contains_with_size_not_found if {
 	arr := ["deny-all", "deny-some"]
 	not contains_with_size(arr, "allow")
 }
 
-test_contains_with_size_empty_array {
+test_contains_with_size_empty_array if {
 	arr := []
 	not contains_with_size(arr, "allow")
 }
 
 # Test get_tag_name_if_exists function
-test_get_tag_name_tags_field {
+test_get_tag_name_tags_field if {
 	resource := {"tags": {"Name": "my-resource"}}
 	result := get_tag_name_if_exists(resource)
 	result == "my-resource"
 }
 
-test_get_tag_name_properties_tags_array {
-	resource := {
-		"Properties": {"Tags": [
-			{"Key": "Environment", "Value": "prod"},
-			{"Key": "Name", "Value": "my-bucket"},
-		]},
-	}
+test_get_tag_name_properties_tags_array if {
+	resource := {"Properties": {"Tags": [
+		{"Key": "Environment", "Value": "prod"},
+		{"Key": "Name", "Value": "my-bucket"},
+	]}}
 	result := get_tag_name_if_exists(resource)
 	result == "my-bucket"
 }
 
-test_get_tag_name_properties_tags_object {
-	resource := {
-		"Properties": {"Tags": {
-			"Environment": "prod",
-			"Name": "my-resource",
-		}},
-	}
+test_get_tag_name_properties_tags_object if {
+	resource := {"Properties": {"Tags": {
+		"Environment": "prod",
+		"Name": "my-resource",
+	}}}
 	result := get_tag_name_if_exists(resource)
 	result == "my-resource"
 }
 
 # Test json_unmarshal function
-test_json_unmarshal_object {
+test_json_unmarshal_object if {
 	obj := {"key": "value"}
 	result := json_unmarshal(obj)
 	result.key == "value"
 }
 
-test_json_unmarshal_array {
+test_json_unmarshal_array if {
 	arr := ["a", "b", "c"]
 	result := json_unmarshal(arr)
 	count(result) == 3
 }
 
-test_json_unmarshal_null {
+test_json_unmarshal_null if {
 	result := json_unmarshal(null)
 	is_object(result)
 }
 
-test_json_unmarshal_json_string {
+test_json_unmarshal_json_string if {
 	str := "{\"key\":\"value\"}"
 	result := json_unmarshal(str)
 	result.key == "value"
 }
 
 # Test get_encryption_if_exists function
-test_get_encryption_encrypted_true {
+test_get_encryption_encrypted_true if {
 	resource := {"encrypted": true}
 	result := get_encryption_if_exists(resource)
 	result == "encrypted"
 }
 
-test_get_encryption_with_key {
+test_get_encryption_with_key if {
 	resource := {"kms_master_key_id": "arn:aws:kms:..."}
 	result := get_encryption_if_exists(resource)
 	result == "encrypted"
 }
 
-test_get_encryption_unencrypted {
+test_get_encryption_unencrypted if {
 	resource := {"name": "my-resource"}
 	result := get_encryption_if_exists(resource)
 	result == "unencrypted"

--- a/assets/libraries/test/terraform_test.rego
+++ b/assets/libraries/test/terraform_test.rego
@@ -3,667 +3,569 @@
 # Run from repo root using `opa test assets/libraries/ -v`
 package generic.terraform
 
+import rego.v1
+
 import data.generic.common as common_lib
 
 # Test check_cidr with open access (0.0.0.0/0)
-test_check_cidr_with_cidr_blocks_open {
-    rule := {"cidr_blocks": ["0.0.0.0/0"]}
-    check_cidr(rule)
+test_check_cidr_with_cidr_blocks_open if {
+	rule := {"cidr_blocks": ["0.0.0.0/0"]}
+	check_cidr(rule)
 }
 
-test_check_cidr_with_cidr_block_open {
-    rule := {"cidr_block": "0.0.0.0/0"}
-    check_cidr(rule)
+test_check_cidr_with_cidr_block_open if {
+	rule := {"cidr_block": "0.0.0.0/0"}
+	check_cidr(rule)
 }
 
-test_check_cidr_with_restricted_access {
-    rule := {"cidr_blocks": ["10.0.0.0/16"]}
-    not check_cidr(rule)
+test_check_cidr_with_restricted_access if {
+	rule := {"cidr_blocks": ["10.0.0.0/16"]}
+	not check_cidr(rule)
 }
 
 # Test portOpenToInternet function
-test_port_open_to_internet_allow {
-    rule := {
-        "action": "allow",
-        "cidr_blocks": ["0.0.0.0/0"],
-        "protocol": "tcp",
-        "from_port": 22,
-        "to_port": 22
-    }
-    portOpenToInternet(rule, 22)
+test_port_open_to_internet_allow if {
+	rule := {
+		"action": "allow",
+		"cidr_blocks": ["0.0.0.0/0"],
+		"protocol": "tcp",
+		"from_port": 22,
+		"to_port": 22,
+	}
+	portOpenToInternet(rule, 22)
 }
 
-test_port_open_to_internet_no_action {
-    rule := {
-        "cidr_blocks": ["0.0.0.0/0"],
-        "protocol": "tcp",
-        "from_port": 22,
-        "to_port": 22
-    }
-    portOpenToInternet(rule, 22)
+test_port_open_to_internet_no_action if {
+	rule := {
+		"cidr_blocks": ["0.0.0.0/0"],
+		"protocol": "tcp",
+		"from_port": 22,
+		"to_port": 22,
+	}
+	portOpenToInternet(rule, 22)
 }
 
-test_port_not_open_when_denied {
-    rule := {
-        "action": "deny",
-        "cidr_blocks": ["0.0.0.0/0"],
-        "protocol": "tcp",
-        "from_port": 22,
-        "to_port": 22
-    }
-    not portOpenToInternet(rule, 22)
+test_port_not_open_when_denied if {
+	rule := {
+		"action": "deny",
+		"cidr_blocks": ["0.0.0.0/0"],
+		"protocol": "tcp",
+		"from_port": 22,
+		"to_port": 22,
+	}
+	not portOpenToInternet(rule, 22)
 }
 
-test_port_not_open_with_restricted_cidr {
-    rule := {
-        "action": "allow",
-        "cidr_blocks": ["10.0.0.0/16"],
-        "protocol": "tcp",
-        "from_port": 22,
-        "to_port": 22
-    }
-    not portOpenToInternet(rule, 22)
+test_port_not_open_with_restricted_cidr if {
+	rule := {
+		"action": "allow",
+		"cidr_blocks": ["10.0.0.0/16"],
+		"protocol": "tcp",
+		"from_port": 22,
+		"to_port": 22,
+	}
+	not portOpenToInternet(rule, 22)
 }
 
 # Test containsPort function
-test_contains_port_in_range {
-    rule := {
-        "from_port": 20,
-        "to_port": 25
-    }
-    containsPort(rule, 22)
+test_contains_port_in_range if {
+	rule := {
+		"from_port": 20,
+		"to_port": 25,
+	}
+	containsPort(rule, 22)
 }
 
-test_contains_port_all_ports {
-    rule := {
-        "from_port": 0,
-        "to_port": 0
-    }
-    containsPort(rule, 80)
+test_contains_port_all_ports if {
+	rule := {
+		"from_port": 0,
+		"to_port": 0,
+	}
+	containsPort(rule, 80)
 }
 
-test_contains_port_outside_range {
-    rule := {
-        "from_port": 443,
-        "to_port": 443
-    }
-    not containsPort(rule, 80)
+test_contains_port_outside_range if {
+	rule := {
+		"from_port": 443,
+		"to_port": 443,
+	}
+	not containsPort(rule, 80)
 }
 
 # Test getProtocolList function
-test_get_protocol_list_wildcard_dash {
-    protocols := getProtocolList("-1")
-    count(protocols) == 3
-    protocols[_] == "TCP"
-    protocols[_] == "UDP"
-    protocols[_] == "ICMP"
+test_get_protocol_list_wildcard_dash if {
+	protocols := getProtocolList("-1")
+	count(protocols) == 3
+	protocols[_] == "TCP"
+	protocols[_] == "UDP"
+	protocols[_] == "ICMP"
 }
 
-test_get_protocol_list_wildcard_asterisk {
-    protocols := getProtocolList("*")
-    count(protocols) == 3
+test_get_protocol_list_wildcard_asterisk if {
+	protocols := getProtocolList("*")
+	count(protocols) == 3
 }
 
-test_get_protocol_list_tcp {
-    protocols := getProtocolList("tcp")
-    count(protocols) == 1
-    protocols[0] == "TCP"
+test_get_protocol_list_tcp if {
+	protocols := getProtocolList("tcp")
+	count(protocols) == 1
+	protocols[0] == "TCP"
 }
 
-test_get_protocol_list_udp {
-    protocols := getProtocolList("UDP")
-    count(protocols) == 1
-    protocols[0] == "UDP"
+test_get_protocol_list_udp if {
+	protocols := getProtocolList("UDP")
+	count(protocols) == 1
+	protocols[0] == "UDP"
 }
 
 # Test anyPrincipal function
-test_any_principal_string {
-    statement := {"Principal": "*"}
-    anyPrincipal(statement)
+test_any_principal_string if {
+	statement := {"Principal": "*"}
+	anyPrincipal(statement)
 }
 
-test_any_principal_aws_string {
-    statement := {"Principal": {"AWS": "*"}}
-    anyPrincipal(statement)
+test_any_principal_aws_string if {
+	statement := {"Principal": {"AWS": "*"}}
+	anyPrincipal(statement)
 }
 
-test_any_principal_aws_array {
-    statement := {"Principal": {"AWS": ["*"]}}
-    anyPrincipal(statement)
+test_any_principal_aws_array if {
+	statement := {"Principal": {"AWS": ["*"]}}
+	anyPrincipal(statement)
 }
 
-test_any_principal_service_string {
-    statement := {"Principal": {"Service": "*"}}
-    anyPrincipal(statement)
+test_any_principal_service_string if {
+	statement := {"Principal": {"Service": "*"}}
+	anyPrincipal(statement)
 }
 
-test_any_principal_service_array {
-    statement := {"Principal": {"Service": ["*"]}}
-    anyPrincipal(statement)
+test_any_principal_service_array if {
+	statement := {"Principal": {"Service": ["*"]}}
+	anyPrincipal(statement)
 }
 
-test_any_principal_specific_account {
-    statement := {"Principal": {"AWS": "arn:aws:iam::123456789012:root"}}
-    not anyPrincipal(statement)
+test_any_principal_specific_account if {
+	statement := {"Principal": {"AWS": "arn:aws:iam::123456789012:root"}}
+	not anyPrincipal(statement)
 }
 
 # Test getSpecInfo function
-test_get_spec_info_job_template {
-    resource := {
-        "spec": {
-            "job_template": {
-                "spec": {
-                    "template": {
-                        "spec": {
-                            "containers": [{"name": "test"}]
-                        }
-                    }
-                }
-            }
-        }
-    }
-    result := getSpecInfo(resource)
-    result.path == "spec.job_template.spec.template.spec"
-    result.spec.containers[0].name == "test"
+test_get_spec_info_job_template if {
+	resource := {"spec": {"job_template": {"spec": {"template": {"spec": {"containers": [{"name": "test"}]}}}}}}
+	result := getSpecInfo(resource)
+	result.path == "spec.job_template.spec.template.spec"
+	result.spec.containers[0].name == "test"
 }
 
-test_get_spec_info_template {
-    resource := {
-        "spec": {
-            "template": {
-                "spec": {
-                    "containers": [{"name": "test"}]
-                }
-            }
-        }
-    }
-    result := getSpecInfo(resource)
-    result.path == "spec.template.spec"
-    result.spec.containers[0].name == "test"
+test_get_spec_info_template if {
+	resource := {"spec": {"template": {"spec": {"containers": [{"name": "test"}]}}}}
+	result := getSpecInfo(resource)
+	result.path == "spec.template.spec"
+	result.spec.containers[0].name == "test"
 }
 
-test_get_spec_info_direct {
-    resource := {
-        "spec": {
-            "containers": [{"name": "test"}]
-        }
-    }
-    result := getSpecInfo(resource)
-    result.path == "spec"
-    result.spec.containers[0].name == "test"
+test_get_spec_info_direct if {
+	resource := {"spec": {"containers": [{"name": "test"}]}}
+	result := getSpecInfo(resource)
+	result.path == "spec"
+	result.spec.containers[0].name == "test"
 }
 
 # Test empty_array function
-test_empty_array_with_empty_array {
-    empty_array([])
+test_empty_array_with_empty_array if {
+	empty_array([])
 }
 
-test_empty_array_with_null {
-    empty_array(null)
+test_empty_array_with_null if {
+	empty_array(null)
 }
 
-test_empty_array_with_non_empty_array {
-    not empty_array([1, 2, 3])
+test_empty_array_with_non_empty_array if {
+	not empty_array([1, 2, 3])
 }
 
 # Test has_key function
-test_has_key_exists {
-    obj := {"key1": "value1", "key2": "value2"}
-    has_key(obj, "key1")
+test_has_key_exists if {
+	obj := {"key1": "value1", "key2": "value2"}
+	has_key(obj, "key1")
 }
 
-test_has_key_not_exists {
-    obj := {"key1": "value1"}
-    not has_key(obj, "key2")
+test_has_key_not_exists if {
+	obj := {"key1": "value1"}
+	not has_key(obj, "key2")
 }
 
 # Test getStatement function
-test_get_statement_array {
-    policy := {
-        "Statement": [
-            {"Effect": "Allow", "Action": "*"},
-            {"Effect": "Deny", "Action": "s3:*"}
-        ]
-    }
-    statements := getStatement(policy)
-    count(statements) == 2
-    statements[0].Effect == "Allow"
+test_get_statement_array if {
+	policy := {"Statement": [
+		{"Effect": "Allow", "Action": "*"},
+		{"Effect": "Deny", "Action": "s3:*"},
+	]}
+	statements := getStatement(policy)
+	count(statements) == 2
+	statements[0].Effect == "Allow"
 }
 
-test_get_statement_single {
-    policy := {
-        "Statement": {"Effect": "Allow", "Action": "*"}
-    }
-    statements := getStatement(policy)
-    count(statements) == 1
-    statements[0].Effect == "Allow"
+test_get_statement_single if {
+	policy := {"Statement": {"Effect": "Allow", "Action": "*"}}
+	statements := getStatement(policy)
+	count(statements) == 1
+	statements[0].Effect == "Allow"
 }
 
 # Test is_publicly_accessible function
-test_is_publicly_accessible_with_wildcard_principal {
-    policy := {
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Principal": "*",
-                "Action": "s3:GetObject"
-            }
-        ]
-    }
-    is_publicly_accessible(policy)
+test_is_publicly_accessible_with_wildcard_principal if {
+	policy := {"Statement": [{
+		"Effect": "Allow",
+		"Principal": "*",
+		"Action": "s3:GetObject",
+	}]}
+	is_publicly_accessible(policy)
 }
 
-test_is_publicly_accessible_with_aws_wildcard {
-    policy := {
-        "Statement": {
-            "Effect": "Allow",
-            "Principal": {"AWS": "*"},
-            "Action": "s3:*"
-        }
-    }
-    is_publicly_accessible(policy)
+test_is_publicly_accessible_with_aws_wildcard if {
+	policy := {"Statement": {
+		"Effect": "Allow",
+		"Principal": {"AWS": "*"},
+		"Action": "s3:*",
+	}}
+	is_publicly_accessible(policy)
 }
 
-test_not_publicly_accessible_with_deny {
-    policy := {
-        "Statement": [
-            {
-                "Effect": "Deny",
-                "Principal": "*",
-                "Action": "s3:*"
-            }
-        ]
-    }
-    not is_publicly_accessible(policy)
+test_not_publicly_accessible_with_deny if {
+	policy := {"Statement": [{
+		"Effect": "Deny",
+		"Principal": "*",
+		"Action": "s3:*",
+	}]}
+	not is_publicly_accessible(policy)
 }
 
-test_not_publicly_accessible_with_specific_principal {
-    policy := {
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
-                "Action": "s3:*"
-            }
-        ]
-    }
-    not is_publicly_accessible(policy)
+test_not_publicly_accessible_with_specific_principal if {
+	policy := {"Statement": [{
+		"Effect": "Allow",
+		"Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+		"Action": "s3:*",
+	}]}
+	not is_publicly_accessible(policy)
 }
 
 # Test is_default_password function
-test_is_default_password_with_common_password {
-    is_default_password("password")
+test_is_default_password_with_common_password if {
+	is_default_password("password")
 }
 
-test_is_default_password_with_repetition {
-    is_default_password("user1111")
+test_is_default_password_with_repetition if {
+	is_default_password("user1111")
 }
 
-test_is_default_password_with_zeros {
-    is_default_password("test000")
+test_is_default_password_with_zeros if {
+	is_default_password("test000")
 }
 
-test_not_default_password_valid {
-    not is_default_password("MyStr0ng!Pass")
+test_not_default_password_valid if {
+	not is_default_password("MyStr0ng!Pass")
 }
 
 # Test matches function
-test_matches_with_dot_notation {
-    matches("aws_s3_bucket.my_bucket", "my_bucket")
+test_matches_with_dot_notation if {
+	matches("aws_s3_bucket.my_bucket", "my_bucket")
 }
 
-test_matches_with_exact_match {
-    matches("my_bucket", "my_bucket")
+test_matches_with_exact_match if {
+	matches("my_bucket", "my_bucket")
 }
 
-test_not_matches_different_name {
-    not matches("aws_s3_bucket.other_bucket", "my_bucket")
+test_not_matches_different_name if {
+	not matches("aws_s3_bucket.other_bucket", "my_bucket")
 }
 
 # Test check_member function
-test_check_member_with_members_array {
-    attribute := {"members": ["allUsers", "user:test@example.com"]}
-    check_member(attribute, "allUsers")
+test_check_member_with_members_array if {
+	attribute := {"members": ["allUsers", "user:test@example.com"]}
+	check_member(attribute, "allUsers")
 }
 
-test_check_member_with_member_string {
-    attribute := {"member": "allAuthenticatedUsers"}
-    check_member(attribute, "allAuthenticated")
+test_check_member_with_member_string if {
+	attribute := {"member": "allAuthenticatedUsers"}
+	check_member(attribute, "allAuthenticated")
 }
 
-test_not_check_member_no_match {
-    attribute := {"members": ["user:test@example.com"]}
-    not check_member(attribute, "allUsers")
+test_not_check_member_no_match if {
+	attribute := {"members": ["user:test@example.com"]}
+	not check_member(attribute, "allUsers")
 }
 
 # Test check_aws_resource_supports_tags function
-test_check_aws_resource_supports_tags_s3 {
-    check_aws_resource_supports_tags("aws_s3_bucket")
+test_check_aws_resource_supports_tags_s3 if {
+	check_aws_resource_supports_tags("aws_s3_bucket")
 }
 
-test_check_aws_resource_supports_tags_ec2 {
-    check_aws_resource_supports_tags("aws_instance")
+test_check_aws_resource_supports_tags_ec2 if {
+	check_aws_resource_supports_tags("aws_instance")
 }
 
-test_check_aws_resource_not_supports_tags {
-    not check_aws_resource_supports_tags("aws_unsupported_resource")
+test_check_aws_resource_not_supports_tags if {
+	not check_aws_resource_supports_tags("aws_unsupported_resource")
 }
 
 # Test check_gcp_resource_supports_labels function
-test_check_gcp_resource_supports_labels_storage {
-    check_gcp_resource_supports_labels("google_storage_bucket")
+test_check_gcp_resource_supports_labels_storage if {
+	check_gcp_resource_supports_labels("google_storage_bucket")
 }
 
-test_check_gcp_resource_supports_labels_compute {
-    check_gcp_resource_supports_labels("google_compute_instance")
+test_check_gcp_resource_supports_labels_compute if {
+	check_gcp_resource_supports_labels("google_compute_instance")
 }
 
-test_check_gcp_resource_not_supports_labels {
-    not check_gcp_resource_supports_labels("google_unsupported_resource")
+test_check_gcp_resource_not_supports_labels if {
+	not check_gcp_resource_supports_labels("google_unsupported_resource")
 }
 
 # Test check_azure_resource_supports_tags function
-test_check_azure_resource_supports_tags_storage {
-    check_azure_resource_supports_tags("azurerm_storage_account")
+test_check_azure_resource_supports_tags_storage if {
+	check_azure_resource_supports_tags("azurerm_storage_account")
 }
 
-test_check_azure_resource_supports_tags_vm {
-    check_azure_resource_supports_tags("azurerm_linux_virtual_machine")
+test_check_azure_resource_supports_tags_vm if {
+	check_azure_resource_supports_tags("azurerm_linux_virtual_machine")
 }
 
-test_check_azure_resource_not_supports_tags {
-    not check_azure_resource_supports_tags("azurerm_unsupported_resource")
+test_check_azure_resource_not_supports_tags if {
+	not check_azure_resource_supports_tags("azurerm_unsupported_resource")
 }
 
 # Test portOpenToInternet with arrays
-test_port_open_to_internet_array_allow {
-    rules := [
-        {
-            "action": "allow",
-            "cidr_blocks": ["0.0.0.0/0"],
-            "protocol": "tcp",
-            "from_port": 22,
-            "to_port": 22
-        }
-    ]
-    portOpenToInternet(rules, 22)
+test_port_open_to_internet_array_allow if {
+	rules := [{
+		"action": "allow",
+		"cidr_blocks": ["0.0.0.0/0"],
+		"protocol": "tcp",
+		"from_port": 22,
+		"to_port": 22,
+	}]
+	portOpenToInternet(rules, 22)
 }
 
-test_port_open_to_internet_array_no_action {
-    rules := [
-        {
-            "cidr_blocks": ["0.0.0.0/0"],
-            "protocol": "tcp",
-            "from_port": 80,
-            "to_port": 80
-        }
-    ]
-    portOpenToInternet(rules, 80)
+test_port_open_to_internet_array_no_action if {
+	rules := [{
+		"cidr_blocks": ["0.0.0.0/0"],
+		"protocol": "tcp",
+		"from_port": 80,
+		"to_port": 80,
+	}]
+	portOpenToInternet(rules, 80)
 }
 
-test_port_not_open_to_internet_array_deny {
-    rules := [
-        {
-            "action": "deny",
-            "cidr_blocks": ["0.0.0.0/0"],
-            "protocol": "tcp",
-            "from_port": 22,
-            "to_port": 22
-        }
-    ]
-    not portOpenToInternet(rules, 22)
+test_port_not_open_to_internet_array_deny if {
+	rules := [{
+		"action": "deny",
+		"cidr_blocks": ["0.0.0.0/0"],
+		"protocol": "tcp",
+		"from_port": 22,
+		"to_port": 22,
+	}]
+	not portOpenToInternet(rules, 22)
 }
 
 # Test portOpenToInternet with rule_action (aws_network_acl_rule)
-test_port_open_to_internet_rule_action_allow {
-    rule := {
-        "rule_action": "allow",
-        "cidr_block": "0.0.0.0/0",
-        "protocol": "tcp",
-        "from_port": 3389,
-        "to_port": 3389
-    }
-    portOpenToInternet(rule, 3389)
+test_port_open_to_internet_rule_action_allow if {
+	rule := {
+		"rule_action": "allow",
+		"cidr_block": "0.0.0.0/0",
+		"protocol": "tcp",
+		"from_port": 3389,
+		"to_port": 3389,
+	}
+	portOpenToInternet(rule, 3389)
 }
 
-test_port_not_open_to_internet_rule_action_deny {
-    rule := {
-        "rule_action": "deny",
-        "cidr_block": "0.0.0.0/0",
-        "protocol": "tcp",
-        "from_port": 3389,
-        "to_port": 3389
-    }
-    not portOpenToInternet(rule, 3389)
+test_port_not_open_to_internet_rule_action_deny if {
+	rule := {
+		"rule_action": "deny",
+		"cidr_block": "0.0.0.0/0",
+		"protocol": "tcp",
+		"from_port": 3389,
+		"to_port": 3389,
+	}
+	not portOpenToInternet(rule, 3389)
 }
 
-test_port_not_open_to_internet_rule_action_deny_with_cidr_blocks {
-    rule := {
-        "rule_action": "deny",
-        "cidr_blocks": ["0.0.0.0/0"],
-        "protocol": "tcp",
-        "from_port": 22,
-        "to_port": 22
-    }
-    not portOpenToInternet(rule, 22)
+test_port_not_open_to_internet_rule_action_deny_with_cidr_blocks if {
+	rule := {
+		"rule_action": "deny",
+		"cidr_blocks": ["0.0.0.0/0"],
+		"protocol": "tcp",
+		"from_port": 22,
+		"to_port": 22,
+	}
+	not portOpenToInternet(rule, 22)
 }
 
-test_port_open_to_internet_rule_action_allow_with_port_range {
-    rule := {
-        "rule_action": "allow",
-        "cidr_block": "0.0.0.0/0",
-        "protocol": "tcp",
-        "from_port": 3300,
-        "to_port": 3400
-    }
-    portOpenToInternet(rule, 3389)
+test_port_open_to_internet_rule_action_allow_with_port_range if {
+	rule := {
+		"rule_action": "allow",
+		"cidr_block": "0.0.0.0/0",
+		"protocol": "tcp",
+		"from_port": 3300,
+		"to_port": 3400,
+	}
+	portOpenToInternet(rule, 3389)
 }
 
-test_port_not_open_to_internet_rule_action_with_restricted_cidr {
-    rule := {
-        "rule_action": "allow",
-        "cidr_block": "10.0.0.0/16",
-        "protocol": "tcp",
-        "from_port": 3389,
-        "to_port": 3389
-    }
-    not portOpenToInternet(rule, 3389)
+test_port_not_open_to_internet_rule_action_with_restricted_cidr if {
+	rule := {
+		"rule_action": "allow",
+		"cidr_block": "10.0.0.0/16",
+		"protocol": "tcp",
+		"from_port": 3389,
+		"to_port": 3389,
+	}
+	not portOpenToInternet(rule, 3389)
 }
 
-test_port_not_open_to_internet_rule_action_with_different_protocol {
-    rule := {
-        "rule_action": "allow",
-        "cidr_block": "0.0.0.0/0",
-        "protocol": "udp",
-        "from_port": 3389,
-        "to_port": 3389
-    }
-    not portOpenToInternet(rule, 3389)
+test_port_not_open_to_internet_rule_action_with_different_protocol if {
+	rule := {
+		"rule_action": "allow",
+		"cidr_block": "0.0.0.0/0",
+		"protocol": "udp",
+		"from_port": 3389,
+		"to_port": 3389,
+	}
+	not portOpenToInternet(rule, 3389)
 }
 
 # Test containsPort with destination_port_range
-test_contains_port_destination_range_exact {
-    rule := {
-        "destination_port_range": "22"
-    }
-    containsPort(rule, 22)
+test_contains_port_destination_range_exact if {
+	rule := {"destination_port_range": "22"}
+	containsPort(rule, 22)
 }
 
-test_contains_port_destination_range_list {
-    rule := {
-        "destination_port_range": "80,443,8080"
-    }
-    containsPort(rule, 443)
+test_contains_port_destination_range_list if {
+	rule := {"destination_port_range": "80,443,8080"}
+	containsPort(rule, 443)
 }
 
-test_contains_port_destination_range_with_dash {
-    rule := {
-        "destination_port_range": "8000-8100"
-    }
-    containsPort(rule, 8050)
+test_contains_port_destination_range_with_dash if {
+	rule := {"destination_port_range": "8000-8100"}
+	containsPort(rule, 8050)
 }
 
 # Test get_resource_name function
-test_get_resource_name {
-    resource := {"name": "test-resource"}
-    name := get_resource_name(resource, "my_resource")
-    name == "my_resource"
+test_get_resource_name if {
+	resource := {"name": "test-resource"}
+	name := get_resource_name(resource, "my_resource")
+	name == "my_resource"
 }
 
 # Test get_specific_resource_name function
-test_get_specific_resource_name_s3 {
-    resource := {"bucket": "my-s3-bucket"}
-    name := get_specific_resource_name(resource, "aws_s3_bucket", "resource_def")
-    name == "my-s3-bucket"
+test_get_specific_resource_name_s3 if {
+	resource := {"bucket": "my-s3-bucket"}
+	name := get_specific_resource_name(resource, "aws_s3_bucket", "resource_def")
+	name == "my-s3-bucket"
 }
 
-test_get_specific_resource_name_fallback {
-    resource := {"name": "test"}
-    name := get_specific_resource_name(resource, "aws_instance", "my_instance")
-    name == "my_instance"
+test_get_specific_resource_name_fallback if {
+	resource := {"name": "test"}
+	name := get_specific_resource_name(resource, "aws_instance", "my_instance")
+	name == "my_instance"
 }
 
-test_get_specific_resource_name_rejects_interpolation {
-    resource := {"bucket": "${aws_s3_bucket.foo.id}"}
-    name := get_specific_resource_name(resource, "aws_s3_bucket", "my_bucket")
-    name == "my_bucket"
+test_get_specific_resource_name_rejects_interpolation if {
+	resource := {"bucket": "${aws_s3_bucket.foo.id}"}
+	name := get_specific_resource_name(resource, "aws_s3_bucket", "my_bucket")
+	name == "my_bucket"
 }
 
-test_get_specific_resource_name_rejects_composite_interpolation {
-    resource := {"bucket": "prefix-${var.env}-suffix"}
-    name := get_specific_resource_name(resource, "aws_s3_bucket", "my_bucket")
-    name == "my_bucket"
+test_get_specific_resource_name_rejects_composite_interpolation if {
+	resource := {"bucket": "prefix-${var.env}-suffix"}
+	name := get_specific_resource_name(resource, "aws_s3_bucket", "my_bucket")
+	name == "my_bucket"
 }
 
 # Test resolve_reference_name function
-test_resolve_reference_name_literal {
-    resource := {"bucket": "my-bucket"}
-    name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
-    name == "my-bucket"
+test_resolve_reference_name_literal if {
+	resource := {"bucket": "my-bucket"}
+	name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
+	name == "my-bucket"
 }
 
-test_resolve_reference_name_composite_interpolation_falls_back {
-    resource := {"bucket": "prefix-${var.env}-suffix"}
-    name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
-    name == "fallback_logical"
+test_resolve_reference_name_composite_interpolation_falls_back if {
+	resource := {"bucket": "prefix-${var.env}-suffix"}
+	name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
+	name == "fallback_logical"
 }
 
-test_resolve_reference_name_unknown_reference_falls_back {
-    resource := {"bucket": "${module.x.bucket_id}"}
-    name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
-    name == "fallback_logical"
+test_resolve_reference_name_unknown_reference_falls_back if {
+	resource := {"bucket": "${module.x.bucket_id}"}
+	name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
+	name == "fallback_logical"
 }
 
-test_resolve_reference_name_missing_attribute_falls_back {
-    resource := {"other": "value"}
-    name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
-    name == "fallback_logical"
+test_resolve_reference_name_missing_attribute_falls_back if {
+	resource := {"other": "value"}
+	name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
+	name == "fallback_logical"
 }
 
-test_resolve_reference_name_var_without_default_falls_back {
-    resource := {"bucket": "${var.bucket_name}"}
-    name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
-    name == "fallback_logical"
+test_resolve_reference_name_var_without_default_falls_back if {
+	resource := {"bucket": "${var.bucket_name}"}
+	name := resolve_reference_name(resource, "bucket", "aws_s3_bucket", "fallback_logical")
+	name == "fallback_logical"
 }
 
 # Test resolve_s3_bucket_name function against mock input.document shape
-test_resolve_s3_bucket_name_literal {
-    resource := {"bucket": "my-literal-bucket"}
-    name := resolve_s3_bucket_name(resource, "policy_logical_name") with input as {}
-    name == "my-literal-bucket"
+test_resolve_s3_bucket_name_literal if {
+	resource := {"bucket": "my-literal-bucket"}
+	name := resolve_s3_bucket_name(resource, "policy_logical_name") with input as {}
+	name == "my-literal-bucket"
 }
 
-test_resolve_s3_bucket_name_same_document_reference {
-    mock_input := {
-        "document": [{
-            "resource": {
-                "aws_s3_bucket": {
-                    "my_bucket": {"bucket": "shopist-prod"},
-                },
-                "aws_s3_bucket_policy": {
-                    "my_policy": {"bucket": "${aws_s3_bucket.my_bucket.id}"},
-                },
-            },
-        }],
-    }
-    policy := mock_input.document[0].resource.aws_s3_bucket_policy.my_policy
-    name := resolve_s3_bucket_name(policy, "my_policy") with input as mock_input
-    name == "shopist-prod"
+test_resolve_s3_bucket_name_same_document_reference if {
+	mock_input := {"document": [{"resource": {
+		"aws_s3_bucket": {"my_bucket": {"bucket": "shopist-prod"}},
+		"aws_s3_bucket_policy": {"my_policy": {"bucket": "${aws_s3_bucket.my_bucket.id}"}},
+	}}]}
+	policy := mock_input.document[0].resource.aws_s3_bucket_policy.my_policy
+	name := resolve_s3_bucket_name(policy, "my_policy") with input as mock_input
+	name == "shopist-prod"
 }
 
-test_resolve_s3_bucket_name_cross_document_reference {
-    mock_input := {
-        "document": [
-            {
-                "resource": {
-                    "aws_s3_bucket": {
-                        "my_bucket": {"bucket": "shopist-cross-file"},
-                    },
-                },
-            },
-            {
-                "resource": {
-                    "aws_s3_bucket_policy": {
-                        "my_policy": {"bucket": "${aws_s3_bucket.my_bucket.id}"},
-                    },
-                },
-            },
-        ],
-    }
-    policy := mock_input.document[1].resource.aws_s3_bucket_policy.my_policy
-    name := resolve_s3_bucket_name(policy, "my_policy") with input as mock_input
-    name == "shopist-cross-file"
+test_resolve_s3_bucket_name_cross_document_reference if {
+	mock_input := {"document": [
+		{"resource": {"aws_s3_bucket": {"my_bucket": {"bucket": "shopist-cross-file"}}}},
+		{"resource": {"aws_s3_bucket_policy": {"my_policy": {"bucket": "${aws_s3_bucket.my_bucket.id}"}}}},
+	]}
+	policy := mock_input.document[1].resource.aws_s3_bucket_policy.my_policy
+	name := resolve_s3_bucket_name(policy, "my_policy") with input as mock_input
+	name == "shopist-cross-file"
 }
 
-test_resolve_s3_bucket_name_reference_to_missing_bucket_falls_back {
-    mock_input := {
-        "document": [{
-            "resource": {
-                "aws_s3_bucket_policy": {
-                    "orphan_policy": {"bucket": "${aws_s3_bucket.not_there.id}"},
-                },
-            },
-        }],
-    }
-    policy := mock_input.document[0].resource.aws_s3_bucket_policy.orphan_policy
-    name := resolve_s3_bucket_name(policy, "orphan_policy") with input as mock_input
-    name == "orphan_policy"
+test_resolve_s3_bucket_name_reference_to_missing_bucket_falls_back if {
+	mock_input := {"document": [{"resource": {"aws_s3_bucket_policy": {"orphan_policy": {"bucket": "${aws_s3_bucket.not_there.id}"}}}}]}
+	policy := mock_input.document[0].resource.aws_s3_bucket_policy.orphan_policy
+	name := resolve_s3_bucket_name(policy, "orphan_policy") with input as mock_input
+	name == "orphan_policy"
 }
 
-test_resolve_s3_bucket_name_reference_to_bucket_without_literal_name_returns_target_logical_name {
-    # When the referenced aws_s3_bucket exists in the scan but its `bucket`
-    # attribute is itself unresolvable (e.g. "${var.bucket_name}" with no
-    # default), prefer the target bucket's Terraform logical name over the
-    # companion resource's own logical name -- it is one step closer to the
-    # runtime asset and still jump-to-code-friendly.
-    mock_input := {
-        "document": [{
-            "resource": {
-                "aws_s3_bucket": {
-                    "dynamic": {"bucket": "${var.bucket_name}"},
-                },
-                "aws_s3_bucket_policy": {
-                    "its_policy": {"bucket": "${aws_s3_bucket.dynamic.id}"},
-                },
-            },
-        }],
-    }
-    policy := mock_input.document[0].resource.aws_s3_bucket_policy.its_policy
-    name := resolve_s3_bucket_name(policy, "its_policy") with input as mock_input
-    name == "dynamic"
+test_resolve_s3_bucket_name_reference_to_bucket_without_literal_name_returns_target_logical_name if {
+	# When the referenced aws_s3_bucket exists in the scan but its `bucket`
+	# attribute is itself unresolvable (e.g. "${var.bucket_name}" with no
+	# default), prefer the target bucket's Terraform logical name over the
+	# companion resource's own logical name -- it is one step closer to the
+	# runtime asset and still jump-to-code-friendly.
+	mock_input := {"document": [{"resource": {
+		"aws_s3_bucket": {"dynamic": {"bucket": "${var.bucket_name}"}},
+		"aws_s3_bucket_policy": {"its_policy": {"bucket": "${aws_s3_bucket.dynamic.id}"}},
+	}}]}
+	policy := mock_input.document[0].resource.aws_s3_bucket_policy.its_policy
+	name := resolve_s3_bucket_name(policy, "its_policy") with input as mock_input
+	name == "dynamic"
 }
 
-test_resolve_s3_bucket_name_module_reference_falls_back {
-    mock_input := {
-        "document": [{
-            "resource": {
-                "aws_s3_bucket_policy": {
-                    "modular_policy": {"bucket": "${module.shopist.bucket_id}"},
-                },
-            },
-        }],
-    }
-    policy := mock_input.document[0].resource.aws_s3_bucket_policy.modular_policy
-    name := resolve_s3_bucket_name(policy, "modular_policy") with input as mock_input
-    name == "modular_policy"
+test_resolve_s3_bucket_name_module_reference_falls_back if {
+	mock_input := {"document": [{"resource": {"aws_s3_bucket_policy": {"modular_policy": {"bucket": "${module.shopist.bucket_id}"}}}}]}
+	policy := mock_input.document[0].resource.aws_s3_bucket_policy.modular_policy
+	name := resolve_s3_bucket_name(policy, "modular_policy") with input as mock_input
+	name == "modular_policy"
 }

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -455,7 +455,11 @@ func (c *Inspector) doRun(ctx context.Context, qCtx *QueryContext) (vulns []mode
 		return nil, errors.Wrap(err, "failed to evaluate query")
 	}
 	if c.enableCoverageReport && cov != nil {
-		module, parseErr := ast.ParseModule(qCtx.Query.Metadata.Query, qCtx.Query.Metadata.Content)
+		module, parseErr := ast.ParseModuleWithOpts(
+			qCtx.Query.Metadata.Query,
+			qCtx.Query.Metadata.Content,
+			ast.ParserOptions{RegoVersion: ast.RegoV1},
+		)
 		if parseErr != nil {
 			return nil, errors.Wrap(parseErr, "failed to parse coverage module")
 		}
@@ -772,6 +776,7 @@ func (q QueryLoader) LoadQuery(ctx context.Context, query *model.QueryMetadata,
 		store := inmem.NewFromReader(bytes.NewBufferString(mergedInputData))
 		opaQuery, err = rego.New(
 			rego.Query(regoQuery),
+			rego.SetRegoVersion(ast.RegoV1),
 			rego.Module("Common", q.commonLibrary.LibraryCode),
 			rego.Module("Generic", platformGeneralQuery.LibraryCode),
 			rego.Module(query.Query, query.Content),

--- a/pkg/engine/testdata/simid/query.rego
+++ b/pkg/engine/testdata/simid/query.rego
@@ -1,8 +1,10 @@
 package datadog
 
+import rego.v1
+
 # Minimal rule for TestInspectorSimilarityID: fires on every aws_instance resource.
 # Deliberately avoids library imports so it works with the stubQueriesSource library stub.
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
 	resource := input.document[i].resource.aws_instance[name]
 	result := {
 		"documentId": input.document[i].id,

--- a/pkg/scan/scan_test.go
+++ b/pkg/scan/scan_test.go
@@ -35,8 +35,8 @@ func Test_ExecuteScan(t *testing.T) {
 	const ruleID = "test-execute-scan-rule"
 	rego := `package datadog
 
-DatadogPolicy[result] {
-	resource := input.document[i].resource.aws_s3_bucket[name]
+DatadogPolicy contains result if {
+	input.document[i].resource.aws_s3_bucket[name]
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_bucket",

--- a/pkg/utils/query.go
+++ b/pkg/utils/query.go
@@ -28,8 +28,9 @@ const (
 	// Once all rules have been migrated to DatadogPolicy, this shim can be removed
 	// and RegoQuery simplified back to `result = data.datadog.DatadogPolicy`.
 	RegoCompatShim = `package dd_iac_compat
-policy[r] { r = data.Cx.CxPolicy[_] }
-policy[r] { r = data.datadog.DatadogPolicy[_] }
+
+policy contains r if { r = data.Cx.CxPolicy[_] }
+policy contains r if { r = data.datadog.DatadogPolicy[_] }
 `
 )
 

--- a/test/e2e/testdata/rules/cicd/unpinned_actions_full_length_commit_sha/query.rego
+++ b/test/e2e/testdata/rules/cicd/unpinned_actions_full_length_commit_sha/query.rego
@@ -1,9 +1,11 @@
 package datadog
 
+import rego.v1
+
 import data.generic.cicd as cicd_lib
 import data.generic.common as common_lib
 
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
 	doc := input.document[i]
 	cicd_lib.check_provider(doc) == "github"
 
@@ -18,13 +20,13 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Action pinned to a full length commit SHA.",
 		"keyActualValue": "Action is not pinned to a full length commit SHA.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "uses"],[]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "uses"], []),
 		"resourceType": "github_action",
-		"resourceName": get_object_name(doc.jobs[j].steps[k], "step", k)
+		"resourceName": get_object_name(doc.jobs[j].steps[k], "step", k),
 	}
 }
 
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
 	doc := input.document[i]
 	cicd_lib.check_provider(doc) == "github"
 
@@ -32,24 +34,24 @@ DatadogPolicy[result] {
 	not isAllowed(uses)
 	not isPinned(uses)
 	not isRelative(uses)
-	
+
 	result := {
 		"documentId": doc.id,
 		"searchKey": sprintf("uses={{%s}}", [uses]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Action pinned to a full length commit SHA.",
 		"keyActualValue": "Action is not pinned to a full length commit SHA.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "uses"],[]),
+		"searchLine": common_lib.build_search_line(["jobs", j, "uses"], []),
 		"resourceType": "github_action",
-		"resourceName": get_object_name(doc.jobs[j], "job", j)
+		"resourceName": get_object_name(doc.jobs[j], "job", j),
 	}
 }
 
 # Composite action: `uses` references under `runs.steps[*]` must also be SHA-pinned.
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
 	doc := input.document[i]
 	cicd_lib.check_provider(doc) == "github"
-	
+
 	cicd_lib.is_composite_action(doc)
 
 	step := doc.runs.steps[k]
@@ -66,27 +68,26 @@ DatadogPolicy[result] {
 		"keyActualValue": "Action is not pinned to a full length commit SHA.",
 		"searchLine": common_lib.build_search_line(["runs", "steps", k, "uses"], []),
 		"resourceType": "github_action",
-		"resourceName": object.get(step, "name", sprintf("step-%d", [k]))
+		"resourceName": object.get(step, "name", sprintf("step-%d", [k])),
 	}
 }
 
-
-isAllowed(use){
+isAllowed(use) if {
 	allowed := ["actions/"]
-    startswith(use,allowed[i])
+	startswith(use, allowed[i])
 }
 
-isPinned(use){
+isPinned(use) if {
 	regex.match("@[a-f0-9]{40}$", use)
 }
 
-isRelative(use){
+isRelative(use) if {
 	allowed := ["./"]
-    startswith(use,allowed[i])
+	startswith(use, allowed[i])
 }
 
-get_object_name(object, object_title, index) := object_name {
+get_object_name(object, object_title, index) := object_name if {
 	object_name := object.name
-} else := object_name {
+} else := object_name if {
 	object_name := sprintf("%s-%v", [object_title, index])
 }

--- a/test/e2e/testdata/rules/k8s/container_is_privileged/query.rego
+++ b/test/e2e/testdata/rules/k8s/container_is_privileged/query.rego
@@ -1,10 +1,12 @@
 package datadog
 
+import rego.v1
+
 import data.generic.k8s as k8sLib
 
 types := {"initContainers", "containers"}
 
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
 	document := input.document[i]
 	metadata := document.metadata
 

--- a/test/e2e/testdata/rules/terraform/team_tag_not_present/query.rego
+++ b/test/e2e/testdata/rules/terraform/team_tag_not_present/query.rego
@@ -1,5 +1,7 @@
 package datadog
 
+import rego.v1
+
 import data.generic.common as common_lib
 import data.generic.terraform as tf_lib
 
@@ -7,87 +9,87 @@ import data.generic.terraform as tf_lib
 required_tags := {"Team"}
 
 # Case where "tags" block exists but required tags are missing (including merge({...}, {...}))
-DatadogPolicy[result] {
-    startswith(resource_name, "aws_")
-    tf_lib.check_aws_resource_supports_tags(resource_name)
+DatadogPolicy contains result if {
+	startswith(resource_name, "aws_")
+	tf_lib.check_aws_resource_supports_tags(resource_name)
 
-    resource_type := input.document[i].resource[resource_name][name]
-    common_lib.valid_key(resource_type, "tags")
+	resource_type := input.document[i].resource[resource_name][name]
+	common_lib.valid_key(resource_type, "tags")
 
-    tags := resource_type.tags
+	tags := resource_type.tags
 
-    # Determine all tag keys (including merge scenarios)
-    all_tag_keys := get_all_tag_keys(tags)
+	# Determine all tag keys (including merge scenarios)
+	all_tag_keys := get_all_tag_keys(tags)
 
-    missing_labels := {
-        req_lower |
-        req := required_tags[_]
-        req_lower := lower(req)
-        not key_in_set_ignore_case(req, all_tag_keys)
-    }
+	missing_labels := {
+	req_lower |
+		req := required_tags[_]
+		req_lower := lower(req)
+		not key_in_set_ignore_case(req, all_tag_keys)
+	}
 
-    count(missing_labels) > 0
+	count(missing_labels) > 0
 
-    result := {
-        "documentId": input.document[i].id,
-        "resourceType": resource_name,
-        "resourceName": tf_lib.get_specific_resource_name(resource_type, resource_name, name),
-        "searchKey": sprintf("%s[%s].tags", [resource_name, name]),
-        "issueType": "MissingAttribute",
-        "keyExpectedValue": sprintf("Every resource should have tags: %v", [required_tags]),
-        "keyActualValue": sprintf("Missing tags: %v", [missing_labels]),
-        "searchLine": common_lib.build_search_line(["resource", resource_name, name, "tags"], [])
-    }
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": resource_name,
+		"resourceName": tf_lib.get_specific_resource_name(resource_type, resource_name, name),
+		"searchKey": sprintf("%s[%s].tags", [resource_name, name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("Every resource should have tags: %v", [required_tags]),
+		"keyActualValue": sprintf("Missing tags: %v", [missing_labels]),
+		"searchLine": common_lib.build_search_line(["resource", resource_name, name, "tags"], []),
+	}
 }
 
 # Case where "tags" block is completely missing
-DatadogPolicy[result] {
-    # Only consider resources whose type begins with "aws_"
-    startswith(resource_type, "aws_")
+DatadogPolicy contains result if {
+	# Only consider resources whose type begins with "aws_"
+	startswith(resource_type, "aws_")
 
-    # Only consider resources that support tags
-    tf_lib.check_aws_resource_supports_tags(resource_type)
+	# Only consider resources that support tags
+	tf_lib.check_aws_resource_supports_tags(resource_type)
 
-    resource := input.document[i].resource[resource_type][name]
-    not common_lib.valid_key(resource, "tags")
+	resource := input.document[i].resource[resource_type][name]
+	not common_lib.valid_key(resource, "tags")
 
-    result := {
-        "documentId": input.document[i].id,
-        "resourceType": resource_type,
-        "resourceName": tf_lib.get_specific_resource_name(resource, resource_type, name),
-        "searchKey": sprintf("%s[%s].tags", [resource_type, name]),
-        "issueType": "MissingAttribute",
-        "keyExpectedValue": sprintf("Every resource should have a 'tags' block containing: %v", [required_tags]),
-        "keyActualValue": "'tags' block is missing",
-        "searchLine": common_lib.build_search_line(["resource", resource_type, name], []),
-    }
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": resource_type,
+		"resourceName": tf_lib.get_specific_resource_name(resource, resource_type, name),
+		"searchKey": sprintf("%s[%s].tags", [resource_type, name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("Every resource should have a 'tags' block containing: %v", [required_tags]),
+		"keyActualValue": "'tags' block is missing",
+		"searchLine": common_lib.build_search_line(["resource", resource_type, name], []),
+	}
 }
 
 # Handles merge(...) and normal map by extracting all tag keys
-get_all_tag_keys(tags) = keys {
-    # Case: tags is a plain object
-    type_name(tags) == "object"
-    keys := {k | tags[k]}
-} else = keys {
-    # Case: tags is a merge() function call
-    is_merge_call(tags)
-    keys := {
-        merged_key |
-        some i
-        part := tags.function_args[i]
-        type_name(part) == "object"
-        part[merged_key]
-    }
+get_all_tag_keys(tags) := keys if {
+	# Case: tags is a plain object
+	type_name(tags) == "object"
+	keys := {k | tags[k]}
+} else := keys if {
+	# Case: tags is a merge() function call
+	is_merge_call(tags)
+	keys := {
+	merged_key |
+		some i
+		part := tags.function_args[i]
+		type_name(part) == "object"
+		part[merged_key]
+	}
 }
 
 # Helper: check if `tags` is a merge(...) function call
-is_merge_call(tags) {
-    tags.function == "merge"
-    tags.function_args
+is_merge_call(tags) if {
+	tags.function == "merge"
+	tags.function_args
 }
 
 # Case-insensitive key match
-key_in_set_ignore_case(key, keyset) {
-    k := keyset[_]
-    lower(k) == lower(key)
+key_in_set_ignore_case(key, keyset) if {
+	k := keyset[_]
+	lower(k) == lower(key)
 }

--- a/test/fixtures/all_auth_users_get_read_access/query.rego
+++ b/test/fixtures/all_auth_users_get_read_access/query.rego
@@ -1,6 +1,8 @@
 package datadog
 
-DatadogPolicy[result] {
+import rego.v1
+
+DatadogPolicy contains result if {
 	resource := input.document[i].resource.aws_s3_bucket[name]
 	role = "authenticated-read"
 	resource.acl == role

--- a/test/fixtures/common_query_test/query.rego
+++ b/test/fixtures/common_query_test/query.rego
@@ -1,6 +1,8 @@
 package datadog
 
-DatadogPolicy[result] {
+import rego.v1
+
+DatadogPolicy contains result if {
 	input.document[i]
 
 	result := {

--- a/test/fixtures/experimental_test/queries/redis_disable_experimental/query.rego
+++ b/test/fixtures/experimental_test/queries/redis_disable_experimental/query.rego
@@ -1,6 +1,8 @@
 package datadog
 
-DatadogPolicy[result] {
+import rego.v1
+
+DatadogPolicy contains result if {
 	resource := input.document[i].resource.aws_elasticache_cluster[name]
 	resource.engine != "redis"
 
@@ -15,72 +17,72 @@ DatadogPolicy[result] {
 		"keyActualValue": sprintf("resource.aws_elasticache_cluster[%s].engine doesn't enable Redis", [name]),
 		"remediation": json.marshal({
 			"before": "memcached",
-			"after": "redis"
+			"after": "redis",
 		}),
 		"remediationType": "replacement",
 	}
 }
 
-get_specific_resource_name(resource, resourceType, resourceDefinitionName) = name {
+get_specific_resource_name(resource, resourceType, resourceDefinitionName) := name if {
 	field := resourceFieldName[resourceType]
 	name := resource[field]
-} else = name {
+} else := name if {
 	name := get_resource_name(resource, resourceDefinitionName)
 }
 
-get_resource_name(resource, resourceDefinitionName) = name {
-	name := resource["name"]
-} else = name {
-	name := resource["display_name"]
-}  else = name {
+get_resource_name(resource, resourceDefinitionName) := name if {
+	name := resource.name
+} else := name if {
+	name := resource.display_name
+} else := name if {
 	name := resource.metadata.name
-} else = name {
+} else := name if {
 	prefix := resource.name_prefix
 	name := sprintf("%s<unknown-sufix>", [prefix])
-} else = name {
+} else := name if {
 	name := get_tag_name_if_exists(resource)
-} else = name {
+} else := name if {
 	name := resourceDefinitionName
 }
 
-build_search_line(path, obj) = resolvedPath {
+build_search_line(path, obj) := resolvedPath if {
 	resolveArray := [x | pathItem := path[n]; x := convert_path_item(pathItem)]
 	resolvedObj := [x | objItem := obj[n]; x := convert_path_item(objItem)]
 	resolvedPath = array.concat(resolveArray, resolvedObj)
 }
 
-convert_path_item(pathItem) = convertedPath {
+convert_path_item(pathItem) := convertedPath if {
 	is_number(pathItem)
 	convertedPath := sprintf("%d", [pathItem])
-} else = convertedPath {
+} else := convertedPath if {
 	convertedPath := sprintf("%s", [pathItem])
 }
 
-get_tag_name_if_exists(resource) = name {
+get_tag_name_if_exists(resource) := name if {
 	name := resource.tags.Name
-} else = name {
+} else := name if {
 	tag := resource.Properties.Tags[_]
 	tag.Key == "Name"
 	name := tag.Value
-} else = name {
+} else := name if {
 	tag := resource.Properties.FileSystemTags[_]
 	tag.Key == "Name"
 	name := tag.Value
-} else = name {
+} else := name if {
 	tag := resource.Properties.Tags[key]
 	key == "Name"
 	name := tag
-} else = name {
+} else := name if {
 	tag := resource.spec.forProvider.tags[_]
 	tag.key == "Name"
 	name := tag.value
-} else = name {
+} else := name if {
 	tag := resource.properties.tags[key]
 	key == "Name"
 	name := tag
 }
 
-resourceFieldName = {
+resourceFieldName := {
 	"google_bigquery_dataset": "friendly_name",
 	"alicloud_actiontrail_trail": "trail_name",
 	"alicloud_ros_stack": "stack_name",

--- a/test/fixtures/experimental_test/queries/redis_disabled/query.rego
+++ b/test/fixtures/experimental_test/queries/redis_disabled/query.rego
@@ -1,6 +1,8 @@
 package datadog
 
-DatadogPolicy[result] {
+import rego.v1
+
+DatadogPolicy contains result if {
 	resource := input.document[i].resource.aws_elasticache_cluster[name]
 	resource.engine != "redis"
 
@@ -15,72 +17,72 @@ DatadogPolicy[result] {
 		"keyActualValue": sprintf("resource.aws_elasticache_cluster[%s].engine doesn't enable Redis", [name]),
 		"remediation": json.marshal({
 			"before": "memcached",
-			"after": "redis"
+			"after": "redis",
 		}),
 		"remediationType": "replacement",
 	}
 }
 
-get_specific_resource_name(resource, resourceType, resourceDefinitionName) = name {
+get_specific_resource_name(resource, resourceType, resourceDefinitionName) := name if {
 	field := resourceFieldName[resourceType]
 	name := resource[field]
-} else = name {
+} else := name if {
 	name := get_resource_name(resource, resourceDefinitionName)
 }
 
-get_resource_name(resource, resourceDefinitionName) = name {
-	name := resource["name"]
-} else = name {
-	name := resource["display_name"]
-}  else = name {
+get_resource_name(resource, resourceDefinitionName) := name if {
+	name := resource.name
+} else := name if {
+	name := resource.display_name
+} else := name if {
 	name := resource.metadata.name
-} else = name {
+} else := name if {
 	prefix := resource.name_prefix
 	name := sprintf("%s<unknown-sufix>", [prefix])
-} else = name {
+} else := name if {
 	name := get_tag_name_if_exists(resource)
-} else = name {
+} else := name if {
 	name := resourceDefinitionName
 }
 
-build_search_line(path, obj) = resolvedPath {
+build_search_line(path, obj) := resolvedPath if {
 	resolveArray := [x | pathItem := path[n]; x := convert_path_item(pathItem)]
 	resolvedObj := [x | objItem := obj[n]; x := convert_path_item(objItem)]
 	resolvedPath = array.concat(resolveArray, resolvedObj)
 }
 
-convert_path_item(pathItem) = convertedPath {
+convert_path_item(pathItem) := convertedPath if {
 	is_number(pathItem)
 	convertedPath := sprintf("%d", [pathItem])
-} else = convertedPath {
+} else := convertedPath if {
 	convertedPath := sprintf("%s", [pathItem])
 }
 
-get_tag_name_if_exists(resource) = name {
+get_tag_name_if_exists(resource) := name if {
 	name := resource.tags.Name
-} else = name {
+} else := name if {
 	tag := resource.Properties.Tags[_]
 	tag.Key == "Name"
 	name := tag.Value
-} else = name {
+} else := name if {
 	tag := resource.Properties.FileSystemTags[_]
 	tag.Key == "Name"
 	name := tag.Value
-} else = name {
+} else := name if {
 	tag := resource.Properties.Tags[key]
 	key == "Name"
 	name := tag
-} else = name {
+} else := name if {
 	tag := resource.spec.forProvider.tags[_]
 	tag.key == "Name"
 	name := tag.value
-} else = name {
+} else := name if {
 	tag := resource.properties.tags[key]
 	key == "Name"
 	name := tag
 }
 
-resourceFieldName = {
+resourceFieldName := {
 	"google_bigquery_dataset": "friendly_name",
 	"alicloud_actiontrail_trail": "trail_name",
 	"alicloud_ros_stack": "stack_name",

--- a/test/fixtures/get_queries_test/common_query.rego
+++ b/test/fixtures/get_queries_test/common_query.rego
@@ -1,6 +1,8 @@
 package datadog
 
-DatadogPolicy[result] {
+import rego.v1
+
+DatadogPolicy contains result if {
 	input.document[i]
 
 	result := {

--- a/test/fixtures/get_queries_test/content_get_queries.rego
+++ b/test/fixtures/get_queries_test/content_get_queries.rego
@@ -1,6 +1,8 @@
 package datadog
 
-DatadogPolicy[result] {
+import rego.v1
+
+DatadogPolicy contains result if {
 	resource := input.document[i].resource.aws_s3_bucket[name]
 	role = "authenticated-read"
 	resource.acl == role

--- a/test/fixtures/test_critical_custom_queries/amazon_mq_broker_encryption_disabled/query/query.rego
+++ b/test/fixtures/test_critical_custom_queries/amazon_mq_broker_encryption_disabled/query/query.rego
@@ -1,9 +1,11 @@
 package datadog
 
-import data.generic.common as common_lib
-import data.generic.cloudformation as cf_lib
+import rego.v1
 
-DatadogPolicy[result] {
+import data.generic.cloudformation as cf_lib
+import data.generic.common as common_lib
+
+DatadogPolicy contains result if {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::AmazonMQ::Broker"

--- a/test/fixtures/test_critical_custom_queries/run_block_injection/query/query.rego
+++ b/test/fixtures/test_critical_custom_queries/run_block_injection/query/query.rego
@@ -1,21 +1,22 @@
 package datadog
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-DatadogPolicy[result] {
-
-	input.document[i].on["pull_request_target"]
+DatadogPolicy contains result if {
+	input.document[i].on.pull_request_target
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.head_ref",
-    "github.event.pull_request.body",
-    "github.event.pull_request.head.label",
-    "github.event.pull_request.head.ref",
-    "github.event.pull_request.head.repo.default_branch",
-    "github.event.pull_request.head.repo.description",
-    "github.event.pull_request.head.repo.homepage",
-    "github.event.pull_request.title"
+		"github.head_ref",
+		"github.event.pull_request.body",
+		"github.event.pull_request.head.label",
+		"github.event.pull_request.head.ref",
+		"github.event.pull_request.head.repo.default_branch",
+		"github.event.pull_request.head.repo.description",
+		"github.event.pull_request.head.repo.homepage",
+		"github.event.pull_request.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -26,19 +27,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issues"]
+DatadogPolicy contains result if {
+	input.document[i].on.issues
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -49,20 +49,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issue_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.issue_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.comment.body",
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -73,19 +72,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -96,20 +94,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.comment.body",
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -120,23 +117,22 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["workflow_run"]
+DatadogPolicy contains result if {
+	input.document[i].on.workflow_run
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.workflow.path",
-	"github.event.workflow_run.head_branch",
-	"github.event.workflow_run.head_commit.author.email",
-	"github.event.workflow_run.head_commit.author.name",
-	"github.event.workflow_run.head_commit.message",
-	"github.event.workflow_run.head_repository.description"
+		"github.event.workflow.path",
+		"github.event.workflow_run.head_branch",
+		"github.event.workflow_run.head_commit.author.email",
+		"github.event.workflow_run.head_commit.author.name",
+		"github.event.workflow_run.head_commit.message",
+		"github.event.workflow_run.head_repository.description",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -147,19 +143,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["author"]
+DatadogPolicy contains result if {
+	input.document[i].on.author
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.*.authors.name",
-	"github.*.authors.email"
+		"github.*.authors.name",
+		"github.*.authors.email",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -170,17 +165,14 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-
-
-containsPatterns(str, patterns) = matched {
-    matched := {pattern |
-        pattern := patterns[_]
-        regex.match(pattern, str)
-    }
+containsPatterns(str, patterns) := matched if {
+	matched := {pattern |
+		pattern := patterns[_]
+		regex.match(pattern, str)
+	}
 }
-

--- a/test/fixtures/test_critical_severity/run_block_injection/query/query.rego
+++ b/test/fixtures/test_critical_severity/run_block_injection/query/query.rego
@@ -1,21 +1,22 @@
 package datadog
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-DatadogPolicy[result] {
-
-	input.document[i].on["pull_request_target"]
+DatadogPolicy contains result if {
+	input.document[i].on.pull_request_target
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.head_ref",
-    "github.event.pull_request.body",
-    "github.event.pull_request.head.label",
-    "github.event.pull_request.head.ref",
-    "github.event.pull_request.head.repo.default_branch",
-    "github.event.pull_request.head.repo.description",
-    "github.event.pull_request.head.repo.homepage",
-    "github.event.pull_request.title"
+		"github.head_ref",
+		"github.event.pull_request.body",
+		"github.event.pull_request.head.label",
+		"github.event.pull_request.head.ref",
+		"github.event.pull_request.head.repo.default_branch",
+		"github.event.pull_request.head.repo.description",
+		"github.event.pull_request.head.repo.homepage",
+		"github.event.pull_request.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -26,19 +27,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issues"]
+DatadogPolicy contains result if {
+	input.document[i].on.issues
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -49,20 +49,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issue_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.issue_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.comment.body",
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -73,19 +72,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -96,20 +94,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.comment.body",
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -120,23 +117,22 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["workflow_run"]
+DatadogPolicy contains result if {
+	input.document[i].on.workflow_run
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.workflow.path",
-	"github.event.workflow_run.head_branch",
-	"github.event.workflow_run.head_commit.author.email",
-	"github.event.workflow_run.head_commit.author.name",
-	"github.event.workflow_run.head_commit.message",
-	"github.event.workflow_run.head_repository.description"
+		"github.event.workflow.path",
+		"github.event.workflow_run.head_branch",
+		"github.event.workflow_run.head_commit.author.email",
+		"github.event.workflow_run.head_commit.author.name",
+		"github.event.workflow_run.head_commit.message",
+		"github.event.workflow_run.head_repository.description",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -147,19 +143,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["author"]
+DatadogPolicy contains result if {
+	input.document[i].on.author
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.*.authors.name",
-	"github.*.authors.email"
+		"github.*.authors.name",
+		"github.*.authors.email",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -170,17 +165,14 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-
-
-containsPatterns(str, patterns) = matched {
-    matched := {pattern |
-        pattern := patterns[_]
-        regex.match(pattern, str)
-    }
+containsPatterns(str, patterns) := matched if {
+	matched := {pattern |
+		pattern := patterns[_]
+		regex.match(pattern, str)
+	}
 }
-

--- a/test/fixtures/test_experimental_queries/experimental_queries_queries/experimental/test/query.rego
+++ b/test/fixtures/test_experimental_queries/experimental_queries_queries/experimental/test/query.rego
@@ -1,11 +1,13 @@
 package datadog
 
+import rego.v1
+
 import data.generic.ansible as ansLib
 import data.generic.common as common_lib
 
 modules := {"community.aws.aws_api_gateway", "aws_api_gateway"}
 
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
 	task := ansLib.tasks[id][t]
 	api_gateway := task[modules[m]]
 	ansLib.checkState(api_gateway)
@@ -23,7 +25,7 @@ DatadogPolicy[result] {
 	}
 }
 
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
 	task := ansLib.tasks[id][t]
 	api_gateway := task[modules[m]]
 	ansLib.checkState(api_gateway)

--- a/test/fixtures/test_experimental_queries/experimental_queries_queries/tested/tested_query/query.rego
+++ b/test/fixtures/test_experimental_queries/experimental_queries_queries/tested/tested_query/query.rego
@@ -1,11 +1,13 @@
 package datadog
 
+import rego.v1
+
 import data.generic.ansible as ansLib
 import data.generic.common as common_lib
 
 modules := {"community.aws.aws_api_gateway", "aws_api_gateway"}
 
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
 	task := ansLib.tasks[id][t]
 	api_gateway := task[modules[m]]
 	ansLib.checkState(api_gateway)
@@ -23,7 +25,7 @@ DatadogPolicy[result] {
 	}
 }
 
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
 	task := ansLib.tasks[id][t]
 	api_gateway := task[modules[m]]
 	ansLib.checkState(api_gateway)

--- a/test/fixtures/test_old_severity/critical/query.rego
+++ b/test/fixtures/test_old_severity/critical/query.rego
@@ -1,21 +1,22 @@
 package datadog
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-DatadogPolicy[result] {
-
-	input.document[i].on["pull_request_target"]
+DatadogPolicy contains result if {
+	input.document[i].on.pull_request_target
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.head_ref",
-    "github.event.pull_request.body",
-    "github.event.pull_request.head.label",
-    "github.event.pull_request.head.ref",
-    "github.event.pull_request.head.repo.default_branch",
-    "github.event.pull_request.head.repo.description",
-    "github.event.pull_request.head.repo.homepage",
-    "github.event.pull_request.title"
+		"github.head_ref",
+		"github.event.pull_request.body",
+		"github.event.pull_request.head.label",
+		"github.event.pull_request.head.ref",
+		"github.event.pull_request.head.repo.default_branch",
+		"github.event.pull_request.head.repo.description",
+		"github.event.pull_request.head.repo.homepage",
+		"github.event.pull_request.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -26,19 +27,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issues"]
+DatadogPolicy contains result if {
+	input.document[i].on.issues
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -49,20 +49,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issue_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.issue_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.comment.body",
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -73,19 +72,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -96,20 +94,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.comment.body",
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -120,23 +117,22 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["workflow_run"]
+DatadogPolicy contains result if {
+	input.document[i].on.workflow_run
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.workflow.path",
-	"github.event.workflow_run.head_branch",
-	"github.event.workflow_run.head_commit.author.email",
-	"github.event.workflow_run.head_commit.author.name",
-	"github.event.workflow_run.head_commit.message",
-	"github.event.workflow_run.head_repository.description"
+		"github.event.workflow.path",
+		"github.event.workflow_run.head_branch",
+		"github.event.workflow_run.head_commit.author.email",
+		"github.event.workflow_run.head_commit.author.name",
+		"github.event.workflow_run.head_commit.message",
+		"github.event.workflow_run.head_repository.description",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -147,19 +143,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["author"]
+DatadogPolicy contains result if {
+	input.document[i].on.author
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.*.authors.name",
-	"github.*.authors.email"
+		"github.*.authors.name",
+		"github.*.authors.email",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -170,17 +165,14 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-
-
-containsPatterns(str, patterns) = matched {
-    matched := {pattern |
-        pattern := patterns[_]
-        regex.match(pattern, str)
-    }
+containsPatterns(str, patterns) := matched if {
+	matched := {pattern |
+		pattern := patterns[_]
+		regex.match(pattern, str)
+	}
 }
-

--- a/test/fixtures/test_old_severity/high/query.rego
+++ b/test/fixtures/test_old_severity/high/query.rego
@@ -1,21 +1,22 @@
 package datadog
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-DatadogPolicy[result] {
-
-	input.document[i].on["pull_request_target"]
+DatadogPolicy contains result if {
+	input.document[i].on.pull_request_target
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.head_ref",
-    "github.event.pull_request.body",
-    "github.event.pull_request.head.label",
-    "github.event.pull_request.head.ref",
-    "github.event.pull_request.head.repo.default_branch",
-    "github.event.pull_request.head.repo.description",
-    "github.event.pull_request.head.repo.homepage",
-    "github.event.pull_request.title"
+		"github.head_ref",
+		"github.event.pull_request.body",
+		"github.event.pull_request.head.label",
+		"github.event.pull_request.head.ref",
+		"github.event.pull_request.head.repo.default_branch",
+		"github.event.pull_request.head.repo.description",
+		"github.event.pull_request.head.repo.homepage",
+		"github.event.pull_request.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -26,19 +27,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issues"]
+DatadogPolicy contains result if {
+	input.document[i].on.issues
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -49,20 +49,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issue_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.issue_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.comment.body",
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -73,19 +72,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -96,20 +94,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.comment.body",
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -120,23 +117,22 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["workflow_run"]
+DatadogPolicy contains result if {
+	input.document[i].on.workflow_run
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.workflow.path",
-	"github.event.workflow_run.head_branch",
-	"github.event.workflow_run.head_commit.author.email",
-	"github.event.workflow_run.head_commit.author.name",
-	"github.event.workflow_run.head_commit.message",
-	"github.event.workflow_run.head_repository.description"
+		"github.event.workflow.path",
+		"github.event.workflow_run.head_branch",
+		"github.event.workflow_run.head_commit.author.email",
+		"github.event.workflow_run.head_commit.author.name",
+		"github.event.workflow_run.head_commit.message",
+		"github.event.workflow_run.head_repository.description",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -147,19 +143,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["author"]
+DatadogPolicy contains result if {
+	input.document[i].on.author
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.*.authors.name",
-	"github.*.authors.email"
+		"github.*.authors.name",
+		"github.*.authors.email",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -170,17 +165,14 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-
-
-containsPatterns(str, patterns) = matched {
-    matched := {pattern |
-        pattern := patterns[_]
-        regex.match(pattern, str)
-    }
+containsPatterns(str, patterns) := matched if {
+	matched := {pattern |
+		pattern := patterns[_]
+		regex.match(pattern, str)
+	}
 }
-

--- a/test/fixtures/test_old_severity/info/query.rego
+++ b/test/fixtures/test_old_severity/info/query.rego
@@ -1,21 +1,22 @@
 package datadog
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-DatadogPolicy[result] {
-
-	input.document[i].on["pull_request_target"]
+DatadogPolicy contains result if {
+	input.document[i].on.pull_request_target
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.head_ref",
-    "github.event.pull_request.body",
-    "github.event.pull_request.head.label",
-    "github.event.pull_request.head.ref",
-    "github.event.pull_request.head.repo.default_branch",
-    "github.event.pull_request.head.repo.description",
-    "github.event.pull_request.head.repo.homepage",
-    "github.event.pull_request.title"
+		"github.head_ref",
+		"github.event.pull_request.body",
+		"github.event.pull_request.head.label",
+		"github.event.pull_request.head.ref",
+		"github.event.pull_request.head.repo.default_branch",
+		"github.event.pull_request.head.repo.description",
+		"github.event.pull_request.head.repo.homepage",
+		"github.event.pull_request.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -26,19 +27,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issues"]
+DatadogPolicy contains result if {
+	input.document[i].on.issues
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -49,20 +49,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issue_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.issue_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.comment.body",
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -73,19 +72,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -96,20 +94,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.comment.body",
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -120,23 +117,22 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["workflow_run"]
+DatadogPolicy contains result if {
+	input.document[i].on.workflow_run
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.workflow.path",
-	"github.event.workflow_run.head_branch",
-	"github.event.workflow_run.head_commit.author.email",
-	"github.event.workflow_run.head_commit.author.name",
-	"github.event.workflow_run.head_commit.message",
-	"github.event.workflow_run.head_repository.description"
+		"github.event.workflow.path",
+		"github.event.workflow_run.head_branch",
+		"github.event.workflow_run.head_commit.author.email",
+		"github.event.workflow_run.head_commit.author.name",
+		"github.event.workflow_run.head_commit.message",
+		"github.event.workflow_run.head_repository.description",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -147,19 +143,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["author"]
+DatadogPolicy contains result if {
+	input.document[i].on.author
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.*.authors.name",
-	"github.*.authors.email"
+		"github.*.authors.name",
+		"github.*.authors.email",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -170,17 +165,14 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-
-
-containsPatterns(str, patterns) = matched {
-    matched := {pattern |
-        pattern := patterns[_]
-        regex.match(pattern, str)
-    }
+containsPatterns(str, patterns) := matched if {
+	matched := {pattern |
+		pattern := patterns[_]
+		regex.match(pattern, str)
+	}
 }
-

--- a/test/fixtures/test_old_severity/low/query.rego
+++ b/test/fixtures/test_old_severity/low/query.rego
@@ -1,21 +1,22 @@
 package datadog
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-DatadogPolicy[result] {
-
-	input.document[i].on["pull_request_target"]
+DatadogPolicy contains result if {
+	input.document[i].on.pull_request_target
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.head_ref",
-    "github.event.pull_request.body",
-    "github.event.pull_request.head.label",
-    "github.event.pull_request.head.ref",
-    "github.event.pull_request.head.repo.default_branch",
-    "github.event.pull_request.head.repo.description",
-    "github.event.pull_request.head.repo.homepage",
-    "github.event.pull_request.title"
+		"github.head_ref",
+		"github.event.pull_request.body",
+		"github.event.pull_request.head.label",
+		"github.event.pull_request.head.ref",
+		"github.event.pull_request.head.repo.default_branch",
+		"github.event.pull_request.head.repo.description",
+		"github.event.pull_request.head.repo.homepage",
+		"github.event.pull_request.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -26,19 +27,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issues"]
+DatadogPolicy contains result if {
+	input.document[i].on.issues
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -49,20 +49,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issue_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.issue_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.comment.body",
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -73,19 +72,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -96,20 +94,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.comment.body",
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -120,23 +117,22 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["workflow_run"]
+DatadogPolicy contains result if {
+	input.document[i].on.workflow_run
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.workflow.path",
-	"github.event.workflow_run.head_branch",
-	"github.event.workflow_run.head_commit.author.email",
-	"github.event.workflow_run.head_commit.author.name",
-	"github.event.workflow_run.head_commit.message",
-	"github.event.workflow_run.head_repository.description"
+		"github.event.workflow.path",
+		"github.event.workflow_run.head_branch",
+		"github.event.workflow_run.head_commit.author.email",
+		"github.event.workflow_run.head_commit.author.name",
+		"github.event.workflow_run.head_commit.message",
+		"github.event.workflow_run.head_repository.description",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -147,19 +143,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["author"]
+DatadogPolicy contains result if {
+	input.document[i].on.author
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.*.authors.name",
-	"github.*.authors.email"
+		"github.*.authors.name",
+		"github.*.authors.email",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -170,17 +165,14 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-
-
-containsPatterns(str, patterns) = matched {
-    matched := {pattern |
-        pattern := patterns[_]
-        regex.match(pattern, str)
-    }
+containsPatterns(str, patterns) := matched if {
+	matched := {pattern |
+		pattern := patterns[_]
+		regex.match(pattern, str)
+	}
 }
-

--- a/test/fixtures/test_old_severity/medium/query.rego
+++ b/test/fixtures/test_old_severity/medium/query.rego
@@ -1,21 +1,22 @@
 package datadog
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-DatadogPolicy[result] {
-
-	input.document[i].on["pull_request_target"]
+DatadogPolicy contains result if {
+	input.document[i].on.pull_request_target
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.head_ref",
-    "github.event.pull_request.body",
-    "github.event.pull_request.head.label",
-    "github.event.pull_request.head.ref",
-    "github.event.pull_request.head.repo.default_branch",
-    "github.event.pull_request.head.repo.description",
-    "github.event.pull_request.head.repo.homepage",
-    "github.event.pull_request.title"
+		"github.head_ref",
+		"github.event.pull_request.body",
+		"github.event.pull_request.head.label",
+		"github.event.pull_request.head.ref",
+		"github.event.pull_request.head.repo.default_branch",
+		"github.event.pull_request.head.repo.description",
+		"github.event.pull_request.head.repo.homepage",
+		"github.event.pull_request.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -26,19 +27,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issues"]
+DatadogPolicy contains result if {
+	input.document[i].on.issues
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -49,20 +49,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issue_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.issue_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.comment.body",
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -73,19 +72,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -96,20 +94,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.comment.body",
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -120,23 +117,22 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["workflow_run"]
+DatadogPolicy contains result if {
+	input.document[i].on.workflow_run
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.workflow.path",
-	"github.event.workflow_run.head_branch",
-	"github.event.workflow_run.head_commit.author.email",
-	"github.event.workflow_run.head_commit.author.name",
-	"github.event.workflow_run.head_commit.message",
-	"github.event.workflow_run.head_repository.description"
+		"github.event.workflow.path",
+		"github.event.workflow_run.head_branch",
+		"github.event.workflow_run.head_commit.author.email",
+		"github.event.workflow_run.head_commit.author.name",
+		"github.event.workflow_run.head_commit.message",
+		"github.event.workflow_run.head_repository.description",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -147,19 +143,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["author"]
+DatadogPolicy contains result if {
+	input.document[i].on.author
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.*.authors.name",
-	"github.*.authors.email"
+		"github.*.authors.name",
+		"github.*.authors.email",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -170,17 +165,14 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-
-
-containsPatterns(str, patterns) = matched {
-    matched := {pattern |
-        pattern := patterns[_]
-        regex.match(pattern, str)
-    }
+containsPatterns(str, patterns) := matched if {
+	matched := {pattern |
+		pattern := patterns[_]
+		regex.match(pattern, str)
+	}
 }
-

--- a/test/fixtures/test_sarif_cwe_report/run_block_injection/query/query.rego
+++ b/test/fixtures/test_sarif_cwe_report/run_block_injection/query/query.rego
@@ -1,21 +1,22 @@
 package datadog
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-DatadogPolicy[result] {
-
-	input.document[i].on["pull_request_target"]
+DatadogPolicy contains result if {
+	input.document[i].on.pull_request_target
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.head_ref",
-    "github.event.pull_request.body",
-    "github.event.pull_request.head.label",
-    "github.event.pull_request.head.ref",
-    "github.event.pull_request.head.repo.default_branch",
-    "github.event.pull_request.head.repo.description",
-    "github.event.pull_request.head.repo.homepage",
-    "github.event.pull_request.title"
+		"github.head_ref",
+		"github.event.pull_request.body",
+		"github.event.pull_request.head.label",
+		"github.event.pull_request.head.ref",
+		"github.event.pull_request.head.repo.default_branch",
+		"github.event.pull_request.head.repo.description",
+		"github.event.pull_request.head.repo.homepage",
+		"github.event.pull_request.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -26,19 +27,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issues"]
+DatadogPolicy contains result if {
+	input.document[i].on.issues
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -49,20 +49,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["issue_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.issue_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.comment.body",
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -73,19 +72,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -96,20 +94,19 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["discussion_comment"]
+DatadogPolicy contains result if {
+	input.document[i].on.discussion_comment
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.comment.body",
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -120,23 +117,22 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["workflow_run"]
+DatadogPolicy contains result if {
+	input.document[i].on.workflow_run
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.event.workflow.path",
-	"github.event.workflow_run.head_branch",
-	"github.event.workflow_run.head_commit.author.email",
-	"github.event.workflow_run.head_commit.author.name",
-	"github.event.workflow_run.head_commit.message",
-	"github.event.workflow_run.head_repository.description"
+		"github.event.workflow.path",
+		"github.event.workflow_run.head_branch",
+		"github.event.workflow_run.head_commit.author.email",
+		"github.event.workflow_run.head_commit.author.name",
+		"github.event.workflow_run.head_commit.message",
+		"github.event.workflow_run.head_repository.description",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -147,19 +143,18 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
-
-	input.document[i].on["author"]
+DatadogPolicy contains result if {
+	input.document[i].on.author
 	run := input.document[i].jobs[j].steps[k].run
 
 	patterns := [
-    "github.*.authors.name",
-	"github.*.authors.email"
+		"github.*.authors.name",
+		"github.*.authors.email",
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -170,17 +165,14 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Run block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"], []),
+		"searchValue": matched[m],
 	}
 }
 
-
-
-containsPatterns(str, patterns) = matched {
-    matched := {pattern |
-        pattern := patterns[_]
-        regex.match(pattern, str)
-    }
+containsPatterns(str, patterns) := matched if {
+	matched := {pattern |
+		pattern := patterns[_]
+		regex.match(pattern, str)
+	}
 }
-

--- a/test/fixtures/test_sarif_cwe_report/script_block_injection/query/query.rego
+++ b/test/fixtures/test_sarif_cwe_report/script_block_injection/query/query.rego
@@ -1,54 +1,27 @@
 package datadog
 
+import rego.v1
+
 import data.generic.common as common_lib
 
-DatadogPolicy[result] {
-
-	input.document[i].on["pull_request_target"]
-
-    uses := input.document[i].jobs[j].steps[k].uses
-
-    startswith(uses, "actions/github-script")
-    
-    script := input.document[i].jobs[j].steps[k]["with"].script
-
-	patterns := [
-    "github.head_ref",
-    "github.event.pull_request.body",
-    "github.event.pull_request.head.label",
-    "github.event.pull_request.head.ref",
-    "github.event.pull_request.head.repo.default_branch",
-    "github.event.pull_request.head.repo.description",
-    "github.event.pull_request.head.repo.homepage",
-    "github.event.pull_request.title"
-	]
-
-	matched = containsPatterns(script, patterns)
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("script={{%s}}", [script]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
-		"keyActualValue": "Script block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"],[]),
-		"searchValue": matched[m]
-	}
-}
-
-DatadogPolicy[result] {
-
-	input.document[i].on["issues"]
+DatadogPolicy contains result if {
+	input.document[i].on.pull_request_target
 
 	uses := input.document[i].jobs[j].steps[k].uses
 
-    startswith(uses, "actions/github-script")
-    
-    script := input.document[i].jobs[j].steps[k]["with"].script
+	startswith(uses, "actions/github-script")
+
+	script := input.document[i].jobs[j].steps[k]["with"].script
 
 	patterns := [
-    "github.event.issue.body",
-	"github.event.issue.title"
+		"github.head_ref",
+		"github.event.pull_request.body",
+		"github.event.pull_request.head.label",
+		"github.event.pull_request.head.ref",
+		"github.event.pull_request.head.repo.default_branch",
+		"github.event.pull_request.head.repo.description",
+		"github.event.pull_request.head.repo.homepage",
+		"github.event.pull_request.title",
 	]
 
 	matched = containsPatterns(script, patterns)
@@ -59,25 +32,23 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Script block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
+	input.document[i].on.issues
 
-	input.document[i].on["issue_comment"]
-	
 	uses := input.document[i].jobs[j].steps[k].uses
 
-    startswith(uses, "actions/github-script")
-    
-    script := input.document[i].jobs[j].steps[k]["with"].script
+	startswith(uses, "actions/github-script")
+
+	script := input.document[i].jobs[j].steps[k]["with"].script
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.issue.body",
-	"github.event.issue.title"
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(script, patterns)
@@ -88,24 +59,24 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Script block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with","script"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
+	input.document[i].on.issue_comment
 
-	input.document[i].on["discussion"]
-	
 	uses := input.document[i].jobs[j].steps[k].uses
 
-    startswith(uses, "actions/github-script")
-    
-    script := input.document[i].jobs[j].steps[k]["with"].script
+	startswith(uses, "actions/github-script")
+
+	script := input.document[i].jobs[j].steps[k]["with"].script
 
 	patterns := [
-    "github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.comment.body",
+		"github.event.issue.body",
+		"github.event.issue.title",
 	]
 
 	matched = containsPatterns(script, patterns)
@@ -116,25 +87,23 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Script block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
+	input.document[i].on.discussion
 
-	input.document[i].on["discussion_comment"]
-	
 	uses := input.document[i].jobs[j].steps[k].uses
 
-    startswith(uses, "actions/github-script")
-    
-    script := input.document[i].jobs[j].steps[k]["with"].script
+	startswith(uses, "actions/github-script")
+
+	script := input.document[i].jobs[j].steps[k]["with"].script
 
 	patterns := [
-    "github.event.comment.body",
-	"github.event.discussion.body",
-	"github.event.discussion.title"
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(script, patterns)
@@ -145,28 +114,24 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Script block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
+	input.document[i].on.discussion_comment
 
-	input.document[i].on["workflow_run"]
-	
 	uses := input.document[i].jobs[j].steps[k].uses
 
-    startswith(uses, "actions/github-script")
-    
-    script := input.document[i].jobs[j].steps[k]["with"].script
+	startswith(uses, "actions/github-script")
+
+	script := input.document[i].jobs[j].steps[k]["with"].script
 
 	patterns := [
-    "github.event.workflow.path",
-	"github.event.workflow_run.head_branch",
-	"github.event.workflow_run.head_commit.author.email",
-	"github.event.workflow_run.head_commit.author.name",
-	"github.event.workflow_run.head_commit.message",
-	"github.event.workflow_run.head_repository.description"
+		"github.event.comment.body",
+		"github.event.discussion.body",
+		"github.event.discussion.title",
 	]
 
 	matched = containsPatterns(script, patterns)
@@ -177,24 +142,27 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Script block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"], []),
+		"searchValue": matched[m],
 	}
 }
 
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
+	input.document[i].on.workflow_run
 
-	input.document[i].on["author"]
-	
 	uses := input.document[i].jobs[j].steps[k].uses
 
-    startswith(uses, "actions/github-script")
-    
-    script := input.document[i].jobs[j].steps[k]["with"].script
+	startswith(uses, "actions/github-script")
+
+	script := input.document[i].jobs[j].steps[k]["with"].script
 
 	patterns := [
-    "github.*.authors.name",
-	"github.*.authors.email"
+		"github.event.workflow.path",
+		"github.event.workflow_run.head_branch",
+		"github.event.workflow_run.head_commit.author.email",
+		"github.event.workflow_run.head_commit.author.name",
+		"github.event.workflow_run.head_commit.message",
+		"github.event.workflow_run.head_repository.description",
 	]
 
 	matched = containsPatterns(script, patterns)
@@ -205,16 +173,41 @@ DatadogPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
 		"keyActualValue": "Script block contains dangerous input controlled by user.",
-		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"],[]),
-		"searchValue": matched[m]
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"], []),
+		"searchValue": matched[m],
 	}
 }
 
+DatadogPolicy contains result if {
+	input.document[i].on.author
 
-containsPatterns(str, patterns) = matched {
-    matched := {pattern |
-        pattern := patterns[_]
-        regex.match(pattern, str)
-    }
+	uses := input.document[i].jobs[j].steps[k].uses
+
+	startswith(uses, "actions/github-script")
+
+	script := input.document[i].jobs[j].steps[k]["with"].script
+
+	patterns := [
+		"github.*.authors.name",
+		"github.*.authors.email",
+	]
+
+	matched = containsPatterns(script, patterns)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("script={{%s}}", [script]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
+		"keyActualValue": "Script block contains dangerous input controlled by user.",
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"], []),
+		"searchValue": matched[m],
+	}
 }
 
+containsPatterns(str, patterns) := matched if {
+	matched := {pattern |
+		pattern := patterns[_]
+		regex.match(pattern, str)
+	}
+}

--- a/test/fixtures/test_scan_cloudfront_logging_disabled/query.rego
+++ b/test/fixtures/test_scan_cloudfront_logging_disabled/query.rego
@@ -1,9 +1,11 @@
 package datadog
 
+import rego.v1
+
 import data.generic.cloudformation as cf_lib
 import data.generic.common as common_lib
 
-DatadogPolicy[result] {
+DatadogPolicy contains result if {
 	docs := input.document[i]
 	[path, Resources] := walk(docs)
 	resource := Resources[name]

--- a/test/fixtures/type-test01/template01/query.rego
+++ b/test/fixtures/type-test01/template01/query.rego
@@ -1,14 +1,16 @@
 package datadog
 
-DatadogPolicy [ result ] {
-  resource := input.document[i].resource
-  resource == "<VALUE>"
+import rego.v1
+
+DatadogPolicy contains result if {
+	resource := input.document[i].resource
+	resource == "<VALUE>"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("%s", [resource]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "<RESOURCE>",
-                "keyActualValue": 	resource
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s", [resource]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "<RESOURCE>",
+		"keyActualValue": resource,
+	}
 }

--- a/test/fixtures/type-test01/template02/query.rego
+++ b/test/fixtures/type-test01/template02/query.rego
@@ -1,14 +1,16 @@
 package datadog
 
-DatadogPolicy [ result ] {
-  resource := input.document[i].resource
-  resource == "<VALUE>"
+import rego.v1
+
+DatadogPolicy contains result if {
+	resource := input.document[i].resource
+	resource == "<VALUE>"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("%s", [resource]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "<RESOURCE>",
-                "keyActualValue": 	resource
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s", [resource]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "<RESOURCE>",
+		"keyActualValue": resource,
+	}
 }

--- a/test/fixtures/type-test01/template03/query.rego
+++ b/test/fixtures/type-test01/template03/query.rego
@@ -1,14 +1,16 @@
 package datadog
 
-DatadogPolicy [ result ] {
-  resource := input.document[i].resource
-  resource == "<VALUE>"
+import rego.v1
+
+DatadogPolicy contains result if {
+	resource := input.document[i].resource
+	resource == "<VALUE>"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("%s", [resource]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "<RESOURCE>",
-                "keyActualValue": 	resource
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s", [resource]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "<RESOURCE>",
+		"keyActualValue": resource,
+	}
 }

--- a/test/fixtures/type-test02/template01/query.rego
+++ b/test/fixtures/type-test02/template01/query.rego
@@ -1,14 +1,16 @@
 package datadog
 
-DatadogPolicy [ result ] {
-  resource := input.document[i].resource
-  resource == "<VALUE>"
+import rego.v1
+
+DatadogPolicy contains result if {
+	resource := input.document[i].resource
+	resource == "<VALUE>"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("%s", [resource]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "<RESOURCE>",
-                "keyActualValue": 	resource
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s", [resource]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "<RESOURCE>",
+		"keyActualValue": resource,
+	}
 }

--- a/test/fixtures/type-test02/template02/query.rego
+++ b/test/fixtures/type-test02/template02/query.rego
@@ -1,14 +1,16 @@
 package datadog
 
-DatadogPolicy [ result ] {
-  resource := input.document[i].resource
-  resource == "<VALUE>"
+import rego.v1
+
+DatadogPolicy contains result if {
+	resource := input.document[i].resource
+	resource == "<VALUE>"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("%s", [resource]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "<RESOURCE>",
-                "keyActualValue": 	resource
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s", [resource]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "<RESOURCE>",
+		"keyActualValue": resource,
+	}
 }


### PR DESCRIPTION
## Motivation

Rego v1 is the current OPA syntax and is the syntax expected for future custom IaC rules. This PR updates the scanner engine and embedded rule assets so generated and authored rules can use Rego v1 directly.

## Changes

**Rule engine**

The engine now prepares rules with Rego v1 enabled and parses coverage modules with Rego v1 parser options. The compatibility query shim was updated to v1 syntax while preserving support for the existing result contract.

**Embedded Rego assets**

Shared libraries, library tests, and scanner test fixtures were migrated to Rego v1 syntax. Removed builtins were replaced with equivalent rule logic where needed.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `opa test assets/libraries/`
2. `go build ./...`
3. `go test $(go list ./... | grep -v e2e) -count=1`
4. `./tool.sh test` in the companion default-rules repo with a local workspace replacement pointing at this branch (`PASS: 1397 rules`).
5. `./tool.sh test` in the companion default-rules repo with the released scanner dependency (`github.com/DataDog/datadog-iac-scanner v1.4.0`) also passed (`PASS: 1397 rules`).

## Deployment order

1. Merge the companion default-rules PR (https://github.com/DataDog/datadog-iac-scanner-default-rules/pull/31) and push the rules to production. Wait for full prod propagation.
2. **Merge this PR** and cut a release.
3. Bump the scanner binary version in `iac-scanning` in dd-source and deploy.

**Do not deploy this binary before step 1 is complete in production.** The v1-default engine rejects v0-syntax rules, so all rules must be migrated first.

## Blast Radius

This impacts scanner rule compilation and embedded Rego libraries. Existing default rules are covered by the companion rules migration, and custom rules are not yet released.

## Additional Notes

Companion default-rules PR: https://github.com/DataDog/datadog-iac-scanner-default-rules/pull/31

I submit this contribution under the Apache-2.0 license.