### PR TITLE
Preserve Terraform data source policies with unknown values

### DIFF
--- a/pkg/parser/terraform/data_source.go
+++ b/pkg/parser/terraform/data_source.go
@@ -257,7 +257,7 @@ func parseDataSourceBody(ctx context.Context, body *hclsyntax.Body, inputVariabl
 			contextLogger.Debug().Msgf("Error trying to eval data source block: %s", decErr.Summary)
 			return ""
 		}
-		contextLogger.Debug().Msgf("Dismissed unresolvable reference when decoding policy: %s", decErr.Summary)
+		contextLogger.Debug().Msgf("Dismissed unresolvable reference when decoding policy: %s: %s", decErr.Summary, decErr.Detail)
 	}
 
 	dataSourceJSON := decodeDataSourcePolicy(ctx, target)

--- a/pkg/parser/terraform/data_source.go
+++ b/pkg/parser/terraform/data_source.go
@@ -122,9 +122,9 @@ func getDataSourcePolicy(ctx context.Context, currentPath string, inputVariables
 
 func decodeDataSourcePolicy(ctx context.Context, value cty.Value) dataSourcePolicy {
 	contextLogger := logger.FromContext(ctx)
-	jsonified, err := ctyjson.Marshal(value, cty.DynamicPseudoType)
+	jsonified, err := ctyjson.Marshal(cty.UnknownAsNull(value), cty.DynamicPseudoType)
 	if err != nil {
-		contextLogger.Error().Msgf("Error trying to decode data source block: %s", err)
+		contextLogger.Warn().Msgf("Error trying to decode data source block: %s", err)
 		return dataSourcePolicy{}
 	}
 	var data dataSource

--- a/pkg/parser/terraform/data_source.go
+++ b/pkg/parser/terraform/data_source.go
@@ -244,13 +244,18 @@ func parseDataSourceBody(ctx context.Context, body *hclsyntax.Body, inputVariabl
 		Functions: functions.TerraformFuncs,
 	})
 
-	// check decode errors
+	// Dismiss diagnostics caused by unresolvable references. "Unknown variable"
+	// fires when var/local/module is absent from the eval context entirely;
+	// "Unsupported attribute" fires when var IS in the context (as a cty.Object
+	// of known defaults) but the specific variable has no default and is therefore
+	// not an attribute on that object. Both leave the affected field as
+	// cty.DynamicVal, which cty.UnknownAsNull handles below.
 	for _, decErr := range decodeErrs {
-		if decErr.Summary != "Unknown variable" {
+		if decErr.Summary != "Unknown variable" && decErr.Summary != "Unsupported attribute" {
 			contextLogger.Debug().Msgf("Error trying to eval data source block: %s", decErr.Summary)
 			return ""
 		}
-		contextLogger.Debug().Msg("Dismissed Error when decoding policy: Found unknown variable")
+		contextLogger.Debug().Msgf("Dismissed unresolvable reference when decoding policy: %s", decErr.Summary)
 	}
 
 	dataSourceJSON := decodeDataSourcePolicy(ctx, target)

--- a/pkg/parser/terraform/data_source.go
+++ b/pkg/parser/terraform/data_source.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/builder/engine"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
@@ -244,14 +245,15 @@ func parseDataSourceBody(ctx context.Context, body *hclsyntax.Body, inputVariabl
 		Functions: functions.TerraformFuncs,
 	})
 
-	// Dismiss diagnostics caused by unresolvable references. "Unknown variable"
-	// fires when var/local/module is absent from the eval context entirely;
-	// "Unsupported attribute" fires when var IS in the context (as a cty.Object
-	// of known defaults) but the specific variable has no default and is therefore
-	// not an attribute on that object. Both leave the affected field as
-	// cty.DynamicVal, which cty.UnknownAsNull handles below.
+	// Dismiss unresolvable variable references; both leave the field as
+	// cty.DynamicVal which cty.UnknownAsNull handles below.
+	// "Unsupported attribute" is narrowed by Detail to avoid swallowing
+	// unrelated attribute errors on non-variable objects.
 	for _, decErr := range decodeErrs {
-		if decErr.Summary != "Unknown variable" && decErr.Summary != "Unsupported attribute" {
+		isUnknownVar := decErr.Summary == "Unknown variable"
+		isUnsupportedAttrOnVar := decErr.Summary == "Unsupported attribute" &&
+			strings.Contains(decErr.Detail, "does not have an attribute named")
+		if !isUnknownVar && !isUnsupportedAttrOnVar {
 			contextLogger.Debug().Msgf("Error trying to eval data source block: %s", decErr.Summary)
 			return ""
 		}

--- a/pkg/parser/terraform/data_source_test.go
+++ b/pkg/parser/terraform/data_source_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 )
 
@@ -19,6 +20,10 @@ func Test_getDataSourcePolicy(t *testing.T) {
 	type args struct {
 		currentPath  string
 		resourceName string
+		// inputVars seeds the variable map passed to getDataSourcePolicy.
+		// nil means an empty map (no var/local context), which is fine for
+		// fixtures that contain no variable references.
+		inputVars converter.VariableMap
 	}
 	tests := []struct {
 		name string
@@ -44,10 +49,20 @@ func Test_getDataSourcePolicy(t *testing.T) {
 `,
 		},
 		{
-			name: "should not drop policy when scalar fields reference unknown variables",
+			// In production, getInputVariables always populates "var" as a
+			// cty.Object whose attributes are only variables that have defaults.
+			// A variable with no default is absent from the object, so
+			// var.sid_value triggers "Unsupported attribute" rather than
+			// "Unknown variable". Without the fix both diagnostics caused the
+			// whole policy to be dropped.
+			name: "should not drop policy when scalar fields reference variables with no default",
 			args: args{
 				currentPath:  filepath.Join("..", "..", "..", "test", "fixtures", "test_terraform_data_source_unknown_vars"),
 				resourceName: "partial_unknowns",
+				// Simulate production: "var" is a known empty object (no defaults resolved).
+				inputVars: converter.VariableMap{
+					"var": cty.EmptyObjectVal,
+				},
 			},
 			want: `{"Statement":[{"Actions":["s3:GetObject"],"Effect":"Allow","Resources":["arn:aws:s3:::my-bucket/*"]}]}
 `,
@@ -57,7 +72,10 @@ func Test_getDataSourcePolicy(t *testing.T) {
 	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inputVars := make(converter.VariableMap)
+			inputVars := tt.args.inputVars
+			if inputVars == nil {
+				inputVars = make(converter.VariableMap)
+			}
 			result := getDataSourcePolicy(ctx, tt.args.currentPath, inputVars)
 			data, ok := result["data"]
 			if !ok {
@@ -75,6 +93,4 @@ func Test_getDataSourcePolicy(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
-
-	// No cleanup needed since we're not using global variables anymore
 }

--- a/pkg/parser/terraform/data_source_test.go
+++ b/pkg/parser/terraform/data_source_test.go
@@ -20,10 +20,7 @@ func Test_getDataSourcePolicy(t *testing.T) {
 	type args struct {
 		currentPath  string
 		resourceName string
-		// inputVars seeds the variable map passed to getDataSourcePolicy.
-		// nil means an empty map (no var/local context), which is fine for
-		// fixtures that contain no variable references.
-		inputVars converter.VariableMap
+		inputVars converter.VariableMap // nil means empty map
 	}
 	tests := []struct {
 		name string
@@ -49,20 +46,22 @@ func Test_getDataSourcePolicy(t *testing.T) {
 `,
 		},
 		{
-			// In production, getInputVariables always populates "var" as a
-			// cty.Object whose attributes are only variables that have defaults.
-			// A variable with no default is absent from the object, so
-			// var.sid_value triggers "Unsupported attribute" rather than
-			// "Unknown variable". Without the fix both diagnostics caused the
-			// whole policy to be dropped.
-			name: "should not drop policy when scalar fields reference variables with no default",
+			// "var" present but no default: raises "Unsupported attribute".
+			name: "should not drop policy when scalar fields reference variables with no default (production var context)",
 			args: args{
 				currentPath:  filepath.Join("..", "..", "..", "test", "fixtures", "test_terraform_data_source_unknown_vars"),
 				resourceName: "partial_unknowns",
-				// Simulate production: "var" is a known empty object (no defaults resolved).
-				inputVars: converter.VariableMap{
-					"var": cty.EmptyObjectVal,
-				},
+				inputVars:    converter.VariableMap{"var": cty.EmptyObjectVal},
+			},
+			want: `{"Statement":[{"Actions":["s3:GetObject"],"Effect":"Allow","Resources":["arn:aws:s3:::my-bucket/*"]}]}
+`,
+		},
+		{
+			// "var" absent entirely: raises "Unknown variable".
+			name: "should not drop policy when scalar fields reference variables with no var context",
+			args: args{
+				currentPath:  filepath.Join("..", "..", "..", "test", "fixtures", "test_terraform_data_source_unknown_vars"),
+				resourceName: "partial_unknowns",
 			},
 			want: `{"Statement":[{"Actions":["s3:GetObject"],"Effect":"Allow","Resources":["arn:aws:s3:::my-bucket/*"]}]}
 `,

--- a/pkg/parser/terraform/data_source_test.go
+++ b/pkg/parser/terraform/data_source_test.go
@@ -43,6 +43,15 @@ func Test_getDataSourcePolicy(t *testing.T) {
 			want: `{"Id":"lala","Statement":[{"Actions":["s3:ListAllMyBuckets","s3:GetBucketLocation"],"Resources":["arn:aws:s3:::*"],"Sid":"1"},{"Actions":["s3:ListBucket"],"Condition":{"StringLike":{"s3:prefix":["","home/","home/&{aws:username}/"]}},"Resources":["arn:aws:s3:::test"]},{"Actions":["s3:*"],"Resources":["arn:aws:s3:::test/home/&{aws:username}","arn:aws:s3:::test/home/&{aws:username}/*"]}]}
 `,
 		},
+		{
+			name: "should not drop policy when scalar fields reference unknown variables",
+			args: args{
+				currentPath:  filepath.Join("..", "..", "..", "test", "fixtures", "test_terraform_data_source_unknown_vars"),
+				resourceName: "partial_unknowns",
+			},
+			want: `{"Statement":[{"Actions":["s3:GetObject"],"Effect":"Allow","Resources":["arn:aws:s3:::my-bucket/*"]}]}
+`,
+		},
 	}
 
 	ctx := context.Background()

--- a/test/fixtures/test_terraform_data_source_unknown_vars/main.tf
+++ b/test/fixtures/test_terraform_data_source_unknown_vars/main.tf
@@ -1,0 +1,16 @@
+variable "sid_value" {}
+
+data "aws_iam_policy_document" "partial_unknowns" {
+  statement {
+    effect = "Allow"
+    sid    = var.sid_value
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::my-bucket/*",
+    ]
+  }
+}


### PR DESCRIPTION
## Motivation

Terraform `aws_iam_policy_document` data sources can contain values that are unknown during static analysis. Previously, a single unknown value caused JSON serialization to fail, which dropped the whole policy document from analysis and emitted noisy error logs.

## Changes

Treat unknown cty values as null before serializing Terraform data source policies, preserving the statically-known portions of the policy instead of dropping the whole document. The remaining serialization failure log is downgraded because routine unknown Terraform values are now handled explicitly.

A regression test covers a policy with an unknown scalar field while preserving known statement fields.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/parser/terraform/... -run Test_getDataSourcePolicy -v`
2. Confirm the unknown-value fixture still emits the known IAM policy statement instead of an empty policy.

## Blast Radius

This PR affects Terraform data source policy parsing in the IaC scanner. It only changes handling of unknown values while decoding `aws_iam_policy_document` data sources.

## Additional Notes

I submit this contribution under the Apache-2.0 license.