### PR TITLE
Helm render error logs

### DIFF
--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -462,11 +462,9 @@ func (s *FileSystemSourceProvider) resolveChartDir(ctx context.Context, path str
 	contextLogger := logger.FromContext(ctx)
 	excluded, errRes := resolverSink(ctx, strings.ReplaceAll(path, "\\", "/"))
 	if errRes != nil {
-		// resolverSink returns an error only for actual chart directories (with Chart.yaml).
-		// For non-chart directories it returns nil/[] and we should not log.
-		if _, statErr := os.Stat(filepath.Join(path, "Chart.yaml")); statErr == nil {
-			contextLogger.Warn().Err(errRes).Msgf("Failed to render Helm chart '%s'; scanning its raw files as a fallback", path)
-		}
+		// The render failure is already logged by the resolver sink; this is
+		// just the fallback announcement, so keep it at Debug.
+		contextLogger.Debug().Msgf("Scanning raw files of Helm chart '%s' as a fallback after render failure", path)
 		return nil
 	}
 	s.mu.Lock()

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -465,7 +465,7 @@ func (s *FileSystemSourceProvider) resolveChartDir(ctx context.Context, path str
 		// resolverSink returns an error only for actual chart directories (with Chart.yaml).
 		// For non-chart directories it returns nil/[] and we should not log.
 		if _, statErr := os.Stat(filepath.Join(path, "Chart.yaml")); statErr == nil {
-			contextLogger.Warn().Msgf("Failed to render Helm chart '%s'; scanning its raw files as a fallback", path)
+			contextLogger.Warn().Err(errRes).Msgf("Failed to render Helm chart '%s'; scanning its raw files as a fallback", path)
 		}
 		return nil
 	}

--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -103,7 +103,6 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 
 	name, charts, err := client.NameAndChart(args)
 	if err != nil {
-		contextLogger.Error().Msgf("failed to parse chart name and path from args %v: %s", args, err)
 		return nil, []string{}, err
 	}
 	contextLogger.Debug().Msgf("Parsed chart name: '%s', chart path: '%s'", name, charts)
@@ -111,7 +110,6 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 
 	cp, err := client.LocateChart(charts, settings)
 	if err != nil {
-		contextLogger.Error().Msgf("failed to locate chart '%s': %s", charts, err)
 		return nil, []string{}, err
 	}
 	contextLogger.Debug().Msgf("Located chart at path: '%s'", cp)
@@ -119,7 +117,6 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 	p := getter.All(settings)
 	vals, err := valueOpts.MergeValues(p)
 	if err != nil {
-		contextLogger.Error().Msgf("failed to merge helm values: %s", err)
 		return nil, []string{}, err
 	}
 	contextLogger.Debug().Msgf("Merged helm values successfully, values count: %d", len(vals))
@@ -128,7 +125,6 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 	contextLogger.Debug().Msgf("Loading chart from path: '%s'", cp)
 	chartRequested, err := loader.Load(cp)
 	if err != nil {
-		contextLogger.Error().Msgf("failed to load chart from '%s': %s", cp, err)
 		return nil, []string{}, err
 	}
 
@@ -144,7 +140,6 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 	chartRequested = setID(chartRequested)
 
 	if instErr := checkIfInstallable(chartRequested); instErr != nil {
-		contextLogger.Error().Msgf("chart is not installable: %s", instErr)
 		return nil, []string{}, instErr
 	}
 	contextLogger.Debug().Msg("Chart installability check passed")
@@ -153,7 +148,6 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 	contextLogger.Debug().Msgf("Running helm chart with namespace: '%s', release name: '%s'", client.Namespace, client.ReleaseName)
 	helmRelease, err := client.Run(chartRequested, vals)
 	if err != nil {
-		contextLogger.Error().Msgf("failed to run helm chart '%s': %s", chartRequested.Metadata.Name, err)
 		return nil, []string{}, err
 	}
 

--- a/pkg/resolver/helm/resolver.go
+++ b/pkg/resolver/helm/resolver.go
@@ -45,8 +45,8 @@ func (r *Resolver) Resolve(ctx context.Context, filePath string) (model.Resolved
 		}
 	}()
 	splits, excluded, err := renderHelm(ctx, filePath)
-	if err != nil { // return error to be logged
-		return model.ResolvedFiles{}, errors.New("failed to render helm chart")
+	if err != nil {
+		return model.ResolvedFiles{}, errors.Wrap(err, "failed to render helm chart")
 	}
 	var rfiles = model.ResolvedFiles{
 		Excluded: excluded,
@@ -84,12 +84,10 @@ func renderHelm(ctx context.Context, path string) (*[]splitManifest, []string, e
 	contextLogger.Debug().Msg("Running helm install")
 	manifest, excluded, err := runInstall(ctx, []string{path}, client, &values.Options{})
 	if err != nil {
-		contextLogger.Error().Msgf("failed to run helm install '%s': %s", path, err)
 		return nil, []string{}, err
 	}
 	splitted, err := splitManifestYAML(manifest)
 	if err != nil {
-		contextLogger.Error().Msgf("failed to split helm manifest YAML for chart '%s': %s", path, err)
 		return nil, []string{}, err
 	}
 	return splitted, excluded, nil

--- a/pkg/runner/resolver_sink.go
+++ b/pkg/runner/resolver_sink.go
@@ -32,7 +32,7 @@ func (s *Service) resolverSink(
 	}
 	resFiles, err := s.Resolver.Resolve(ctx, filename, kind)
 	if err != nil {
-		contextLogger.Err(err).Msgf("failed to render file content '%s' with fileType '%s'", filename, kind)
+		s.logResolverResolveError(ctx, kind, filename, err)
 		return []string{}, err
 	}
 
@@ -51,7 +51,7 @@ func (s *Service) resolverSink(
 			if kind == model.KindHELM && isCommentOnlyContent(rfile.Content) {
 				continue
 			}
-			contextLogger.Error().Msgf("failed to parse file content '%s' with fileType '%s'", rfile.FileName, kind)
+			contextLogger.Error().Err(err).Msgf("failed to parse file content '%s' with fileType '%s'", rfile.FileName, kind)
 			return []string{}, nil
 		}
 
@@ -116,6 +116,49 @@ func (s *Service) resolverSink(
 		}
 	}
 	return resFiles.Excluded, nil
+}
+
+// logResolverResolveError logs a Helm resolve/render failure as debug when it
+// matches missing deploy-time values (expected at scan time), otherwise as error.
+// Both paths fall back to raw-file scanning; only expected failures call
+// recordFailedHelmChart, which suppresses subsequent parse-error noise for those files.
+func (s *Service) logResolverResolveError(ctx context.Context, kind model.FileKind, filename string, err error) {
+	contextLogger := logger.FromContext(ctx)
+	if kind == model.KindHELM && isExpectedHelmRenderError(err) {
+		s.recordFailedHelmChart(filename)
+		contextLogger.Debug().Err(err).Msgf("helm chart '%s' could not be rendered with available values", filename)
+		return
+	}
+	contextLogger.Error().Err(err).Msgf("failed to render file content '%s' with fileType '%s'", filename, kind)
+}
+
+// expectedHelmRenderErrorSignatures matches Go template execution errors caused
+// by missing deploy-time values — the expected failure mode for charts that
+// require values unavailable at scan time.
+// "error calling required:" covers the Helm required helper, which exists
+// exclusively to guard absent values.
+// "error calling fail:" is intentionally excluded: fail is also used for real
+// validation logic (e.g. unsupported kube version) that can trigger even when
+// all values are present, so classifying it as expected would silence genuine
+// chart errors.
+var expectedHelmRenderErrorSignatures = []string{
+	"nil pointer evaluating",
+	"map has no entry for key",
+	"can't evaluate field",
+	"error calling required:",
+}
+
+func isExpectedHelmRenderError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, sig := range expectedHelmRenderErrorSignatures {
+		if strings.Contains(msg, sig) {
+			return true
+		}
+	}
+	return false
 }
 
 // isCommentOnlyContent returns true when every non-blank line in content starts

--- a/pkg/runner/resolver_sink_test.go
+++ b/pkg/runner/resolver_sink_test.go
@@ -6,10 +6,108 @@
 package runner
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestIsExpectedHelmRenderError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"nil pointer evaluating", errors.New("template: chart/templates/deploy.yaml:5:14: executing \"deploy\" at <.Values.global.name>: nil pointer evaluating interface {}.name"), true},
+		{"map has no entry for key", errors.New("map has no entry for key \"datacenter\""), true},
+		{"can't evaluate field", errors.New("can't evaluate field Images in type interface {}"), true},
+		{"required helper", errors.New("template: chart/templates/deploy.yaml:3:10: executing \"deploy\" at <required \"datacenter\" .Values.datacenter>: error calling required: HELM_ERR_STARTdatacenterHELM_ERR_END"), true},
+		// fail is excluded from expected signatures — it is also used for real validation
+		// logic (e.g. unsupported kube version) that can trigger with values present.
+		{"fail helper stays at error", errors.New("template: chart/templates/deploy.yaml:2:5: executing \"deploy\" at <fail \"env required\">: error calling fail: HELM_ERR_STARTenv requiredHELM_ERR_END"), false},
+		{"unrelated render failure", errors.New("chart requires kubeVersion: >=1.20.0 which is incompatible with Kubernetes v1.14.0"), false},
+		{"load error", errors.New("failed to load chart from '/repo/chart': no Chart.yaml found"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isExpectedHelmRenderError(tt.err))
+		})
+	}
+}
+
+func TestIsUnderFailedHelmChart(t *testing.T) {
+	svc := &Service{}
+	svc.recordFailedHelmChart("/repo/charts/watchdog")
+	svc.recordFailedHelmChart("/repo/charts/ingester/")
+
+	tests := []struct {
+		name     string
+		filePath string
+		want     bool
+	}{
+		{"direct child template", "/repo/charts/watchdog/templates/deploy.yaml", true},
+		{"nested path", "/repo/charts/watchdog/templates/subdir/cm.yaml", true},
+		{"trailing-slash chart normalised", "/repo/charts/ingester/templates/svc.yaml", true},
+		{"sibling chart not matched", "/repo/charts/other/templates/deploy.yaml", false},
+		{"chart root itself not matched", "/repo/charts/watchdog", false},
+		{"unrelated file", "/repo/main.tf", false},
+		// Non-template chart files must not be suppressed: genuine YAML errors there
+		// are real bugs, not expected Go-template fallout.
+		{"values.yaml not suppressed", "/repo/charts/watchdog/values.yaml", false},
+		{"crds not suppressed", "/repo/charts/watchdog/crds/my-crd.yaml", false},
+		{"Chart.yaml not suppressed", "/repo/charts/watchdog/Chart.yaml", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, svc.isUnderFailedHelmChart(tt.filePath))
+		})
+	}
+}
+
+func TestIsUnderFailedHelmChart_NilMap(t *testing.T) {
+	// Before any chart has failed, the map is nil; iterating it must be a no-op.
+	svc := &Service{}
+	require.False(t, svc.isUnderFailedHelmChart("/repo/charts/anything/templates/deploy.yaml"))
+}
+
+func TestIsUnderFailedHelmChart_RelativeRoot(t *testing.T) {
+	// filepath.Walk(".") reports children as "templates/deploy.yaml" (no leading "./"),
+	// so prefix matching must work even when the chart dir is relative.
+	svc := &Service{}
+	svc.recordFailedHelmChart(".")
+
+	require.True(t, svc.isUnderFailedHelmChart("templates/deploy.yaml"))
+	require.True(t, svc.isUnderFailedHelmChart("templates/subdir/cm.yaml"))
+	// Non-template files in the same chart must not be suppressed.
+	require.False(t, svc.isUnderFailedHelmChart("values.yaml"))
+	require.False(t, svc.isUnderFailedHelmChart("crds/my-crd.yaml"))
+	// An absolute path outside cwd must not match.
+	require.False(t, svc.isUnderFailedHelmChart("/other/repo/templates/deploy.yaml"))
+}
+
+func TestIsCommentOnlyContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		want    bool
+	}{
+		{"empty", []byte(""), true},
+		{"blank lines only", []byte("\n\n"), true},
+		{"all comments", []byte("# foo\n# bar"), true},
+		// isCommentOnlyContent is called on post-split segments, so --- never
+		// appears in practice, but the function correctly rejects it as a non-comment.
+		{"yaml separator is not a comment", []byte("---\n# comment"), false},
+		{"real yaml line", []byte("foo: 1"), false},
+		{"comment then yaml", []byte("# ok\nfoo: 1"), false},
+		{"whitespace then yaml", []byte("  foo: bar"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isCommentOnlyContent(tt.content))
+		})
+	}
+}
 
 func TestFilterHelmGeneratedLines(t *testing.T) {
 	// Rendered Helm split content that resembles real scanner output.

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -10,6 +10,8 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine"
@@ -65,6 +67,48 @@ type Service struct {
 	files          model.FileMetadatas
 	filesMu        sync.Mutex
 	MaxFileSize    int
+	// failedHelmChartDirsMu guards failedHelmChartDirs.
+	failedHelmChartDirsMu sync.RWMutex
+	// failedHelmChartDirs tracks chart directories that could not be rendered,
+	// so their raw template files are not mistaken for parse bugs in sink.
+	failedHelmChartDirs map[string]struct{}
+}
+
+func (s *Service) recordFailedHelmChart(chartDir string) {
+	// Absolutize so that relative roots (e.g. ".") match correctly when
+	// isUnderFailedHelmChart receives the children reported by filepath.Walk.
+	if abs, err := filepath.Abs(chartDir); err == nil {
+		chartDir = filepath.ToSlash(abs)
+	}
+	// Record only the templates/ subtree so that non-template YAML files
+	// (values.yaml, crds/, Chart.yaml) still produce Error-level parse
+	// failures when they have genuine syntax errors.
+	templatesDir := strings.TrimRight(chartDir, "/") + "/templates"
+	s.failedHelmChartDirsMu.Lock()
+	defer s.failedHelmChartDirsMu.Unlock()
+	if s.failedHelmChartDirs == nil {
+		s.failedHelmChartDirs = make(map[string]struct{})
+	}
+	s.failedHelmChartDirs[templatesDir] = struct{}{}
+}
+
+func (s *Service) isUnderFailedHelmChart(filePath string) bool {
+	s.failedHelmChartDirsMu.RLock()
+	defer s.failedHelmChartDirsMu.RUnlock()
+	if len(s.failedHelmChartDirs) == 0 {
+		return false
+	}
+	// Normalize to absolute so relative paths (e.g. from a "." root walk)
+	// match the absolute dirs stored by recordFailedHelmChart.
+	if abs, err := filepath.Abs(filePath); err == nil {
+		filePath = filepath.ToSlash(abs)
+	}
+	for dir := range s.failedHelmChartDirs {
+		if strings.HasPrefix(filePath, dir+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 // PrepareSources will prepare the sources to be scanned

--- a/pkg/runner/sink.go
+++ b/pkg/runner/sink.go
@@ -49,7 +49,16 @@ func (s *Service) sink(ctx context.Context, filename, scanID string,
 	}
 	documents, err := s.Parser.Parse(ctx, filename, *content, openAPIResolveReferences, c.IsMinified, maxResolverDepth)
 	if err != nil {
-		contextLogger.Error().Msgf("failed to parse file content: %s", filename)
+		// failedHelmChartDirs is fully populated by collectFiles (Phase 1) before
+		// processFilesParallel (Phase 2) dispatches workers, so the map is always
+		// complete when this check runs.
+		// Raw templates inside a failed chart are not valid YAML; parse failures
+		// there are expected. Everything else stays at Error.
+		if s.isUnderFailedHelmChart(filename) {
+			contextLogger.Debug().Err(err).Msgf("skipping unparseable raw Helm template: %s", filename)
+		} else {
+			contextLogger.Error().Err(err).Msgf("failed to parse file content: %s", filename)
+		}
 		return nil
 	}
 

--- a/pkg/runner/sink_test.go
+++ b/pkg/runner/sink_test.go
@@ -6,11 +6,15 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser"
+	yamlParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/default"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -153,3 +157,67 @@ func compareJSONLine(t *testing.T, test1 interface{}, test2 string) {
 	require.NoError(t, err)
 	require.JSONEq(t, test2, string(stringefiedJSON))
 }
+
+// TestSink_ParseFailureLogLevel verifies that sink demotes the parse-error log
+// from Error to Debug when the file is under a chart that was already recorded
+// as a render failure — the central behaviour introduced by this PR.
+func TestSink_ParseFailureLogLevel(t *testing.T) {
+	ctx := context.Background()
+
+	parsers, err := parser.NewBuilder(ctx).
+		Add(&yamlParser.Parser{}).
+		Build([]string{""}, []string{""})
+	require.NoError(t, err)
+	require.NotEmpty(t, parsers)
+
+	tests := []struct {
+		name        string
+		filename    string
+		failedChart string // if non-empty, register before calling sink
+		wantLevel   string
+	}{
+		{
+			name:      "not under failed chart logs at error",
+			filename:  "/repo/other/deploy.yaml",
+			wantLevel: `"level":"error"`,
+		},
+		{
+			name:        "under failed chart logs at debug",
+			filename:    "/repo/charts/watchdog/templates/deploy.yaml",
+			failedChart: "/repo/charts/watchdog",
+			wantLevel:   `"level":"debug"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			testCtx := zerolog.New(&logBuf).WithContext(ctx)
+
+			svc := &Service{
+				Parser:      parsers[0],
+				Tracker:     noopTracker{},
+				MaxFileSize: 1,
+			}
+			if tt.failedChart != "" {
+				svc.recordFailedHelmChart(tt.failedChart)
+			}
+
+			// "{" is an unclosed YAML flow mapping — guaranteed parse error.
+			rc := bytes.NewReader([]byte("{"))
+			buf := make([]byte, 64)
+			_ = svc.sink(testCtx, tt.filename, "scan1", rc, buf, false, 1)
+
+			require.Contains(t, logBuf.String(), tt.wantLevel)
+		})
+	}
+}
+
+type noopTracker struct{}
+
+func (noopTracker) TrackFileFound(_ string)            {}
+func (noopTracker) TrackFileParse(_ string)            {}
+func (noopTracker) TrackFileFoundCountLines(_ int)     {}
+func (noopTracker) TrackFileParseCountLines(_ int)     {}
+func (noopTracker) TrackFileIgnoreCountLines(_ int)    {}
+func (noopTracker) TrackFileFoundCountResources(_ int) {}


### PR DESCRIPTION
## Motivation

Many Helm charts in large monorepos are deployed via build systems that inject additional value files at deploy time (release names, datacenter config, OCI image references, etc.) that are not present in the chart's own `values.yaml`. The scanner cannot replicate that injection at scan time, so rendering those charts fails with Go template missing-value errors. This is a known, intentional limitation: full value resolution from build metadata would require parsing BAZEL files, which is out of scope given the complexity and narrow population of affected charts.

The consequence of these render failures was a severe log-level problem, not a loss of findings. When rendering fails the scanner falls back to scanning raw template files, which still detects and emits genuine security findings,  the only degradation is that `resource_name` may contain an unresolved template expression rather than the concrete deployed name. Each render failure was producing 3–4 duplicate ERROR lines across independent pipeline layers, compounding further because each raw template file containing Go template syntax then produced an additional ERROR from the YAML parser. None of these logs carried information not already available at the outermost layer, and their volume made the ERROR logs noisy relative to failures that actually warrant attention.

## Changes

**Helm resolver**

All `Error()` calls in `runInstall` and `renderHelm` are removed. Every failure path in those functions now returns the error silently. The `resolverSink` is the canonical signal for a chart render failure and now carries the full specific error message via `errors.Wrap` rather than the generic message that previously discarded the underlying cause.

**Render-failure classification**

`resolverSink` now distinguishes expected render failures (charts that reference deploy-time values absent at scan time, identified by well-known Go template missing-value error signatures) from unexpected ones. Expected failures log at Debug and register the chart directory as a known fallback; any other render failure stays at Error. The fallback announcement in `resolveChartDir` is similarly demoted to Debug since the render error is already logged by the layer below.

**Raw template parse errors**

`Service` tracks which chart directories failed to render. When the YAML parser fails on a file inside one of those directories, the expected outcome for raw Go templates, the error is logged at Debug. Parse failures on all other files remain at Error, preserving visibility into genuine parser bugs.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/runner/... ./pkg/resolver/helm/... ./pkg/engine/provider/...`
2. Scan a Helm chart that requires deploy-time values and confirm: zero ERROR lines are emitted for that chart, the raw template files inside it produce no ERROR, and a single Debug line with the specific template error is present when debug logging is enabled.
3. Scan a non-Helm YAML file with intentionally invalid syntax and confirm the parse failure still surfaces at Error.

## Impact

Only the Helm rendering and raw-template fallback path are affected. No scan results, rule logic, or output formats change, only log levels for known, handled failure conditions are reduced.

## Additional Notes

I submit this contribution under the Apache-2.0 license.