### PR TITLE
IaC Resources Inventory

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -77,6 +77,10 @@ var scanAction = &cli.Command{
 			Usage: "ids of queries to exclude",
 			Value: []string{},
 		},
+		&cli.BoolFlag{
+			Name:  "resource-inventory",
+			Usage: "also emit a JSON inventory of all scanned IaC resources",
+		},
 		&cli.StringSliceFlag{
 			Name:    "type",
 			Aliases: []string{"t"},
@@ -351,6 +355,9 @@ func runScan(ctx context.Context, c *cli.Command) error {
 	if err := validateReportFormats(reportFormats); err != nil {
 		return errorWithExitCode(err, constants.InvalidConfigErrorCode)
 	}
+	if c.Bool("resource-inventory") {
+		reportFormats = appendReportFormatIfMissing(reportFormats, "iac-inventory")
+	}
 	modulesSetting, err := scan.ParseTerraformModules(c.String("terraform-modules"))
 	if err != nil {
 		return errorWithExitCode(err, constants.InvalidConfigErrorCode)
@@ -457,6 +464,15 @@ func runScan(ctx context.Context, c *cli.Command) error {
 	}
 
 	return getExitCode(&metadata)
+}
+
+func appendReportFormatIfMissing(formats []string, format string) []string {
+	for _, f := range formats {
+		if strings.EqualFold(strings.TrimSpace(f), format) {
+			return formats
+		}
+	}
+	return append(formats, format)
 }
 
 func getCommonDir(paths []string) (string, error) {

--- a/docs/schemas/iac-resource-inventory-v1.schema.json
+++ b/docs/schemas/iac-resource-inventory-v1.schema.json
@@ -10,7 +10,7 @@
     "schema_version": {
       "type": "string",
       "description": "Version of this inventory document format.",
-      "const": "1.0"
+      "const": "1.1"
     },
     "tool": {
       "type": "object",
@@ -96,6 +96,10 @@
           "type": "string",
           "description": "The `version` constraint of a module block, e.g. \"~> 5.0\". Present only when block_type is \"module\" and a version is specified."
         },
+        "module": {
+          "$ref": "#/$defs/module_attribution",
+          "description": "Terraform module provenance aligned with SARIF properties.module. Present on module blocks and on resources/data declared inside instantiated modules. Direct module relationships omit module_path; transitive relationships include the ordered call chain."
+        },
         "api_version": {
           "type": "string",
           "description": "The Kubernetes manifest apiVersion, e.g. \"apps/v1\". Present only when block_type is \"manifest\"."
@@ -119,6 +123,59 @@
       "properties": {
         "start": { "type": "integer", "minimum": 0 },
         "end": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "source_location": {
+      "type": "object",
+      "required": ["filename"],
+      "additionalProperties": false,
+      "properties": {
+        "filename": { "type": "string" },
+        "line_start": { "type": "integer", "minimum": 0 },
+        "line_end": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "module_path_hop": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "source": { "type": "string" },
+        "source_type": {
+          "type": "string",
+          "description": "Module source classification: local, registry, git, or unknown."
+        },
+        "version": {
+          "type": "string",
+          "description": "Resolved registry semver or git commit SHA when known."
+        },
+        "code_location": { "$ref": "#/$defs/source_location" }
+      }
+    },
+    "module_attribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "source": {
+          "type": "string",
+          "description": "Normalized, credential-free module source."
+        },
+        "source_type": { "type": "string" },
+        "version": { "type": "string" },
+        "dependency_type": {
+          "type": "string",
+          "enum": ["direct", "transitive"]
+        },
+        "code_location": {
+          "$ref": "#/$defs/source_location",
+          "description": "Module-relative location of the resource block when this object describes a resource inside a module."
+        },
+        "module_path": {
+          "type": "array",
+          "description": "Ordered module call chain from the customer declaration to the leaf module. Omitted for direct relationships.",
+          "items": { "$ref": "#/$defs/module_path_hop" }
+        }
       }
     }
   }

--- a/docs/schemas/iac-resource-inventory-v1.schema.json
+++ b/docs/schemas/iac-resource-inventory-v1.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.datadoghq.com/schemas/iac-resource-inventory-v1.schema.json",
+  "title": "Datadog IaC Resource Inventory",
+  "description": "A purpose-built inventory of the Infrastructure-as-Code resources discovered by the Datadog IaC Scanner. Unlike the SARIF findings report, this document enumerates every resource present in the scanned files, independent of whether any rule matched it.",
+  "type": "object",
+  "required": ["schema_version", "tool", "generated_at", "resource_count", "resources"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Version of this inventory document format.",
+      "const": "1.0"
+    },
+    "tool": {
+      "type": "object",
+      "description": "The tool that produced the inventory.",
+      "required": ["name", "vendor", "version"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "vendor": { "type": "string" },
+        "version": { "type": "string" }
+      }
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC 3339 timestamp of when the inventory was generated."
+    },
+    "root_path": {
+      "type": "string",
+      "description": "The scanned root path or repository location."
+    },
+    "resource_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of resources in the inventory."
+    },
+    "resources": {
+      "type": "array",
+      "description": "The enumerated IaC resources.",
+      "items": { "$ref": "#/$defs/resource" }
+    }
+  },
+  "$defs": {
+    "resource": {
+      "type": "object",
+      "required": [
+        "address",
+        "iac_platform",
+        "block_type",
+        "resource_type",
+        "name",
+        "file_path",
+        "line_range"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "Stable, platform-native identifier for the resource. Examples: Terraform \"aws_s3_bucket.b\", \"data.aws_ami.example\", \"module.network\"; Kubernetes \"default/Deployment/my-app\" (\"<namespace>/<kind>/<name>\", namespace omitted for cluster-scoped objects); CloudFormation logical ID \"MyBucket\"; Ansible task name; Dockerfile stage alias or base image; CI/CD job identifier."
+        },
+        "iac_platform": {
+          "type": "string",
+          "description": "The IaC technology the resource was parsed from.",
+          "examples": ["terraform", "kubernetes", "cloudformation", "ansible", "dockerfile", "cicd"]
+        },
+        "block_type": {
+          "type": "string",
+          "description": "The category of block the resource originates from. \"resource\"/\"data\"/\"module\" are Terraform blocks (\"resource\" is also a CloudFormation logical resource); \"manifest\" is a Kubernetes object; \"task\" is an Ansible task; \"stage\" is a Dockerfile build stage; \"job\" is a CI/CD job or Dependabot update.",
+          "enum": ["resource", "data", "module", "manifest", "task", "stage", "job"]
+        },
+        "resource_type": {
+          "type": ["string", "null"],
+          "description": "The resource's type in its platform: Terraform type (e.g. \"aws_s3_bucket\"), Kubernetes kind (e.g. \"Deployment\"), CloudFormation type (e.g. \"AWS::S3::Bucket\"), Ansible module (e.g. \"ansible.builtin.copy\"), Dockerfile base image (e.g. \"alpine:3.19\"), or Dependabot package ecosystem. null when the block has no meaningful type (Terraform modules, CI/CD jobs)."
+        },
+        "name": {
+          "type": "string",
+          "description": "The resource's local identifier: Terraform label, Kubernetes metadata.name, CloudFormation logical ID, Ansible task name, Dockerfile stage alias/image, or CI/CD job id."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Provider inferred from the resource type prefix, e.g. \"aws\" (from \"aws_s3_bucket\" or \"AWS::S3::Bucket\"). Absent when it cannot be inferred."
+        },
+        "file_path": {
+          "type": "string",
+          "description": "Path of the file the resource was declared in."
+        },
+        "line_range": { "$ref": "#/$defs/line_range" },
+        "module_source": {
+          "type": "string",
+          "description": "The `source` argument of a module block. Present only when block_type is \"module\"."
+        },
+        "module_version": {
+          "type": "string",
+          "description": "The `version` constraint of a module block, e.g. \"~> 5.0\". Present only when block_type is \"module\" and a version is specified."
+        },
+        "api_version": {
+          "type": "string",
+          "description": "The Kubernetes manifest apiVersion, e.g. \"apps/v1\". Present only when block_type is \"manifest\"."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The Kubernetes metadata.namespace. Present only when block_type is \"manifest\" and a namespace is declared."
+        },
+        "attributes": {
+          "type": "object",
+          "description": "Every attribute declared in the resource block, extracted verbatim from the parsed source. Nested blocks are preserved as objects; repeated blocks as arrays. No filtering or curation is applied — unresolved references appear as their raw string representation. Annotation keys prefixed with _dd_ are stripped.",
+          "additionalProperties": true
+        }
+      }
+    },
+    "line_range": {
+      "type": "object",
+      "description": "The line span of the resource. Values are 1-based when line information is available; 0 means the parser did not record a location (e.g. an empty or unannotated block). \"end\" is derived from the furthest annotated attribute inside the block and equals \"start\" when no wider range is known.",
+      "required": ["start", "end"],
+      "additionalProperties": false,
+      "properties": {
+        "start": { "type": "integer", "minimum": 0 },
+        "end": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -246,6 +246,7 @@ type Inspector struct {
 	remoteModuleDirs       map[string]RemoteModuleDirectory
 	remoteModuleProvenance map[string]RemoteModuleProvenance
 	externalPathRoots      map[string]bool
+	parsedTerraformModules map[string]tfmodules.ParsedModule
 }
 
 func (c *Inspector) SetRemoteModuleDirectories(sourceToDir map[string]RemoteModuleDirectory) {
@@ -517,6 +518,7 @@ func (c *Inspector) Inspect(
 		}
 		contextLogger.Warn().Err(err).Msg("Failed to parse Terraform modules")
 	}
+	c.parsedTerraformModules = parsedModules
 	contextLogger.Info().Msgf("Found %d modules", len(parsedModules))
 
 	// Step 2: Enrich modules with parsed variables. As with Step 1, a context
@@ -734,6 +736,12 @@ func (c *Inspector) GetFailedQueries() map[string]error {
 	c.failedQueriesMu.Lock()
 	defer c.failedQueriesMu.Unlock()
 	return maps.Clone(c.failedQueries)
+}
+
+// ParsedTerraformModules returns the module index built during the last Inspect
+// call. The map is read-only for callers and is reused by inventory export.
+func (c *Inspector) ParsedTerraformModules() map[string]tfmodules.ParsedModule {
+	return c.parsedTerraformModules
 }
 
 func ruleArgumentsValue(rc config.IacRuleConfig) (ast.Value, bool, error) {

--- a/pkg/inventory/ansible.go
+++ b/pkg/inventory/ansible.go
@@ -1,0 +1,114 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package inventory
+
+import "github.com/DataDog/datadog-iac-scanner/pkg/model"
+
+const platformAnsible = "ansible"
+
+var ansibleTaskLists = []string{"tasks", "pre_tasks", "post_tasks", "handlers"}
+
+var ansibleBlockLists = []string{"block", "rescue", "always"}
+
+// ansibleDirectives are task keywords that are not module names.
+// The invoked module is the first non-directive key of a task mapping.
+var ansibleDirectives = map[string]struct{}{
+	"name": {}, "when": {}, "become": {}, "become_user": {}, "become_method": {},
+	"become_flags": {}, "become_exe": {}, "register": {}, "loop": {}, "loop_control": {},
+	"with_items": {}, "with_dict": {}, "with_fileglob": {}, "with_together": {},
+	"with_subelements": {}, "with_nested": {}, "with_sequence": {}, "with_first_found": {},
+	"with_random_choice": {}, "until": {}, "retries": {}, "delay": {}, "notify": {},
+	"tags": {}, "vars": {}, "environment": {}, "delegate_to": {}, "delegate_facts": {},
+	"run_once": {}, "ignore_errors": {}, "ignore_unreachable": {}, "changed_when": {},
+	"failed_when": {}, "check_mode": {}, "diff": {}, "no_log": {}, "args": {},
+	"async": {}, "poll": {}, "throttle": {}, "timeout": {}, "any_errors_fatal": {},
+	"block": {}, "rescue": {}, "always": {}, "listen": {}, "connection": {}, "port": {},
+	"remote_user": {}, "module_defaults": {}, "collections": {}, "action": {},
+	"local_action": {},
+}
+
+type ansibleWalker struct{}
+
+func (ansibleWalker) Platform() string { return platformAnsible }
+
+func (ansibleWalker) Kinds() []model.FileKind {
+	return []model.FileKind{model.KindYAML, model.KindYML}
+}
+
+// Walk handles playbook files only (top-level list wrapped in a "playbooks"
+// key by the YAML parser). Role task files (bare YAML lists without a
+// "playbooks" key) are not supported and will return handled=false.
+func (ansibleWalker) Walk(filePath string, doc model.Document) ([]Resource, bool) {
+	plays, ok := doc["playbooks"].([]interface{})
+	if !ok || len(plays) == 0 {
+		return nil, false
+	}
+
+	var resources []Resource
+	for _, p := range plays {
+		play, ok := toMap(p)
+		if !ok {
+			continue
+		}
+		for _, key := range ansibleTaskLists {
+			if tasks, ok := play[key].([]interface{}); ok {
+				resources = append(resources, walkAnsibleTasks(filePath, tasks)...)
+			}
+		}
+	}
+	// Return handled=true even when resources is nil so no other walker
+	// attempts to claim a playbook file that has plays but no tasks.
+	return resources, true
+}
+
+func walkAnsibleTasks(filePath string, tasks []interface{}) []Resource {
+	var resources []Resource
+	for _, t := range tasks {
+		task, ok := toMap(t)
+		if !ok {
+			continue
+		}
+
+		for _, blockKey := range ansibleBlockLists {
+			if nested, ok := task[blockKey].([]interface{}); ok {
+				resources = append(resources, walkAnsibleTasks(filePath, nested)...)
+			}
+		}
+
+		module := ansibleModule(task)
+		if module == "" {
+			continue
+		}
+		name, _ := task["name"].(string)
+		start, end := lineBounds(task)
+		resources = append(resources, Resource{
+			Platform:   platformAnsible,
+			BlockType:  BlockTask,
+			Type:       module,
+			Name:       name,
+			File:       filePath,
+			StartLine:  start,
+			EndLine:    end,
+			Attributes: attrsFromBody(task),
+		})
+	}
+	return resources
+}
+
+// ansibleModule returns the module name by picking the first non-directive key
+// in alphabetical order. This is a heuristic: tasks with multiple non-directive
+// keys (e.g. module + args) may not resolve correctly, but in practice the
+// module is the only non-directive key for well-formed tasks.
+func ansibleModule(task map[string]interface{}) string {
+	for _, k := range sortedKeys(task) {
+		if _, isDirective := ansibleDirectives[k]; isDirective {
+			continue
+		}
+		return k
+	}
+	return ""
+}

--- a/pkg/inventory/cicd.go
+++ b/pkg/inventory/cicd.go
@@ -1,0 +1,104 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package inventory
+
+import "github.com/DataDog/datadog-iac-scanner/pkg/model"
+
+const platformCICD = "cicd"
+
+// ciCDWalker enumerates GitHub Actions jobs, composite actions, and Dependabot
+// update entries.
+type ciCDWalker struct{}
+
+func (ciCDWalker) Platform() string { return platformCICD }
+
+func (ciCDWalker) Kinds() []model.FileKind {
+	return []model.FileKind{model.KindYAML, model.KindYML}
+}
+
+func (ciCDWalker) Walk(filePath string, doc model.Document) ([]Resource, bool) {
+	if jobs, ok := toMap(doc["jobs"]); ok {
+		return walkCICDJobs(filePath, jobs), true
+	}
+	if updates, ok := doc["updates"].([]interface{}); ok {
+		return walkDependabotUpdates(filePath, updates), true
+	}
+	if runs, ok := toMap(doc["runs"]); ok {
+		if _, isAction := runs["using"]; isAction {
+			return []Resource{newCompositeAction(filePath, doc)}, true
+		}
+	}
+	return nil, false
+}
+
+func walkCICDJobs(filePath string, jobs map[string]interface{}) []Resource {
+	var resources []Resource
+	for _, jobID := range sortedKeys(jobs) {
+		body, ok := toMap(jobs[jobID])
+		if !ok {
+			continue
+		}
+		start, end := lineBounds(body)
+		resources = append(resources, Resource{
+			Platform:   platformCICD,
+			BlockType:  BlockJob,
+			Name:       jobID,
+			File:       filePath,
+			StartLine:  start,
+			EndLine:    end,
+			Attributes: attrsFromBody(body),
+		})
+	}
+	return resources
+}
+
+func walkDependabotUpdates(filePath string, updates []interface{}) []Resource {
+	var resources []Resource
+	for _, u := range updates {
+		update, ok := toMap(u)
+		if !ok {
+			continue
+		}
+		ecosystem, _ := update["package-ecosystem"].(string)
+		name, _ := update["directory"].(string)
+		if name == "" {
+			name = ecosystem
+		}
+		if name == "" {
+			continue // skip malformed entries with neither directory nor ecosystem
+		}
+		start, end := lineBounds(update)
+		resources = append(resources, Resource{
+			Platform:   platformCICD,
+			BlockType:  BlockJob,
+			Type:       ecosystem,
+			Name:       name,
+			File:       filePath,
+			StartLine:  start,
+			EndLine:    end,
+			Attributes: attrsFromBody(update),
+		})
+	}
+	return resources
+}
+
+func newCompositeAction(filePath string, doc model.Document) Resource {
+	name, _ := doc["name"].(string)
+	start, end := lineBounds(doc)
+	attrs := attrsFromBody(doc)
+	deleteInjectedKeys(attrs)
+	return Resource{
+		Platform:   platformCICD,
+		BlockType:  BlockJob,
+		Type:       "composite-action",
+		Name:       name,
+		File:       filePath,
+		StartLine:  start,
+		EndLine:    end,
+		Attributes: attrs,
+	}
+}

--- a/pkg/inventory/cloudformation.go
+++ b/pkg/inventory/cloudformation.go
@@ -1,0 +1,100 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package inventory
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+const platformCloudFormation = "cloudformation"
+
+// cloudFormationWalker enumerates the logical resources declared under a
+// template's top-level `Resources` mapping.
+type cloudFormationWalker struct{}
+
+func (cloudFormationWalker) Platform() string { return platformCloudFormation }
+
+func (cloudFormationWalker) Kinds() []model.FileKind {
+	return []model.FileKind{model.KindYAML, model.KindYML, model.KindJSON}
+}
+
+func (cloudFormationWalker) Walk(filePath string, doc model.Document) ([]Resource, bool) {
+	// Require a CloudFormation marker before touching the Resources map, so
+	// arbitrary YAML with a "Resources" key (Helm values, K8s ResourceQuota,
+	// etc.) is not misclassified.
+	if !isCFNTemplate(doc) {
+		return nil, false
+	}
+	resourcesMap, ok := toMap(doc["Resources"])
+	if !ok {
+		return nil, false
+	}
+
+	var resources []Resource
+	for _, logicalID := range sortedKeys(resourcesMap) {
+		body, ok := toMap(resourcesMap[logicalID])
+		if !ok {
+			continue
+		}
+		resType, _ := body["Type"].(string)
+		start, end := lineBounds(body)
+		resources = append(resources, Resource{
+			Platform:   platformCloudFormation,
+			BlockType:  BlockResource,
+			Type:       resType,
+			Name:       logicalID,
+			Provider:   cfnProvider(resType),
+			File:       filePath,
+			StartLine:  start,
+			EndLine:    end,
+			Attributes: attrsFromBody(body),
+		})
+	}
+	if len(resources) == 0 {
+		return nil, false
+	}
+	return resources, true
+}
+
+// isCFNTemplate reports whether a document looks like a CloudFormation template.
+// We require either the canonical AWSTemplateFormatVersion/Transform keys, or
+// at least one resource entry with a Type field (the CFN resource shape).
+func isCFNTemplate(doc model.Document) bool {
+	if _, ok := doc["AWSTemplateFormatVersion"]; ok {
+		return true
+	}
+	if _, ok := doc["Transform"]; ok {
+		return true
+	}
+	// Fallback: at least one entry in Resources must be a map with a Type field.
+	resourcesMap, ok := toMap(doc["Resources"])
+	if !ok {
+		return false
+	}
+	for _, v := range resourcesMap {
+		if body, ok := toMap(v); ok {
+			if _, hasType := body["Type"]; hasType {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// cfnProvider derives a provider from a CloudFormation resource type, e.g.
+// "AWS::S3::Bucket" -> "aws", "Custom::MyThing" -> "custom".
+func cfnProvider(resType string) string {
+	if resType == "" {
+		return ""
+	}
+	if idx := strings.Index(resType, "::"); idx > 0 {
+		return strings.ToLower(resType[:idx])
+	}
+	return strings.ToLower(resType)
+}

--- a/pkg/inventory/dockerfile.go
+++ b/pkg/inventory/dockerfile.go
@@ -1,0 +1,111 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package inventory
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+const platformDockerfile = "dockerfile"
+
+// dockerfileWalker enumerates the build stages of a Dockerfile. The parser
+// groups instructions per FROM into a "command" map keyed by the FROM value, so
+// each entry is one stage and its base image.
+type dockerfileWalker struct{}
+
+func (dockerfileWalker) Platform() string { return platformDockerfile }
+
+func (dockerfileWalker) Kinds() []model.FileKind { return []model.FileKind{model.KindDOCKER} }
+
+func (dockerfileWalker) Walk(filePath string, doc model.Document) ([]Resource, bool) {
+	stages, ok := toMap(doc["command"])
+	if !ok {
+		return nil, false
+	}
+
+	var resources []Resource
+	for _, from := range sortedKeys(stages) {
+		instructions, ok := toList(stages[from])
+		if !ok {
+			continue
+		}
+		image, alias := parseDockerFrom(from)
+		name := alias
+		if name == "" {
+			name = image
+		}
+		start, end := dockerStageLines(instructions)
+		attrs := map[string]interface{}{"from": from}
+		if cleaned := cleanAttrs(instructions); cleaned != nil {
+			attrs["instructions"] = cleaned
+		}
+		resources = append(resources, Resource{
+			Platform:   platformDockerfile,
+			BlockType:  BlockStage,
+			Type:       image,
+			Name:       name,
+			File:       filePath,
+			StartLine:  start,
+			EndLine:    end,
+			Attributes: attrs,
+		})
+	}
+	return resources, true
+}
+
+// parseDockerFrom splits a FROM value into its base image and optional stage
+// alias, e.g. "node:18 AS builder" -> ("node:18", "builder").
+func parseDockerFrom(from string) (image, alias string) {
+	fields := strings.Fields(from)
+	if len(fields) == 0 {
+		return from, ""
+	}
+	image = fields[0]
+	for i := 1; i+1 < len(fields); i++ {
+		if strings.EqualFold(fields[i], "AS") {
+			alias = fields[i+1]
+			break
+		}
+	}
+	return image, alias
+}
+
+// dockerStageLines derives a stage's line span from its instruction nodes, each
+// of which carries a "_dd_line" start and an "EndLine".
+func dockerStageLines(instructions []interface{}) (start, end int) {
+	for _, c := range instructions {
+		m, ok := toMap(c)
+		if !ok {
+			continue
+		}
+		if l, ok := genericLine(m); ok {
+			if start == 0 || l < start {
+				start = l
+			}
+			if l > end {
+				end = l
+			}
+		}
+		if e, ok := intFromNumber(m["EndLine"]); ok && e > end {
+			end = e
+		}
+	}
+	return start, end
+}
+
+// intFromNumber reads an int from the int/float64 forms JSON decoding produces.
+func intFromNumber(v interface{}) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case float64:
+		return int(n), true
+	}
+	return 0, false
+}

--- a/pkg/inventory/helpers.go
+++ b/pkg/inventory/helpers.go
@@ -1,0 +1,203 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package inventory
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+// internalKeyPrefixes covers parser bookkeeping keys that are never declared
+// attributes: line annotations (_dd_), legacy field names (_kics_), and the
+// CI/CD parser's run/expression enrichments (_parsed).
+var internalKeyPrefixes = []string{"_dd_", "_kics_", "_parsed"}
+
+// scannerInjectedKeys are document-root keys injected by the scan pipeline
+// (path, id, file) that are not part of the IaC source. Both the Kubernetes
+// and CI/CD parsers inject these same keys.
+var scannerInjectedKeys = []string{"_path", "id", "file"}
+
+// deleteInjectedKeys removes scannerInjectedKeys from an attrs map. Safe to
+// call with a nil map (no-op).
+func deleteInjectedKeys(attrs map[string]interface{}) {
+	for _, k := range scannerInjectedKeys {
+		delete(attrs, k)
+	}
+}
+
+func isInternalKey(k string) bool {
+	for _, p := range internalKeyPrefixes {
+		if strings.HasPrefix(k, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// cleanAttrs strips internal annotation keys from a parsed body at every
+// nesting level. map[string]model.LineObject values are annotation-only and
+// dropped entirely.
+func cleanAttrs(v interface{}) interface{} {
+	switch t := v.(type) {
+	case model.Document:
+		return cleanMap(map[string]interface{}(t))
+	case map[string]interface{}:
+		return cleanMap(t)
+	case []interface{}:
+		out := make([]interface{}, 0, len(t))
+		for _, item := range t {
+			out = append(out, cleanAttrs(item))
+		}
+		return out
+	case map[string]model.LineObject, map[string]*model.LineObject:
+		return nil
+	default:
+		return v
+	}
+}
+
+func attrsFromBody(body interface{}) map[string]interface{} {
+	cleaned := cleanAttrs(body)
+	if m, ok := cleaned.(map[string]interface{}); ok {
+		return m
+	}
+	return nil
+}
+
+func cleanMap(m map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		if isInternalKey(k) {
+			continue
+		}
+		cleaned := cleanAttrs(v)
+		// Preserve explicit source nulls (v == nil); only drop values that
+		// became nil because cleanAttrs consumed them (annotation maps, etc.).
+		if cleaned != nil || v == nil {
+			out[k] = cleaned
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// lineBounds returns the min/max line numbers annotated anywhere in a parsed
+// body, tolerating both the Terraform converter's struct form and the
+// JSON-decoded form used by YAML/JSON parsers.
+func lineBounds(body interface{}) (minLine, maxLine int) {
+	tracker := &lineTracker{}
+	tracker.walk(body)
+	return tracker.min, tracker.max
+}
+
+type lineTracker struct{ min, max int }
+
+func (t *lineTracker) consider(line int) {
+	if line <= 0 {
+		return
+	}
+	if t.min == 0 || line < t.min {
+		t.min = line
+	}
+	if line > t.max {
+		t.max = line
+	}
+}
+
+func (t *lineTracker) walk(v interface{}) {
+	switch val := v.(type) {
+	case map[string]model.LineObject:
+		t.walkLineObjects(val)
+	case map[string]*model.LineObject:
+		for _, lo := range val {
+			if lo != nil {
+				t.consider(lo.Line)
+			}
+		}
+	case model.Document:
+		for _, child := range val {
+			t.walk(child)
+		}
+	case map[string]interface{}:
+		if line, ok := genericLine(val); ok {
+			t.consider(line)
+		}
+		for _, child := range val {
+			t.walk(child)
+		}
+	case []interface{}:
+		for _, child := range val {
+			t.walk(child)
+		}
+	}
+}
+
+func (t *lineTracker) walkLineObjects(m map[string]model.LineObject) {
+	for _, lo := range m {
+		t.consider(lo.Line)
+		for _, arr := range lo.Arr {
+			for _, p := range arr {
+				if p != nil {
+					t.consider(p.Line)
+				}
+			}
+		}
+	}
+}
+
+func genericLine(m map[string]interface{}) (int, bool) {
+	switch v := m["_dd_line"].(type) {
+	case int:
+		return v, true
+	case float64:
+		return int(v), true
+	}
+	return 0, false
+}
+
+func stringAttr(body interface{}, key string) string {
+	bodyMap, ok := toMap(body)
+	if !ok {
+		return ""
+	}
+	if s, ok := bodyMap[key].(string); ok {
+		return s
+	}
+	return ""
+}
+
+func toMap(v interface{}) (map[string]interface{}, bool) {
+	switch m := v.(type) {
+	case model.Document:
+		return m, true
+	case map[string]interface{}:
+		return m, true
+	default:
+		return nil, false
+	}
+}
+
+func toList(v interface{}) ([]interface{}, bool) {
+	list, ok := v.([]interface{})
+	return list, ok
+}
+
+func sortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		if isInternalKey(k) {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -11,11 +11,12 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/constants"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 )
 
 // SchemaVersion is bumped on backward-incompatible changes.
 // The JSON Schema lives at docs/schemas/iac-resource-inventory-v1.schema.json.
-const SchemaVersion = "1.0"
+const SchemaVersion = "1.1"
 
 // Inventory is the top-level IaC resource inventory document.
 type Inventory struct {
@@ -43,9 +44,10 @@ type InventoryEntry struct {
 	Provider      string                 `json:"provider,omitempty"`
 	FilePath      string                 `json:"file_path"`
 	LineRange     LineRange              `json:"line_range"`
-	ModuleSource  string                 `json:"module_source,omitempty"`
-	ModuleVersion string                 `json:"module_version,omitempty"`
-	APIVersion    string                 `json:"api_version,omitempty"`
+	ModuleSource  string                        `json:"module_source,omitempty"`
+	ModuleVersion string                        `json:"module_version,omitempty"`
+	Module        *model.ModuleAttributionSARIF `json:"module,omitempty"`
+	APIVersion    string                        `json:"api_version,omitempty"`
 	Namespace     string                 `json:"namespace,omitempty"`
 	Attributes    map[string]interface{} `json:"attributes,omitempty"`
 }
@@ -92,6 +94,7 @@ func toEntry(r *Resource) InventoryEntry {
 		LineRange:     LineRange{Start: r.StartLine, End: r.EndLine},
 		ModuleSource:  r.ModuleSource,
 		ModuleVersion: r.ModuleVersion,
+		Module:        r.Module,
 		APIVersion:    r.APIVersion,
 		Namespace:     r.Namespace,
 		Attributes:    r.Attributes,

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -1,0 +1,129 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package inventory
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-iac-scanner/internal/constants"
+)
+
+// SchemaVersion is bumped on backward-incompatible changes.
+// The JSON Schema lives at docs/schemas/iac-resource-inventory-v1.schema.json.
+const SchemaVersion = "1.0"
+
+// Inventory is the top-level IaC resource inventory document.
+type Inventory struct {
+	SchemaVersion string           `json:"schema_version"`
+	Tool          InventoryTool    `json:"tool"`
+	GeneratedAt   string           `json:"generated_at"`
+	RootPath      string           `json:"root_path,omitempty"`
+	ResourceCount int              `json:"resource_count"`
+	Resources     []InventoryEntry `json:"resources"`
+}
+
+type InventoryTool struct {
+	Name    string `json:"name"`
+	Vendor  string `json:"vendor"`
+	Version string `json:"version"`
+}
+
+// InventoryEntry is a single resource in the inventory.
+type InventoryEntry struct {
+	Address       string                 `json:"address"`
+	IaCPlatform   string                 `json:"iac_platform"`
+	BlockType     string                 `json:"block_type"`
+	ResourceType  *string                `json:"resource_type"` // null for module blocks
+	Name          string                 `json:"name"`
+	Provider      string                 `json:"provider,omitempty"`
+	FilePath      string                 `json:"file_path"`
+	LineRange     LineRange              `json:"line_range"`
+	ModuleSource  string                 `json:"module_source,omitempty"`
+	ModuleVersion string                 `json:"module_version,omitempty"`
+	APIVersion    string                 `json:"api_version,omitempty"`
+	Namespace     string                 `json:"namespace,omitempty"`
+	Attributes    map[string]interface{} `json:"attributes,omitempty"`
+}
+
+// LineRange is the 1-based line span of a resource. End is best-effort.
+type LineRange struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+func BuildInventory(resources []Resource, rootPath string) *Inventory {
+	entries := make([]InventoryEntry, 0, len(resources))
+	for i := range resources {
+		entries = append(entries, toEntry(&resources[i]))
+	}
+
+	return &Inventory{
+		SchemaVersion: SchemaVersion,
+		Tool: InventoryTool{
+			Name:    "Datadog IaC Scanner",
+			Vendor:  "Datadog",
+			Version: constants.Version,
+		},
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		RootPath:      rootPath,
+		ResourceCount: len(entries),
+		Resources:     entries,
+	}
+}
+
+func toEntry(r *Resource) InventoryEntry {
+	var resourceType *string
+	if r.Type != "" {
+		resourceType = &r.Type
+	}
+	return InventoryEntry{
+		Address:       resourceAddress(r),
+		IaCPlatform:   r.Platform,
+		BlockType:     string(r.BlockType),
+		ResourceType:  resourceType,
+		Name:          r.Name,
+		Provider:      r.Provider,
+		FilePath:      r.File,
+		LineRange:     LineRange{Start: r.StartLine, End: r.EndLine},
+		ModuleSource:  r.ModuleSource,
+		ModuleVersion: r.ModuleVersion,
+		APIVersion:    r.APIVersion,
+		Namespace:     r.Namespace,
+		Attributes:    r.Attributes,
+	}
+}
+
+func resourceAddress(r *Resource) string {
+	switch r.BlockType {
+	case BlockModule:
+		return fmt.Sprintf("module.%s", r.Name)
+	case BlockData:
+		return fmt.Sprintf("data.%s.%s", r.Type, r.Name)
+	case BlockManifest:
+		// kubectl-style <namespace>/<kind>/<name>; omit namespace for cluster-scoped objects.
+		if r.Namespace != "" {
+			return fmt.Sprintf("%s/%s/%s", r.Namespace, r.Type, r.Name)
+		}
+		return fmt.Sprintf("%s/%s", r.Type, r.Name)
+	case BlockTask:
+		if r.Name != "" {
+			return r.Name
+		}
+		return r.Type
+	case BlockStage, BlockJob:
+		return r.Name
+	case BlockResource:
+		// CloudFormation uses its logical ID; Terraform uses type.name.
+		if r.Platform == platformCloudFormation {
+			return r.Name
+		}
+		return fmt.Sprintf("%s.%s", r.Type, r.Name)
+	default:
+		return fmt.Sprintf("%s.%s", r.Type, r.Name)
+	}
+}

--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -41,9 +41,10 @@ func parseTF(t *testing.T, name, content string) *model.FileMetadata {
 	require.NoError(t, err)
 	require.Len(t, docs, 1)
 	return &model.FileMetadata{
-		FilePath: name,
-		Kind:     model.KindTerraform,
-		Document: docs[0],
+		FilePath:     name,
+		Kind:         model.KindTerraform,
+		Document:     docs[0],
+		OriginalData: content,
 	}
 }
 
@@ -114,7 +115,7 @@ func findResource(resources []Resource, blockType BlockType, name string) (Resou
 
 func TestWalkFiles_Terraform(t *testing.T) {
 	files := model.FileMetadatas{parseTF(t, "main.tf", sampleTF)}
-	resources := WalkFiles(files, nil)
+	resources := WalkFiles(files, nil, nil)
 
 	require.Len(t, resources, 3)
 
@@ -145,12 +146,12 @@ func TestWalkFiles_SkipsNonTerraform(t *testing.T) {
 		{FilePath: "k8s.yaml", Kind: model.KindYAML, Document: model.Document{"kind": "Pod"}},
 		{FilePath: "empty.tf", Kind: model.KindTerraform, Document: model.Document{}},
 	}
-	require.Empty(t, WalkFiles(files, nil))
+	require.Empty(t, WalkFiles(files, nil, nil))
 }
 
 func TestBuildInventory(t *testing.T) {
 	files := model.FileMetadatas{parseTF(t, "main.tf", sampleTF)}
-	inv := BuildInventory(WalkFiles(files, nil), "my-repo")
+	inv := BuildInventory(WalkFiles(files, nil, nil), "my-repo")
 
 	require.Equal(t, SchemaVersion, inv.SchemaVersion)
 	require.Equal(t, "Datadog", inv.Tool.Vendor)
@@ -224,7 +225,7 @@ func TestResourceAddress(t *testing.T) {
 }
 
 func TestWalkFiles_Kubernetes(t *testing.T) {
-	resources := WalkFiles(parseYAML(t, "deploy.yaml", sampleK8s), nil)
+	resources := WalkFiles(parseYAML(t, "deploy.yaml", sampleK8s), nil, nil)
 	require.Len(t, resources, 2)
 
 	dep, ok := findResource(resources, BlockManifest, "my-app")
@@ -255,7 +256,7 @@ func TestWalkFiles_Kubernetes(t *testing.T) {
 }
 
 func TestBuildInventory_Kubernetes(t *testing.T) {
-	inv := BuildInventory(WalkFiles(parseYAML(t, "deploy.yaml", sampleK8s), nil), "my-repo")
+	inv := BuildInventory(WalkFiles(parseYAML(t, "deploy.yaml", sampleK8s), nil, nil), "my-repo")
 	require.Equal(t, 2, inv.ResourceCount)
 
 	var dep *InventoryEntry
@@ -279,7 +280,7 @@ func TestWalkFiles_SkipsNonKubernetesYAML(t *testing.T) {
 	files := model.FileMetadatas{
 		{FilePath: "vars.yaml", Kind: model.KindYAML, Document: model.Document{"foo": "bar"}, LineInfoDocument: map[string]interface{}{"foo": "bar"}},
 	}
-	require.Empty(t, WalkFiles(files, nil))
+	require.Empty(t, WalkFiles(files, nil, nil))
 }
 
 const sampleCFN = `AWSTemplateFormatVersion: "2010-09-09"
@@ -295,7 +296,7 @@ Resources:
 `
 
 func TestWalkFiles_CloudFormation(t *testing.T) {
-	resources := WalkFiles(parseYAML(t, "template.yaml", sampleCFN), nil)
+	resources := WalkFiles(parseYAML(t, "template.yaml", sampleCFN), nil, nil)
 	require.Len(t, resources, 2)
 
 	bucket, ok := findResource(resources, BlockResource, "MyBucket")
@@ -336,7 +337,7 @@ const sampleAnsible = `---
 `
 
 func TestWalkFiles_Ansible(t *testing.T) {
-	resources := WalkFiles(parseYAML(t, "playbook.yaml", sampleAnsible), nil)
+	resources := WalkFiles(parseYAML(t, "playbook.yaml", sampleAnsible), nil, nil)
 	require.Len(t, resources, 3, "two top-level tasks plus one inside the block")
 
 	install, ok := findResource(resources, BlockTask, "install nginx")
@@ -361,7 +362,7 @@ ENTRYPOINT ["/app"]
 `
 
 func TestWalkFiles_Dockerfile(t *testing.T) {
-	resources := WalkFiles(parseDockerfile(t, "Dockerfile", sampleDockerfile), nil)
+	resources := WalkFiles(parseDockerfile(t, "Dockerfile", sampleDockerfile), nil, nil)
 	require.Len(t, resources, 2, "two build stages")
 
 	builder, ok := findResource(resources, BlockStage, "builder")
@@ -391,7 +392,7 @@ jobs:
 `
 
 func TestWalkFiles_CICD(t *testing.T) {
-	resources := WalkFiles(parseYAML(t, ".github/workflows/ci.yaml", sampleWorkflow), nil)
+	resources := WalkFiles(parseYAML(t, ".github/workflows/ci.yaml", sampleWorkflow), nil, nil)
 	require.Len(t, resources, 2, "two jobs")
 
 	build, ok := findResource(resources, BlockJob, "build")
@@ -410,21 +411,21 @@ func TestWalkFiles_GatesOnEnabledPlatforms(t *testing.T) {
 	files := append(parseTFFiles(t, "main.tf", sampleTF), parseYAML(t, "deploy.yaml", sampleK8s)...)
 
 	// Only Terraform enabled: Kubernetes manifests are excluded.
-	tfOnly := WalkFiles(files, []string{"Terraform"})
+	tfOnly := WalkFiles(files, []string{"Terraform"}, nil)
 	require.NotEmpty(t, tfOnly)
 	for _, r := range tfOnly {
 		require.Equal(t, platformTerraform, r.Platform)
 	}
 
 	// Only Kubernetes enabled (case-insensitive): Terraform is excluded.
-	k8sOnly := WalkFiles(files, []string{"kubernetes"})
+	k8sOnly := WalkFiles(files, []string{"kubernetes"}, nil)
 	require.NotEmpty(t, k8sOnly)
 	for _, r := range k8sOnly {
 		require.Equal(t, platformKubernetes, r.Platform)
 	}
 
 	// No filter enables everything.
-	require.Equal(t, len(tfOnly)+len(k8sOnly), len(WalkFiles(files, nil)))
+	require.Equal(t, len(tfOnly)+len(k8sOnly), len(WalkFiles(files, nil, nil)))
 }
 
 const sampleDependabot = `version: 2
@@ -440,7 +441,7 @@ updates:
 `
 
 func TestWalkFiles_CICD_Dependabot(t *testing.T) {
-	resources := WalkFiles(parseYAML(t, ".github/dependabot.yaml", sampleDependabot), nil)
+	resources := WalkFiles(parseYAML(t, ".github/dependabot.yaml", sampleDependabot), nil, nil)
 	require.Len(t, resources, 2, "one resource per update entry")
 
 	var gomod, npm *Resource
@@ -471,7 +472,7 @@ runs:
 `
 
 func TestWalkFiles_CICD_CompositeAction(t *testing.T) {
-	resources := WalkFiles(parseYAML(t, "action.yaml", sampleCompositeAction), nil)
+	resources := WalkFiles(parseYAML(t, "action.yaml", sampleCompositeAction), nil, nil)
 	require.Len(t, resources, 1)
 
 	action := resources[0]

--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -1,0 +1,649 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package inventory
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	dockerParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/docker"
+	terraformParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform"
+	defaultYaml "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/default"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleTF = `
+resource "aws_s3_bucket" "b" {
+  bucket = "my-bucket"
+}
+
+data "aws_ami" "example" {
+  most_recent = true
+}
+
+module "network" {
+  source  = "./modules/network"
+  version = "~> 2.0"
+}
+`
+
+// parseTF parses Terraform source into a FileMetadata the way the scanner does.
+func parseTF(t *testing.T, name, content string) *model.FileMetadata {
+	t.Helper()
+	p := terraformParser.NewDefault()
+	_, docs, _, _, err := p.Parse(context.Background(), []byte(content), name, true, 15)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	return &model.FileMetadata{
+		FilePath: name,
+		Kind:     model.KindTerraform,
+		Document: docs[0],
+	}
+}
+
+const sampleK8s = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: prod
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.25
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-svc
+spec:
+  ports:
+    - port: 80
+`
+
+// parseYAML parses a (possibly multi-document) YAML file into one FileMetadata
+// per document, the way the scanner does.
+func parseYAML(t *testing.T, name, content string) model.FileMetadatas {
+	t.Helper()
+	p := &defaultYaml.Parser{}
+	_, docs, _, _, err := p.Parse(context.Background(), []byte(content), name, true, 15)
+	require.NoError(t, err)
+	files := make(model.FileMetadatas, 0, len(docs))
+	for _, doc := range docs {
+		files = append(files, &model.FileMetadata{
+			FilePath:         name,
+			Kind:             model.KindYAML,
+			Document:         doc,
+			LineInfoDocument: doc,
+		})
+	}
+	return files
+}
+
+// parseDockerfile parses a Dockerfile into a FileMetadata the way the scanner does.
+func parseDockerfile(t *testing.T, name, content string) model.FileMetadatas {
+	t.Helper()
+	p := &dockerParser.Parser{}
+	_, docs, _, _, err := p.Parse(context.Background(), []byte(content), name, true, 15)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	return model.FileMetadatas{{
+		FilePath:         name,
+		Kind:             model.KindDOCKER,
+		Document:         docs[0],
+		LineInfoDocument: docs[0],
+	}}
+}
+
+func findResource(resources []Resource, blockType BlockType, name string) (Resource, bool) {
+	for _, r := range resources {
+		if r.BlockType == blockType && r.Name == name {
+			return r, true
+		}
+	}
+	return Resource{}, false
+}
+
+func TestWalkFiles_Terraform(t *testing.T) {
+	files := model.FileMetadatas{parseTF(t, "main.tf", sampleTF)}
+	resources := WalkFiles(files, nil)
+
+	require.Len(t, resources, 3)
+
+	bucket, ok := findResource(resources, BlockResource, "b")
+	require.True(t, ok, "expected aws_s3_bucket resource")
+	require.Equal(t, platformTerraform, bucket.Platform)
+	require.Equal(t, "aws_s3_bucket", bucket.Type)
+	require.Equal(t, "aws", bucket.Provider)
+	require.Equal(t, "main.tf", bucket.File)
+	require.Greater(t, bucket.StartLine, 0, "resource should carry a start line")
+	require.GreaterOrEqual(t, bucket.EndLine, bucket.StartLine, "end line should be >= start line")
+
+	data, ok := findResource(resources, BlockData, "example")
+	require.True(t, ok, "expected aws_ami data source")
+	require.Equal(t, "aws_ami", data.Type)
+	require.Equal(t, "aws", data.Provider)
+
+	mod, ok := findResource(resources, BlockModule, "network")
+	require.True(t, ok, "expected network module")
+	require.Empty(t, mod.Type)
+	require.Empty(t, mod.Provider)
+	require.Equal(t, "./modules/network", mod.ModuleSource)
+	require.Equal(t, "~> 2.0", mod.ModuleVersion)
+}
+
+func TestWalkFiles_SkipsNonTerraform(t *testing.T) {
+	files := model.FileMetadatas{
+		{FilePath: "k8s.yaml", Kind: model.KindYAML, Document: model.Document{"kind": "Pod"}},
+		{FilePath: "empty.tf", Kind: model.KindTerraform, Document: model.Document{}},
+	}
+	require.Empty(t, WalkFiles(files, nil))
+}
+
+func TestBuildInventory(t *testing.T) {
+	files := model.FileMetadatas{parseTF(t, "main.tf", sampleTF)}
+	inv := BuildInventory(WalkFiles(files, nil), "my-repo")
+
+	require.Equal(t, SchemaVersion, inv.SchemaVersion)
+	require.Equal(t, "Datadog", inv.Tool.Vendor)
+	require.NotEmpty(t, inv.GeneratedAt)
+	require.Equal(t, "my-repo", inv.RootPath)
+	require.Equal(t, 3, inv.ResourceCount)
+	require.Len(t, inv.Resources, 3)
+
+	var bucket *InventoryEntry
+	for i := range inv.Resources {
+		if inv.Resources[i].Address == "aws_s3_bucket.b" {
+			bucket = &inv.Resources[i]
+			break
+		}
+	}
+	require.NotNil(t, bucket, "expected entry for the s3 bucket")
+	require.Equal(t, "terraform", bucket.IaCPlatform)
+	require.Equal(t, "resource", bucket.BlockType)
+	require.NotNil(t, bucket.ResourceType)
+	require.Equal(t, "aws_s3_bucket", *bucket.ResourceType)
+	require.Equal(t, "b", bucket.Name)
+	require.Equal(t, "aws", bucket.Provider)
+	require.Equal(t, "main.tf", bucket.FilePath)
+	require.Greater(t, bucket.LineRange.Start, 0)
+	require.GreaterOrEqual(t, bucket.LineRange.End, bucket.LineRange.Start)
+	require.NotNil(t, bucket.Attributes, "attributes must be populated")
+	require.Equal(t, "my-bucket", bucket.Attributes["bucket"], "bucket attribute should be extracted")
+	for k := range bucket.Attributes {
+		require.False(t, strings.HasPrefix(k, "_dd_"), "attributes must not contain _dd_ keys, found: %s", k)
+	}
+
+	// data resource attributes
+	var dataEntry *InventoryEntry
+	for i := range inv.Resources {
+		if inv.Resources[i].Address == "data.aws_ami.example" {
+			dataEntry = &inv.Resources[i]
+			break
+		}
+	}
+	require.NotNil(t, dataEntry)
+	require.NotNil(t, dataEntry.Attributes)
+	_, hasMostRecent := dataEntry.Attributes["most_recent"]
+	require.True(t, hasMostRecent, "most_recent attribute should be present")
+
+	// module entries must have null resource_type
+	var modEntry *InventoryEntry
+	for i := range inv.Resources {
+		if inv.Resources[i].Address == "module.network" {
+			modEntry = &inv.Resources[i]
+			break
+		}
+	}
+	require.NotNil(t, modEntry)
+	require.Nil(t, modEntry.ResourceType, "module entries should have null resource_type")
+	require.Equal(t, "./modules/network", modEntry.ModuleSource)
+	require.Equal(t, "~> 2.0", modEntry.ModuleVersion)
+}
+
+func TestResourceAddress(t *testing.T) {
+	addr := func(r Resource) string { return resourceAddress(&r) }
+	require.Equal(t, "aws_s3_bucket.b",
+		addr(Resource{BlockType: BlockResource, Type: "aws_s3_bucket", Name: "b"}))
+	require.Equal(t, "data.aws_ami.example",
+		addr(Resource{BlockType: BlockData, Type: "aws_ami", Name: "example"}))
+	require.Equal(t, "module.network",
+		addr(Resource{BlockType: BlockModule, Name: "network"}))
+	require.Equal(t, "prod/Deployment/my-app",
+		addr(Resource{BlockType: BlockManifest, Type: "Deployment", Name: "my-app", Namespace: "prod"}))
+	require.Equal(t, "Service/my-svc",
+		addr(Resource{BlockType: BlockManifest, Type: "Service", Name: "my-svc"}))
+}
+
+func TestWalkFiles_Kubernetes(t *testing.T) {
+	resources := WalkFiles(parseYAML(t, "deploy.yaml", sampleK8s), nil)
+	require.Len(t, resources, 2)
+
+	dep, ok := findResource(resources, BlockManifest, "my-app")
+	require.True(t, ok, "expected Deployment manifest")
+	require.Equal(t, platformKubernetes, dep.Platform)
+	require.Equal(t, "Deployment", dep.Type)
+	require.Equal(t, "apps/v1", dep.APIVersion)
+	require.Equal(t, "prod", dep.Namespace)
+	require.Empty(t, dep.Provider)
+	require.Equal(t, "deploy.yaml", dep.File)
+	require.Greater(t, dep.StartLine, 0, "manifest should carry a start line")
+	require.GreaterOrEqual(t, dep.EndLine, dep.StartLine, "end line should be >= start line")
+
+	require.NotNil(t, dep.Attributes)
+	require.Equal(t, "Deployment", dep.Attributes["kind"])
+	require.Contains(t, dep.Attributes, "spec")
+	for _, injected := range []string{"_path", "id", "file"} {
+		require.NotContains(t, dep.Attributes, injected, "injected key must be stripped")
+	}
+	for k := range dep.Attributes {
+		require.False(t, strings.HasPrefix(k, "_dd_"), "attributes must not contain _dd_ keys, found: %s", k)
+	}
+
+	svc, ok := findResource(resources, BlockManifest, "my-svc")
+	require.True(t, ok, "expected Service manifest")
+	require.Equal(t, "Service", svc.Type)
+	require.Empty(t, svc.Namespace)
+}
+
+func TestBuildInventory_Kubernetes(t *testing.T) {
+	inv := BuildInventory(WalkFiles(parseYAML(t, "deploy.yaml", sampleK8s), nil), "my-repo")
+	require.Equal(t, 2, inv.ResourceCount)
+
+	var dep *InventoryEntry
+	for i := range inv.Resources {
+		if inv.Resources[i].Address == "prod/Deployment/my-app" {
+			dep = &inv.Resources[i]
+			break
+		}
+	}
+	require.NotNil(t, dep, "expected entry addressed prod/Deployment/my-app")
+	require.Equal(t, "kubernetes", dep.IaCPlatform)
+	require.Equal(t, "manifest", dep.BlockType)
+	require.NotNil(t, dep.ResourceType)
+	require.Equal(t, "Deployment", *dep.ResourceType)
+	require.Equal(t, "apps/v1", dep.APIVersion)
+	require.Equal(t, "prod", dep.Namespace)
+	require.Empty(t, dep.Provider)
+}
+
+func TestWalkFiles_SkipsNonKubernetesYAML(t *testing.T) {
+	files := model.FileMetadatas{
+		{FilePath: "vars.yaml", Kind: model.KindYAML, Document: model.Document{"foo": "bar"}, LineInfoDocument: map[string]interface{}{"foo": "bar"}},
+	}
+	require.Empty(t, WalkFiles(files, nil))
+}
+
+const sampleCFN = `AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: my-cfn-bucket
+  MyQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: my-queue
+`
+
+func TestWalkFiles_CloudFormation(t *testing.T) {
+	resources := WalkFiles(parseYAML(t, "template.yaml", sampleCFN), nil)
+	require.Len(t, resources, 2)
+
+	bucket, ok := findResource(resources, BlockResource, "MyBucket")
+	require.True(t, ok, "expected MyBucket resource")
+	require.Equal(t, platformCloudFormation, bucket.Platform)
+	require.Equal(t, "AWS::S3::Bucket", bucket.Type)
+	require.Equal(t, "aws", bucket.Provider)
+	require.Greater(t, bucket.StartLine, 0)
+	require.GreaterOrEqual(t, bucket.EndLine, bucket.StartLine)
+	require.Equal(t, "my-cfn-bucket", attrMap(t, bucket.Attributes, "Properties")["BucketName"])
+
+	inv := BuildInventory(resources, "repo")
+	var addrs []string
+	for _, e := range inv.Resources {
+		addrs = append(addrs, e.Address)
+	}
+	require.Contains(t, addrs, "MyBucket")
+}
+
+const sampleAnsible = `---
+- name: configure web servers
+  hosts: web
+  tasks:
+    - name: install nginx
+      ansible.builtin.package:
+        name: nginx
+        state: present
+    - name: start nginx
+      ansible.builtin.service:
+        name: nginx
+        state: started
+    - name: grouped
+      block:
+        - name: write config
+          ansible.builtin.copy:
+            src: nginx.conf
+            dest: /etc/nginx/nginx.conf
+`
+
+func TestWalkFiles_Ansible(t *testing.T) {
+	resources := WalkFiles(parseYAML(t, "playbook.yaml", sampleAnsible), nil)
+	require.Len(t, resources, 3, "two top-level tasks plus one inside the block")
+
+	install, ok := findResource(resources, BlockTask, "install nginx")
+	require.True(t, ok)
+	require.Equal(t, platformAnsible, install.Platform)
+	require.Equal(t, "ansible.builtin.package", install.Type)
+	require.Greater(t, install.StartLine, 0)
+	require.Equal(t, "present", attrMap(t, install.Attributes, "ansible.builtin.package")["state"])
+
+	_, ok = findResource(resources, BlockTask, "write config")
+	require.True(t, ok, "task nested in a block should be walked")
+}
+
+const sampleDockerfile = `FROM golang:1.22 AS builder
+WORKDIR /src
+COPY . .
+RUN go build -o app
+
+FROM alpine:3.19
+COPY --from=builder /src/app /app
+ENTRYPOINT ["/app"]
+`
+
+func TestWalkFiles_Dockerfile(t *testing.T) {
+	resources := WalkFiles(parseDockerfile(t, "Dockerfile", sampleDockerfile), nil)
+	require.Len(t, resources, 2, "two build stages")
+
+	builder, ok := findResource(resources, BlockStage, "builder")
+	require.True(t, ok, "expected the aliased builder stage")
+	require.Equal(t, platformDockerfile, builder.Platform)
+	require.Equal(t, "golang:1.22", builder.Type, "base image should be the resource type")
+	require.Greater(t, builder.StartLine, 0)
+	require.GreaterOrEqual(t, builder.EndLine, builder.StartLine)
+
+	runtime, ok := findResource(resources, BlockStage, "alpine:3.19")
+	require.True(t, ok, "unaliased stage should be named by its image")
+	require.Equal(t, "alpine:3.19", runtime.Type)
+}
+
+const sampleWorkflow = `name: ci
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make build
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: make test
+`
+
+func TestWalkFiles_CICD(t *testing.T) {
+	resources := WalkFiles(parseYAML(t, ".github/workflows/ci.yaml", sampleWorkflow), nil)
+	require.Len(t, resources, 2, "two jobs")
+
+	build, ok := findResource(resources, BlockJob, "build")
+	require.True(t, ok)
+	require.Equal(t, platformCICD, build.Platform)
+	require.Greater(t, build.StartLine, 0)
+	for k := range build.Attributes {
+		require.False(t, strings.HasPrefix(k, "_parsed"), "parser enrichments must be stripped, found: %s", k)
+	}
+
+	_, ok = findResource(resources, BlockJob, "test")
+	require.True(t, ok)
+}
+
+func TestWalkFiles_GatesOnEnabledPlatforms(t *testing.T) {
+	files := append(parseTFFiles(t, "main.tf", sampleTF), parseYAML(t, "deploy.yaml", sampleK8s)...)
+
+	// Only Terraform enabled: Kubernetes manifests are excluded.
+	tfOnly := WalkFiles(files, []string{"Terraform"})
+	require.NotEmpty(t, tfOnly)
+	for _, r := range tfOnly {
+		require.Equal(t, platformTerraform, r.Platform)
+	}
+
+	// Only Kubernetes enabled (case-insensitive): Terraform is excluded.
+	k8sOnly := WalkFiles(files, []string{"kubernetes"})
+	require.NotEmpty(t, k8sOnly)
+	for _, r := range k8sOnly {
+		require.Equal(t, platformKubernetes, r.Platform)
+	}
+
+	// No filter enables everything.
+	require.Equal(t, len(tfOnly)+len(k8sOnly), len(WalkFiles(files, nil)))
+}
+
+const sampleDependabot = `version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+`
+
+func TestWalkFiles_CICD_Dependabot(t *testing.T) {
+	resources := WalkFiles(parseYAML(t, ".github/dependabot.yaml", sampleDependabot), nil)
+	require.Len(t, resources, 2, "one resource per update entry")
+
+	var gomod, npm *Resource
+	for i := range resources {
+		switch resources[i].Type {
+		case "gomod":
+			gomod = &resources[i]
+		case "npm":
+			npm = &resources[i]
+		}
+	}
+	require.NotNil(t, gomod, "expected gomod update")
+	require.Equal(t, platformCICD, gomod.Platform)
+	require.Equal(t, BlockJob, gomod.BlockType)
+	require.Equal(t, "/", gomod.Name, "name falls back to directory when set")
+
+	require.NotNil(t, npm, "expected npm update")
+	require.Equal(t, "/frontend", npm.Name)
+}
+
+const sampleCompositeAction = `name: My Composite Action
+description: does things
+runs:
+  using: composite
+  steps:
+    - run: echo hello
+      shell: bash
+`
+
+func TestWalkFiles_CICD_CompositeAction(t *testing.T) {
+	resources := WalkFiles(parseYAML(t, "action.yaml", sampleCompositeAction), nil)
+	require.Len(t, resources, 1)
+
+	action := resources[0]
+	require.Equal(t, platformCICD, action.Platform)
+	require.Equal(t, BlockJob, action.BlockType)
+	require.Equal(t, "composite-action", action.Type)
+	require.Equal(t, "My Composite Action", action.Name)
+	require.Greater(t, action.StartLine, 0)
+}
+
+func TestResourceAddress_AllBlockTypes(t *testing.T) {
+	addr := func(r Resource) string { return resourceAddress(&r) }
+
+	require.Equal(t, "install nginx",
+		addr(Resource{BlockType: BlockTask, Name: "install nginx", Type: "ansible.builtin.package"}))
+	require.Equal(t, "ansible.builtin.package",
+		addr(Resource{BlockType: BlockTask, Name: "", Type: "ansible.builtin.package"}))
+	require.Equal(t, "builder",
+		addr(Resource{BlockType: BlockStage, Name: "builder"}))
+	require.Equal(t, "build",
+		addr(Resource{BlockType: BlockJob, Name: "build"}))
+	require.Equal(t, "MyBucket",
+		addr(Resource{BlockType: BlockResource, Platform: platformCloudFormation, Name: "MyBucket", Type: "AWS::S3::Bucket"}))
+}
+
+func TestCFNProvider(t *testing.T) {
+	require.Equal(t, "aws", cfnProvider("AWS::S3::Bucket"))
+	require.Equal(t, "custom", cfnProvider("Custom::MyThing"))
+	require.Equal(t, "nonamespace", cfnProvider("NoNamespace"))
+	require.Empty(t, cfnProvider(""))
+}
+
+func TestStartLine_Forms(t *testing.T) {
+	lo := model.LineObject{Line: 42}
+	loPtr := &lo
+
+	bodyStructForm := map[string]interface{}{
+		ddLinesKey: map[string]model.LineObject{ddDefaultKey: lo},
+	}
+	require.Equal(t, 42, startLine(bodyStructForm))
+
+	bodyPtrForm := map[string]interface{}{
+		ddLinesKey: map[string]*model.LineObject{ddDefaultKey: loPtr},
+	}
+	require.Equal(t, 42, startLine(bodyPtrForm))
+
+	bodyGeneric := map[string]interface{}{
+		ddLinesKey: map[string]interface{}{
+			ddDefaultKey: map[string]interface{}{"_dd_line": float64(7)},
+		},
+	}
+	require.Equal(t, 7, startLine(bodyGeneric))
+
+	require.Equal(t, 0, startLine(map[string]interface{}{}))
+	require.Equal(t, 0, startLine("not a map"))
+}
+
+func TestLineFromGeneric(t *testing.T) {
+	lo := model.LineObject{Line: 10}
+	loPtr := &lo
+
+	require.Equal(t, 10, lineFromGeneric(lo))
+	require.Equal(t, 10, lineFromGeneric(loPtr))
+	require.Equal(t, 0, lineFromGeneric((*model.LineObject)(nil)))
+	require.Equal(t, 5, lineFromGeneric(map[string]interface{}{"_dd_line": float64(5)}))
+	require.Equal(t, 0, lineFromGeneric("unexpected"))
+}
+
+func TestWalkTypedBlocks_ListBodies(t *testing.T) {
+	// When a type maps to a list of bodies, each body gets a synthetic
+	// indexed name to avoid a malformed "type." address.
+	doc := model.Document{
+		"resource": map[string]interface{}{
+			"aws_security_group": []interface{}{
+				map[string]interface{}{"description": "sg1"},
+				map[string]interface{}{"description": "sg2"},
+			},
+		},
+	}
+	resources := walkTypedBlocks("f.tf", doc, "resource", BlockResource)
+	require.Len(t, resources, 2)
+	require.Equal(t, "aws_security_group[0]", resources[0].Name)
+	require.Equal(t, "aws_security_group[1]", resources[1].Name)
+	for _, r := range resources {
+		require.Equal(t, "aws_security_group", r.Type)
+		require.Equal(t, "aws", r.Provider)
+	}
+}
+
+func TestCleanAttrs_AnnotationMapDropped(t *testing.T) {
+	annotationMap := map[string]model.LineObject{"field": {Line: 1}}
+	require.Nil(t, cleanAttrs(annotationMap))
+
+	ptrMap := map[string]*model.LineObject{"field": {Line: 1}}
+	require.Nil(t, cleanAttrs(ptrMap))
+}
+
+func TestAttrsFromBody_NonMap(t *testing.T) {
+	require.Nil(t, attrsFromBody("a string"))
+	require.Nil(t, attrsFromBody(nil))
+}
+
+func TestIntFromNumber(t *testing.T) {
+	n, ok := intFromNumber(int(5))
+	require.True(t, ok)
+	require.Equal(t, 5, n)
+
+	n, ok = intFromNumber(float64(3.0))
+	require.True(t, ok)
+	require.Equal(t, 3, n)
+
+	_, ok = intFromNumber("not a number")
+	require.False(t, ok)
+}
+
+func TestGenericLine_IntForm(t *testing.T) {
+	line, ok := genericLine(map[string]interface{}{"_dd_line": int(12)})
+	require.True(t, ok)
+	require.Equal(t, 12, line)
+
+	_, ok = genericLine(map[string]interface{}{"_dd_line": "not a number"})
+	require.False(t, ok)
+}
+
+func TestWalkLineObjects_WithArr(t *testing.T) {
+	lo := model.LineObject{
+		Line: 5,
+		Arr: []map[string]*model.LineObject{
+			{"elem": {Line: 9}},
+			{"other": nil},
+		},
+	}
+	m := map[string]model.LineObject{"field": lo}
+	tracker := &lineTracker{}
+	tracker.walkLineObjects(m)
+	require.Equal(t, 5, tracker.min)
+	require.Equal(t, 9, tracker.max)
+}
+
+func TestStringAttr_MissingAndNonString(t *testing.T) {
+	require.Empty(t, stringAttr(nil, "key"))
+	require.Empty(t, stringAttr(map[string]interface{}{"key": 42}, "key"))
+	require.Equal(t, "val", stringAttr(map[string]interface{}{"key": "val"}, "key"))
+}
+
+func TestProviderFromType_NoUnderscore(t *testing.T) {
+	require.Equal(t, "justtype", providerFromType("justtype"))
+	require.Empty(t, providerFromType(""))
+}
+
+func TestK8sNameAndNamespace_NoMetadata(t *testing.T) {
+	name, ns := k8sNameAndNamespace(model.Document{})
+	require.Empty(t, name)
+	require.Empty(t, ns)
+}
+
+func TestNewPlatformSet_EmptyPlatform(t *testing.T) {
+	ps := newPlatformSet([]string{""})
+	require.True(t, ps.all, "an empty string in the list should enable all platforms")
+}
+
+// parseTFFiles wraps parseTF as a FileMetadatas slice for combining with other platforms.
+func parseTFFiles(t *testing.T, name, content string) model.FileMetadatas {
+	t.Helper()
+	return model.FileMetadatas{parseTF(t, name, content)}
+}
+
+// attrMap fetches a nested map attribute, failing the test when it is absent.
+func attrMap(t *testing.T, attrs map[string]interface{}, key string) map[string]interface{} {
+	t.Helper()
+	require.NotNil(t, attrs)
+	m, ok := attrs[key].(map[string]interface{})
+	require.True(t, ok, "expected attribute %q to be a map", key)
+	return m
+}

--- a/pkg/inventory/kubernetes.go
+++ b/pkg/inventory/kubernetes.go
@@ -1,0 +1,67 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package inventory
+
+import "github.com/DataDog/datadog-iac-scanner/pkg/model"
+
+const platformKubernetes = "kubernetes"
+
+// kubernetesWalker matches Kubernetes (and Knative/Crossplane) manifests by
+// the defining apiVersion/kind pair.
+type kubernetesWalker struct{}
+
+func (kubernetesWalker) Platform() string { return platformKubernetes }
+
+func (kubernetesWalker) Kinds() []model.FileKind {
+	return []model.FileKind{model.KindYAML, model.KindYML, model.KindJSON}
+}
+
+func (kubernetesWalker) Walk(filePath string, doc model.Document) ([]Resource, bool) {
+	r, ok := walkKubernetesDocument(filePath, doc)
+	if !ok {
+		return nil, false
+	}
+	return []Resource{r}, true
+}
+
+// walkKubernetesDocument returns ok=false when apiVersion or kind is absent.
+func walkKubernetesDocument(filePath string, doc model.Document) (Resource, bool) {
+	apiVersion, _ := doc["apiVersion"].(string)
+	kind, _ := doc["kind"].(string)
+	if apiVersion == "" || kind == "" {
+		return Resource{}, false
+	}
+
+	name, namespace := k8sNameAndNamespace(doc)
+	start, end := lineBounds(doc)
+
+	attrs := attrsFromBody(doc)
+	deleteInjectedKeys(attrs)
+
+	return Resource{
+		Platform:   platformKubernetes,
+		BlockType:  BlockManifest,
+		Type:       kind,
+		Name:       name,
+		File:       filePath,
+		StartLine:  start,
+		EndLine:    end,
+		APIVersion: apiVersion,
+		Namespace:  namespace,
+		Attributes: attrs,
+	}, true
+}
+
+func k8sNameAndNamespace(doc model.Document) (name, namespace string) {
+	metadata, ok := toMap(doc["metadata"])
+	if !ok {
+		return "", ""
+	}
+	name, _ = metadata["name"].(string)
+	namespace, _ = metadata["namespace"].(string)
+	return name, namespace
+}

--- a/pkg/inventory/modules.go
+++ b/pkg/inventory/modules.go
@@ -1,0 +1,493 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package inventory
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/modulegraph"
+)
+
+const (
+	moduleDependencyDirect     = "direct"
+	moduleDependencyTransitive = "transitive"
+)
+
+type moduleIndex struct {
+	repoPath        string
+	extractionMap   map[string]model.ExtractedPathObject
+	resolved        []modulegraph.ResolvedModule
+	byLocalPath     []modulegraph.ResolvedModule
+	parsedByAbsPath map[string][]tfmodules.ParsedModule
+}
+
+func newModuleIndex(opts *WalkOptions, files model.FileMetadatas) *moduleIndex {
+	if opts == nil || opts.RepoPath == "" {
+		return nil
+	}
+	idx := &moduleIndex{
+		repoPath:      filepath.Clean(opts.RepoPath),
+		extractionMap: opts.ExtractionMap,
+		resolved:      append([]modulegraph.ResolvedModule(nil), opts.ResolvedModules...),
+	}
+	sort.Slice(idx.resolved, func(i, j int) bool {
+		return len(idx.resolved[i].LocalPath) > len(idx.resolved[j].LocalPath)
+	})
+	idx.byLocalPath = idx.resolved
+
+	if len(opts.ParsedModules) > 0 {
+		idx.parsedByAbsPath = indexParsedModulesByAbsSource(opts.ParsedModules)
+	} else {
+		ctx := opts.Ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		parsed, err := tfmodules.ParseTerraformModules(
+			ctx, nil, normalizeFilesForModuleParse(files, opts.RepoPath), 0)
+		if err == nil && len(parsed) > 0 {
+			idx.parsedByAbsPath = indexParsedModulesByAbsSource(parsed)
+		}
+	}
+	return idx
+}
+
+func indexParsedModulesByAbsSource(
+	parsed map[string]tfmodules.ParsedModule,
+) map[string][]tfmodules.ParsedModule {
+	if len(parsed) == 0 {
+		return nil
+	}
+	indexed := make(map[string][]tfmodules.ParsedModule)
+	for key := range parsed {
+		mod := parsed[key]
+		if mod.AbsSource == "" {
+			continue
+		}
+		abs := filepath.Clean(mod.AbsSource)
+		indexed[abs] = append(indexed[abs], mod)
+	}
+	return indexed
+}
+
+func enrichTerraformModules(resources []Resource, idx *moduleIndex) {
+	if idx == nil {
+		return
+	}
+	for i := range resources {
+		if resources[i].Platform != platformTerraform {
+			continue
+		}
+		switch resources[i].BlockType {
+		case BlockModule:
+			enrichModuleBlock(&resources[i], idx)
+		case BlockResource, BlockData:
+			enrichModuleResource(&resources[i], idx)
+		}
+	}
+}
+
+func enrichModuleBlock(r *Resource, idx *moduleIndex) {
+	if resolved := idx.matchResolvedDeclaration(r.File, r.Name, r.StartLine); resolved != nil {
+		r.Module = moduleDeclarationPayload(resolved, idx.repoPath, false)
+		r.ModuleSource = r.Module.Source
+		if r.Module.Version != "" {
+			r.ModuleVersion = r.Module.Version
+		} else {
+			r.ModuleVersion = stringAttrFromResource(r, "version")
+		}
+		return
+	}
+	if parsed := idx.matchParsedDeclaration(r.File, r.Name, r.StartLine); parsed != nil {
+		r.Module = moduleDeclarationFromParsed(parsed, idx.repoPath)
+		r.ModuleSource = r.Module.Source
+		r.ModuleVersion = parsed.Version
+		return
+	}
+	if r.ModuleSource != "" {
+		sourceType, _ := tfmodules.DetectModuleSourceType(r.ModuleSource)
+		r.Module = &model.ModuleAttributionSARIF{
+			Name:           r.Name,
+			Source:         model.ModuleAttributionForSARIF(&model.ModuleAttribution{Source: r.ModuleSource}).Source,
+			SourceType:     sourceType,
+			DependencyType: moduleDependencyDirect,
+			ModuleCodeLocation: model.SourceLocation{
+				Filename:  repoRelativeFile(r.File, idx.repoPath),
+				LineStart: r.StartLine,
+				LineEnd:   r.EndLine,
+			},
+		}
+	}
+}
+
+func enrichModuleResource(r *Resource, idx *moduleIndex) {
+	chain := idx.resolvedChain(r.File)
+	if len(chain) > 0 {
+		attr := attributionFromResolvedChain(chain, r, idx.repoPath)
+		if attr == nil {
+			return
+		}
+		r.Module = model.ModuleAttributionForSARIF(attr)
+		anchor := chain[0]
+		r.File = repoRelativeFile(anchor.CallerFile, idx.repoPath)
+		r.StartLine = anchor.CallerLine
+		r.EndLine = anchor.CallerEndLine
+		return
+	}
+	parsedChain := idx.parsedChain(r.File)
+	if len(parsedChain) == 0 {
+		return
+	}
+	attr := attributionFromParsedChain(parsedChain, r, idx.repoPath)
+	if attr == nil {
+		return
+	}
+	r.Module = model.ModuleAttributionForSARIF(attr)
+	root := parsedChain[0]
+	r.File = repoRelativeFile(root.FileName, idx.repoPath)
+	r.StartLine = root.DefLine
+	r.EndLine = root.DefEndLine
+}
+
+func (idx *moduleIndex) matchResolvedDeclaration(filePath, name string, line int) *modulegraph.ResolvedModule {
+	absFile := absPath(filePath, idx.repoPath)
+	for i := range idx.resolved {
+		mod := &idx.resolved[i]
+		if mod.Name != name {
+			continue
+		}
+		if !samePath(mod.CallerFile, absFile) {
+			continue
+		}
+		if line > 0 && mod.CallerLine > 0 && line < mod.CallerLine {
+			continue
+		}
+		if line > 0 && mod.CallerEndLine > 0 && line > mod.CallerEndLine {
+			continue
+		}
+		return mod
+	}
+	return nil
+}
+
+func (idx *moduleIndex) matchParsedDeclaration(filePath, name string, line int) *tfmodules.ParsedModule {
+	absFile := absPath(filePath, idx.repoPath)
+	for _, mods := range idx.parsedByAbsPath {
+		for i := range mods {
+			mod := &mods[i]
+			if mod.Name != name || !samePath(mod.FileName, absFile) {
+				continue
+			}
+			if line > 0 && mod.DefLine > 0 && line < mod.DefLine {
+				continue
+			}
+			if line > 0 && mod.DefEndLine > 0 && line > mod.DefEndLine {
+				continue
+			}
+			return mod
+		}
+	}
+	return nil
+}
+
+func (idx *moduleIndex) resolvedChain(filePath string) []modulegraph.ResolvedModule {
+	absFile := absPath(filePath, idx.repoPath)
+	var matches []modulegraph.ResolvedModule
+	for _, mod := range idx.resolved {
+		if mod.LocalPath == "" {
+			continue
+		}
+		if pathWithinRoot(absFile, mod.LocalPath) {
+			matches = append(matches, mod)
+		}
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].Depth != matches[j].Depth {
+			return matches[i].Depth < matches[j].Depth
+		}
+		return len(matches[i].LocalPath) < len(matches[j].LocalPath)
+	})
+	return matches
+}
+
+func (idx *moduleIndex) parsedChain(filePath string) []tfmodules.ParsedModule {
+	absFile := absPath(filePath, idx.repoPath)
+	var owner *tfmodules.ParsedModule
+	var bestSource string
+	for absSource, mods := range idx.parsedByAbsPath {
+		if !pathWithinRoot(absFile, absSource) {
+			continue
+		}
+		if len(absSource) <= len(bestSource) {
+			continue
+		}
+		bestSource = absSource
+		owner = &mods[0]
+	}
+	if owner == nil {
+		return nil
+	}
+	chain := []tfmodules.ParsedModule{*owner}
+	for {
+		parent := idx.parentParsedModule(chain[len(chain)-1])
+		if parent == nil {
+			break
+		}
+		chain = append([]tfmodules.ParsedModule{*parent}, chain...)
+	}
+	return chain
+}
+
+func (idx *moduleIndex) parentParsedModule(child tfmodules.ParsedModule) *tfmodules.ParsedModule {
+	childRoot := filepath.Clean(child.AbsSource)
+	for _, mods := range idx.parsedByAbsPath {
+		for i := range mods {
+			mod := &mods[i]
+			if mod.AbsSource == childRoot {
+				continue
+			}
+			if !pathWithinRoot(childRoot, mod.AbsSource) {
+				continue
+			}
+			return mod
+		}
+	}
+	return nil
+}
+
+func attributionFromResolvedChain(chain []modulegraph.ResolvedModule, r *Resource, repoPath string) *model.ModuleAttribution {
+	if len(chain) == 0 {
+		return nil
+	}
+	path := make([]model.ModulePathHop, 0, len(chain))
+	for i, mod := range chain {
+		path = append(path, hopFromResolvedModule(mod, repoPath, i > 0))
+	}
+	leaf := chain[len(chain)-1]
+	sourceType, _ := tfmodules.DetectModuleSourceType(leaf.Source)
+	dependencyType := moduleDependencyDirect
+	if len(chain) > 1 {
+		dependencyType = moduleDependencyTransitive
+	}
+	bodyFile := moduleRelativePath(r.File, leaf.LocalPath, repoPath)
+	var modulePath []model.ModulePathHop
+	if len(path) > 1 {
+		modulePath = path
+	}
+	return &model.ModuleAttribution{
+		Name:           leaf.Name,
+		Source:         leafSource(leaf),
+		SourceType:     sourceType,
+		Version:        leafVersion(leaf),
+		DependencyType: dependencyType,
+		CodeLocation:   path[0].CodeLocation,
+		ModuleCodeLocation: model.SourceLocation{
+			Filename:  bodyFile,
+			LineStart: r.StartLine,
+			LineEnd:   r.EndLine,
+		},
+		ModulePath: modulePath,
+	}
+}
+
+func attributionFromParsedChain(chain []tfmodules.ParsedModule, r *Resource, repoPath string) *model.ModuleAttribution {
+	if len(chain) == 0 {
+		return nil
+	}
+	path := make([]model.ModulePathHop, 0, len(chain))
+	for i, mod := range chain {
+		path = append(path, hopFromParsedModule(mod, repoPath, i > 0))
+	}
+	leaf := chain[len(chain)-1]
+	dependencyType := moduleDependencyDirect
+	if len(chain) > 1 {
+		dependencyType = moduleDependencyTransitive
+	}
+	bodyFile := moduleRelativePath(r.File, leaf.AbsSource, repoPath)
+	var modulePath []model.ModulePathHop
+	if len(path) > 1 {
+		modulePath = path
+	}
+	return &model.ModuleAttribution{
+		Name:           leaf.Name,
+		Source:         path[len(path)-1].Source,
+		SourceType:     path[len(path)-1].SourceType,
+		Version:        path[len(path)-1].Version,
+		DependencyType: dependencyType,
+		CodeLocation:   path[0].CodeLocation,
+		ModuleCodeLocation: model.SourceLocation{
+			Filename:  bodyFile,
+			LineStart: r.StartLine,
+			LineEnd:   r.EndLine,
+		},
+		ModulePath: modulePath,
+	}
+}
+
+func moduleDeclarationPayload(mod *modulegraph.ResolvedModule, repoPath string, nested bool) *model.ModuleAttributionSARIF {
+	sourceType, _ := tfmodules.DetectModuleSourceType(mod.Source)
+	attr := &model.ModuleAttribution{
+		Name:           mod.Name,
+		Source:         leafSource(*mod),
+		SourceType:     sourceType,
+		Version:        leafVersion(*mod),
+		DependencyType: moduleDependencyDirect,
+		ModuleCodeLocation: hopFromResolvedModule(*mod, repoPath, nested).CodeLocation,
+	}
+	return model.ModuleAttributionForSARIF(attr)
+}
+
+func moduleDeclarationFromParsed(mod *tfmodules.ParsedModule, repoPath string) *model.ModuleAttributionSARIF {
+	attr := &model.ModuleAttribution{
+		Name:           mod.Name,
+		Source:         hopFromParsedModule(*mod, repoPath, false).Source,
+		SourceType:     mod.SourceType,
+		Version:        mod.Version,
+		DependencyType: moduleDependencyDirect,
+		ModuleCodeLocation: model.SourceLocation{
+			Filename:  repoRelativeFile(mod.FileName, repoPath),
+			LineStart: mod.DefLine,
+			LineEnd:   mod.DefEndLine,
+		},
+	}
+	return model.ModuleAttributionForSARIF(attr)
+}
+
+func hopFromResolvedModule(mod modulegraph.ResolvedModule, repoPath string, nested bool) model.ModulePathHop {
+	sourceType, _ := tfmodules.DetectModuleSourceType(mod.Source)
+	filename := repoRelativeFile(mod.CallerFile, repoPath)
+	if nested {
+		filename = filepath.ToSlash(filepath.Base(mod.CallerFile))
+	}
+	return model.ModulePathHop{
+		Name:       mod.Name,
+		Source:     model.ModuleAttributionForSARIF(&model.ModuleAttribution{Source: leafSource(mod)}).Source,
+		SourceType: sourceType,
+		Version:    leafVersion(mod),
+		CodeLocation: model.SourceLocation{
+			Filename:  filename,
+			LineStart: mod.CallerLine,
+			LineEnd:   mod.CallerEndLine,
+		},
+	}
+}
+
+func hopFromParsedModule(mod tfmodules.ParsedModule, repoPath string, nested bool) model.ModulePathHop {
+	source := mod.Source
+	if mod.SourceType == "local" && mod.AbsSource != "" {
+		if rel, err := filepath.Rel(filepath.Clean(repoPath), filepath.Clean(mod.AbsSource)); err == nil {
+			source = filepath.ToSlash(rel)
+		}
+	}
+	filename := repoRelativeFile(mod.FileName, repoPath)
+	if nested {
+		filename = filepath.ToSlash(filepath.Base(mod.FileName))
+	}
+	return model.ModulePathHop{
+		Name:       mod.Name,
+		Source:     model.ModuleAttributionForSARIF(&model.ModuleAttribution{Source: source}).Source,
+		SourceType: mod.SourceType,
+		Version:    mod.Version,
+		CodeLocation: model.SourceLocation{
+			Filename:  filename,
+			LineStart: mod.DefLine,
+			LineEnd:   mod.DefEndLine,
+		},
+	}
+}
+
+func leafSource(mod modulegraph.ResolvedModule) string {
+	if mod.CanonicalSource != "" {
+		return mod.CanonicalSource
+	}
+	return mod.Source
+}
+
+func leafVersion(mod modulegraph.ResolvedModule) string {
+	sourceType, _ := tfmodules.DetectModuleSourceType(mod.Source)
+	switch sourceType {
+	case "registry":
+		return strings.TrimSpace(mod.ResolvedVersion)
+	case "git":
+		return strings.TrimSpace(mod.ResolvedRef)
+	default:
+		return ""
+	}
+}
+
+func stringAttrFromResource(r *Resource, key string) string {
+	if r.Attributes == nil {
+		return ""
+	}
+	value, ok := r.Attributes[key].(string)
+	if !ok {
+		return ""
+	}
+	return value
+}
+
+func repoRelativeFile(filePath, repoPath string) string {
+	abs := absPath(filePath, repoPath)
+	rel, err := filepath.Rel(filepath.Clean(repoPath), abs)
+	if err != nil {
+		return filepath.ToSlash(filepath.Base(abs))
+	}
+	return filepath.ToSlash(rel)
+}
+
+func moduleRelativePath(filePath, moduleRoot, repoPath string) string {
+	absFile := absPath(filePath, repoPath)
+	if moduleRoot != "" {
+		rel, err := filepath.Rel(filepath.Clean(moduleRoot), absFile)
+		if err == nil && pathWithinRoot(absFile, moduleRoot) {
+			return filepath.ToSlash(rel)
+		}
+	}
+	return repoRelativeFile(absFile, repoPath)
+}
+
+func absPath(path, repoPath string) string {
+	if path == "" {
+		return ""
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(filepath.Join(repoPath, path))
+}
+
+func pathWithinRoot(path, root string) bool {
+	if path == "" || root == "" {
+		return false
+	}
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func samePath(a, b string) bool {
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+func normalizeFilesForModuleParse(files model.FileMetadatas, repoPath string) model.FileMetadatas {
+	if repoPath == "" {
+		return files
+	}
+	out := make(model.FileMetadatas, 0, len(files))
+	for _, f := range files {
+		if f == nil || f.Kind != model.KindTerraform {
+			continue
+		}
+		clone := f.ShallowCopy()
+		clone.FilePath = absPath(f.FilePath, repoPath)
+		out = append(out, clone)
+	}
+	return out
+}

--- a/pkg/inventory/modules_test.go
+++ b/pkg/inventory/modules_test.go
@@ -1,0 +1,128 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package inventory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/modulegraph"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnrichModuleBlock_LocalDeclaration(t *testing.T) {
+	repo := t.TempDir()
+	mainTF := filepath.Join(repo, "stack", "main.tf")
+	moduleTF := filepath.Join(repo, "modules", "bucket", "main.tf")
+	writeInventoryFixture(t, mainTF, `
+module "bucket" {
+  source = "../modules/bucket"
+}
+`)
+	writeInventoryFixture(t, moduleTF, `
+resource "aws_s3_bucket" "this" {
+  bucket = "logs"
+}
+`)
+
+	files := model.FileMetadatas{
+		parseTFAt(t, mainTF, repo),
+		parseTFAt(t, moduleTF, repo),
+	}
+	opts := &WalkOptions{RepoPath: repo}
+	resources := WalkFiles(files, []string{"terraform"}, opts)
+
+	mod, ok := findResource(resources, BlockModule, "bucket")
+	require.True(t, ok)
+	require.NotNil(t, mod.Module)
+	require.Equal(t, "bucket", mod.Module.Name)
+	require.Equal(t, "local", mod.Module.SourceType)
+	require.Equal(t, "direct", mod.Module.DependencyType)
+	require.Equal(t, "stack/main.tf", mod.Module.ModuleCodeLocation.Filename)
+
+	bucket, ok := findResource(resources, BlockResource, "this")
+	require.True(t, ok)
+	require.NotNil(t, bucket.Module)
+	require.Equal(t, "bucket", bucket.Module.Name)
+	require.Equal(t, "direct", bucket.Module.DependencyType)
+	require.Equal(t, "stack/main.tf", bucket.File)
+	require.Equal(t, "main.tf", bucket.Module.ModuleCodeLocation.Filename)
+	require.Equal(t, 2, bucket.Module.ModuleCodeLocation.LineStart)
+}
+
+func TestEnrichModuleResource_ResolvedRemoteModule(t *testing.T) {
+	repo := t.TempDir()
+	caller := filepath.Join(repo, "stack", "main.tf")
+	moduleBody := filepath.Join(repo, "cache", "bucket", "main.tf")
+	writeInventoryFixture(t, caller, `
+module "bucket" {
+  source  = "registry.terraform.io/acme/bucket/aws"
+  version = "9.3.2"
+}
+`)
+	writeInventoryFixture(t, moduleBody, `
+resource "aws_s3_bucket" "this" {
+  bucket = "logs"
+}
+`)
+
+	files := model.FileMetadatas{
+		parseTFAt(t, caller, repo),
+		parseTFAt(t, moduleBody, repo),
+	}
+	opts := &WalkOptions{
+		RepoPath: repo,
+		ResolvedModules: []modulegraph.ResolvedModule{{
+			CallerRoot: filepath.Join(repo, "stack"),
+			CallerFile: caller,
+			CallerLine: 2,
+			CallerEndLine: 5,
+			Name:       "bucket",
+			Source:          "registry.terraform.io/acme/bucket/aws",
+			Version:         "9.3.2",
+			ResolvedVersion: "9.3.2",
+			LocalPath:       filepath.Join(repo, "cache", "bucket"),
+			CanonicalSource: "registry.terraform.io/acme/bucket/aws",
+			Depth:           1,
+		}},
+	}
+	resources := WalkFiles(files, []string{"terraform"}, opts)
+
+	bucket, ok := findResource(resources, BlockResource, "this")
+	require.True(t, ok)
+	require.NotNil(t, bucket.Module)
+	require.Equal(t, "bucket", bucket.Module.Name)
+	require.Equal(t, "registry", bucket.Module.SourceType)
+	require.Equal(t, "9.3.2", bucket.Module.Version)
+	require.Equal(t, "direct", bucket.Module.DependencyType)
+	require.Equal(t, "stack/main.tf", bucket.File)
+	require.Equal(t, 2, bucket.StartLine)
+	require.Equal(t, "main.tf", bucket.Module.ModuleCodeLocation.Filename)
+}
+
+func writeInventoryFixture(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, writeFile(path, content))
+}
+
+func writeFile(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func parseTFAt(t *testing.T, path, repo string) *model.FileMetadata {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	rel, err := filepath.Rel(repo, path)
+	require.NoError(t, err)
+	return parseTF(t, filepath.ToSlash(rel), string(content))
+}

--- a/pkg/inventory/options.go
+++ b/pkg/inventory/options.go
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package inventory
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/modulegraph"
+)
+
+// WalkOptions carries scan context needed to attach Terraform module provenance
+// to inventory entries, aligned with SARIF properties.module from PR #319.
+type WalkOptions struct {
+	Ctx             context.Context
+	RepoPath        string
+	ExtractionMap   map[string]model.ExtractedPathObject
+	ResolvedModules []modulegraph.ResolvedModule
+	// ParsedModules is the Terraform module index produced during the scan.
+	// When set, inventory enrichment reuses it instead of re-parsing HCL.
+	ParsedModules map[string]tfmodules.ParsedModule
+}

--- a/pkg/inventory/resource.go
+++ b/pkg/inventory/resource.go
@@ -1,0 +1,41 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+// Package inventory enumerates every IaC resource found during a scan,
+// independent of whether any rule matched it.
+package inventory
+
+// BlockType is the category of block a resource originates from.
+type BlockType string
+
+const (
+	BlockResource BlockType = "resource"
+	BlockData     BlockType = "data"
+	BlockModule   BlockType = "module"
+	BlockManifest BlockType = "manifest"
+	BlockTask     BlockType = "task"
+	BlockStage    BlockType = "stage"
+	BlockJob      BlockType = "job"
+)
+
+// Resource is a single IaC resource extracted from a parsed document.
+type Resource struct {
+	Platform      string
+	BlockType     BlockType
+	Type          string
+	Name          string
+	Provider      string
+	File          string
+	StartLine     int
+	EndLine       int
+	ModuleSource  string
+	ModuleVersion string
+	APIVersion    string
+	Namespace     string
+	// Attributes contains every declared attribute; annotation keys are stripped.
+	// Nested blocks are maps; arrays are slices. No filtering is applied.
+	Attributes map[string]interface{}
+}

--- a/pkg/inventory/resource.go
+++ b/pkg/inventory/resource.go
@@ -8,6 +8,10 @@
 // independent of whether any rule matched it.
 package inventory
 
+import (
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
 // BlockType is the category of block a resource originates from.
 type BlockType string
 
@@ -33,6 +37,7 @@ type Resource struct {
 	EndLine       int
 	ModuleSource  string
 	ModuleVersion string
+	Module        *model.ModuleAttributionSARIF
 	APIVersion    string
 	Namespace     string
 	// Attributes contains every declared attribute; annotation keys are stripped.

--- a/pkg/inventory/terraform.go
+++ b/pkg/inventory/terraform.go
@@ -1,0 +1,165 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package inventory
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+func itoa(n int) string { return strconv.Itoa(n) }
+
+const platformTerraform = "terraform"
+
+// ddLinesKey / ddDefaultKey are the Terraform converter's line-annotation keys.
+const (
+	ddLinesKey   = "_dd_lines"
+	ddDefaultKey = "_dd__default"
+)
+
+type terraformWalker struct{}
+
+func (terraformWalker) Platform() string { return platformTerraform }
+
+func (terraformWalker) Kinds() []model.FileKind { return []model.FileKind{model.KindTerraform} }
+
+func (terraformWalker) Walk(filePath string, doc model.Document) ([]Resource, bool) {
+	var resources []Resource
+	resources = append(resources, walkTypedBlocks(filePath, doc, "resource", BlockResource)...)
+	resources = append(resources, walkTypedBlocks(filePath, doc, "data", BlockData)...)
+	resources = append(resources, walkModuleBlocks(filePath, doc)...)
+	return resources, true
+}
+
+// walkTypedBlocks handles the {blockKey: {type: {name: body}}} shape.
+// The Terraform parser always produces the named-map form for resource and data
+// blocks; the list branch is purely defensive and skips bodies with no name to
+// avoid producing a malformed "type." address.
+func walkTypedBlocks(filePath string, doc model.Document, blockKey string, blockType BlockType) []Resource {
+	typesMap, ok := toMap(doc[blockKey])
+	if !ok {
+		return nil
+	}
+
+	var resources []Resource
+	for _, resourceType := range sortedKeys(typesMap) {
+		switch named := typesMap[resourceType].(type) {
+		case nil:
+			continue
+		default:
+			if bodies, isList := toList(named); isList {
+				for i, body := range bodies {
+					// Use a 1-based index as a synthetic name so the address is
+					// never empty (e.g. "aws_s3_bucket[0]").
+					name := resourceType + "[" + itoa(i) + "]"
+					resources = append(resources, newTerraformResource(filePath, blockType, resourceType, name, body))
+				}
+				continue
+			}
+			nameMap, isMap := toMap(named)
+			if !isMap {
+				continue
+			}
+			for _, name := range sortedKeys(nameMap) {
+				resources = append(resources, newTerraformResource(filePath, blockType, resourceType, name, nameMap[name]))
+			}
+		}
+	}
+	return resources
+}
+
+func walkModuleBlocks(filePath string, doc model.Document) []Resource {
+	moduleMap, ok := toMap(doc["module"])
+	if !ok {
+		return nil
+	}
+
+	var resources []Resource
+	for _, name := range sortedKeys(moduleMap) {
+		resources = append(resources, newTerraformResource(filePath, BlockModule, "", name, moduleMap[name]))
+	}
+	return resources
+}
+
+func newTerraformResource(filePath string, blockType BlockType, resourceType, name string, body interface{}) Resource {
+	start := startLine(body)
+	r := Resource{
+		Platform:   platformTerraform,
+		BlockType:  blockType,
+		Type:       resourceType,
+		Name:       name,
+		Provider:   providerFromType(resourceType),
+		File:       filePath,
+		StartLine:  start,
+		EndLine:    endLine(body, start),
+		Attributes: attrsFromBody(body),
+	}
+	if blockType == BlockModule {
+		r.ModuleSource = stringAttr(body, "source")
+		r.ModuleVersion = stringAttr(body, "version")
+	}
+	return r
+}
+
+func providerFromType(resourceType string) string {
+	if resourceType == "" {
+		return ""
+	}
+	if idx := strings.Index(resourceType, "_"); idx > 0 {
+		return resourceType[:idx]
+	}
+	return resourceType
+}
+
+// startLine reads the block's opening line from _dd_lines/_dd__default,
+// tolerating both the struct and JSON-decoded forms.
+func startLine(body interface{}) int {
+	bodyMap, ok := toMap(body)
+	if !ok {
+		return 0
+	}
+
+	switch lines := bodyMap[ddLinesKey].(type) {
+	case map[string]model.LineObject:
+		return lines[ddDefaultKey].Line
+	case map[string]*model.LineObject:
+		if def := lines[ddDefaultKey]; def != nil {
+			return def.Line
+		}
+	case map[string]interface{}:
+		return lineFromGeneric(lines[ddDefaultKey])
+	}
+	return 0
+}
+
+// endLine returns the last annotated line inside the block (>= start). The
+// Terraform converter does not record closing braces, so this is best-effort.
+func endLine(body interface{}, start int) int {
+	_, maxLine := lineBounds(body)
+	if maxLine < start {
+		return start
+	}
+	return maxLine
+}
+
+func lineFromGeneric(def interface{}) int {
+	switch d := def.(type) {
+	case model.LineObject:
+		return d.Line
+	case *model.LineObject:
+		if d != nil {
+			return d.Line
+		}
+	case map[string]interface{}:
+		if line, ok := genericLine(d); ok {
+			return line
+		}
+	}
+	return 0
+}

--- a/pkg/inventory/walker.go
+++ b/pkg/inventory/walker.go
@@ -1,0 +1,126 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package inventory
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+// platformWalker converts a single parsed document into inventory resources.
+// handled=false lets the next walker try — necessary for the shared YAML/JSON
+// kinds where multiple platforms compete for the same file.
+type platformWalker interface {
+	// Platform returns the lowercase canonical name (e.g. "terraform"),
+	// matched case-insensitively against the enabled platforms set.
+	Platform() string
+	Kinds() []model.FileKind
+	Walk(filePath string, doc model.Document) (resources []Resource, handled bool)
+}
+
+// registry order matters for shared YAML/JSON kinds: more specific detections
+// before more permissive ones (Ansible last — task shape is most permissive).
+var registry = []platformWalker{
+	terraformWalker{},
+	dockerfileWalker{},
+	cloudFormationWalker{},
+	kubernetesWalker{},
+	ciCDWalker{},
+	ansibleWalker{},
+}
+
+// WalkFiles enumerates IaC resources across all parsed files. Only platforms
+// present in enabledPlatforms are walked; nil or empty enables all platforms.
+func WalkFiles(files model.FileMetadatas, enabledPlatforms []string) []Resource {
+	enabled := newPlatformSet(enabledPlatforms)
+	var resources []Resource
+	// A YAML file can produce multiple FileMetadata entries (parsed by both the
+	// default and CI/CD parsers), so resources are deduplicated by stable key.
+	seen := make(map[string]struct{})
+	for _, f := range files {
+		if f == nil {
+			continue
+		}
+		// LineInfoDocument retains _dd_ line annotations stripped from Document.
+		doc := model.Document(f.LineInfoDocument)
+		if len(doc) == 0 {
+			doc = f.Document
+		}
+		if len(doc) == 0 {
+			continue
+		}
+		for _, w := range registry {
+			if !enabled.has(w.Platform()) || !kindMatches(w.Kinds(), f.Kind) {
+				continue
+			}
+			rs, handled := w.Walk(f.FilePath, doc)
+			if !handled {
+				continue
+			}
+			for i := range rs {
+				key := resourceKey(&rs[i])
+				if _, dup := seen[key]; dup {
+					continue
+				}
+				seen[key] = struct{}{}
+				resources = append(resources, rs[i])
+			}
+			break
+		}
+	}
+	return resources
+}
+
+func resourceKey(r *Resource) string {
+	return strings.Join([]string{
+		r.Platform,
+		r.File,
+		resourceAddress(r),
+		strconv.Itoa(r.StartLine),
+		strconv.Itoa(r.EndLine),
+	}, "\x00")
+}
+
+func kindMatches(kinds []model.FileKind, kind model.FileKind) bool {
+	for _, k := range kinds {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
+type platformSet struct {
+	all     bool
+	members map[string]struct{}
+}
+
+func newPlatformSet(platforms []string) platformSet {
+	if len(platforms) == 0 {
+		return platformSet{all: true}
+	}
+	members := make(map[string]struct{}, len(platforms))
+	for _, p := range platforms {
+		if p == "" {
+			// A single empty string in the list means "all platforms"; any
+			// valid names seen so far are discarded.
+			return platformSet{all: true}
+		}
+		members[strings.ToLower(p)] = struct{}{}
+	}
+	return platformSet{members: members}
+}
+
+func (s platformSet) has(platform string) bool {
+	if s.all {
+		return true
+	}
+	_, ok := s.members[strings.ToLower(platform)]
+	return ok
+}

--- a/pkg/inventory/walker.go
+++ b/pkg/inventory/walker.go
@@ -37,7 +37,9 @@ var registry = []platformWalker{
 
 // WalkFiles enumerates IaC resources across all parsed files. Only platforms
 // present in enabledPlatforms are walked; nil or empty enables all platforms.
-func WalkFiles(files model.FileMetadatas, enabledPlatforms []string) []Resource {
+// When opts is set, Terraform module provenance is attached to module blocks and
+// to resources declared inside resolved or local module bodies.
+func WalkFiles(files model.FileMetadatas, enabledPlatforms []string, opts *WalkOptions) []Resource {
 	enabled := newPlatformSet(enabledPlatforms)
 	var resources []Resource
 	// A YAML file can produce multiple FileMetadata entries (parsed by both the
@@ -74,6 +76,8 @@ func WalkFiles(files model.FileMetadatas, enabledPlatforms []string) []Resource 
 			break
 		}
 	}
+	idx := newModuleIndex(opts, files)
+	enrichTerraformModules(resources, idx)
 	return resources
 }
 

--- a/pkg/report/iac_inventory.go
+++ b/pkg/report/iac_inventory.go
@@ -23,9 +23,9 @@ import (
 // enabledPlatforms are inventoried; an empty list enables every platform.
 func PrintIaCInventoryReport(
 	ctx context.Context, path, filename, rootPath string,
-	files model.FileMetadatas, enabledPlatforms []string,
+	files model.FileMetadatas, enabledPlatforms []string, opts *inventory.WalkOptions,
 ) error {
-	resources := inventory.WalkFiles(files, enabledPlatforms)
+	resources := inventory.WalkFiles(files, enabledPlatforms, opts)
 	inv := inventory.BuildInventory(resources, rootPath)
 
 	base := strings.TrimSuffix(filename, filepath.Ext(filename))

--- a/pkg/report/iac_inventory.go
+++ b/pkg/report/iac_inventory.go
@@ -1,0 +1,48 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package report
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/inventory"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+// PrintIaCInventoryReport builds the IaC resource inventory from the parsed
+// files and writes it as JSON to path/filename. The output filename is prefixed
+// with "iac-inventory-" and forced to a .json extension. Only resources for the
+// enabledPlatforms are inventoried; an empty list enables every platform.
+func PrintIaCInventoryReport(
+	ctx context.Context, path, filename, rootPath string,
+	files model.FileMetadatas, enabledPlatforms []string,
+) error {
+	resources := inventory.WalkFiles(files, enabledPlatforms)
+	inv := inventory.BuildInventory(resources, rootPath)
+
+	base := strings.TrimSuffix(filename, filepath.Ext(filename))
+	if base == "" {
+		base = "results"
+	}
+	outName := "iac-inventory-" + base + ".json"
+	fullPath := filepath.Join(path, outName)
+
+	f, err := os.OpenFile(filepath.Clean(fullPath), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, filePerms)
+	if err != nil {
+		return err
+	}
+	defer closeFile(ctx, fullPath, outName, f)
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	return enc.Encode(inv)
+}

--- a/pkg/report/iac_inventory_test.go
+++ b/pkg/report/iac_inventory_test.go
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package report
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/inventory"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintIaCInventoryReport(t *testing.T) {
+	cases := []struct {
+		name         string
+		filename     string
+		wantFilename string
+	}{
+		{"explicit filename", "results", "iac-inventory-results.json"},
+		{"filename with extension", "results.sarif", "iac-inventory-results.json"},
+		{"empty filename falls back to results", "", "iac-inventory-results.json"},
+	}
+
+	files := model.FileMetadatas{} // no parsed files — just tests file I/O and naming
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := PrintIaCInventoryReport(context.Background(), dir, tc.filename, "/repo", files, nil)
+			require.NoError(t, err)
+
+			outPath := filepath.Join(dir, tc.wantFilename)
+			raw, err := os.ReadFile(outPath)
+			require.NoError(t, err, "expected output file %s to exist", tc.wantFilename)
+
+			var inv inventory.Inventory
+			require.NoError(t, json.Unmarshal(raw, &inv))
+			require.Equal(t, inventory.SchemaVersion, inv.SchemaVersion)
+			require.Equal(t, "Datadog", inv.Tool.Vendor)
+			require.Equal(t, "/repo", inv.RootPath)
+			require.Equal(t, 0, inv.ResourceCount)
+
+			// Verify HTML escaping is disabled (ampersands must not be escaped).
+			require.NotContains(t, string(raw), `\u0026`)
+		})
+	}
+}

--- a/pkg/report/iac_inventory_test.go
+++ b/pkg/report/iac_inventory_test.go
@@ -34,7 +34,7 @@ func TestPrintIaCInventoryReport(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			err := PrintIaCInventoryReport(context.Background(), dir, tc.filename, "/repo", files, nil)
+			err := PrintIaCInventoryReport(context.Background(), dir, tc.filename, "/repo", files, nil, nil)
 			require.NoError(t, err)
 
 			outPath := filepath.Join(dir, tc.wantFilename)

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -18,6 +18,8 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/modulegraph"
 	tfresolver "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
 	"github.com/DataDog/datadog-iac-scanner/pkg/platforms"
 	consolePrinter "github.com/DataDog/datadog-iac-scanner/pkg/printer"
@@ -133,7 +135,9 @@ type Client struct {
 	inMemoryPaths []string
 	walkInventory []string
 	chartRoots    []string
-	contentCache  map[string][]byte
+	contentCache     map[string][]byte
+	inventoryModules       []modulegraph.ResolvedModule
+	inventoryParsedModules map[string]tfmodules.ParsedModule
 }
 
 // ClientOption customizes a Client at construction time.

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	consolePrinter "github.com/DataDog/datadog-iac-scanner/pkg/printer"
+	"github.com/DataDog/datadog-iac-scanner/pkg/inventory"
 	"github.com/DataDog/datadog-iac-scanner/pkg/report"
 )
 
@@ -60,6 +61,7 @@ func (c *Client) resolveOutputs(
 	documents model.Documents,
 	files model.FileMetadatas,
 	printer *consolePrinter.Printer,
+	extractedPaths provider.ExtractedPath,
 ) error {
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("console.resolveOutputs()")
@@ -105,6 +107,13 @@ func (c *Client) resolveOutputs(
 			c.ScanParams.RepoPath,
 			files,
 			c.ScanParams.GetEffectivePlatforms(),
+			&inventory.WalkOptions{
+				Ctx:             ctx,
+				RepoPath:        c.ScanParams.RepoPath,
+				ExtractionMap:   extractedPaths.ExtractionMap,
+				ResolvedModules: c.inventoryModules,
+				ParsedModules:   c.inventoryParsedModules,
+			},
 		)
 	}
 
@@ -171,7 +180,8 @@ func (c *Client) postScan(ctx context.Context, scanResults *Results) (ScanMetada
 		&summary,
 		scanResults.Files.Combine(ctx, c.ScanParams.LineInfoPayload),
 		scanResults.Files,
-		c.Printer); err != nil {
+		c.Printer,
+		scanResults.ExtractedPaths); err != nil {
 		contextLogger.Err(err).Msgf("failed to resolve outputs %v", err)
 		memwatch.Sample(ctx, memwatch.PhaseGenerateReport)
 		return metadata, err

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -8,6 +8,7 @@ package scan
 import (
 	"context"
 	_ "embed" // Embed scanner CLI img and scan-flags
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -57,6 +58,7 @@ func (c *Client) resolveOutputs(
 	ctx context.Context,
 	summary *model.Summary,
 	documents model.Documents,
+	files model.FileMetadatas,
 	printer *consolePrinter.Printer,
 ) error {
 	contextLogger := logger.FromContext(ctx)
@@ -77,13 +79,54 @@ func (c *Client) resolveOutputs(
 		}
 	}
 
-	return printOutput(
+	// The IaC resource inventory is built from the parsed files rather than the
+	// finding summary, so it is handled separately from the generic report
+	// formats that consume the Summary.
+	formats, wantInventory := extractInventoryFormat(c.ScanParams.ReportFormats)
+
+	if err := printOutput(
 		ctx,
 		c.ScanParams.OutputPath,
 		c.ScanParams.OutputName,
-		summary, c.ScanParams.ReportFormats,
+		summary, formats,
 		&c.ScanParams.SCIInfo,
-	)
+	); err != nil {
+		return err
+	}
+
+	if wantInventory {
+		if c.ScanParams.OutputPath == "" {
+			return errors.New("--resource-inventory requires --output-path to be set")
+		}
+		return report.PrintIaCInventoryReport(
+			ctx,
+			c.ScanParams.OutputPath,
+			c.ScanParams.OutputName,
+			c.ScanParams.RepoPath,
+			files,
+			c.ScanParams.GetEffectivePlatforms(),
+		)
+	}
+
+	return nil
+}
+
+// inventoryReportFormat is the report format name that triggers the IaC
+// resource inventory output.
+const inventoryReportFormat = "iac-inventory"
+
+// extractInventoryFormat removes the inventory format from the list of generic
+// report formats and reports whether it was requested.
+func extractInventoryFormat(formats []string) (remaining []string, wantInventory bool) {
+	remaining = make([]string, 0, len(formats))
+	for _, f := range formats {
+		if strings.EqualFold(strings.TrimSpace(f), inventoryReportFormat) {
+			wantInventory = true
+			continue
+		}
+		remaining = append(remaining, f)
+	}
+	return remaining, wantInventory
 }
 
 func printOutput(ctx context.Context, outputPath, filename string, body interface{}, formats []string, sciInfo *model.SCIInfo) error {
@@ -127,6 +170,7 @@ func (c *Client) postScan(ctx context.Context, scanResults *Results) (ScanMetada
 		ctx,
 		&summary,
 		scanResults.Files.Combine(ctx, c.ScanParams.LineInfoPayload),
+		scanResults.Files,
 		c.Printer); err != nil {
 		contextLogger.Err(err).Msgf("failed to resolve outputs %v", err)
 		memwatch.Sample(ctx, memwatch.PhaseGenerateReport)

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -36,27 +36,28 @@ func (c *Client) resolveTerraformModulesForScan(
 	remoteModulePaths []string,
 	remoteSourceDirs map[string]engine.RemoteModuleDirectory,
 	remoteModuleProvenance map[string]engine.RemoteModuleProvenance,
+	resolvedModules []modulegraph.ResolvedModule,
 	err error,
 ) {
 	if !platformsIncludeTerraform(paramsPlatforms) || !c.shouldPreScanTerraformModules(extractedPaths.Path) {
-		return nil, nil, nil, nil, nil
+		return nil, nil, nil, nil, nil, nil
 	}
 
 	contextLogger := logger.FromContext(ctx)
 	filteredFilesSource, err := c.getFileSystemSourceProvider(ctx, extractedPaths.Path)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 	moduleDiscoveryPaths, err := filteredFilesSource.TerraformFiles(ctx)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 	resolveCtx, cancel := c.moduleResolutionContext(ctx)
 	defer cancel()
 
 	chain, err := c.buildModuleResolverChain(resolveCtx, moduleDiscoveryPaths)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 
 	if c.ScanParams.TerraformModules == TerraformModulesOn {
@@ -122,7 +123,7 @@ func (c *Client) resolveTerraformModulesForScan(
 			remoteModuleProvenance[key] = provenance
 		}
 	}
-	return result.Cleanup, result.ScanPaths, remoteSourceDirs, remoteModuleProvenance, nil
+	return result.Cleanup, result.ScanPaths, remoteSourceDirs, remoteModuleProvenance, result.Modules, nil
 }
 
 func (c *Client) resolveTerraformModuleGraph(

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -87,13 +87,14 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 			baselinePaths = append(baselinePaths, path)
 		}
 	}
-	moduleCleanup, remoteModulePaths, remoteSourceDirs, remoteModuleProvenance, err := c.resolveTerraformModulesForScan(
+	moduleCleanup, remoteModulePaths, remoteSourceDirs, remoteModuleProvenance, inventoryModules, err := c.resolveTerraformModulesForScan(
 		ctx, paramsPlatforms, &extractedPaths, baselinePaths,
 	)
 	memwatch.Sample(ctx, memwatch.PhaseModuleResolve)
 	if err != nil {
 		return nil, err
 	}
+	c.inventoryModules = inventoryModules
 	initSucceeded := false
 	defer func() {
 		if initSucceeded {
@@ -242,6 +243,7 @@ func (c *Client) executeScan(ctx context.Context) (*Results, error) {
 	contextLogger.Info().Msg("Scan finished")
 
 	failedQueries := executeScanParameters.inspector.GetFailedQueries()
+	c.inventoryParsedModules = executeScanParameters.inspector.ParsedTerraformModules()
 
 	results, err := c.Storage.GetVulnerabilities(ctx, c.ScanParams.ScanID)
 	if err != nil {


### PR DESCRIPTION
## Motivation

The scanner already produces a SARIF report of findings, but SARIF only surfaces resources that matched a rule — it carries no record of resources that were clean. This gap means downstream consumers (dashboards, asset inventories, policy tools) cannot tell whether a resource was scanned and clean or simply absent from the configuration. This PR adds a purpose-built JSON resource inventory that enumerates every IaC resource the scanner parsed, independent of whether any rule fired on it.

## Changes

**New `pkg/inventory` package**

A platform walker registry dispatches each parsed document to the right walker based on file kind and document shape. Six walkers are implemented: Terraform (resource/data/module blocks), Kubernetes (apiVersion+kind manifests), CloudFormation (logical resources), Ansible (tasks across plays and nested block groups), Dockerfile (build stages), and CI/CD (GitHub Actions jobs, composite actions, Dependabot update entries). Each walker produces typed `Resource` values with platform, block type, address, file path, line range, and all declared attributes — with internal parser annotation keys stripped. A shared `helpers.go` centralises attribute cleaning and line-range computation across parsers that use different annotation formats.

**Deduplication and platform gating**

A single YAML file can be parsed multiple times by different parsers (e.g. both the default YAML parser and the CI/CD parser). Resources are deduplicated by a stable key before the inventory is assembled. Inventory extraction is also gated on the set of platforms enabled for the scan, if a platform is not in scope for the rule run, it is skipped for the inventory too.

**Report integration**

`pkg/report/iac_inventory.go` adds `PrintIaCInventoryReport`, called from `post_scan.go` only when `--resource-inventory` is passed and an output path is set. This keeps the feature opt-in and adds no overhead to standard scans.

**JSON Schema**

`docs/schemas/iac-resource-inventory-v1.schema.json` documents the output format, covering all block types, platform-specific fields (`api_version`, `namespace`, `module_source`, `module_version`), and the full `attributes` object. This is to be migrated to the [official schema repository](https://github.com/DataDog/schema) once we are sure of the format.

## QA Instruction

1. `go test ./pkg/inventory/...` — 93% statement coverage, all green.
2. `go build ./...` and `golangci-lint run` — no new lint issues.
3. Run a scan with the flag: `./bin/datadog-iac-scanner scan -p <terraform-fixture> --output-path /tmp --resource-inventory`; confirm `iac-inventory-results.json` is written and validates against the schema in `docs/schemas/`.
4. Run without the flag and confirm no inventory file is produced and scan output is unchanged.

## Impact

CLI only — the `--resource-inventory` flag is opt-in. No changes to SARIF output, scan rules, or the existing report formats. The new `pkg/inventory` package is self-contained and does not affect scan performance when the flag is absent.