### PR TITLE
Remove legacy Rego compat shim (follow-up to Rego v1)

### DIFF
--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -780,7 +780,6 @@ func (q QueryLoader) LoadQuery(ctx context.Context, query *model.QueryMetadata,
 			rego.Module("Common", q.commonLibrary.LibraryCode),
 			rego.Module("Generic", platformGeneralQuery.LibraryCode),
 			rego.Module(query.Query, query.Content),
-			rego.Module("dd_iac_compat.rego", utils.RegoCompatShim),
 			rego.Store(store),
 			rego.UnsafeBuiltins(unsafeRegoFunctions),
 		).PrepareForEval(ctx)

--- a/pkg/utils/query.go
+++ b/pkg/utils/query.go
@@ -18,20 +18,7 @@ const (
 	UnresolvedPlaceholder       = "__UNRESOLVED__"
 
 	// RegoQuery is the OPA query evaluated against every rule module.
-	// It delegates to RegoCompatShim so both legacy (package Cx / CxPolicy) and
-	// current (package datadog / DatadogPolicy) rules are accepted during migration.
-	RegoQuery = `result = data.dd_iac_compat.policy`
-
-	// RegoCompatShim is injected as an extra OPA module alongside every rule.
-	// The two incremental definitions union CxPolicy and DatadogPolicy results,
-	// so each evaluates to an empty set when the corresponding package is absent.
-	// Once all rules have been migrated to DatadogPolicy, this shim can be removed
-	// and RegoQuery simplified back to `result = data.datadog.DatadogPolicy`.
-	RegoCompatShim = `package dd_iac_compat
-
-policy contains r if { r = data.Cx.CxPolicy[_] }
-policy contains r if { r = data.datadog.DatadogPolicy[_] }
-`
+	RegoQuery = `result = data.datadog.DatadogPolicy`
 )
 
 func ChooseQueryID(queryID, legacyQueryID string) string {


### PR DESCRIPTION
## Motivation

This is a small follow-up to [PR #179](https://github.com/DataDog/datadog-iac-scanner/pull/179). After defaulting the engine to Rego v1, the `dd_iac_compat` shim still merged results from the pre-rename `data.Cx.CxPolicy` path even though every shipped rule now exposes `data.datadog.DatadogPolicy`. The `CxPolicy` leg is unused dead code; removing it drops an extra OPA module from every evaluation and simplifies the top-level query.

## Changes

**Engine**

Stop injecting `dd_iac_compat.rego` alongside rule modules.

**Query defaults**

Set `RegoQuery` to `result = data.datadog.DatadogPolicy` and delete the `RegoCompatShim` constant.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/engine/... ./pkg/utils/... ./pkg/scan/...`
2. Run a scan against a fixture or project that uses Datadog-sourced rules and confirm findings still appear as before.

## Blast Radius

Datadog IaC Scanner OPA evaluation only: rule modules must continue to define `package datadog` with a `DatadogPolicy` rule set, which is already the contract after the rename migration.

## Additional Notes

None.

I submit this contribution under the Apache-2.0 license.