### PR TITLE
Add test-rules command and CI workflow

### DIFF
--- a/.github/workflows/test-rules.yml
+++ b/.github/workflows/test-rules.yml
@@ -1,0 +1,85 @@
+name: test-rules
+
+# Runs the scanner's engine against the rule fixtures stored in the Datadog
+# backend. This catches engine regressions that break existing rule tests.
+#
+# Requires DD_API_KEY and DD_APP_KEY repository secrets (and optionally
+# DD_SITE if the target org is not on datadoghq.com).
+#
+# Runs on push to main and on manual dispatch. Secrets are not available on
+# fork pull requests, so automatic per-PR runs are not supported.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: "Comma-separated list of platforms to test (empty = all)"
+        required: false
+        default: ""
+      rules:
+        description: "Space-separated list of rule IDs to test (empty = all)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  test-rules:
+    name: test-rules
+    runs-on: ubuntu-latest
+    # Secrets are not available on fork pull requests; skip the job rather than
+    # failing with an unauthenticated API call.
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Check out code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Get cache paths
+        id: go-cache-paths
+        run: echo "GO_BUILD=$(go env GOCACHE)" >>$GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.GO_BUILD }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-
+            ${{ runner.OS }}-
+
+      - name: Build
+        run: go build -o bin/datadog-iac-scanner ./cmd/scanner
+
+      - name: Run rule tests
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+          DD_SITE: ${{ secrets.DD_SITE }}
+        run: |
+          ARGS=""
+          if [ -n "${{ inputs.platforms }}" ]; then
+            for p in $(echo "${{ inputs.platforms }}" | tr ',' ' '); do
+              ARGS="$ARGS --type $p"
+            done
+          fi
+          if [ -n "${{ inputs.rules }}" ]; then
+            for r in ${{ inputs.rules }}; do
+              ARGS="$ARGS --rule $r"
+            done
+          fi
+          ./bin/datadog-iac-scanner test-rules $ARGS

--- a/.github/workflows/test-rules.yml
+++ b/.github/workflows/test-rules.yml
@@ -2,12 +2,6 @@ name: test-rules
 
 # Runs the scanner's engine against the rule fixtures stored in the Datadog
 # backend. This catches engine regressions that break existing rule tests.
-#
-# Requires DD_API_KEY and DD_APP_KEY repository secrets (and optionally
-# DD_SITE if the target org is not on datadoghq.com).
-#
-# Runs on push to main and on manual dispatch. Secrets are not available on
-# fork pull requests, so automatic per-PR runs are not supported.
 
 on:
   pull_request:
@@ -21,7 +15,7 @@ on:
         required: false
         default: ""
       rules:
-        description: "Space-separated list of rule IDs to test (empty = all)"
+        description: "Comma-separated list of rule IDs to test (empty = all)"
         required: false
         default: ""
 
@@ -32,11 +26,6 @@ jobs:
   test-rules:
     name: test-rules
     runs-on: ubuntu-latest
-    # Secrets are not available on fork pull requests; skip the job rather than
-    # failing with an unauthenticated API call.
-    if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -66,20 +55,12 @@ jobs:
         run: go build -o bin/datadog-iac-scanner ./cmd/scanner
 
       - name: Run rule tests
-        env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY }}
-          DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
-          DD_SITE: ${{ secrets.DD_SITE }}
         run: |
-          ARGS=""
+          args=()
           if [ -n "${{ inputs.platforms }}" ]; then
-            for p in $(echo "${{ inputs.platforms }}" | tr ',' ' '); do
-              ARGS="$ARGS --type $p"
-            done
+            args+=(--type "${{ inputs.platforms }}")
           fi
           if [ -n "${{ inputs.rules }}" ]; then
-            for r in ${{ inputs.rules }}; do
-              ARGS="$ARGS --rule $r"
-            done
+            args+=(--rule "${{ inputs.rules }}")
           fi
-          ./bin/datadog-iac-scanner test-rules $ARGS
+          ./bin/datadog-iac-scanner test-rules "${args[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ payload.json
 __pycache__
 
 module_support
+
+# local scanner binary
+/scanner

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -33,6 +33,7 @@ func main() {
 			listPlatformsAction,
 			listQueriesAction,
 			showConfigAction,
+			testRulesAction,
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/scanner/test_rules.go
+++ b/cmd/scanner/test_rules.go
@@ -37,7 +37,7 @@ import (
 const (
 	defaultRuleTestQueryTimeoutSecs = 60
 	defaultRuleTestMaxResolverDepth = 15
-	fixtureDirPerm                  = 0750
+	fixtureDirPerm                  = 0700
 	fixtureFilePerm                 = 0600
 )
 

--- a/cmd/scanner/test_rules.go
+++ b/cmd/scanner/test_rules.go
@@ -1,0 +1,518 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/config"
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
+	"github.com/DataDog/datadog-iac-scanner/pkg/detector"
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine"
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
+	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser"
+	ansibleConfigParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/ansible/ini/config"
+	ansibleHostsParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/ansible/ini/hosts"
+	bicepParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/bicep"
+	buildahParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/buildah"
+	dockerParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/docker"
+	protoParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/grpc"
+	jsonParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/json"
+	terraformParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform"
+	cicdParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/cicd"
+	yamlParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/default"
+	"github.com/DataDog/datadog-iac-scanner/pkg/runner"
+	scanUtils "github.com/DataDog/datadog-iac-scanner/pkg/utils"
+	"github.com/google/uuid"
+	cli "github.com/urfave/cli/v3"
+)
+
+const (
+	defaultRuleTestQueryTimeoutSecs = 60
+	defaultRuleTestMaxResolverDepth = 15
+	testFixtureDirPerm              = 0750
+	testFixtureFilePerm             = 0600
+)
+
+// testResultShape is the per-rule Rego result contract checked during tests.
+var testResultShape = struct {
+	Required     []string
+	ResourceKeys []string
+}{
+	Required: []string{
+		"documentId",
+		"searchKey",
+		"issueType",
+		"keyExpectedValue",
+		"keyActualValue",
+	},
+	ResourceKeys: []string{"resourceType", "resourceName"},
+}
+
+// testAllowedIssueTypes is the set of issueType values a rule result may emit.
+var testAllowedIssueTypes = map[string]struct{}{
+	"MissingAttribute":   {},
+	"IncorrectValue":     {},
+	"RedundantAttribute": {},
+}
+
+// ruleFinding is one result emitted by a rule's DatadogPolicy evaluation.
+type ruleFinding struct {
+	QueryName string
+	Severity  string
+	Line      int
+	FileName  string
+}
+
+type testRuleOutcome struct {
+	id         string
+	mismatches []string
+}
+
+var testRulesAction = &cli.Command{
+	Name:  "test-rules",
+	Usage: "runs the rule tests stored in the Datadog backend against the local engine",
+	Flags: []cli.Flag{
+		&cli.StringSliceFlag{
+			Name:  "rule",
+			Usage: "only test rules with these IDs or names (default: all rules)",
+		},
+		&cli.StringSliceFlag{
+			Name:    "type",
+			Aliases: []string{"t"},
+			Usage:   "only test rules for these platforms",
+		},
+	},
+	Action: runTestRules,
+}
+
+func runTestRules(ctx context.Context, c *cli.Command) error {
+	client := datadog.NewDatadogClient()
+	ruleset, err := client.GetDefaultRulesetWithTests(ctx)
+	if err != nil {
+		return fmt.Errorf("fetching rules with tests: %w", err)
+	}
+
+	ruleFilter := c.StringSlice("rule")
+	platformFilter := c.StringSlice("type")
+
+	var results []testRuleOutcome
+	allPass := true
+
+	for _, rule := range ruleset.Rules {
+		if !testRuleShouldRun(rule, platformFilter, ruleFilter) {
+			continue
+		}
+
+		mismatches, err := testRule(ctx, rule)
+		if err != nil {
+			return fmt.Errorf("testing rule %s: %w", rule.ID, err)
+		}
+		results = append(results, testRuleOutcome{id: rule.ID, mismatches: mismatches})
+		allPass = allPass && len(mismatches) == 0
+	}
+
+	return testRulesFinish(results, allPass)
+}
+
+func testRuleShouldRun(rule *datadog.Rule, platformFilter, ruleFilter []string) bool {
+	if !rule.IsPublished || rule.Tests == nil {
+		return false
+	}
+	if len(platformFilter) > 0 && !slices.ContainsFunc(platformFilter, func(p string) bool {
+		return strings.EqualFold(p, rule.Platform)
+	}) {
+		return false
+	}
+	if len(ruleFilter) == 0 {
+		return true
+	}
+	legacyID := ""
+	if rule.LegacyId != nil {
+		legacyID = *rule.LegacyId
+	}
+	return slices.Contains(ruleFilter, rule.ID) || slices.Contains(ruleFilter, legacyID)
+}
+
+func testRulesFinish(results []testRuleOutcome, allPass bool) error {
+	if allPass {
+		if len(results) == 0 {
+			fmt.Println("No rules with tests were found")
+			os.Exit(1)
+		}
+		fmt.Printf("PASS: %s\n", testPlural(len(results), "%d rule", "%d rules"))
+		return nil
+	}
+
+	var failed, passed int
+	for _, r := range results {
+		if len(r.mismatches) == 0 {
+			passed++
+			fmt.Printf("PASS: %s\n", r.id)
+		} else {
+			failed++
+			fmt.Printf("FAIL: %s\n", r.id)
+			for _, m := range r.mismatches {
+				fmt.Printf("  %s\n", m)
+			}
+		}
+	}
+	fmt.Printf("FAIL: %s, %s\n",
+		testPlural(failed, "%d rule failed", "%d rules failed"),
+		testPlural(passed, "%d rule passed", "%d rules passed"))
+	os.Exit(1)
+	return nil
+}
+
+// testRule materializes a rule's fixtures into a temp directory and runs them.
+func testRule(ctx context.Context, rule *datadog.Rule) ([]string, error) {
+	tmpDir, err := os.MkdirTemp("", "iac-rule-test-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir) // nolint:errcheck
+
+	var positiveFiles, negativeFiles []string
+	for _, tf := range rule.Tests.Files {
+		dest := filepath.Join(tmpDir, filepath.FromSlash(tf.FileName))
+		if err := os.MkdirAll(filepath.Dir(dest), testFixtureDirPerm); err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(dest, tf.Content, testFixtureFilePerm); err != nil {
+			return nil, err
+		}
+		base := filepath.Base(tf.FileName)
+		switch {
+		case strings.HasPrefix(base, "positive"):
+			positiveFiles = append(positiveFiles, dest)
+		case strings.HasPrefix(base, "negative"):
+			negativeFiles = append(negativeFiles, dest)
+		}
+	}
+
+	if len(positiveFiles) == 0 && len(negativeFiles) == 0 {
+		return nil, nil
+	}
+
+	expected := make([]ruleFinding, len(rule.Tests.Expected))
+	for i, ef := range rule.Tests.Expected {
+		expected[i] = ruleFinding{
+			QueryName: ef.ShortDescription,
+			Severity:  ef.Severity,
+			Line:      ef.Line,
+			FileName:  ef.FileName,
+		}
+	}
+
+	query := source.ConvertRule(rule)
+	queryPtr := &query
+
+	platformStr := rule.Platform
+	resourcePlatforms := testResourcePlatformsFor(platformStr)
+
+	var mismatches []string
+
+	positiveGot, positiveShape, err := testRunFiles(ctx, tmpDir, rule.ID, queryPtr, positiveFiles, resourcePlatforms)
+	if err != nil {
+		return nil, err
+	}
+	negativeGot, negativeShape, err := testRunFiles(ctx, tmpDir, rule.ID, queryPtr, negativeFiles, resourcePlatforms)
+	if err != nil {
+		return nil, err
+	}
+
+	mismatches = append(mismatches, positiveShape...)
+	mismatches = append(mismatches, negativeShape...)
+	mismatches = append(mismatches, testCompareFindings(expected, positiveGot)...)
+	mismatches = append(mismatches, testCompareFindings([]ruleFinding{}, negativeGot)...)
+
+	return mismatches, nil
+}
+
+// testResourcePlatformsFor returns the set of platforms that require resourceType/resourceName.
+// Mirrors the logic used in the default-rules test tool.
+func testResourcePlatformsFor(platform string) map[string]struct{} {
+	resourcePlatforms := map[string]struct{}{
+		"terraform":               {},
+		"cloudformation":          {},
+		"ansible":                 {},
+		"kubernetes":              {},
+		"k8s":                     {},
+		"googledeploymentmanager": {},
+		"crossplane":              {},
+		"azureresourcemanager":    {},
+		"pulumi":                  {},
+	}
+	out := map[string]struct{}{}
+	normalized := strings.ToLower(platform)
+	if _, ok := resourcePlatforms[normalized]; ok {
+		out[normalized] = struct{}{}
+	}
+	return out
+}
+
+// testRunFiles evaluates the rule against the given files and returns findings
+// plus any result-shape errors.
+func testRunFiles(
+	ctx context.Context,
+	rootPath, ruleID string,
+	query *model.QueryMetadata,
+	files []string,
+	resourcePlatforms map[string]struct{},
+) ([]ruleFinding, []string, error) {
+	var allFiles model.FileMetadatas
+	platformStr, _ := query.Metadata["platform"].(string)
+	for _, f := range files {
+		parsed, err := testParseFile(ctx, rootPath, f, platformStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parsing %s: %w", f, err)
+		}
+		allFiles = append(allFiles, parsed...)
+	}
+
+	var shapeErrs []string
+	builder := testWrapShapeValidator(
+		strings.ToLower(platformStr),
+		resourcePlatforms,
+		ruleID,
+		&shapeErrs,
+	)
+
+	inspector, err := engine.NewInspector(ctx,
+		&testSingleRuleSource{query: query},
+		builder,
+		&testNoopTracker{},
+		&source.QueryInspectorParameters{
+			FlagEvaluator: featureflags.NewLocalEvaluator(),
+		},
+		map[string]bool{},
+		map[string]config.IacRuleConfig{},
+		rootPath,
+		defaultRuleTestQueryTimeoutSecs,
+		false,
+		false,
+		0,
+		false,
+		featureflags.NewLocalEvaluator(),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	vulns, err := inspector.Inspect(ctx, "test", allFiles, []string{rootPath}, []string{platformStr})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	out := make([]ruleFinding, len(vulns))
+	for i := range vulns {
+		v := vulns[i]
+		out[i] = ruleFinding{
+			QueryName: v.QueryName,
+			Severity:  string(v.Severity),
+			Line:      v.Line,
+			FileName:  filepath.Base(v.FileName),
+		}
+	}
+	return out, shapeErrs, nil
+}
+
+func testWrapShapeValidator(
+	platform string,
+	resourcePlatforms map[string]struct{},
+	ruleID string,
+	errs *[]string,
+) engine.VulnerabilityBuilder {
+	return func(ctx context.Context, qCtx *engine.QueryContext, tracker engine.Tracker, v interface{},
+		dl *detector.DetectLine, useOldSeverities bool, kicsComputeNewSimID bool, queryDuration time.Duration) (*model.Vulnerability, error) {
+		if m, ok := v.(map[string]interface{}); ok {
+			*errs = append(*errs, testValidateResultShape(m, platform, resourcePlatforms, ruleID)...)
+		}
+		return engine.DefaultVulnerabilityBuilder(ctx, qCtx, tracker, v, dl, useOldSeverities, kicsComputeNewSimID, queryDuration)
+	}
+}
+
+func testValidateResultShape(m map[string]interface{}, platform string, resourcePlatforms map[string]struct{}, ruleID string) []string {
+	var errs []string
+	for _, key := range testResultShape.Required {
+		if _, ok := m[key]; !ok {
+			errs = append(errs, fmt.Sprintf("Result missing required field %q", key))
+		}
+	}
+	if _, ok := resourcePlatforms[platform]; ok {
+		for _, key := range testResultShape.ResourceKeys {
+			if _, ok := m[key]; !ok {
+				errs = append(errs, fmt.Sprintf("Result missing required field %q for platform %q in rule %s", key, platform, ruleID))
+			}
+		}
+	}
+	_, hasRemediation := m["remediation"]
+	_, hasRemediationType := m["remediationType"]
+	if hasRemediation != hasRemediationType {
+		errs = append(errs, "Result has remediation/remediationType only on one side; both must be set together")
+	}
+	if issueType, _ := m["issueType"].(string); issueType != "" {
+		if _, ok := testAllowedIssueTypes[issueType]; !ok {
+			errs = append(errs, fmt.Sprintf("Result issueType %q is not in the allowed set", issueType))
+		}
+	}
+	return errs
+}
+
+// testCompareFindings returns mismatch messages between expected and actual findings.
+// An empty FileName in an expected finding acts as a wildcard.
+func testCompareFindings(expected, got []ruleFinding) []string {
+	remaining := slices.Clone(got)
+
+	sorted := slices.Clone(expected)
+	slices.SortStableFunc(sorted, func(a, b ruleFinding) int {
+		if (a.FileName == "") == (b.FileName == "") {
+			return 0
+		}
+		if a.FileName != "" {
+			return -1
+		}
+		return 1
+	})
+
+	var mismatches []string
+	for _, exp := range sorted {
+		idx := slices.IndexFunc(remaining, func(g ruleFinding) bool {
+			return testFindingsMatch(exp, g)
+		})
+		if idx == -1 {
+			mismatches = append(mismatches, fmt.Sprintf("Missing expected: %#v", exp))
+		} else {
+			remaining = slices.Delete(remaining, idx, idx+1)
+		}
+	}
+	for _, g := range remaining {
+		mismatches = append(mismatches, fmt.Sprintf("Unexpected finding: %#v", g))
+	}
+	return mismatches
+}
+
+func testFindingsMatch(exp, got ruleFinding) bool {
+	return exp.QueryName == got.QueryName &&
+		exp.Severity == got.Severity &&
+		exp.Line == got.Line &&
+		(exp.FileName == "" || exp.FileName == got.FileName)
+}
+
+func testParseFile(ctx context.Context, tmpRoot, filePath, platform string) (model.FileMetadatas, error) {
+	cleanRoot := filepath.Clean(tmpRoot)
+	cleanPath := filepath.Clean(filePath)
+	rel, err := filepath.Rel(cleanRoot, cleanPath)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return nil, fmt.Errorf("test file path %q escapes fixture root", filePath)
+	}
+
+	content, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return nil, err
+	}
+
+	ps, err := getTestParsers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var files model.FileMetadatas
+	for _, p := range ps {
+		if !p.Parsers.SupportedTypes()[testNormalizePlatform(platform)] {
+			continue
+		}
+		docs, _ := p.Parse(ctx, cleanPath, content, true, false, defaultRuleTestMaxResolverDepth)
+		for _, doc := range docs.Docs {
+			files = append(files, &model.FileMetadata{
+				ID:                uuid.NewString(),
+				ScanID:            "test",
+				Document:          runner.PrepareScanDocument(ctx, doc, docs.Kind),
+				LineInfoDocument:  doc,
+				OriginalData:      docs.Content,
+				Kind:              docs.Kind,
+				FilePath:          cleanPath,
+				ResolvedFiles:     docs.ResolvedFiles,
+				LinesOriginalData: scanUtils.SplitLines(docs.Content),
+			})
+		}
+	}
+	return files, nil
+}
+
+func testNormalizePlatform(platform string) string {
+	if strings.EqualFold(platform, "k8s") {
+		return "kubernetes"
+	}
+	return strings.ToLower(platform)
+}
+
+var (
+	testParsersOnce sync.Once
+	testParsers     []*parser.Parser
+	testParsersErr  error
+)
+
+func getTestParsers(ctx context.Context) ([]*parser.Parser, error) {
+	testParsersOnce.Do(func() {
+		testParsers, testParsersErr = parser.NewBuilder(ctx).
+			Add(&jsonParser.Parser{}).
+			Add(&yamlParser.Parser{}).
+			Add(terraformParser.NewDefault()).
+			Add(&bicepParser.Parser{}).
+			Add(&cicdParser.Parser{}).
+			Add(&dockerParser.Parser{}).
+			Add(&protoParser.Parser{}).
+			Add(&buildahParser.Parser{}).
+			Add(&ansibleConfigParser.Parser{}).
+			Add(&ansibleHostsParser.Parser{}).
+			Build([]string{""}, []string{""})
+	})
+	return testParsers, testParsersErr
+}
+
+type testSingleRuleSource struct {
+	query *model.QueryMetadata
+}
+
+func (s *testSingleRuleSource) GetQueries(_ context.Context, _ *source.QueryInspectorParameters) ([]model.QueryMetadata, error) {
+	return []model.QueryMetadata{*s.query}, nil
+}
+
+func (s *testSingleRuleSource) GetQueryLibrary(_ context.Context, platform string) (source.RegoLibraries, error) {
+	// Import assets here to avoid a circular init between the scanner packages.
+	// The embedded libraries live in the assets package and are needed for evaluation.
+	from := source.NewFilesystemSource(
+		context.Background(),
+		[]string{""},
+		[]string{strings.ToLower(platform)},
+		[]string{""},
+		"./assets/libraries",
+		true,
+	)
+	return from.GetQueryLibrary(context.Background(), platform)
+}
+
+type testNoopTracker struct{}
+
+func (t *testNoopTracker) TrackQueryLoad(int)            {}
+func (t *testNoopTracker) TrackQueryExecuting(int)       {}
+func (t *testNoopTracker) TrackQueryExecution(int)       {}
+func (t *testNoopTracker) FailedDetectLine()             {}
+func (t *testNoopTracker) FailedComputeSimilarityID()    {}
+func (t *testNoopTracker) FailedComputeOldSimilarityID() {}
+func (t *testNoopTracker) GetOutputLines() int           { return 0 }
+
+func testPlural(n int, singular, pluralStr string) string {
+	if n == 1 {
+		return fmt.Sprintf(singular, n)
+	}
+	return fmt.Sprintf(pluralStr, n)
+}

--- a/cmd/scanner/test_rules.go
+++ b/cmd/scanner/test_rules.go
@@ -37,12 +37,12 @@ import (
 const (
 	defaultRuleTestQueryTimeoutSecs = 60
 	defaultRuleTestMaxResolverDepth = 15
-	testFixtureDirPerm              = 0750
-	testFixtureFilePerm             = 0600
+	fixtureDirPerm                  = 0750
+	fixtureFilePerm                 = 0600
 )
 
-// testResultShape is the per-rule Rego result contract checked during tests.
-var testResultShape = struct {
+// resultShape is the per-rule Rego result contract checked during tests.
+var resultShape = struct {
 	Required     []string
 	ResourceKeys []string
 }{
@@ -56,11 +56,25 @@ var testResultShape = struct {
 	ResourceKeys: []string{"resourceType", "resourceName"},
 }
 
-// testAllowedIssueTypes is the set of issueType values a rule result may emit.
-var testAllowedIssueTypes = map[string]struct{}{
+// allowedIssueTypes is the set of issueType values a rule result may emit.
+var allowedIssueTypes = map[string]struct{}{
 	"MissingAttribute":   {},
 	"IncorrectValue":     {},
 	"RedundantAttribute": {},
+}
+
+// platformsRequiringResourceKeys is the set of platforms whose Rego results
+// must include resourceType and resourceName.
+var platformsRequiringResourceKeys = map[string]struct{}{
+	"terraform":               {},
+	"cloudformation":          {},
+	"ansible":                 {},
+	"kubernetes":              {},
+	"k8s":                     {},
+	"googledeploymentmanager": {},
+	"crossplane":              {},
+	"azureresourcemanager":    {},
+	"pulumi":                  {},
 }
 
 // ruleFinding is one result emitted by a rule's DatadogPolicy evaluation.
@@ -71,7 +85,7 @@ type ruleFinding struct {
 	FileName  string
 }
 
-type testRuleOutcome struct {
+type ruleOutcome struct {
 	id         string
 	mismatches []string
 }
@@ -103,26 +117,26 @@ func runTestRules(ctx context.Context, c *cli.Command) error {
 	ruleFilter := c.StringSlice("rule")
 	platformFilter := c.StringSlice("type")
 
-	var results []testRuleOutcome
+	var results []ruleOutcome
 	allPass := true
 
 	for _, rule := range ruleset.Rules {
-		if !testRuleShouldRun(rule, platformFilter, ruleFilter) {
+		if !shouldRunRule(rule, platformFilter, ruleFilter) {
 			continue
 		}
 
-		mismatches, err := testRule(ctx, rule)
+		mismatches, err := runRule(ctx, rule)
 		if err != nil {
 			return fmt.Errorf("testing rule %s: %w", rule.ID, err)
 		}
-		results = append(results, testRuleOutcome{id: rule.ID, mismatches: mismatches})
+		results = append(results, ruleOutcome{id: rule.ID, mismatches: mismatches})
 		allPass = allPass && len(mismatches) == 0
 	}
 
-	return testRulesFinish(results, allPass)
+	return finishTests(results, allPass)
 }
 
-func testRuleShouldRun(rule *datadog.Rule, platformFilter, ruleFilter []string) bool {
+func shouldRunRule(rule *datadog.Rule, platformFilter, ruleFilter []string) bool {
 	if !rule.IsPublished || rule.Tests == nil {
 		return false
 	}
@@ -141,13 +155,13 @@ func testRuleShouldRun(rule *datadog.Rule, platformFilter, ruleFilter []string) 
 	return slices.Contains(ruleFilter, rule.ID) || slices.Contains(ruleFilter, legacyID)
 }
 
-func testRulesFinish(results []testRuleOutcome, allPass bool) error {
+func finishTests(results []ruleOutcome, allPass bool) error {
 	if allPass {
 		if len(results) == 0 {
 			fmt.Println("No rules with tests were found")
 			os.Exit(1)
 		}
-		fmt.Printf("PASS: %s\n", testPlural(len(results), "%d rule", "%d rules"))
+		fmt.Printf("PASS: %s\n", plural("%d rule", "%d rules", len(results)))
 		return nil
 	}
 
@@ -165,14 +179,14 @@ func testRulesFinish(results []testRuleOutcome, allPass bool) error {
 		}
 	}
 	fmt.Printf("FAIL: %s, %s\n",
-		testPlural(failed, "%d rule failed", "%d rules failed"),
-		testPlural(passed, "%d rule passed", "%d rules passed"))
+		plural("%d rule failed", "%d rules failed", failed),
+		plural("%d rule passed", "%d rules passed", passed))
 	os.Exit(1)
 	return nil
 }
 
-// testRule materializes a rule's fixtures into a temp directory and runs them.
-func testRule(ctx context.Context, rule *datadog.Rule) ([]string, error) {
+// runRule materializes a rule's fixtures into a temp directory and runs them.
+func runRule(ctx context.Context, rule *datadog.Rule) ([]string, error) {
 	tmpDir, err := os.MkdirTemp("", "iac-rule-test-*")
 	if err != nil {
 		return nil, fmt.Errorf("creating temp dir: %w", err)
@@ -182,10 +196,10 @@ func testRule(ctx context.Context, rule *datadog.Rule) ([]string, error) {
 	var positiveFiles, negativeFiles []string
 	for _, tf := range rule.Tests.Files {
 		dest := filepath.Join(tmpDir, filepath.FromSlash(tf.FileName))
-		if err := os.MkdirAll(filepath.Dir(dest), testFixtureDirPerm); err != nil {
+		if err := os.MkdirAll(filepath.Dir(dest), fixtureDirPerm); err != nil {
 			return nil, err
 		}
-		if err := os.WriteFile(dest, tf.Content, testFixtureFilePerm); err != nil {
+		if err := os.WriteFile(dest, tf.Content, fixtureFilePerm); err != nil {
 			return nil, err
 		}
 		base := filepath.Base(tf.FileName)
@@ -212,65 +226,38 @@ func testRule(ctx context.Context, rule *datadog.Rule) ([]string, error) {
 	}
 
 	query := source.ConvertRule(rule)
-	queryPtr := &query
-
-	platformStr := rule.Platform
-	resourcePlatforms := testResourcePlatformsFor(platformStr)
 
 	var mismatches []string
 
-	positiveGot, positiveShape, err := testRunFiles(ctx, tmpDir, rule.ID, queryPtr, positiveFiles, resourcePlatforms)
+	positiveGot, positiveShape, err := runFiles(ctx, tmpDir, rule.ID, &query, positiveFiles)
 	if err != nil {
 		return nil, err
 	}
-	negativeGot, negativeShape, err := testRunFiles(ctx, tmpDir, rule.ID, queryPtr, negativeFiles, resourcePlatforms)
+	negativeGot, negativeShape, err := runFiles(ctx, tmpDir, rule.ID, &query, negativeFiles)
 	if err != nil {
 		return nil, err
 	}
 
 	mismatches = append(mismatches, positiveShape...)
 	mismatches = append(mismatches, negativeShape...)
-	mismatches = append(mismatches, testCompareFindings(expected, positiveGot)...)
-	mismatches = append(mismatches, testCompareFindings([]ruleFinding{}, negativeGot)...)
+	mismatches = append(mismatches, compareFindings(expected, positiveGot)...)
+	mismatches = append(mismatches, compareFindings([]ruleFinding{}, negativeGot)...)
 
 	return mismatches, nil
 }
 
-// testResourcePlatformsFor returns the set of platforms that require resourceType/resourceName.
-// Mirrors the logic used in the default-rules test tool.
-func testResourcePlatformsFor(platform string) map[string]struct{} {
-	resourcePlatforms := map[string]struct{}{
-		"terraform":               {},
-		"cloudformation":          {},
-		"ansible":                 {},
-		"kubernetes":              {},
-		"k8s":                     {},
-		"googledeploymentmanager": {},
-		"crossplane":              {},
-		"azureresourcemanager":    {},
-		"pulumi":                  {},
-	}
-	out := map[string]struct{}{}
-	normalized := strings.ToLower(platform)
-	if _, ok := resourcePlatforms[normalized]; ok {
-		out[normalized] = struct{}{}
-	}
-	return out
-}
-
-// testRunFiles evaluates the rule against the given files and returns findings
+// runFiles evaluates the rule against the given files and returns findings
 // plus any result-shape errors.
-func testRunFiles(
+func runFiles(
 	ctx context.Context,
 	rootPath, ruleID string,
 	query *model.QueryMetadata,
 	files []string,
-	resourcePlatforms map[string]struct{},
 ) ([]ruleFinding, []string, error) {
 	var allFiles model.FileMetadatas
 	platformStr, _ := query.Metadata["platform"].(string)
 	for _, f := range files {
-		parsed, err := testParseFile(ctx, rootPath, f, platformStr)
+		parsed, err := parseFixtureFile(ctx, rootPath, f, platformStr)
 		if err != nil {
 			return nil, nil, fmt.Errorf("parsing %s: %w", f, err)
 		}
@@ -278,17 +265,16 @@ func testRunFiles(
 	}
 
 	var shapeErrs []string
-	builder := testWrapShapeValidator(
+	builder := wrapShapeValidator(
 		strings.ToLower(platformStr),
-		resourcePlatforms,
 		ruleID,
 		&shapeErrs,
 	)
 
 	inspector, err := engine.NewInspector(ctx,
-		&testSingleRuleSource{query: query},
+		&singleRuleSource{query: query},
 		builder,
-		&testNoopTracker{},
+		&noopTracker{},
 		&source.QueryInspectorParameters{
 			FlagEvaluator: featureflags.NewLocalEvaluator(),
 		},
@@ -324,30 +310,29 @@ func testRunFiles(
 	return out, shapeErrs, nil
 }
 
-func testWrapShapeValidator(
+func wrapShapeValidator(
 	platform string,
-	resourcePlatforms map[string]struct{},
 	ruleID string,
 	errs *[]string,
 ) engine.VulnerabilityBuilder {
 	return func(ctx context.Context, qCtx *engine.QueryContext, tracker engine.Tracker, v interface{},
 		dl *detector.DetectLine, useOldSeverities bool, kicsComputeNewSimID bool, queryDuration time.Duration) (*model.Vulnerability, error) {
 		if m, ok := v.(map[string]interface{}); ok {
-			*errs = append(*errs, testValidateResultShape(m, platform, resourcePlatforms, ruleID)...)
+			*errs = append(*errs, validateResultShape(m, platform, ruleID)...)
 		}
 		return engine.DefaultVulnerabilityBuilder(ctx, qCtx, tracker, v, dl, useOldSeverities, kicsComputeNewSimID, queryDuration)
 	}
 }
 
-func testValidateResultShape(m map[string]interface{}, platform string, resourcePlatforms map[string]struct{}, ruleID string) []string {
+func validateResultShape(m map[string]interface{}, platform, ruleID string) []string {
 	var errs []string
-	for _, key := range testResultShape.Required {
+	for _, key := range resultShape.Required {
 		if _, ok := m[key]; !ok {
 			errs = append(errs, fmt.Sprintf("Result missing required field %q", key))
 		}
 	}
-	if _, ok := resourcePlatforms[platform]; ok {
-		for _, key := range testResultShape.ResourceKeys {
+	if _, ok := platformsRequiringResourceKeys[platform]; ok {
+		for _, key := range resultShape.ResourceKeys {
 			if _, ok := m[key]; !ok {
 				errs = append(errs, fmt.Sprintf("Result missing required field %q for platform %q in rule %s", key, platform, ruleID))
 			}
@@ -359,16 +344,16 @@ func testValidateResultShape(m map[string]interface{}, platform string, resource
 		errs = append(errs, "Result has remediation/remediationType only on one side; both must be set together")
 	}
 	if issueType, _ := m["issueType"].(string); issueType != "" {
-		if _, ok := testAllowedIssueTypes[issueType]; !ok {
+		if _, ok := allowedIssueTypes[issueType]; !ok {
 			errs = append(errs, fmt.Sprintf("Result issueType %q is not in the allowed set", issueType))
 		}
 	}
 	return errs
 }
 
-// testCompareFindings returns mismatch messages between expected and actual findings.
+// compareFindings returns mismatch messages between expected and actual findings.
 // An empty FileName in an expected finding acts as a wildcard.
-func testCompareFindings(expected, got []ruleFinding) []string {
+func compareFindings(expected, got []ruleFinding) []string {
 	remaining := slices.Clone(got)
 
 	sorted := slices.Clone(expected)
@@ -385,7 +370,7 @@ func testCompareFindings(expected, got []ruleFinding) []string {
 	var mismatches []string
 	for _, exp := range sorted {
 		idx := slices.IndexFunc(remaining, func(g ruleFinding) bool {
-			return testFindingsMatch(exp, g)
+			return findingsMatch(exp, g)
 		})
 		if idx == -1 {
 			mismatches = append(mismatches, fmt.Sprintf("Missing expected: %#v", exp))
@@ -399,14 +384,14 @@ func testCompareFindings(expected, got []ruleFinding) []string {
 	return mismatches
 }
 
-func testFindingsMatch(exp, got ruleFinding) bool {
+func findingsMatch(exp, got ruleFinding) bool {
 	return exp.QueryName == got.QueryName &&
 		exp.Severity == got.Severity &&
 		exp.Line == got.Line &&
 		(exp.FileName == "" || exp.FileName == got.FileName)
 }
 
-func testParseFile(ctx context.Context, tmpRoot, filePath, platform string) (model.FileMetadatas, error) {
+func parseFixtureFile(ctx context.Context, tmpRoot, filePath, platform string) (model.FileMetadatas, error) {
 	cleanRoot := filepath.Clean(tmpRoot)
 	cleanPath := filepath.Clean(filePath)
 	rel, err := filepath.Rel(cleanRoot, cleanPath)
@@ -419,14 +404,14 @@ func testParseFile(ctx context.Context, tmpRoot, filePath, platform string) (mod
 		return nil, err
 	}
 
-	ps, err := getTestParsers(ctx)
+	ps, err := getFixtureParsers(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	var files model.FileMetadatas
 	for _, p := range ps {
-		if !p.Parsers.SupportedTypes()[testNormalizePlatform(platform)] {
+		if !p.Parsers.SupportedTypes()[normalizePlatform(platform)] {
 			continue
 		}
 		docs, _ := p.Parse(ctx, cleanPath, content, true, false, defaultRuleTestMaxResolverDepth)
@@ -447,7 +432,7 @@ func testParseFile(ctx context.Context, tmpRoot, filePath, platform string) (mod
 	return files, nil
 }
 
-func testNormalizePlatform(platform string) string {
+func normalizePlatform(platform string) string {
 	if strings.EqualFold(platform, "k8s") {
 		return "kubernetes"
 	}
@@ -455,14 +440,14 @@ func testNormalizePlatform(platform string) string {
 }
 
 var (
-	testParsersOnce sync.Once
-	testParsers     []*parser.Parser
-	testParsersErr  error
+	fixtureParsersOnce sync.Once
+	fixtureParsers     []*parser.Parser
+	fixtureParsersErr  error
 )
 
-func getTestParsers(ctx context.Context) ([]*parser.Parser, error) {
-	testParsersOnce.Do(func() {
-		testParsers, testParsersErr = parser.NewBuilder(ctx).
+func getFixtureParsers(ctx context.Context) ([]*parser.Parser, error) {
+	fixtureParsersOnce.Do(func() {
+		fixtureParsers, fixtureParsersErr = parser.NewBuilder(ctx).
 			Add(&jsonParser.Parser{}).
 			Add(&yamlParser.Parser{}).
 			Add(terraformParser.NewDefault()).
@@ -475,18 +460,18 @@ func getTestParsers(ctx context.Context) ([]*parser.Parser, error) {
 			Add(&ansibleHostsParser.Parser{}).
 			Build([]string{""}, []string{""})
 	})
-	return testParsers, testParsersErr
+	return fixtureParsers, fixtureParsersErr
 }
 
-type testSingleRuleSource struct {
+type singleRuleSource struct {
 	query *model.QueryMetadata
 }
 
-func (s *testSingleRuleSource) GetQueries(_ context.Context, _ *source.QueryInspectorParameters) ([]model.QueryMetadata, error) {
+func (s *singleRuleSource) GetQueries(_ context.Context, _ *source.QueryInspectorParameters) ([]model.QueryMetadata, error) {
 	return []model.QueryMetadata{*s.query}, nil
 }
 
-func (s *testSingleRuleSource) GetQueryLibrary(_ context.Context, platform string) (source.RegoLibraries, error) {
+func (s *singleRuleSource) GetQueryLibrary(_ context.Context, platform string) (source.RegoLibraries, error) {
 	// Import assets here to avoid a circular init between the scanner packages.
 	// The embedded libraries live in the assets package and are needed for evaluation.
 	from := source.NewFilesystemSource(
@@ -500,19 +485,12 @@ func (s *testSingleRuleSource) GetQueryLibrary(_ context.Context, platform strin
 	return from.GetQueryLibrary(context.Background(), platform)
 }
 
-type testNoopTracker struct{}
+type noopTracker struct{}
 
-func (t *testNoopTracker) TrackQueryLoad(int)            {}
-func (t *testNoopTracker) TrackQueryExecuting(int)       {}
-func (t *testNoopTracker) TrackQueryExecution(int)       {}
-func (t *testNoopTracker) FailedDetectLine()             {}
-func (t *testNoopTracker) FailedComputeSimilarityID()    {}
-func (t *testNoopTracker) FailedComputeOldSimilarityID() {}
-func (t *testNoopTracker) GetOutputLines() int           { return 0 }
-
-func testPlural(n int, singular, pluralStr string) string {
-	if n == 1 {
-		return fmt.Sprintf(singular, n)
-	}
-	return fmt.Sprintf(pluralStr, n)
-}
+func (t *noopTracker) TrackQueryLoad(int)            {}
+func (t *noopTracker) TrackQueryExecuting(int)       {}
+func (t *noopTracker) TrackQueryExecution(int)       {}
+func (t *noopTracker) FailedDetectLine()             {}
+func (t *noopTracker) FailedComputeSimilarityID()    {}
+func (t *noopTracker) FailedComputeOldSimilarityID() {}
+func (t *noopTracker) GetOutputLines() int           { return 0 }

--- a/pkg/config/reader_test.go
+++ b/pkg/config/reader_test.go
@@ -337,6 +337,10 @@ func (f *fakeDatadogClient) GetDefaultRuleset(ctx context.Context) (*datadog.Rul
 	panic("unimplemented")
 }
 
+func (f *fakeDatadogClient) GetDefaultRulesetWithTests(ctx context.Context) (*datadog.Ruleset, error) {
+	panic("unimplemented")
+}
+
 func (f *fakeDatadogClient) GetRemoteConfig(_ context.Context, repoUrl string, localConfig []byte) ([]byte, error) {
 	assert.Equal(f.t, f.expectedRepoUrl, repoUrl)
 	assert.Equal(f.t, string(f.expectedSentConfig), string(localConfig))

--- a/pkg/datadog/client.go
+++ b/pkg/datadog/client.go
@@ -150,11 +150,7 @@ func (s *datadogClient) GetDefaultRulesetWithTests(ctx context.Context) (*Rulese
 }
 
 func (s *datadogClient) fetchDefaultRuleset(ctx context.Context, includeTests bool) (*Ruleset, error) {
-	testsParam := "false"
-	if includeTests {
-		testsParam = "true"
-	}
-	path := "iac/rulesets/default-ruleset?include_tests=" + testsParam + "&include_testing_rules=true"
+	path := fmt.Sprintf("iac/rulesets/default-ruleset?include_tests=%t&include_testing_rules=true", includeTests)
 	response, err := s.sendRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/datadog/client.go
+++ b/pkg/datadog/client.go
@@ -15,6 +15,8 @@ import (
 type Client interface {
 	// GetDefaultRuleset returns the content of the default ruleset.
 	GetDefaultRuleset(ctx context.Context) (*Ruleset, error)
+	// GetDefaultRulesetWithTests returns the default ruleset with per-rule test fixtures included.
+	GetDefaultRulesetWithTests(ctx context.Context) (*Ruleset, error)
 	// GetRemoteConfig applies server-side changes to the local configuration.
 	GetRemoteConfig(ctx context.Context, repoUrl string, localConfig []byte) ([]byte, error)
 }
@@ -139,7 +141,20 @@ type datadogClient struct {
 
 // GetDefaultRuleset returns the content of the default ruleset.
 func (s *datadogClient) GetDefaultRuleset(ctx context.Context) (*Ruleset, error) {
-	path := "iac/rulesets/default-ruleset?include_tests=false&include_testing_rules=true"
+	return s.fetchDefaultRuleset(ctx, false)
+}
+
+// GetDefaultRulesetWithTests returns the default ruleset with per-rule test fixtures included.
+func (s *datadogClient) GetDefaultRulesetWithTests(ctx context.Context) (*Ruleset, error) {
+	return s.fetchDefaultRuleset(ctx, true)
+}
+
+func (s *datadogClient) fetchDefaultRuleset(ctx context.Context, includeTests bool) (*Ruleset, error) {
+	testsParam := "false"
+	if includeTests {
+		testsParam = "true"
+	}
+	path := "iac/rulesets/default-ruleset?include_tests=" + testsParam + "&include_testing_rules=true"
 	response, err := s.sendRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -270,8 +285,32 @@ type Rule struct {
 	Overrides         []RuleOverride `jsonapi:"attribute" json:"overrides,omitempty"`
 	DefaultFrameworks []Framework    `jsonapi:"attribute" json:"default_frameworks,omitempty"`
 	CustomFrameworks  []Framework    `jsonapi:"attribute" json:"custom_frameworks,omitempty"`
+	Tests             *RuleTests     `jsonapi:"attribute" json:"tests,omitempty"`
 	IsTesting         bool           `jsonapi:"attribute" json:"is_testing"`
 	IsPublished       bool           `jsonapi:"attribute" json:"is_published"`
+}
+
+// RuleTests holds the test suite stored alongside a rule in the backend.
+type RuleTests struct {
+	// Files contains all fixture files (positive*, negative*, and any support files).
+	Files []TestFile `jsonapi:"attribute" json:"files,omitempty"`
+	// Expected contains the expected findings produced by scanning the positive* files.
+	Expected []TestFinding `jsonapi:"attribute" json:"expected,omitempty"`
+}
+
+// TestFile is one fixture file stored in the backend alongside a rule.
+type TestFile struct {
+	FileName string `jsonapi:"attribute" json:"name"`
+	Content  []byte `jsonapi:"attribute" json:"content"`
+}
+
+// TestFinding is one expected finding in a rule's test suite.
+type TestFinding struct {
+	ShortDescription string `jsonapi:"attribute" json:"short_description"`
+	// FileName is the base name of the positive file; empty means any file.
+	FileName string `jsonapi:"attribute" json:"file_name,omitempty"`
+	Line     int    `jsonapi:"attribute" json:"line"`
+	Severity string `jsonapi:"attribute" json:"severity"`
 }
 
 // RuleOverride contains a set of keyed changes for the rule configuration

--- a/pkg/engine/source/datadog_test.go
+++ b/pkg/engine/source/datadog_test.go
@@ -500,6 +500,10 @@ func (f fakeDatadogClient) GetDefaultRuleset(ctx context.Context) (*datadog.Rule
 	return out, nil
 }
 
+func (f fakeDatadogClient) GetDefaultRulesetWithTests(ctx context.Context) (*datadog.Ruleset, error) {
+	panic("unimplemented")
+}
+
 func (f fakeDatadogClient) GetRemoteConfig(ctx context.Context, repoUrl string, localConfig []byte) ([]byte, error) {
 	panic("unimplemented")
 }


### PR DESCRIPTION
## Motivation

When the scanner engine changes, there is no automated way to verify that existing rules still produce the expected findings. The rule test fixtures live in the default-rules repository and are now also stored in the backend API (alongside the rules themselves). This PR wires up the scanner to fetch and run those tests, so every PR gets a signal that the engine has not regressed against the full default rule suite.

## Changes

**API client**

The `Client` interface gains a `GetDefaultRulesetWithTests` method that calls the same endpoint as `GetDefaultRuleset` but with `include_tests=true`. Three new types mirror the backend model: `RuleTests`, `TestFile`, and `TestFinding`. The `Rule` struct gains a `Tests *RuleTests` field that is populated when tests are requested.

**test-rules command**

A new `test-rules` subcommand fetches the default ruleset (with tests) from the Datadog API, materialises each rule's fixture files into a temporary directory, and runs the scanner engine against them. Positive fixtures are compared against the stored expected findings; negative fixtures must produce no findings. The command exits non-zero if any rule fails, prints a per-rule pass/fail summary, and accepts `--type` and `--rule` flags to scope the run to a subset of platforms or rules.

The rule is converted to a `QueryMetadata` via a JSON:API round-trip through the scanner's own `datadog.Rule` type, meaning the test exercises the exact same rule representation the scanner uses in production.

**CI workflow**

`.github/workflows/test-rules.yml` runs the command on every pull request targeting `main` and on every push to `main`. It requires `DD_API_KEY` and `DD_APP_KEY` repository secrets. Fork pull requests will pass vacuously since secrets are not available in that context.

## QA Instruction

CI should pass

## Impact

Adds a new CLI subcommand (`test-rules`) and a CI workflow. No changes to scan behaviour, output formats, or existing commands.