### PR TITLE
[K9CODESEC-2306] Resolve local Terraform modules during IaC scans

### DIFF
--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -275,6 +275,13 @@ func (c *Inspector) Inspect(
 	platforms []string) ([]model.Vulnerability, error) {
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("engine.Inspect()")
+
+	// Instantiate local Terraform modules into resolved-resource documents and
+	// drop the called module bodies from the standalone scan to avoid duplicates.
+	moduleDocs := c.instantiateLocalModules(ctx, files)
+
+	// instantiateLocalModules mutates files in place (clears suppressed bodies).
+	// Combine skips empty documents, so this must stay before Combine.
 	combinedFiles := files.Combine(ctx, false)
 
 	vulnerabilities := make([]model.Vulnerability, 0)
@@ -292,9 +299,12 @@ func (c *Inspector) Inspect(
 
 	// Convert combined documents directly to OPA AST, skipping the
 	// json.Marshal -> UnmarshalJSON round-trip to avoid intermediate copies.
-	docs := make([]interface{}, len(combinedFiles.Documents))
-	for i, d := range combinedFiles.Documents {
-		docs[i] = map[string]interface{}(d)
+	docs := make([]interface{}, 0, len(combinedFiles.Documents))
+	for _, d := range combinedFiles.Documents {
+		docs = append(docs, map[string]interface{}(d))
+	}
+	for _, d := range moduleDocs {
+		docs = append(docs, map[string]interface{}(d))
 	}
 	astPayload, err := ast.InterfaceToValue(map[string]interface{}{
 		"document": docs,

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -63,6 +63,7 @@ type inspectorOpts struct {
 	computeNewSimID bool
 	vb                  VulnerabilityBuilder
 	tracker             Tracker
+	flagEvaluator       featureflags.FlagEvaluator
 }
 
 // newTestInspector runs the real [NewInspector] against a configurable
@@ -98,6 +99,9 @@ func newTestInspector(t *testing.T, opts inspectorOpts) *Inspector {
 	if opts.tracker == nil {
 		opts.tracker = &tracker.CITracker{}
 	}
+	if opts.flagEvaluator == nil {
+		opts.flagEvaluator = featureflags.NewLocalEvaluator()
+	}
 
 	ins, err := NewInspector(
 		context.Background(),
@@ -113,7 +117,7 @@ func newTestInspector(t *testing.T, opts inspectorOpts) *Inspector {
 		opts.needsLog,
 		opts.numWorkers,
 		opts.computeNewSimID,
-		featureflags.NewLocalEvaluator(),
+		opts.flagEvaluator,
 	)
 	require.NoError(t, err)
 	return ins

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -18,39 +18,36 @@ import (
 )
 
 // instantiateLocalModules evaluates local modules and injects resolved resource
-// documents. Called module body files are suppressed (their resources are
-// emitted instantiated instead), and the "module" key is stripped from root
-// documents so call-site rule branches don't fire alongside the instantiated ones.
+// documents. In a called module body only the resource blocks are dropped (they
+// are re-emitted instantiated, with caller-resolved values); variable, output,
+// data and locals blocks are kept so their rules still fire exactly as in a
+// standalone scan. The instantiated local "module" call-sites are stripped from
+// root documents so call-site rule branches don't fire alongside the
+// instantiated resources.
 //
-// It mutates the input FileMetadata slice in place (clears Document /
-// LineInfoDocument for suppressed files; strips module blocks on other .tf files).
-func (c *Inspector) instantiateLocalModules(ctx context.Context, files model.FileMetadatas) (out []model.Document) {
-	defer func() {
-		if r := recover(); r != nil {
-			contextLogger := logger.FromContext(ctx)
-			contextLogger.Error().Interface("panic", r).Msg(
-				"instantiateLocalModules: recovered from panic; skipping synthetic module docs (input files may be partially updated)",
-			)
-			out = nil
-		}
-	}()
-
-	moduleDocs, suppressed, calledDirs, ok := resolveModuleDocuments(ctx, files, c.repoPath)
+// It mutates the input FileMetadata documents in place. Mutations are applied
+// only after evaluation succeeds (see resolveModulesSafely); a panic during
+// evaluation leaves the scan input untouched rather than removing coverage
+// without a synthetic replacement.
+func (c *Inspector) instantiateLocalModules(ctx context.Context, files model.FileMetadatas) []model.Document {
+	moduleDocs, suppressed, calledDirs, ok := c.resolveModulesSafely(ctx, files)
 	if !ok {
 		return nil
 	}
 	for _, f := range files {
-		if f == nil {
+		if f == nil || !isTerraformFile(f.FilePath) {
 			continue
 		}
 		if suppressed[f.ID] {
-			f.Document = model.Document{}
-			f.LineInfoDocument = nil
-		} else if isTerraformFile(f.FilePath) {
-			// Only remove local module call-sites that were instantiated; remote/registry
-			// module blocks must remain so the corresponding Rego branches can still fire.
-			stripLocalModuleCalls(f.Document, f.FilePath, c.repoPath, calledDirs)
+			// Resource blocks are re-emitted as instantiated synthetic docs, so
+			// drop only those to avoid double-counting; keep the rest of the body
+			// (variable/output/data/locals) so those rules still fire.
+			delete(f.Document, "resource")
+			delete(f.LineInfoDocument, "resource")
 		}
+		// Only remove local module call-sites that were instantiated; remote/registry
+		// module blocks must remain so the corresponding Rego branches can still fire.
+		stripLocalModuleCalls(f.Document, f.FilePath, c.repoPath, calledDirs)
 	}
 	contextLogger := logger.FromContext(ctx)
 	if len(moduleDocs) > 0 {
@@ -61,14 +58,34 @@ func (c *Inspector) instantiateLocalModules(ctx context.Context, files model.Fil
 	return moduleDocs
 }
 
+// resolveModulesSafely runs the panic-prone module evaluation under a recover so
+// a malformed module aborts only the synthetic-doc injection, not the scan. It
+// performs no in-place mutation of files, so returning ok=false on panic leaves
+// the scan input untouched and the caller skips all document mutations.
+func (c *Inspector) resolveModulesSafely(
+	ctx context.Context,
+	files model.FileMetadatas,
+) (moduleDocs []model.Document, suppressed, calledDirs map[string]bool, ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			contextLogger := logger.FromContext(ctx)
+			contextLogger.Error().Interface("panic", r).Msg(
+				"instantiateLocalModules: recovered from panic; skipping synthetic module docs",
+			)
+			moduleDocs, suppressed, calledDirs, ok = nil, nil, nil, false
+		}
+	}()
+	return resolveModuleDocuments(ctx, files, c.repoPath)
+}
+
 // resolveModuleDocuments instantiates all local modules referenced by the
 // scanned files and returns synthetic resource documents (one per resolved
 // resource, attributed to its defining file) and the set of FileMetadata IDs
 // that should be suppressed to avoid double-scanning. Uncalled modules are
 // left untouched and continue to be scanned standalone.
 //
-// The boolean is true when at least one root module evaluated successfully and
-// the caller should apply call-site / suppression mutations; otherwise false
+// `ok` is true when at least one root module evaluated successfully and the
+// caller should apply call-site / suppression mutations; otherwise it is false
 // and the returned maps are nil.
 func resolveModuleDocuments(
 	ctx context.Context,
@@ -92,7 +109,7 @@ func resolveModuleDocuments(
 	contextLogger := logger.FromContext(ctx)
 	evaluator := tfeval.New()
 	seen := make(map[string]bool)
-	var rootEvalOK int
+	var rootEvalOK bool
 	actualCalledDirs := make(map[string]bool)
 
 	for dir := range dirsWithTf {
@@ -104,7 +121,7 @@ func resolveModuleDocuments(
 			contextLogger.Warn().Err(err).Msgf("tfeval: failed to evaluate root module %s", dir)
 			continue
 		}
-		rootEvalOK++
+		rootEvalOK = true
 		for d := range childDirs {
 			actualCalledDirs[d] = true
 		}
@@ -115,7 +132,7 @@ func resolveModuleDocuments(
 
 	// If every root evaluation failed, do not strip or suppress module bodies: that would
 	// remove coverage with no synthetic replacement.
-	if rootEvalOK == 0 {
+	if !rootEvalOK {
 		return nil, nil, nil, false
 	}
 

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -1,0 +1,275 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package engine
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/tfeval"
+)
+
+// instantiateLocalModules evaluates local modules and injects resolved resource
+// documents. Called module body files are suppressed (their resources are
+// emitted instantiated instead), and the "module" key is stripped from root
+// documents so call-site rule branches don't fire alongside the instantiated ones.
+//
+// It mutates the input FileMetadata slice in place (clears Document /
+// LineInfoDocument for suppressed files; strips module blocks on other .tf files).
+func (c *Inspector) instantiateLocalModules(ctx context.Context, files model.FileMetadatas) (out []model.Document) {
+	defer func() {
+		if r := recover(); r != nil {
+			contextLogger := logger.FromContext(ctx)
+			contextLogger.Error().Interface("panic", r).Msg(
+				"instantiateLocalModules: recovered from panic; skipping synthetic module docs (input files may be partially updated)",
+			)
+			out = nil
+		}
+	}()
+
+	moduleDocs, suppressed, calledDirs, ok := resolveModuleDocuments(ctx, files, c.repoPath)
+	if !ok {
+		return nil
+	}
+	for _, f := range files {
+		if f == nil {
+			continue
+		}
+		if suppressed[f.ID] {
+			f.Document = model.Document{}
+			f.LineInfoDocument = nil
+		} else if isTerraformFile(f.FilePath) {
+			// Only remove local module call-sites that were instantiated; remote/registry
+			// module blocks must remain so the corresponding Rego branches can still fire.
+			stripLocalModuleCalls(f.Document, f.FilePath, c.repoPath, calledDirs)
+		}
+	}
+	contextLogger := logger.FromContext(ctx)
+	if len(moduleDocs) > 0 {
+		contextLogger.Info().Msgf("Instantiated %d local module resources", len(moduleDocs))
+	} else {
+		contextLogger.Debug().Msg("Instantiated 0 local module resources")
+	}
+	return moduleDocs
+}
+
+// resolveModuleDocuments instantiates all local modules referenced by the
+// scanned files and returns synthetic resource documents (one per resolved
+// resource, attributed to its defining file) and the set of FileMetadata IDs
+// that should be suppressed to avoid double-scanning. Uncalled modules are
+// left untouched and continue to be scanned standalone.
+//
+// The boolean is true when at least one root module evaluated successfully and
+// the caller should apply call-site / suppression mutations; otherwise false
+// and the returned maps are nil.
+func resolveModuleDocuments(
+	ctx context.Context,
+	files model.FileMetadatas,
+	repoPath string,
+) (extra []model.Document, suppressed, calledDirs map[string]bool, ok bool) {
+	byAbsPath, filesByDir, dirsWithTf := indexTerraformFiles(ctx, files, repoPath)
+	if len(dirsWithTf) == 0 {
+		return nil, nil, nil, false
+	}
+
+	// staticCalledDirs is used only to classify root vs. child dirs before evaluation.
+	// Suppression and stripping are driven by actualCalledDirs (evaluation results).
+	staticCalledDirs := make(map[string]bool)
+	for dir := range dirsWithTf {
+		for _, called := range tfeval.CalledLocalDirs(dir) {
+			staticCalledDirs[called] = true
+		}
+	}
+
+	contextLogger := logger.FromContext(ctx)
+	evaluator := tfeval.New()
+	seen := make(map[string]bool)
+	var rootEvalOK int
+	actualCalledDirs := make(map[string]bool)
+
+	for dir := range dirsWithTf {
+		if staticCalledDirs[dir] {
+			continue // instantiated via a module call, not a root
+		}
+		resources, _, childDirs, err := evaluator.EvaluateModule(ctx, dir, tfeval.LoadRootVars(dir))
+		if err != nil {
+			contextLogger.Warn().Err(err).Msgf("tfeval: failed to evaluate root module %s", dir)
+			continue
+		}
+		rootEvalOK++
+		for d := range childDirs {
+			actualCalledDirs[d] = true
+		}
+		// evalRootDir distinguishes the same child module reached from different roots
+		// (different variable bindings) so synthetic documents are not incorrectly deduped.
+		extra = append(extra, instantiatedDocs(resources, byAbsPath, repoPath, seen, dir)...)
+	}
+
+	// If every root evaluation failed, do not strip or suppress module bodies: that would
+	// remove coverage with no synthetic replacement.
+	if rootEvalOK == 0 {
+		return nil, nil, nil, false
+	}
+
+	suppressed = make(map[string]bool)
+	for dir := range actualCalledDirs {
+		for _, f := range filesByDir[dir] {
+			suppressed[f.ID] = true
+		}
+	}
+
+	// Only strip call sites for dirs that contributed synthetic documents (i.e.,
+	// their files are present in the scan input). If a module was read from disk
+	// by EvaluateModule but its files are absent from the scan, instantiatedDocs
+	// drops its resources; stripping the call site would remove the only payload
+	// those files provide without any synthetic replacement.
+	strippedDirs := make(map[string]bool, len(actualCalledDirs))
+	for dir := range actualCalledDirs {
+		if len(filesByDir[dir]) > 0 {
+			strippedDirs[dir] = true
+		}
+	}
+
+	return extra, suppressed, strippedDirs, true
+}
+
+// instantiatedDocs builds a synthetic resource document for each resolved
+// module resource, attributed to its defining file. Root resources and those
+// whose file is out of scope are skipped. seen dedupes across multiple roots.
+//
+// v1 limitation: count/for_each and multiple calls to the same module directory
+// are not expanded into separate instances; dedupe and document id attribution
+// use the defining file only, so distinct instances can collapse to one synthetic doc.
+func instantiatedDocs(
+	resources []tfeval.ResolvedResource,
+	byAbsPath map[string]*model.FileMetadata,
+	repoPath string,
+	seen map[string]bool,
+	evalRootDir string,
+) []model.Document {
+	var docs []model.Document
+	for i := range resources {
+		r := &resources[i]
+		if r.ModuleAddress == "" {
+			continue
+		}
+		abs := absPath(r.DefinedIn, repoPath)
+		fm, ok := byAbsPath[abs]
+		if !ok {
+			continue
+		}
+		key := strings.Join([]string{evalRootDir, abs, r.ModuleAddress, r.Type, r.Name, strconv.Itoa(r.DefLine)}, "\x00")
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		docs = append(docs, model.Document{
+			"id":   fm.ID,
+			"file": fm.FilePath,
+			"resource": map[string]interface{}{
+				r.Type: map[string]interface{}{
+					r.Name: tfeval.AttributesToDocument(r),
+				},
+			},
+		})
+	}
+	return docs
+}
+
+// stripLocalModuleCalls removes module entries from doc whose source resolves
+// to one of calledDirs. Remote/registry sources are left intact so existing
+// Rego branches that match call-site attributes continue to work.
+//
+// The Terraform parser stores nested HCL blocks as model.Document (a named map
+// type), so we accept both model.Document and map[string]interface{} to handle
+// either representation safely.
+func stripLocalModuleCalls(doc model.Document, filePath, repoPath string, calledDirs map[string]bool) {
+	modules := docAsMap(doc["module"])
+	if modules == nil {
+		return
+	}
+	fileDir := filepath.Dir(absPath(filePath, repoPath))
+	for name, callRaw := range modules {
+		call := docAsMap(callRaw)
+		if call == nil {
+			continue
+		}
+		source, _ := call["source"].(string)
+		if source == "" {
+			continue
+		}
+		cleanSource := tfeval.StripGetterPrefix(source)
+		if !tfmodules.LooksLikeLocalModuleSource(cleanSource) {
+			continue
+		}
+		if calledDirs[filepath.Clean(filepath.Join(fileDir, cleanSource))] {
+			delete(modules, name)
+		}
+	}
+	if len(modules) == 0 {
+		delete(doc, "module")
+	}
+}
+
+// indexTerraformFiles builds lookup maps from a flat FileMetadatas slice.
+func indexTerraformFiles(ctx context.Context, files model.FileMetadatas, repoPath string) (
+	byAbsPath map[string]*model.FileMetadata,
+	filesByDir map[string][]*model.FileMetadata,
+	dirsWithTf map[string]bool,
+) {
+	contextLogger := logger.FromContext(ctx)
+	byAbsPath = make(map[string]*model.FileMetadata)
+	filesByDir = make(map[string][]*model.FileMetadata)
+	dirsWithTf = make(map[string]bool)
+	for _, f := range files {
+		if f == nil || !isTerraformFile(f.FilePath) {
+			continue
+		}
+		abs := absPath(f.FilePath, repoPath)
+		dir := filepath.Dir(abs)
+		if prev, exists := byAbsPath[abs]; exists && prev != nil && prev.ID != f.ID {
+			contextLogger.Warn().Msgf(
+				"duplicate terraform file path in scan input %s (file ids %s and %s); using the latter",
+				abs, prev.ID, f.ID,
+			)
+		}
+		byAbsPath[abs] = f
+		filesByDir[dir] = append(filesByDir[dir], f)
+		dirsWithTf[dir] = true
+	}
+	return
+}
+
+// docAsMap coerces v to a string-keyed map regardless of whether it is a
+// model.Document (the Terraform parser's named type) or a plain map.
+func docAsMap(v interface{}) map[string]interface{} {
+	switch m := v.(type) {
+	case model.Document:
+		return map[string]interface{}(m)
+	case map[string]interface{}:
+		return m
+	}
+	return nil
+}
+
+// absPath returns a cleaned path. Relative paths are resolved against base
+// (typically the scan repo root), not the process working directory.
+func absPath(p, base string) string {
+	if filepath.IsAbs(p) {
+		return filepath.Clean(p)
+	}
+	return filepath.Clean(filepath.Join(base, p))
+}
+
+func isTerraformFile(path string) bool {
+	return strings.HasSuffix(strings.ToLower(path), ".tf")
+}

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -1,0 +1,229 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	terraformParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform"
+	scanUtils "github.com/DataDog/datadog-iac-scanner/pkg/utils"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// aclRule fires when an aws_s3_bucket has acl == "public-read". It only matches
+// after a module is instantiated with that concrete value.
+const aclRule = `package datadog
+
+DatadogPolicy contains result if {
+	some name, i
+	bucket := input.document[i].resource.aws_s3_bucket[name]
+	bucket.acl == "public-read"
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_s3_bucket",
+		"resourceName": name,
+		"searchKey": sprintf("aws_s3_bucket[%s].acl", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "acl should not be public-read",
+		"keyActualValue": "acl is public-read",
+	}
+}
+`
+
+func parseTerraform(t *testing.T, path string) model.FileMetadatas {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Clean(path))
+	require.NoError(t, err)
+
+	_, docs, ignore, resolved, err := terraformParser.NewDefault().Parse(context.Background(), content, path, true, 15)
+	require.NoError(t, err)
+
+	var out model.FileMetadatas
+	for _, doc := range docs {
+		out = append(out, &model.FileMetadata{
+			ID:                uuid.NewString(),
+			ScanID:            "test",
+			Document:          doc,
+			LineInfoDocument:  doc,
+			OriginalData:      string(content),
+			Kind:              model.KindTerraform,
+			FilePath:          path,
+			LinesIgnore:       ignore,
+			ResolvedFiles:     resolved,
+			LinesOriginalData: scanUtils.SplitLines(string(content)),
+		})
+	}
+	return out
+}
+
+// TestInspect_InstantiatesModuleAndFindsResolvedValue verifies end-to-end that a
+// module called with acl = "public-read" is instantiated so the value-specific
+// rule fires and the finding is reported at the module's resource definition file.
+func TestInspect_InstantiatesModuleAndFindsResolvedValue(t *testing.T) {
+	root := t.TempDir()
+
+	rootDir := filepath.Join(root, "stack")
+	modDir := filepath.Join(root, "modules", "bucket")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+
+	rootPath := filepath.Join(rootDir, "main.tf")
+	modPath := filepath.Join(modDir, "main.tf")
+
+	require.NoError(t, os.WriteFile(rootPath, []byte(`
+module "bucket" {
+  source = "../modules/bucket"
+  acl    = "public-read"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(modPath, []byte(`
+variable "acl" {
+  type = string
+}
+
+resource "aws_s3_bucket" "this" {
+  acl = var.acl
+}
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, rootPath)...)
+	files = append(files, parseTerraform(t, modPath)...)
+
+	queries := []model.QueryMetadata{{
+		Query:       "acl_rule",
+		Content:     aclRule,
+		InputData:   "{}",
+		Platform:    "terraform",
+		Metadata:    map[string]interface{}{"id": "acl-rule"},
+		Aggregation: 1,
+	}}
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
+	})
+
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{root}, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries(), "no query should fail")
+
+	require.Len(t, vulns, 1, "expected exactly one finding from the instantiated module")
+	v := vulns[0]
+	require.Equal(t, "aws_s3_bucket", v.ResourceType)
+	require.Equal(t, "main.tf", filepath.Base(v.FileName))
+	require.Equal(t, modPath, v.FileName, "finding should be reported at the module resource definition")
+	require.Greater(t, v.Line, 0, "line should be detected in the module file")
+}
+
+// legacyAclRule mimics the two-branch pattern used in the real rules repo:
+// one branch scans the resource directly, and one uses the module call-site
+// (the legacy get_module_equivalent_key pattern, simplified here to just
+// match module[name].acl). With the flag on we must get exactly one finding,
+// not two, because the module call-site block is stripped from the payload.
+const legacyAclRule = `package datadog
+
+# resource branch: fires on a directly-declared or instantiated aws_s3_bucket
+DatadogPolicy contains result if {
+	some name, i
+	bucket := input.document[i].resource.aws_s3_bucket[name]
+	bucket.acl == "public-read"
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_s3_bucket",
+		"resourceName": name,
+		"searchKey": sprintf("aws_s3_bucket[%s].acl", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "acl should not be public-read",
+		"keyActualValue": "acl is public-read",
+	}
+}
+
+# legacy module branch: fires on the module call-site block when acl is passed directly
+DatadogPolicy contains result if {
+	some name, i
+	mod := input.document[i].module[name]
+	mod.acl == "public-read"
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "module",
+		"resourceName": name,
+		"searchKey": sprintf("module[%s].acl", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "acl should not be public-read",
+		"keyActualValue": "acl is public-read",
+	}
+}
+`
+
+// TestInspect_NoDoubleFindings_WithLegacyModuleBranch verifies that a rule with
+// both a resource branch and a legacy module branch produces exactly one finding.
+// The module call-site block is stripped from the payload so the legacy branch skips.
+func TestInspect_NoDoubleFindings_WithLegacyModuleBranch(t *testing.T) {
+	root := t.TempDir()
+
+	rootDir := filepath.Join(root, "stack")
+	modDir := filepath.Join(root, "modules", "bucket")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+
+	rootPath := filepath.Join(rootDir, "main.tf")
+	modPath := filepath.Join(modDir, "main.tf")
+
+	require.NoError(t, os.WriteFile(rootPath, []byte(`
+module "bucket" {
+  source = "../modules/bucket"
+  acl    = "public-read"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(modPath, []byte(`
+variable "acl" {
+  type = string
+}
+
+resource "aws_s3_bucket" "this" {
+  acl = var.acl
+}
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, rootPath)...)
+	files = append(files, parseTerraform(t, modPath)...)
+
+	queries := []model.QueryMetadata{{
+		Query:       "legacy_acl_rule",
+		Content:     legacyAclRule,
+		InputData:   "{}",
+		Platform:    "terraform",
+		Metadata:    map[string]interface{}{"id": "legacy-acl-rule"},
+		Aggregation: 1,
+	}}
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
+	})
+
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{root}, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries())
+
+	// Exactly one finding: the resource branch fires on the instantiated doc.
+	// The legacy module branch does NOT fire because the module key is stripped.
+	require.Len(t, vulns, 1, "legacy module branch must not fire alongside instantiated resource (no double-findings)")
+	require.Equal(t, "aws_s3_bucket", vulns[0].ResourceType, "finding must come from the resource branch, not the module branch")
+}
+

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -126,6 +126,85 @@ resource "aws_s3_bucket" "this" {
 	require.Greater(t, v.Line, 0, "line should be detected in the module file")
 }
 
+// variableTypeRule fires on a variable declaration that has no type, mirroring
+// real rules that match non-resource blocks (variable/output/data/locals).
+const variableTypeRule = `package datadog
+
+DatadogPolicy contains result if {
+	some name, i
+	var_block := input.document[i].variable[name]
+	not var_block.type
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "variable",
+		"resourceName": name,
+		"searchKey": sprintf("variable[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "variable should declare a type",
+		"keyActualValue": "variable has no type",
+	}
+}
+`
+
+// TestInspect_PreservesNonResourceBlocksInModuleBody verifies that suppressing a
+// called module body keeps its non-resource blocks scannable: a rule matching a
+// typeless variable in the module file still fires, while the module's resource
+// is only reported once (via the instantiated synthetic doc, not the body file).
+func TestInspect_PreservesNonResourceBlocksInModuleBody(t *testing.T) {
+	root := t.TempDir()
+
+	rootDir := filepath.Join(root, "stack")
+	modDir := filepath.Join(root, "modules", "bucket")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+
+	rootPath := filepath.Join(rootDir, "main.tf")
+	modPath := filepath.Join(modDir, "main.tf")
+
+	require.NoError(t, os.WriteFile(rootPath, []byte(`
+module "bucket" {
+  source = "../modules/bucket"
+  acl    = "public-read"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(modPath, []byte(`
+variable "acl" {
+}
+
+resource "aws_s3_bucket" "this" {
+  acl = var.acl
+}
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, rootPath)...)
+	files = append(files, parseTerraform(t, modPath)...)
+
+	queries := []model.QueryMetadata{{
+		Query:       "variable_type_rule",
+		Content:     variableTypeRule,
+		InputData:   "{}",
+		Platform:    "terraform",
+		Metadata:    map[string]interface{}{"id": "variable-type-rule"},
+		Aggregation: 1,
+	}}
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
+	})
+
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{root}, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries())
+
+	require.Len(t, vulns, 1, "typeless variable in the suppressed module body should still be reported")
+	require.Equal(t, "variable", vulns[0].ResourceType)
+	require.Equal(t, modPath, vulns[0].FileName, "variable finding should be reported in the module body file")
+}
+
 // legacyAclRule mimics the two-branch pattern used in the real rules repo:
 // one branch scans the resource directly, and one uses the module call-site
 // (the legacy get_module_equivalent_key pattern, simplified here to just

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -1,0 +1,351 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+// writeFile creates dir/name with content and returns the absolute path.
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func fileMeta(id, path string) *model.FileMetadata {
+	return &model.FileMetadata{ID: id, FilePath: path, Document: model.Document{}}
+}
+
+func TestResolveModuleDocuments_InstantiatesAndSuppresses(t *testing.T) {
+	root := t.TempDir()
+
+	rootDir := filepath.Join(root, "stack")
+	modDir := filepath.Join(root, "modules", "bucket")
+
+	rootFile := writeFile(t, rootDir, "main.tf", `
+module "bucket" {
+  source = "../modules/bucket"
+  name   = "prod-logs"
+}
+`)
+	modFile := writeFile(t, modDir, "main.tf", `
+variable "name" {
+  type = string
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.name
+}
+`)
+
+	files := model.FileMetadatas{
+		fileMeta("root-id", rootFile),
+		fileMeta("mod-id", modFile),
+	}
+
+	extra, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
+	if !ok {
+		t.Fatalf("resolveModuleDocuments ok = false, want true")
+	}
+
+	if len(extra) != 1 {
+		t.Fatalf("expected 1 instantiated resource document, got %d: %#v", len(extra), extra)
+	}
+	doc := extra[0]
+	if doc["id"] != "mod-id" {
+		t.Fatalf("instantiated doc id = %v, want mod-id (resource definition file)", doc["id"])
+	}
+
+	resource, _ := doc["resource"].(map[string]interface{})
+	bucketType, _ := resource["aws_s3_bucket"].(map[string]interface{})
+	this, _ := bucketType["this"].(map[string]interface{})
+	if this["bucket"] != "prod-logs" {
+		t.Fatalf("instantiated bucket = %#v, want prod-logs", this["bucket"])
+	}
+
+	// The module body must be suppressed (so it isn't scanned standalone), but
+	// the root file must still be scanned.
+	if !suppressed["mod-id"] {
+		t.Fatalf("module file should be suppressed")
+	}
+	if suppressed["root-id"] {
+		t.Fatalf("root file should not be suppressed")
+	}
+}
+
+func TestResolveModuleDocuments_RelativeFilePaths(t *testing.T) {
+	root := t.TempDir()
+
+	rootDir := filepath.Join(root, "stack")
+	modDir := filepath.Join(root, "modules", "bucket")
+
+	writeFile(t, rootDir, "main.tf", `
+module "bucket" {
+  source = "../modules/bucket"
+  name   = "prod-logs"
+}
+`)
+	writeFile(t, modDir, "main.tf", `
+variable "name" {
+  type = string
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.name
+}
+`)
+
+	// FilePath is repo-relative (not cwd-absolute), as many callers provide.
+	files := model.FileMetadatas{
+		fileMeta("root-id", filepath.Join("stack", "main.tf")),
+		fileMeta("mod-id", filepath.Join("modules", "bucket", "main.tf")),
+	}
+
+	extra, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
+	if !ok {
+		t.Fatalf("resolveModuleDocuments ok = false, want true")
+	}
+
+	if len(extra) != 1 {
+		t.Fatalf("expected 1 instantiated resource document, got %d: %#v", len(extra), extra)
+	}
+	if doc := extra[0]; doc["id"] != "mod-id" {
+		t.Fatalf("instantiated doc id = %v, want mod-id", doc["id"])
+	}
+	if !suppressed["mod-id"] || suppressed["root-id"] {
+		t.Fatalf("unexpected suppression map: %#v", suppressed)
+	}
+}
+
+func TestResolveModuleDocuments_TwoRootsSameChildDifferentVars(t *testing.T) {
+	root := t.TempDir()
+	modDir := filepath.Join(root, "modules", "bucket")
+	if err := os.MkdirAll(filepath.Join(root, "stack-a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "stack-b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(modDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(root, "stack-a"), "main.tf", `
+module "bucket" {
+  source = "../modules/bucket"
+  name   = "from-a"
+}
+`)
+	writeFile(t, filepath.Join(root, "stack-b"), "main.tf", `
+module "bucket" {
+  source = "../modules/bucket"
+  name   = "from-b"
+}
+`)
+	modFile := writeFile(t, modDir, "main.tf", `
+variable "name" {
+  type = string
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.name
+}
+`)
+
+	files := model.FileMetadatas{
+		fileMeta("a-root", filepath.Join(root, "stack-a", "main.tf")),
+		fileMeta("b-root", filepath.Join(root, "stack-b", "main.tf")),
+		fileMeta("mod-id", modFile),
+	}
+
+	extra, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
+	if !ok {
+		t.Fatalf("resolveModuleDocuments ok = false, want true")
+	}
+	if len(extra) != 2 {
+		t.Fatalf("want 2 instantiated bucket docs (one per root), got %d: %#v", len(extra), extra)
+	}
+	names := make(map[string]int)
+	for _, doc := range extra {
+		if doc["id"] != "mod-id" {
+			t.Fatalf("doc id = %v, want mod-id", doc["id"])
+		}
+		res, _ := doc["resource"].(map[string]interface{})
+		bt, _ := res["aws_s3_bucket"].(map[string]interface{})
+		th, _ := bt["this"].(map[string]interface{})
+		b, _ := th["bucket"].(string)
+		names[b]++
+	}
+	if names["from-a"] != 1 || names["from-b"] != 1 {
+		t.Fatalf("bucket values = %#v, want one from-a and one from-b", names)
+	}
+	if !suppressed["mod-id"] {
+		t.Fatalf("shared module file should be suppressed")
+	}
+}
+
+func TestResolveModuleDocuments_AllRootsFailEvalNoSuppression(t *testing.T) {
+	root := t.TempDir()
+	stackDir := filepath.Join(root, "stack")
+	writeFile(t, stackDir, "main.tf", `
+module "bucket" {
+  source = "../modules/bucket"
+  name   = "x"
+}
+`)
+	if err := os.RemoveAll(stackDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only the missing root stack is in the scan input so no other directory
+	// is misclassified as an unevaluated "root" when CalledLocalDirs cannot run.
+	files := model.FileMetadatas{
+		fileMeta("root-id", filepath.Join("stack", "main.tf")),
+	}
+
+	extra, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
+	if ok {
+		t.Fatalf("resolveModuleDocuments ok = true, want false when all roots fail")
+	}
+	if len(extra) != 0 {
+		t.Fatalf("want no instantiation when root eval fails, got %#v", extra)
+	}
+	if len(suppressed) != 0 {
+		t.Fatalf("want no suppression when all root evals fail, got %#v", suppressed)
+	}
+}
+
+func TestResolveModuleDocuments_OrphanModuleNotSuppressed(t *testing.T) {
+	root := t.TempDir()
+	// A module directory that nothing calls: it should keep being scanned
+	// standalone (not suppressed) and produce no instantiated documents.
+	orphan := filepath.Join(root, "orphan")
+	orphanFile := writeFile(t, orphan, "main.tf", `
+variable "name" { type = string }
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.name
+}
+`)
+
+	files := model.FileMetadatas{fileMeta("orphan-id", orphanFile)}
+
+	extra, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
+	if !ok {
+		t.Fatalf("resolveModuleDocuments ok = false, want true for orphan root")
+	}
+	if len(extra) != 0 {
+		t.Fatalf("orphan module should not instantiate resources, got %#v", extra)
+	}
+	if suppressed["orphan-id"] {
+		t.Fatalf("orphan module should not be suppressed")
+	}
+}
+
+func TestResolveModuleDocuments_NestedModules(t *testing.T) {
+	root := t.TempDir()
+
+	rootFile := writeFile(t, filepath.Join(root, "stack"), "main.tf", `
+module "a" {
+  source = "../a"
+  name   = "deep"
+}
+`)
+	writeFile(t, filepath.Join(root, "a"), "main.tf", `
+variable "name" { type = string }
+
+module "b" {
+  source = "../b"
+  name   = var.name
+}
+`)
+	leafFile := writeFile(t, filepath.Join(root, "b"), "main.tf", `
+variable "name" { type = string }
+
+resource "aws_s3_bucket" "leaf" {
+  bucket = var.name
+}
+`)
+
+	files := model.FileMetadatas{
+		fileMeta("root-id", rootFile),
+		fileMeta("a-id", filepath.Join(root, "a", "main.tf")),
+		fileMeta("leaf-id", leafFile),
+	}
+
+	extra, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
+	if !ok {
+		t.Fatalf("resolveModuleDocuments ok = false, want true")
+	}
+
+	if len(extra) != 1 {
+		t.Fatalf("expected 1 instantiated resource, got %d: %#v", len(extra), extra)
+	}
+	doc := extra[0]
+	if doc["id"] != "leaf-id" {
+		t.Fatalf("doc id = %v, want leaf-id", doc["id"])
+	}
+	resource, _ := doc["resource"].(map[string]interface{})
+	bucketType, _ := resource["aws_s3_bucket"].(map[string]interface{})
+	leaf, _ := bucketType["leaf"].(map[string]interface{})
+	if leaf["bucket"] != "deep" {
+		t.Fatalf("leaf bucket = %#v, want deep", leaf["bucket"])
+	}
+
+	if !suppressed["a-id"] || !suppressed["leaf-id"] {
+		t.Fatalf("intermediate and leaf module files should be suppressed: %#v", suppressed)
+	}
+	if suppressed["root-id"] {
+		t.Fatalf("root file should not be suppressed")
+	}
+}
+
+func TestInstantiateLocalModules_NoMutationWhenResolveFails(t *testing.T) {
+	root := t.TempDir()
+	stackDir := filepath.Join(root, "stack")
+	writeFile(t, stackDir, "main.tf", `
+module "bucket" {
+  source = "../modules/bucket"
+  name   = "x"
+}
+`)
+	if err := os.RemoveAll(stackDir); err != nil {
+		t.Fatal(err)
+	}
+
+	rootFM := &model.FileMetadata{
+		ID:       "root-id",
+		FilePath: filepath.Join("stack", "main.tf"),
+		Document: model.Document{
+			"module": map[string]interface{}{
+				"bucket": map[string]interface{}{"source": "../modules/bucket"},
+			},
+		},
+	}
+	files := model.FileMetadatas{rootFM}
+
+	ins := newTestInspector(t, inspectorOpts{
+		repoPath: root,
+	})
+	if docs := ins.instantiateLocalModules(context.Background(), files); docs != nil {
+		t.Fatalf("instantiateLocalModules = %#v, want nil when resolve aborts", docs)
+	}
+	if _, has := rootFM.Document["module"]; !has {
+		t.Fatalf("expected module block preserved on root when evaluation failed")
+	}
+}

--- a/pkg/parser/terraform/tfeval/document.go
+++ b/pkg/parser/terraform/tfeval/document.go
@@ -1,0 +1,108 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package tfeval
+
+import (
+	"encoding/json"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// UnknownAttributePlaceholder is stored for cty unknown values when converting
+// to the document shape rules consume, so keys stay present and MissingAttribute
+// checks do not treat unresolved expressions as absent (which would false-positive).
+const UnknownAttributePlaceholder = "__DD_TFEVAL_UNKNOWN__"
+
+// AttributesToDocument converts a resolved resource's attributes into the
+// map[string]interface{} shape the rule pipeline consumes. Every attribute is
+// always included: unknown or unsupported values use UnknownAttributePlaceholder
+// so presence-based rules do not fire false positives on unresolved expressions.
+func AttributesToDocument(r *ResolvedResource) map[string]interface{} {
+	out := make(map[string]interface{}, len(r.Attributes))
+	for key, val := range r.Attributes {
+		out[key] = ctyValueToDocument(val)
+	}
+	return out
+}
+
+// ctyValueToDocument converts a cty.Value to a JSON-serializable value.
+// Unknowns and any type that cannot be represented become UnknownAttributePlaceholder
+// so every attribute key is preserved in the output document.
+func ctyValueToDocument(v cty.Value) interface{} {
+	if !v.IsKnown() {
+		return UnknownAttributePlaceholder
+	}
+	if v.IsNull() {
+		return nil
+	}
+
+	t := v.Type()
+	switch t {
+	case cty.String:
+		return v.AsString()
+	case cty.Bool:
+		return v.True()
+	case cty.Number:
+		// json.Number avoids float64 precision loss for large integers.
+		return json.Number(v.AsBigFloat().Text('f', -1))
+	}
+
+	switch {
+	case t.IsTupleType(), t.IsListType(), t.IsSetType():
+		return ctySeqToDocument(v)
+	case t.IsObjectType(), t.IsMapType():
+		return ctyMapToDocument(v)
+	}
+	return UnknownAttributePlaceholder
+}
+
+// ctySeqToDocument converts a tuple/list/set to a slice.
+func ctySeqToDocument(v cty.Value) []interface{} {
+	list := make([]interface{}, 0, v.LengthInt())
+	for it := v.ElementIterator(); it.Next(); {
+		_, ev := it.Element()
+		list = append(list, ctyValueToDocument(ev))
+	}
+	return list
+}
+
+// ctyMapToDocument converts an object/map to a Go map; non-string or unknown
+// keys are skipped (keys are always strings in well-formed Terraform).
+func ctyMapToDocument(v cty.Value) map[string]interface{} {
+	obj := make(map[string]interface{}, v.LengthInt())
+	for it := v.ElementIterator(); it.Next(); {
+		key, ev := it.Element()
+		if key.Type() != cty.String || !key.IsKnown() {
+			continue
+		}
+		obj[key.AsString()] = ctyValueToDocument(ev)
+	}
+	return obj
+}
+
+// CalledLocalDirs returns the resolved directories of every local module called
+// from dir. Remote/registry sources are ignored.
+func CalledLocalDirs(dir string) []string {
+	bodies, err := parseDir(dir)
+	if err != nil {
+		return nil
+	}
+	moduleBlocks := collectModuleBlocks(bodies)
+
+	emptyCtx := &hcl.EvalContext{}
+	var dirs []string
+	for _, mb := range moduleBlocks {
+		source := knownString(mb.Body.Attributes["source"], emptyCtx)
+		if source == "" || !tfmodules.LooksLikeLocalModuleSource(StripGetterPrefix(source)) {
+			continue
+		}
+		dirs = append(dirs, resolveLocalDir(dir, source))
+	}
+	return dirs
+}

--- a/pkg/parser/terraform/tfeval/document_test.go
+++ b/pkg/parser/terraform/tfeval/document_test.go
@@ -1,0 +1,101 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package tfeval
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestCtyValueToDocument(t *testing.T) {
+	tests := []struct {
+		name  string
+		value cty.Value
+		want  interface{}
+	}{
+		{"string", cty.StringVal("hello"), "hello"},
+		{"bool", cty.True, true},
+		{"number", cty.NumberIntVal(42), json.Number("42")},
+		{"null", cty.NullVal(cty.String), nil},
+		{"unknown", cty.UnknownVal(cty.DynamicPseudoType), UnknownAttributePlaceholder},
+		{
+			"list",
+			cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			[]interface{}{"a", "b"},
+		},
+		{
+			"object",
+			cty.ObjectVal(map[string]cty.Value{"enabled": cty.True}),
+			map[string]interface{}{"enabled": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ctyValueToDocument(tt.value)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAttributesToDocumentPreservesUnknownKeys(t *testing.T) {
+	r := ResolvedResource{
+		Attributes: map[string]cty.Value{
+			"bucket": cty.StringVal("my-bucket"),
+			"acl":    cty.UnknownVal(cty.DynamicPseudoType),
+		},
+	}
+	doc := AttributesToDocument(&r)
+	if doc["bucket"] != "my-bucket" {
+		t.Fatalf("bucket = %#v, want my-bucket", doc["bucket"])
+	}
+	if got, ok := doc["acl"]; !ok || got != UnknownAttributePlaceholder {
+		t.Fatalf("unknown attribute acl = %#v, want %q", got, UnknownAttributePlaceholder)
+	}
+}
+
+func TestCalledLocalDirs(t *testing.T) {
+	root := t.TempDir()
+
+	writeModule(t, root, "child", map[string]string{
+		"main.tf": `resource "aws_s3_bucket" "this" { bucket = "x" }`,
+	})
+	rootDir := writeModule(t, root, "root", map[string]string{
+		"main.tf": `
+module "child" {
+  source = "../child"
+}
+
+module "remote" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+}
+`,
+	})
+
+	got := CalledLocalDirs(rootDir)
+	want := []string{filepath.Join(root, "child")}
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CalledLocalDirs = %#v, want %#v", got, want)
+	}
+}
+
+func TestCalledLocalDirs_NoModules(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `resource "aws_s3_bucket" "this" { bucket = "x" }`,
+	})
+	if got := CalledLocalDirs(dir); got != nil {
+		t.Fatalf("CalledLocalDirs = %#v, want nil", got)
+	}
+}

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -1,0 +1,330 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+// Package tfeval evaluates local Terraform modules by binding caller inputs to
+// module variables, resolving locals, recursing into nested modules, and
+// returning a flat list of resources with concrete attribute values.
+// Unresolvable references (data sources, cross-resource refs, etc.) are left
+// as cty.UnknownVal rather than sentinel strings.
+package tfeval
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	tffunctions "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/functions"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+const (
+	// defaultMaxDepth bounds nested-module recursion to protect against
+	// pathological or cyclic local module graphs.
+	defaultMaxDepth = 15
+	// localsMaxPasses bounds the fixed-point iteration used to resolve locals
+	// that reference one another.
+	localsMaxPasses = 10
+)
+
+// ResolvedResource is a resource block after evaluation with attributes
+// resolved to concrete cty values where possible, unknown otherwise.
+type ResolvedResource struct {
+	Type       string
+	Name       string
+	Attributes map[string]cty.Value
+
+	// Source location and module address for finding attribution.
+	DefinedIn     string
+	DefLine       int
+	ModuleAddress string // "" for root module resources
+	CallChain     []CallSite
+}
+
+// CallSite records one hop in a module call chain.
+type CallSite struct {
+	ModuleName string
+	Source     string
+	CalledFrom string
+	CalledLine int
+}
+
+// Evaluator evaluates local Terraform modules.
+type Evaluator struct {
+	funcs    map[string]function.Function
+	maxDepth int
+}
+
+func New() *Evaluator {
+	return &Evaluator{
+		funcs:    tffunctions.TerraformFuncs,
+		maxDepth: defaultMaxDepth,
+	}
+}
+
+// EvaluateModule evaluates the module rooted at dir with the given inputs and
+// returns all resources materialized by this module and its nested modules.
+// visitedChildDirs contains every child directory that was successfully evaluated
+// as a module (i.e. dirs that should be suppressed from standalone scanning).
+func (e *Evaluator) EvaluateModule(
+	ctx context.Context,
+	dir string,
+	inputs map[string]cty.Value,
+) (resources []ResolvedResource, outputs map[string]cty.Value, visitedChildDirs map[string]bool, err error) {
+	abs, absErr := filepath.Abs(dir)
+	if absErr != nil {
+		contextLogger := logger.FromContext(ctx)
+		contextLogger.Warn().Err(absErr).Msgf("tfeval: filepath.Abs failed for %s, falling back to Clean", dir)
+		abs = filepath.Clean(dir)
+	}
+	visiting := map[string]bool{}
+	allVisited := map[string]bool{}
+	resources, outputs, err = e.evaluate(ctx, abs, inputs, "", nil, 0, visiting, allVisited)
+	return resources, outputs, allVisited, err
+}
+
+// evaluate is the recursive worker; visiting tracks dirs on the current stack for cycle
+// detection; allVisited accumulates every child dir successfully evaluated as a module.
+func (e *Evaluator) evaluate(
+	ctx context.Context,
+	dir string,
+	inputs map[string]cty.Value,
+	addr string,
+	chain []CallSite,
+	depth int,
+	visiting map[string]bool,
+	allVisited map[string]bool,
+) ([]ResolvedResource, map[string]cty.Value, error) {
+	contextLogger := logger.FromContext(ctx)
+
+	if depth > e.maxDepth {
+		contextLogger.Warn().Msgf("tfeval: max module depth %d exceeded at %s", e.maxDepth, dir)
+		return nil, map[string]cty.Value{}, nil
+	}
+	if visiting[dir] {
+		contextLogger.Warn().Msgf("tfeval: module cycle detected at %s, stopping recursion", dir)
+		return nil, map[string]cty.Value{}, nil
+	}
+	visiting[dir] = true
+	defer delete(visiting, dir)
+
+	bodies, err := parseDir(dir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	varExprs, localExprs, moduleBlocks, resourceBlocks, outputExprs := collectBlocks(bodies)
+
+	varVals := e.resolveVariables(varExprs, inputs)
+
+	evalCtx := &hcl.EvalContext{
+		Variables: map[string]cty.Value{
+			"var": objectOrEmpty(varVals),
+		},
+		Functions: e.funcs,
+	}
+
+	localVals := e.resolveLocals(localExprs, evalCtx)
+	evalCtx.Variables["local"] = objectOrEmpty(localVals)
+
+	var childResources []ResolvedResource
+	moduleOutputs := map[string]cty.Value{}
+
+	for _, mb := range moduleBlocks {
+		label := blockLabel(mb)
+		if label == "" {
+			continue
+		}
+		source := knownString(mb.Body.Attributes["source"], evalCtx)
+		if source == "" || !tfmodules.LooksLikeLocalModuleSource(StripGetterPrefix(source)) {
+			continue // remote/registry sources are out of scope
+		}
+
+		childDir := resolveLocalDir(dir, source)
+
+		// Skip module instances that are explicitly disabled.
+		if isLiteralZero(mb.Body.Attributes["count"], evalCtx) {
+			continue
+		}
+		if isEmptyCollection(mb.Body.Attributes["for_each"], evalCtx) {
+			continue
+		}
+
+		modInputs := e.evalBody(mb.Body, evalCtx, reservedModuleAttrs)
+
+		site := CallSite{
+			ModuleName: label,
+			Source:     source,
+			CalledFrom: mb.TypeRange.Filename,
+			CalledLine: mb.TypeRange.Start.Line,
+		}
+		childAddr := joinAddr(addr, "module."+label)
+
+		childRes, childOuts, cErr := e.evaluate(
+			ctx, childDir, modInputs, childAddr, append(cloneChain(chain), site), depth+1, visiting, allVisited,
+		)
+		if cErr != nil {
+			contextLogger.Warn().Msgf("tfeval: failed to evaluate module %q at %s: %v", label, childDir, cErr)
+			continue
+		}
+		allVisited[childDir] = true
+		childResources = append(childResources, childRes...)
+		moduleOutputs[label] = objectOrEmpty(childOuts)
+	}
+
+	if len(moduleOutputs) > 0 {
+		// Re-evaluate locals now that module.* outputs are available.
+		evalCtx.Variables["module"] = cty.ObjectVal(moduleOutputs)
+		localVals = e.resolveLocals(localExprs, evalCtx)
+		evalCtx.Variables["local"] = objectOrEmpty(localVals)
+	}
+
+	resources := make([]ResolvedResource, 0, len(resourceBlocks)+len(childResources))
+	resources = append(resources, e.evalResourceBlocks(resourceBlocks, evalCtx, addr, chain)...)
+	resources = append(resources, childResources...)
+
+	outputs := make(map[string]cty.Value, len(outputExprs))
+	for name, expr := range outputExprs {
+		outputs[name] = e.evalExpr(expr, evalCtx)
+	}
+
+	return resources, outputs, nil
+}
+
+// evalResourceBlocks evaluates all resource blocks in the current module scope.
+func (e *Evaluator) evalResourceBlocks(
+	resourceBlocks []*hclsyntax.Block,
+	evalCtx *hcl.EvalContext,
+	addr string,
+	chain []CallSite,
+) []ResolvedResource {
+	resources := make([]ResolvedResource, 0, len(resourceBlocks))
+	for _, rb := range resourceBlocks {
+		if len(rb.Labels) < 2 {
+			continue
+		}
+		// Skip resources with count = 0 or for_each = {}; Terraform creates no instances.
+		if isLiteralZero(rb.Body.Attributes["count"], evalCtx) {
+			continue
+		}
+		if isEmptyCollection(rb.Body.Attributes["for_each"], evalCtx) {
+			continue
+		}
+		resources = append(resources, ResolvedResource{
+			Type:          rb.Labels[0],
+			Name:          rb.Labels[1],
+			Attributes:    e.evalBody(rb.Body, evalCtx, nil),
+			DefinedIn:     rb.TypeRange.Filename,
+			DefLine:       rb.TypeRange.Start.Line,
+			ModuleAddress: addr,
+			CallChain:     cloneChain(chain),
+		})
+	}
+	return resources
+}
+
+// resolveVariables binds inputs to variables, falling back to the default then unknown.
+func (e *Evaluator) resolveVariables(
+	varExprs map[string]hclsyntax.Expression,
+	inputs map[string]cty.Value,
+) map[string]cty.Value {
+	out := make(map[string]cty.Value, len(varExprs))
+	for name, defaultExpr := range varExprs {
+		if v, ok := inputs[name]; ok {
+			out[name] = v
+			continue
+		}
+		if defaultExpr != nil {
+			if v, diags := defaultExpr.Value(&hcl.EvalContext{Functions: e.funcs}); !diags.HasErrors() {
+				out[name] = v
+				continue
+			}
+		}
+		out[name] = cty.UnknownVal(cty.DynamicPseudoType)
+	}
+	return out
+}
+
+// resolveLocals evaluates locals to a fixed point, retrying cross-references until no progress.
+func (e *Evaluator) resolveLocals(
+	localExprs map[string]hclsyntax.Expression,
+	base *hcl.EvalContext,
+) map[string]cty.Value {
+	resolved := make(map[string]cty.Value, len(localExprs))
+
+	for pass := 0; pass < localsMaxPasses; pass++ {
+		progressed := false
+		ctx := base.NewChild()
+		ctx.Variables = map[string]cty.Value{"local": objectOrEmpty(resolved)}
+
+		for name, expr := range localExprs {
+			if _, done := resolved[name]; done {
+				continue
+			}
+			v, diags := expr.Value(ctx)
+			if diags.HasErrors() || !v.IsWhollyKnown() {
+				continue
+			}
+			resolved[name] = v
+			progressed = true
+		}
+		if !progressed {
+			break
+		}
+	}
+
+	for name := range localExprs {
+		if _, ok := resolved[name]; !ok {
+			resolved[name] = cty.UnknownVal(cty.DynamicPseudoType)
+		}
+	}
+	return resolved
+}
+
+// evalBody evaluates an HCL body into an attribute map. Attributes in skip are
+// omitted. Nested blocks of the same type are always encoded as tuples (including
+// a single block) so the shape matches the canonical Terraform parser output rules expect.
+func (e *Evaluator) evalBody(
+	body *hclsyntax.Body,
+	ctx *hcl.EvalContext,
+	skip map[string]bool,
+) map[string]cty.Value {
+	out := make(map[string]cty.Value, len(body.Attributes)+len(body.Blocks))
+
+	for name, attr := range body.Attributes {
+		if skip[name] {
+			continue
+		}
+		out[name] = e.evalExpr(attr.Expr, ctx)
+	}
+
+	grouped := map[string][]cty.Value{}
+	order := make([]string, 0, len(body.Blocks))
+	for _, b := range body.Blocks {
+		if _, seen := grouped[b.Type]; !seen {
+			order = append(order, b.Type)
+		}
+		grouped[b.Type] = append(grouped[b.Type], objectOrEmpty(e.evalBody(b.Body, ctx, nil)))
+	}
+	for _, t := range order {
+		list := grouped[t]
+		out[t] = cty.TupleVal(list)
+	}
+	return out
+}
+
+// evalExpr evaluates an expression, returning unknown on any resolution failure.
+func (e *Evaluator) evalExpr(expr hclsyntax.Expression, ctx *hcl.EvalContext) cty.Value {
+	v, diags := expr.Value(ctx)
+	if diags.HasErrors() {
+		return cty.UnknownVal(cty.DynamicPseudoType)
+	}
+	return v
+}

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -134,6 +134,19 @@ func (e *Evaluator) evaluate(
 	localVals := e.resolveLocals(localExprs, evalCtx)
 	evalCtx.Variables["local"] = objectOrEmpty(localVals)
 
+	// Pre-pass: collect sibling module outputs so they are available in evalCtx
+	// when computing inputs in the main loop. Terraform allows module inputs to
+	// reference outputs of sibling modules regardless of block order; without
+	// this pass those references always resolve to unknown.
+	if len(moduleBlocks) > 1 {
+		prelimOutputs := e.preliminaryModuleOutputs(ctx, moduleBlocks, evalCtx, dir, addr, depth, visiting)
+		if len(prelimOutputs) > 0 {
+			evalCtx.Variables["module"] = cty.ObjectVal(prelimOutputs)
+			localVals = e.resolveLocals(localExprs, evalCtx)
+			evalCtx.Variables["local"] = objectOrEmpty(localVals)
+		}
+	}
+
 	var childResources []ResolvedResource
 	moduleOutputs := map[string]cty.Value{}
 
@@ -327,4 +340,50 @@ func (e *Evaluator) evalExpr(expr hclsyntax.Expression, ctx *hcl.EvalContext) ct
 		return cty.UnknownVal(cty.DynamicPseudoType)
 	}
 	return v
+}
+
+// preliminaryModuleOutputs runs a lightweight first pass over local module
+// blocks to collect their outputs. The results are installed into evalCtx
+// before the real evaluation loop so sibling module references (e.g.
+// module.a.out used as an input to module.b) resolve to known values.
+//
+// Uses a throw-away allVisited map so the main pass records accurate visited
+// dirs. The visiting set is copied to preserve cycle detection.
+func (e *Evaluator) preliminaryModuleOutputs(
+	ctx context.Context,
+	moduleBlocks []*hclsyntax.Block,
+	evalCtx *hcl.EvalContext,
+	dir, addr string,
+	depth int,
+	visiting map[string]bool,
+) map[string]cty.Value {
+	out := map[string]cty.Value{}
+	tmpVisiting := make(map[string]bool, len(visiting))
+	for k, v := range visiting {
+		tmpVisiting[k] = v
+	}
+	for _, mb := range moduleBlocks {
+		label := blockLabel(mb)
+		if label == "" {
+			continue
+		}
+		source := knownString(mb.Body.Attributes["source"], evalCtx)
+		if source == "" || !tfmodules.LooksLikeLocalModuleSource(StripGetterPrefix(source)) {
+			continue
+		}
+		if isLiteralZero(mb.Body.Attributes["count"], evalCtx) {
+			continue
+		}
+		if isEmptyCollection(mb.Body.Attributes["for_each"], evalCtx) {
+			continue
+		}
+		childDir := resolveLocalDir(dir, source)
+		modInputs := e.evalBody(mb.Body, evalCtx, reservedModuleAttrs)
+		childAddr := joinAddr(addr, "module."+label)
+		_, childOuts, _ := e.evaluate(ctx, childDir, modInputs, childAddr, nil, depth+1, tmpVisiting, map[string]bool{})
+		if len(childOuts) > 0 {
+			out[label] = objectOrEmpty(childOuts)
+		}
+	}
+	return out
 }

--- a/pkg/parser/terraform/tfeval/evaluator_test.go
+++ b/pkg/parser/terraform/tfeval/evaluator_test.go
@@ -485,6 +485,54 @@ resource "aws_security_group" "this" {
 	}
 }
 
+func TestEvaluateModule_SiblingModuleOutputInInput(t *testing.T) {
+	// module.b uses module.a's output as an input; without the pre-pass,
+	// module.a.suffix would resolve to unknown when computing b's inputs.
+	root := t.TempDir()
+
+	writeModule(t, root, "naming", map[string]string{
+		"main.tf": `
+variable "env" { type = string }
+
+output "suffix" {
+  value = "-${var.env}"
+}
+`,
+	})
+
+	writeModule(t, root, "bucket", map[string]string{
+		"main.tf": `
+variable "suffix" { type = string }
+
+resource "aws_s3_bucket" "this" {
+  bucket = "logs${var.suffix}"
+}
+`,
+	})
+
+	rootDir := writeModule(t, root, "root", map[string]string{
+		"main.tf": `
+module "naming" {
+  source = "../naming"
+  env    = "prod"
+}
+
+module "bucket" {
+  source = "../bucket"
+  suffix = module.naming.suffix
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), rootDir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "this")
+	requireString(t, r.Attributes, "bucket", "logs-prod")
+}
+
 func TestEvaluateModule_SingleNestedBlockIsSingletonTuple(t *testing.T) {
 	root := t.TempDir()
 	dir := writeModule(t, root, "mod", map[string]string{

--- a/pkg/parser/terraform/tfeval/evaluator_test.go
+++ b/pkg/parser/terraform/tfeval/evaluator_test.go
@@ -1,0 +1,521 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package tfeval
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// writeModule lays down a module directory containing the given files (name ->
+// content) under root and returns its path.
+func writeModule(t *testing.T, root, name string, files map[string]string) string {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	for fname, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, fname), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", fname, err)
+		}
+	}
+	return dir
+}
+
+// findResource returns the first resolved resource matching type and name.
+func findResource(t *testing.T, resources []ResolvedResource, typ, name string) ResolvedResource {
+	t.Helper()
+	for _, r := range resources {
+		if r.Type == typ && r.Name == name {
+			return r
+		}
+	}
+	t.Fatalf("resource %s.%s not found in %d resources", typ, name, len(resources))
+	return ResolvedResource{}
+}
+
+// requireString asserts that the attribute is a known string equal to want.
+func requireString(t *testing.T, attrs map[string]cty.Value, key, want string) {
+	t.Helper()
+	v, ok := attrs[key]
+	if !ok {
+		t.Fatalf("attribute %q missing", key)
+	}
+	if !v.IsKnown() {
+		t.Fatalf("attribute %q is unknown, want %q", key, want)
+	}
+	if v.Type() != cty.String {
+		t.Fatalf("attribute %q is %s, want string", key, v.Type().FriendlyName())
+	}
+	if got := v.AsString(); got != want {
+		t.Fatalf("attribute %q = %q, want %q", key, got, want)
+	}
+}
+
+// requireUnknown asserts that the attribute exists and is not known.
+func requireUnknown(t *testing.T, attrs map[string]cty.Value, key string) {
+	t.Helper()
+	v, ok := attrs[key]
+	if !ok {
+		t.Fatalf("attribute %q missing", key)
+	}
+	if v.IsKnown() {
+		t.Fatalf("attribute %q = %#v, want unknown", key, v)
+	}
+}
+
+func TestEvaluateModule_InputPropagatedToChildResource(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+variable "bucket_name" {
+  type = string
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+}
+`,
+	})
+
+	inputs := map[string]cty.Value{"bucket_name": cty.StringVal("my-bucket")}
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, inputs)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "this")
+	requireString(t, r.Attributes, "bucket", "my-bucket")
+}
+
+func TestEvaluateModule_DefaultAppliedWhenInputOmitted(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+variable "acl" {
+  type    = string
+  default = "private"
+}
+
+resource "aws_s3_bucket" "this" {
+  acl = var.acl
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "this")
+	requireString(t, r.Attributes, "acl", "private")
+}
+
+func TestEvaluateModule_UnknownWhenNoInputNoDefault(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+variable "acl" {
+  type = string
+}
+
+resource "aws_s3_bucket" "this" {
+  acl = var.acl
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "this")
+	requireUnknown(t, r.Attributes, "acl")
+}
+
+func TestEvaluateModule_WrappedInputsResolve(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+variable "name" {
+  type = string
+}
+
+variable "public" {
+  type    = bool
+  default = false
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket    = format("%s-bucket", var.name)
+  upper_acl = upper(var.name)
+  acl       = var.public ? "public-read" : "private"
+}
+`,
+	})
+
+	inputs := map[string]cty.Value{"name": cty.StringVal("data")}
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, inputs)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "this")
+	requireString(t, r.Attributes, "bucket", "data-bucket")
+	requireString(t, r.Attributes, "upper_acl", "DATA")
+	requireString(t, r.Attributes, "acl", "private")
+}
+
+func TestEvaluateModule_ChainedLocalsReachFixedPoint(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+variable "env" {
+  type    = string
+  default = "prod"
+}
+
+locals {
+  prefix = "app-${var.env}"
+  full   = "${local.prefix}-${local.suffix}"
+  suffix = upper(var.env)
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = local.full
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "this")
+	requireString(t, r.Attributes, "bucket", "app-prod-PROD")
+}
+
+func TestEvaluateModule_NestedLocalModules(t *testing.T) {
+	root := t.TempDir()
+
+	// B: leaf module using its input.
+	writeModule(t, root, "b", map[string]string{
+		"main.tf": `
+variable "name" {
+  type = string
+}
+
+resource "aws_s3_bucket" "leaf" {
+  bucket = var.name
+}
+`,
+	})
+
+	// A: passes its input down to B.
+	writeModule(t, root, "a", map[string]string{
+		"main.tf": `
+variable "name" {
+  type = string
+}
+
+module "b" {
+  source = "../b"
+  name   = var.name
+}
+`,
+	})
+
+	// root: calls A with a concrete value.
+	rootDir := writeModule(t, root, "root", map[string]string{
+		"main.tf": `
+module "a" {
+  source = "../a"
+  name   = "deep-value"
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), rootDir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "leaf")
+	requireString(t, r.Attributes, "bucket", "deep-value")
+	if r.ModuleAddress != "module.a.module.b" {
+		t.Fatalf("ModuleAddress = %q, want module.a.module.b", r.ModuleAddress)
+	}
+	if len(r.CallChain) != 2 {
+		t.Fatalf("CallChain length = %d, want 2", len(r.CallChain))
+	}
+}
+
+func TestEvaluateModule_OutputConsumedByCaller(t *testing.T) {
+	root := t.TempDir()
+
+	writeModule(t, root, "child", map[string]string{
+		"main.tf": `
+variable "name" {
+  type = string
+}
+
+output "bucket_name" {
+  value = "${var.name}-out"
+}
+`,
+	})
+
+	rootDir := writeModule(t, root, "root", map[string]string{
+		"main.tf": `
+module "child" {
+  source = "../child"
+  name   = "hello"
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = module.child.bucket_name
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), rootDir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "this")
+	requireString(t, r.Attributes, "bucket", "hello-out")
+}
+
+func TestEvaluateModule_TopLevelOutputsReturned(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+variable "name" {
+  type    = string
+  default = "x"
+}
+
+output "name_out" {
+  value = var.name
+}
+`,
+	})
+
+	_, outputs, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	v, ok := outputs["name_out"]
+	if !ok {
+		t.Fatalf("output name_out not returned")
+	}
+	if !v.IsKnown() || v.AsString() != "x" {
+		t.Fatalf("output name_out = %#v, want \"x\"", v)
+	}
+}
+
+func TestEvaluateModule_CycleTerminates(t *testing.T) {
+	root := t.TempDir()
+
+	// a -> b -> a (cycle). Each also declares a resource so we can confirm we
+	// still materialize what we can before stopping.
+	writeModule(t, root, "a", map[string]string{
+		"main.tf": `
+module "b" {
+  source = "../b"
+}
+
+resource "aws_s3_bucket" "a_bucket" {
+  bucket = "a"
+}
+`,
+	})
+	writeModule(t, root, "b", map[string]string{
+		"main.tf": `
+module "a" {
+  source = "../a"
+}
+
+resource "aws_s3_bucket" "b_bucket" {
+  bucket = "b"
+}
+`,
+	})
+
+	aDir := filepath.Join(root, "a")
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, _, err := New().EvaluateModule(context.Background(), aDir, nil)
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("EvaluateModule: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("EvaluateModule did not terminate on a cyclic module graph")
+	}
+}
+
+func TestEvaluateModule_DepthGuardTerminates(t *testing.T) {
+	root := t.TempDir()
+
+	// self-referential module: a calls a (same dir). The cycle guard catches
+	// this, but it also exercises that recursion is bounded.
+	writeModule(t, root, "a", map[string]string{
+		"main.tf": `
+module "self" {
+  source = "./"
+}
+
+resource "aws_s3_bucket" "a_bucket" {
+  bucket = "a"
+}
+`,
+	})
+
+	aDir := filepath.Join(root, "a")
+	resources, _, _, err := New().EvaluateModule(context.Background(), aDir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	findResource(t, resources, "aws_s3_bucket", "a_bucket")
+}
+
+func TestEvaluateModule_UnresolvedReferenceIsUnknown(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "this" {
+  bucket    = data.aws_caller_identity.current.account_id
+  other_ref = aws_kms_key.example.arn
+  literal   = "ok"
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "this")
+	requireUnknown(t, r.Attributes, "bucket")
+	requireUnknown(t, r.Attributes, "other_ref")
+	requireString(t, r.Attributes, "literal", "ok")
+}
+
+func TestEvaluateModule_RemoteModuleSkipped(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "root", map[string]string{
+		"main.tf": `
+module "remote" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+  bucket = "remote-bucket"
+}
+
+resource "aws_s3_bucket" "local" {
+  bucket = "local-bucket"
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	// The remote module is skipped; only the root resource is materialized.
+	findResource(t, resources, "aws_s3_bucket", "local")
+	for _, r := range resources {
+		if r.ModuleAddress != "" {
+			t.Fatalf("unexpected resource from remote module: %+v", r)
+		}
+	}
+}
+
+func TestEvaluateModule_RepeatedBlocksGroupedIntoTuple(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "aws_security_group" "this" {
+  ingress {
+    from_port = 80
+  }
+  ingress {
+    from_port = 443
+  }
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_security_group", "this")
+	ingress, ok := r.Attributes["ingress"]
+	if !ok {
+		t.Fatalf("ingress block group missing")
+	}
+	if !ingress.Type().IsTupleType() {
+		t.Fatalf("ingress = %s, want tuple", ingress.Type().FriendlyName())
+	}
+	if got := ingress.LengthInt(); got != 2 {
+		t.Fatalf("ingress tuple length = %d, want 2", got)
+	}
+}
+
+func TestEvaluateModule_SingleNestedBlockIsSingletonTuple(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "this" {
+  versioning {
+    enabled = true
+  }
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "this")
+	versioning, ok := r.Attributes["versioning"]
+	if !ok {
+		t.Fatalf("versioning block missing")
+	}
+	if !versioning.Type().IsTupleType() || versioning.LengthInt() != 1 {
+		t.Fatalf("versioning = %s (len %d), want 1-tuple", versioning.Type().FriendlyName(), versioning.LengthInt())
+	}
+	block := versioning.Index(cty.NumberIntVal(0))
+	if !block.Type().IsObjectType() {
+		t.Fatalf("versioning[0] = %s, want object", block.Type().FriendlyName())
+	}
+	enabled := block.GetAttr("enabled")
+	if !enabled.True() {
+		t.Fatalf("versioning[0].enabled = %#v, want true", enabled)
+	}
+}

--- a/pkg/parser/terraform/tfeval/parse.go
+++ b/pkg/parser/terraform/tfeval/parse.go
@@ -1,0 +1,269 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package tfeval
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const blockTypeModule = "module"
+
+// reservedModuleAttrs are module-block keys that are not passed as inputs.
+var reservedModuleAttrs = map[string]bool{
+	"source":     true,
+	"version":    true,
+	"providers":  true,
+	"count":      true,
+	"for_each":   true,
+	"depends_on": true,
+}
+
+// parseDir parses all .tf files in dir (non-recursively) and returns their bodies.
+// Files that fail to parse are skipped.
+func parseDir(dir string) ([]*hclsyntax.Body, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(strings.ToLower(entry.Name()), ".tf") {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+
+	bodies := make([]*hclsyntax.Body, 0, len(names))
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		src, rErr := os.ReadFile(filepath.Clean(path))
+		if rErr != nil {
+			continue
+		}
+		f, diags := hclsyntax.ParseConfig(src, path, hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			continue
+		}
+		if body, ok := f.Body.(*hclsyntax.Body); ok {
+			bodies = append(bodies, body)
+		}
+	}
+	return bodies, nil
+}
+
+// collectBlocks partitions blocks across all bodies into variables, locals,
+// module calls, resources, and outputs.
+func collectBlocks(bodies []*hclsyntax.Body) (
+	varExprs map[string]hclsyntax.Expression,
+	localExprs map[string]hclsyntax.Expression,
+	modules []*hclsyntax.Block,
+	resources []*hclsyntax.Block,
+	outputs map[string]hclsyntax.Expression,
+) {
+	varExprs = map[string]hclsyntax.Expression{}
+	localExprs = map[string]hclsyntax.Expression{}
+	outputs = map[string]hclsyntax.Expression{}
+
+	for _, body := range bodies {
+		for _, block := range body.Blocks {
+			switch block.Type {
+			case "variable":
+				if len(block.Labels) != 1 {
+					continue
+				}
+				var defExpr hclsyntax.Expression
+				if def, ok := block.Body.Attributes["default"]; ok {
+					defExpr = def.Expr
+				}
+				varExprs[block.Labels[0]] = defExpr
+			case "locals":
+				for name, attr := range block.Body.Attributes {
+					localExprs[name] = attr.Expr
+				}
+			case blockTypeModule:
+				modules = append(modules, block)
+			case "resource":
+				resources = append(resources, block)
+			case "output":
+				if len(block.Labels) != 1 {
+					continue
+				}
+				if val, ok := block.Body.Attributes["value"]; ok {
+					outputs[block.Labels[0]] = val.Expr
+				}
+			}
+		}
+	}
+	return varExprs, localExprs, modules, resources, outputs
+}
+
+func collectModuleBlocks(bodies []*hclsyntax.Body) []*hclsyntax.Block {
+	var modules []*hclsyntax.Block
+	for _, body := range bodies {
+		for _, block := range body.Blocks {
+			if block.Type == blockTypeModule {
+				modules = append(modules, block)
+			}
+		}
+	}
+	return modules
+}
+
+// knownString evaluates attr and returns its string value, or "" if unknown/unset.
+func knownString(attr *hclsyntax.Attribute, ctx *hcl.EvalContext) string {
+	if attr == nil {
+		return ""
+	}
+	v, diags := attr.Expr.Value(ctx)
+	if diags.HasErrors() || !v.IsKnown() || v.IsNull() || v.Type() != cty.String {
+		return ""
+	}
+	return v.AsString()
+}
+
+// resolveLocalDir resolves a local module source path relative to callerDir.
+func resolveLocalDir(callerDir, source string) string {
+	clean := StripGetterPrefix(source)
+	if filepath.IsAbs(clean) {
+		return filepath.Clean(clean)
+	}
+	return filepath.Clean(filepath.Join(callerDir, clean))
+}
+
+// StripGetterPrefix removes go-getter scheme prefixes so the source can be treated as a path.
+// Compound prefixes like "git::file://./path" are fully stripped in two passes.
+func StripGetterPrefix(source string) string {
+	source = strings.TrimSpace(source)
+	for _, scheme := range []string{"git::", "hg::", "http::", "https::"} {
+		if after, ok := strings.CutPrefix(source, scheme); ok {
+			source = after
+			break
+		}
+	}
+	source = strings.TrimPrefix(source, "file://")
+	return source
+}
+
+// isEmptyCollection returns true when attr evaluates to a known empty collection under ctx.
+// Unknown or unevaluable for_each expressions return false (conservative: keep the block).
+func isEmptyCollection(attr *hclsyntax.Attribute, ctx *hcl.EvalContext) bool {
+	if attr == nil {
+		return false
+	}
+	v, diags := attr.Expr.Value(ctx)
+	if diags.HasErrors() || !v.IsKnown() || v.IsNull() {
+		return false
+	}
+	t := v.Type()
+	if t.IsObjectType() || t.IsMapType() || t.IsListType() || t.IsTupleType() || t.IsSetType() {
+		return v.LengthInt() == 0
+	}
+	return false
+}
+
+// LoadRootVars reads terraform.tfvars and *.auto.tfvars from dir and returns a
+// variable map for use as root-module inputs. Terraform loads terraform.tfvars
+// first, then *.auto.tfvars in lexicographic order; later files override earlier
+// ones. Files that fail to read or parse are silently skipped.
+func LoadRootVars(dir string) map[string]cty.Value {
+	candidates := []string{filepath.Join(dir, "terraform.tfvars")}
+	entries, _ := os.ReadDir(dir)
+	var autoFiles []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(strings.ToLower(e.Name()), ".auto.tfvars") {
+			autoFiles = append(autoFiles, e.Name())
+		}
+	}
+	sort.Strings(autoFiles)
+	for _, name := range autoFiles {
+		candidates = append(candidates, filepath.Join(dir, name))
+	}
+
+	out := map[string]cty.Value{}
+	emptyCtx := &hcl.EvalContext{}
+	for _, p := range candidates {
+		src, err := os.ReadFile(filepath.Clean(p))
+		if err != nil {
+			continue
+		}
+		f, diags := hclsyntax.ParseConfig(src, p, hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			continue
+		}
+		body, ok := f.Body.(*hclsyntax.Body)
+		if !ok {
+			continue
+		}
+		for name, attr := range body.Attributes {
+			v, attrDiags := attr.Expr.Value(emptyCtx)
+			if !attrDiags.HasErrors() && v.IsKnown() {
+				out[name] = v
+			}
+		}
+	}
+	return out
+}
+
+func blockLabel(b *hclsyntax.Block) string {
+	if len(b.Labels) == 0 {
+		return ""
+	}
+	return b.Labels[0]
+}
+
+// isLiteralZero returns true when attr evaluates to the number zero under ctx.
+// Unknown or unevaluable count expressions return false (conservative: keep the block).
+func isLiteralZero(attr *hclsyntax.Attribute, ctx *hcl.EvalContext) bool {
+	if attr == nil {
+		return false
+	}
+	v, diags := attr.Expr.Value(ctx)
+	if diags.HasErrors() || !v.IsKnown() || v.IsNull() {
+		return false
+	}
+	if v.Type() == cty.Number {
+		f, _ := v.AsBigFloat().Float64()
+		return f == 0
+	}
+	return false
+}
+
+// objectOrEmpty wraps m as a cty object; cty.ObjectVal panics on empty maps.
+func objectOrEmpty(m map[string]cty.Value) cty.Value {
+	if len(m) == 0 {
+		return cty.EmptyObjectVal
+	}
+	return cty.ObjectVal(m)
+}
+
+func joinAddr(parent, seg string) string {
+	if parent == "" {
+		return seg
+	}
+	return parent + "." + seg
+}
+
+// cloneChain copies the slice to avoid aliasing across sibling recursions.
+func cloneChain(chain []CallSite) []CallSite {
+	if len(chain) == 0 {
+		return nil
+	}
+	out := make([]CallSite, len(chain))
+	copy(out, chain)
+	return out
+}


### PR DESCRIPTION
> [!TIP]
> This PR is best reviewed commit by commit.

## Motivation

Terraform scans previously treated local module calls as call-site blocks only. A rule could inspect a `module` block's inputs and map a subset of them back to expected resource attributes via `get_module_equivalent_key`, but the scanner never **materialized the resources inside a local module with the caller's values**. So a misconfiguration that only exists because of what the caller passed in was invisible to any rule that didn't carry a bespoke module-mapping branch.

This PR instantiates local modules during scans: it binds caller inputs to the module's variables (→ defaults → unknown), evaluates locals/functions/conditionals, recurses into nested local modules, and emits the resolved resources into the scan payload. Rules then run against real resources (e.g. `aws_s3_bucket`) with no module-awareness required.

Related Ticket: [K9CODESEC-2306](https://datadoghq.atlassian.net/browse/K9CODESEC-2306?atlOrigin=eyJpIjoiYmQ4MmVhNzQ0MzcxNGE0ZGFiY2VhNWRmNGEwMzE5MDUiLCJwIjoiaiJ9)

## Before / After

```hcl
# main.tf (root)
module "logs" {
  source      = "./modules/bucket"
  bucket_name = "app-logs"
  acl         = "public-read"   # insecure, set by the caller
}
```
```hcl
# modules/bucket/main.tf
variable "bucket_name" {}
variable "acl" { default = "private" }

resource "aws_s3_bucket" "this" {
  bucket = var.bucket_name
  acl    = var.acl
}
```

**Before:** the root saw the `module "logs"` call-site, and `modules/bucket/main.tf` was scanned standalone with `acl = var.acl` unresolved. The public ACL was only catchable if the S3 rule had a `get_module_equivalent_key` branch, most don't, so it was **missed**.

**After:** the module is instantiated with `acl = "public-read"`, materialized as `aws_s3_bucket.this`, and the normal "S3 bucket must not be public" rule fires on the resolved value. The called body file is suppressed and the local call-site stripped, so there is exactly one finding.

## Implementation

- New evaluator package `pkg/parser/terraform/tfeval` (module-instance tree: input binding, variable defaults, locals fixed-point, nested local modules with depth + cycle guards, output up-propagation).
- Engine wiring in `pkg/engine/module_resolve.go` + `Inspect`: instantiate local modules, inject synthetic resource documents, suppress called bodies, strip instantiated local call-sites.

## Things reviewers should know

- **Unknown values use a placeholder** (`__DD_TFEVAL_UNKNOWN__`) so attribute keys stay present. This prevents `MissingAttribute` false-positives from treating an unresolved expression as absent. Trade-off: value-equality rules see the sentinel rather than a concrete value (i.e. this swaps potential MissingAttribute FPs for potential IncorrectValue FPs).
- **Finding attribution shifts for local modules.** Findings now report at the module's *resource definition* (file + line) with the call chain, not at the call site. This changes findingId, which matters for suppression and ticket continuity in hosted scans.
- **Dedup model:** called module body files are suppressed; only *instantiated* local call-sites are stripped from root docs; remote/registry call-sites are left intact so existing Rego branches still fire; uncalled modules are still scanned standalone. Call-sites are only stripped when the module contributed synthetic docs (never remove coverage without a replacement).
- **Resilience:** evaluation is wrapped in `recover()` (a bad module logs and is skipped, scan continues); if every root fails to evaluate, no suppression/stripping is applied.
- **Root `*.tfvars` / `*.auto.tfvars`** feed module inputs; root-module resources themselves are unchanged (still scanned via the standard converter).

## Out of scope (follow-ups)

- **Remote / registry modules**: unchanged; still treated as call-site blocks. It will come in the future.
- **`count` / `for_each` expansion to N>1**: only the disable case (`count = 0`, `for_each = {}`) is handled; otherwise a block is materialized once, and `count.index` / `each.key` resolve to unknown. Incoming in the next PR.
- **Cross-resource references** (`x = aws_y.z.id`, data sources): resolve to unknown. Incoming in the next PR.
- **Multiple calls to the same module directory / per-instance attribution**: distinct instances can collapse to one synthetic doc (same defining file/line).
- **Retiring `get_module_equivalent_key`**: kept running in parallel; removal is a later PR once instantiated coverage is proven.

[Followup ticket](https://datadoghq.atlassian.net/browse/K9CODESEC-2307)

## Blast radius

All Terraform scans: local modules are evaluated and merged into the OPA payload. Remote and registry modules are unchanged.

## Testing / QA

1. `go test ./pkg/parser/terraform/tfeval/... ./pkg/engine/...`
2. `test-rules` (authoritative): confirm no regressions and net-new coverage on local-module fixtures; watch the unknown-placeholder FP rate.
3. Scan a fixture that calls a local module and confirm findings target instantiated resources with caller-resolved attributes; confirm remote/registry `module` call-sites are unchanged and there are no duplicate findings (stripped call-site + instantiated resource).

I submit this contribution under the Apache-2.0 license.


[K9CODESEC-2306]: https://datadoghq.atlassian.net/browse/K9CODESEC-2306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ