### PR TITLE
[K9CODESEC-2307] Expand local module tfeval for count, for_each, and same-module refs

### DIFF
--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -276,12 +276,10 @@ func (c *Inspector) Inspect(
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("engine.Inspect()")
 
-	// Instantiate local Terraform modules into resolved-resource documents and
-	// drop the called module bodies from the standalone scan to avoid duplicates.
+	// Instantiate local modules into synthetic resource docs; suppress duplicate module bodies.
 	moduleDocs := c.instantiateLocalModules(ctx, files)
 
-	// instantiateLocalModules mutates files in place (clears suppressed bodies).
-	// Combine skips empty documents, so this must stay before Combine.
+	// Must run before Combine: instantiateLocalModules clears suppressed file bodies in place.
 	combinedFiles := files.Combine(ctx, false)
 
 	vulnerabilities := make([]model.Vulnerability, 0)

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -143,11 +143,7 @@ func resolveModuleDocuments(
 		}
 	}
 
-	// Only strip call sites for dirs that contributed synthetic documents (i.e.,
-	// their files are present in the scan input). If a module was read from disk
-	// by EvaluateModule but its files are absent from the scan, instantiatedDocs
-	// drops its resources; stripping the call site would remove the only payload
-	// those files provide without any synthetic replacement.
+	// Only strip call sites when that module's files are in the scan (avoid dropping sole coverage).
 	strippedDirs := make(map[string]bool, len(actualCalledDirs))
 	for dir := range actualCalledDirs {
 		if len(filesByDir[dir]) > 0 {
@@ -158,13 +154,8 @@ func resolveModuleDocuments(
 	return extra, suppressed, strippedDirs, true
 }
 
-// instantiatedDocs builds a synthetic resource document for each resolved
-// module resource, attributed to its defining file. Root resources and those
-// whose file is out of scope are skipped. seen dedupes across multiple roots.
-//
-// v1 limitation: count/for_each and multiple calls to the same module directory
-// are not expanded into separate instances; dedupe and document id attribution
-// use the defining file only, so distinct instances can collapse to one synthetic doc.
+// instantiatedDocs builds one synthetic document per resolved module resource (skips root
+// and out-of-scope). seen dedupes across eval roots; dedupe key includes type, name, line, module path.
 func instantiatedDocs(
 	resources []tfeval.ResolvedResource,
 	byAbsPath map[string]*model.FileMetadata,
@@ -189,12 +180,14 @@ func instantiatedDocs(
 		}
 		seen[key] = true
 
+		// Use the bare resource label (not the expanded name like k[0]) so that
+		// Rego rules matching input.document[_].resource.TYPE.NAME find the resource.
 		docs = append(docs, model.Document{
 			"id":   fm.ID,
 			"file": fm.FilePath,
 			"resource": map[string]interface{}{
 				r.Type: map[string]interface{}{
-					r.Name: tfeval.AttributesToDocument(r),
+					tfeval.ResourceBaseName(r.Name): tfeval.AttributesToDocument(r),
 				},
 			},
 		})
@@ -202,13 +195,9 @@ func instantiatedDocs(
 	return docs
 }
 
-// stripLocalModuleCalls removes module entries from doc whose source resolves
-// to one of calledDirs. Remote/registry sources are left intact so existing
-// Rego branches that match call-site attributes continue to work.
-//
-// The Terraform parser stores nested HCL blocks as model.Document (a named map
-// type), so we accept both model.Document and map[string]interface{} to handle
-// either representation safely.
+// stripLocalModuleCalls drops local module blocks whose source dir is in calledDirs.
+// Remote/registry sources stay so existing Rego call-site rules still match.
+// Accepts model.Document or map[string]interface{} for nested module maps.
 func stripLocalModuleCalls(doc model.Document, filePath, repoPath string, calledDirs map[string]bool) {
 	modules := docAsMap(doc["module"])
 	if modules == nil {

--- a/pkg/parser/terraform/tfeval/cache.go
+++ b/pkg/parser/terraform/tfeval/cache.go
@@ -1,0 +1,76 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package tfeval
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+// evalCacheKey identifies a unique module evaluation by directory, module address, and resolved inputs.
+// Including addr ensures two callers that reach the same dir via different paths (different addr
+// prefixes) are treated as separate entries whose resource ModuleAddress values are already distinct.
+type evalCacheKey struct {
+	dir    string
+	addr   string
+	inputs string // canonical encoding of the resolved input map
+}
+
+// evalCacheEntry holds the result of a completed module evaluation.
+// visitedDirs is the set of child dirs that were added to allVisited *inside* this
+// evaluation (not including the module dir itself, which is tracked by the caller).
+type evalCacheEntry struct {
+	resources   []ResolvedResource
+	outputs     map[string]cty.Value
+	visitedDirs []string
+}
+
+// canonicalInputsKey returns a stable string for a set of resolved module inputs.
+// Map keys are sorted; values are JSON-encoded via cty/json (which itself sorts object
+// attribute names). Unknown or unencodable values fall back to their type name.
+func canonicalInputsKey(inputs map[string]cty.Value) string {
+	if len(inputs) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(inputs))
+	for k := range inputs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(encodeCtyForKey(inputs[k]))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// encodeCtyForKey encodes a cty.Value to a stable string for use inside a cache key.
+// cty/json is used because it produces sorted, deterministic output for object/map types.
+// The null check must precede the known check because null values are also considered known.
+// All DynamicPseudoType values are unknown (IsKnown()==false), so they are handled by
+// the unknown branch and the DynamicPseudoType case never needs a special guard.
+func encodeCtyForKey(v cty.Value) string {
+	if v.IsNull() {
+		// Include the type so cty.NullVal(cty.String) and cty.NullVal(cty.Number)
+		// do not collide.
+		return "null(" + v.Type().FriendlyName() + ")"
+	}
+	if !v.IsKnown() {
+		return "?" + v.Type().FriendlyName()
+	}
+	data, err := ctyjson.Marshal(v, v.Type())
+	if err != nil {
+		return "?" + v.Type().FriendlyName()
+	}
+	return string(data)
+}

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/gocty"
 )
 
 const (
@@ -398,8 +399,10 @@ func (e *Evaluator) expandCountInstances(
 	}
 	cv, diags := countAttr.Expr.Value(evalCtx)
 	if !diags.HasErrors() && cv.IsKnown() && !cv.IsNull() && cv.Type() == cty.Number {
-		f, _ := cv.AsBigFloat().Float64()
-		n := int(f)
+		var n int
+		if err := gocty.FromCtyValue(cv, &n); err != nil {
+			return nil, false
+		}
 		if n <= 0 {
 			return nil, true
 		}

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -4,16 +4,17 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
  */
 
-// Package tfeval evaluates local Terraform modules by binding caller inputs to
-// module variables, resolving locals, recursing into nested modules, and
-// returning a flat list of resources with concrete attribute values.
-// Unresolvable references (data sources, cross-resource refs, etc.) are left
-// as cty.UnknownVal rather than sentinel strings.
+// Package tfeval evaluates local Terraform modules: bind inputs, resolve locals,
+// recurse into nested modules, emit resources with concrete cty values where possible.
+// Anything still unresolvable (e.g. data sources) stays cty.UnknownVal, not sentinels.
 package tfeval
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
+	"sort"
+	"strconv"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	tffunctions "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/functions"
@@ -26,12 +27,14 @@ import (
 )
 
 const (
-	// defaultMaxDepth bounds nested-module recursion to protect against
-	// pathological or cyclic local module graphs.
+	// defaultMaxDepth caps nested module recursion (cycles, deep graphs).
 	defaultMaxDepth = 15
-	// localsMaxPasses bounds the fixed-point iteration used to resolve locals
-	// that reference one another.
+	// localsMaxPasses caps fixed-point resolution of locals that reference each other.
 	localsMaxPasses = 10
+	// resourceRefPasses caps passes that install same-module resource attrs for refs.
+	resourceRefPasses = 3
+	// maxCountExpansion caps instances per count/for_each block.
+	maxCountExpansion = 10
 )
 
 // ResolvedResource is a resource block after evaluation with attributes
@@ -60,12 +63,18 @@ type CallSite struct {
 type Evaluator struct {
 	funcs    map[string]function.Function
 	maxDepth int
+	// cache memoizes completed module evaluations keyed by (dir, addr, canonical-inputs).
+	// A single Evaluator is used for an entire scan, so the cache is shared across root
+	// module calls — entries with the same key represent the same module called with the
+	// same resolved inputs from the same structural position in the module tree.
+	cache map[evalCacheKey]*evalCacheEntry
 }
 
 func New() *Evaluator {
 	return &Evaluator{
 		funcs:    tffunctions.TerraformFuncs,
 		maxDepth: defaultMaxDepth,
+		cache:    make(map[evalCacheKey]*evalCacheEntry),
 	}
 }
 
@@ -112,8 +121,26 @@ func (e *Evaluator) evaluate(
 		contextLogger.Warn().Msgf("tfeval: module cycle detected at %s, stopping recursion", dir)
 		return nil, map[string]cty.Value{}, nil
 	}
+
+	// Cache lookup: after guard checks but before file I/O. The pre-pass and main loop
+	// call evaluate with identical (dir, addr, inputs, chain) once chain is threaded
+	// through, so the second call always hits the cache.
+	cacheKey := evalCacheKey{dir: dir, addr: addr, inputs: canonicalInputsKey(inputs)}
+	if entry, ok := e.cache[cacheKey]; ok {
+		for _, d := range entry.visitedDirs {
+			allVisited[d] = true
+		}
+		return entry.resources, entry.outputs, nil
+	}
+
 	visiting[dir] = true
 	defer delete(visiting, dir)
+
+	// Snapshot allVisited so we can determine which dirs this subtree adds.
+	prevAllVisited := make(map[string]bool, len(allVisited))
+	for k := range allVisited {
+		prevAllVisited[k] = true
+	}
 
 	bodies, err := parseDir(dir)
 	if err != nil {
@@ -134,21 +161,107 @@ func (e *Evaluator) evaluate(
 	localVals := e.resolveLocals(localExprs, evalCtx)
 	evalCtx.Variables["local"] = objectOrEmpty(localVals)
 
-	// Pre-pass: collect sibling module outputs so they are available in evalCtx
-	// when computing inputs in the main loop. Terraform allows module inputs to
-	// reference outputs of sibling modules regardless of block order; without
-	// this pass those references always resolve to unknown.
-	if len(moduleBlocks) > 1 {
-		prelimOutputs := e.preliminaryModuleOutputs(ctx, moduleBlocks, evalCtx, dir, addr, depth, visiting)
-		if len(prelimOutputs) > 0 {
-			evalCtx.Variables["module"] = cty.ObjectVal(prelimOutputs)
-			localVals = e.resolveLocals(localExprs, evalCtx)
-			evalCtx.Variables["local"] = objectOrEmpty(localVals)
-		}
+	// Pre-inject sibling resource attrs so module inputs that reference them
+	// (e.g. module "x" { val = aws_resource.y.attr }) resolve on first evaluation.
+	if len(resourceBlocks) > 0 && len(moduleBlocks) > 0 {
+		earlyRes := e.evalResourceBlocks(resourceBlocks, evalCtx, addr, chain)
+		injectResourceRefs(evalCtx, earlyRes)
+		localVals = e.resolveLocals(localExprs, evalCtx)
+		evalCtx.Variables["local"] = objectOrEmpty(localVals)
 	}
 
-	var childResources []ResolvedResource
-	moduleOutputs := map[string]cty.Value{}
+	e.applySiblingModulePrepass(ctx, moduleBlocks, evalCtx, localExprs, dir, addr, chain, depth, visiting)
+
+	childResources, moduleOutputs := e.evaluateLocalModuleBlocks(
+		ctx, moduleBlocks, evalCtx, dir, addr, chain, depth, visiting, allVisited,
+	)
+
+	if len(moduleOutputs) > 0 {
+		evalCtx.Variables["module"] = cty.ObjectVal(moduleOutputs)
+		localVals = e.resolveLocals(localExprs, evalCtx)
+		evalCtx.Variables["local"] = objectOrEmpty(localVals)
+	}
+
+	rootResources := e.rootResourcesWithRefPasses(resourceBlocks, localExprs, evalCtx, addr, chain)
+
+	// Re-inject the final-pass resource values so that outputs and locals that
+	// reference the Nth hop of an N-hop chain can resolve. For chains shorter
+	// than resourceRefPasses hops all resources were already injected inside the
+	// loop, so injectResourceRefs returns false and the locals refresh is skipped.
+	if injectResourceRefs(evalCtx, rootResources) {
+		localVals = e.resolveLocals(localExprs, evalCtx)
+		evalCtx.Variables["local"] = objectOrEmpty(localVals)
+	}
+
+	resources := make([]ResolvedResource, 0, len(rootResources)+len(childResources))
+	resources = append(resources, rootResources...)
+	resources = append(resources, childResources...)
+
+	outputs := make(map[string]cty.Value, len(outputExprs))
+	for name, expr := range outputExprs {
+		outputs[name] = e.evalExpr(expr, evalCtx)
+	}
+
+	// Collect dirs added to allVisited during this evaluation for the cache entry.
+	var visitedDirs []string
+	for d := range allVisited {
+		if !prevAllVisited[d] {
+			visitedDirs = append(visitedDirs, d)
+		}
+	}
+	e.cache[cacheKey] = &evalCacheEntry{
+		resources:   resources,
+		outputs:     outputs,
+		visitedDirs: visitedDirs,
+	}
+
+	return resources, outputs, nil
+}
+
+func (e *Evaluator) applySiblingModulePrepass(
+	ctx context.Context,
+	moduleBlocks []*hclsyntax.Block,
+	evalCtx *hcl.EvalContext,
+	localExprs map[string]hclsyntax.Expression,
+	dir, addr string,
+	chain []CallSite,
+	depth int,
+	visiting map[string]bool,
+) {
+	if len(moduleBlocks) <= 1 {
+		return
+	}
+	prelimOutputs := e.preliminaryModuleOutputs(ctx, moduleBlocks, evalCtx, dir, addr, chain, depth, visiting)
+	if len(prelimOutputs) == 0 {
+		return
+	}
+	evalCtx.Variables["module"] = cty.ObjectVal(prelimOutputs)
+	localVals := e.resolveLocals(localExprs, evalCtx)
+	evalCtx.Variables["local"] = objectOrEmpty(localVals)
+}
+
+func (e *Evaluator) evaluateLocalModuleBlocks(
+	ctx context.Context,
+	moduleBlocks []*hclsyntax.Block,
+	evalCtx *hcl.EvalContext,
+	dir, addr string,
+	chain []CallSite,
+	depth int,
+	visiting map[string]bool,
+	allVisited map[string]bool,
+) (childResources []ResolvedResource, moduleOutputs map[string]cty.Value) {
+	contextLogger := logger.FromContext(ctx)
+
+	// Seed with the pre-pass values already in evalCtx so that forward dependencies
+	// (module B referencing module C where C appears later in file order) survive the
+	// first iteration's evalCtx.Variables["module"] update.
+	moduleOutputs = map[string]cty.Value{}
+	if existing, ok := evalCtx.Variables["module"]; ok && existing.Type().IsObjectType() {
+		for it := existing.ElementIterator(); it.Next(); {
+			k, v := it.Element()
+			moduleOutputs[k.AsString()] = v
+		}
+	}
 
 	for _, mb := range moduleBlocks {
 		label := blockLabel(mb)
@@ -157,12 +270,11 @@ func (e *Evaluator) evaluate(
 		}
 		source := knownString(mb.Body.Attributes["source"], evalCtx)
 		if source == "" || !tfmodules.LooksLikeLocalModuleSource(StripGetterPrefix(source)) {
-			continue // remote/registry sources are out of scope
+			continue
 		}
 
 		childDir := resolveLocalDir(dir, source)
 
-		// Skip module instances that are explicitly disabled.
 		if isLiteralZero(mb.Body.Attributes["count"], evalCtx) {
 			continue
 		}
@@ -190,28 +302,43 @@ func (e *Evaluator) evaluate(
 		allVisited[childDir] = true
 		childResources = append(childResources, childRes...)
 		moduleOutputs[label] = objectOrEmpty(childOuts)
-	}
-
-	if len(moduleOutputs) > 0 {
-		// Re-evaluate locals now that module.* outputs are available.
+		// Update evalCtx so the next sibling's modInputs can reference this
+		// module's now-resolved outputs (e.g. module.B.x = module.A.output).
 		evalCtx.Variables["module"] = cty.ObjectVal(moduleOutputs)
-		localVals = e.resolveLocals(localExprs, evalCtx)
-		evalCtx.Variables["local"] = objectOrEmpty(localVals)
 	}
-
-	resources := make([]ResolvedResource, 0, len(resourceBlocks)+len(childResources))
-	resources = append(resources, e.evalResourceBlocks(resourceBlocks, evalCtx, addr, chain)...)
-	resources = append(resources, childResources...)
-
-	outputs := make(map[string]cty.Value, len(outputExprs))
-	for name, expr := range outputExprs {
-		outputs[name] = e.evalExpr(expr, evalCtx)
-	}
-
-	return resources, outputs, nil
+	return childResources, moduleOutputs
 }
 
-// evalResourceBlocks evaluates all resource blocks in the current module scope.
+func (e *Evaluator) rootResourcesWithRefPasses(
+	resourceBlocks []*hclsyntax.Block,
+	localExprs map[string]hclsyntax.Expression,
+	evalCtx *hcl.EvalContext,
+	addr string,
+	chain []CallSite,
+) []ResolvedResource {
+	var rootResources []ResolvedResource
+	for pass := 0; pass < resourceRefPasses; pass++ {
+		rootResources = e.evalResourceBlocks(resourceBlocks, evalCtx, addr, chain)
+		// Always inject so resolved attrs reach evalCtx on every pass including the last.
+		changed := injectResourceRefs(evalCtx, rootResources)
+		if !changed {
+			break
+		}
+		// Refresh locals after every successful injection so that locals referencing
+		// newly-resolved resource attrs are up-to-date before outputs are computed.
+		localVals := e.resolveLocals(localExprs, evalCtx)
+		evalCtx.Variables["local"] = objectOrEmpty(localVals)
+		if pass+1 >= resourceRefPasses {
+			break
+		}
+	}
+	// One final evaluation picks up attrs that were only injected on the last pass
+	// (e.g. the Nth resource in an A→B→C→D chain whose evalCtx was updated after the
+	// last evalResourceBlocks call).
+	return e.evalResourceBlocks(resourceBlocks, evalCtx, addr, chain)
+}
+
+// evalResourceBlocks evaluates resource blocks (count/for_each expanded when known).
 func (e *Evaluator) evalResourceBlocks(
 	resourceBlocks []*hclsyntax.Block,
 	evalCtx *hcl.EvalContext,
@@ -220,27 +347,213 @@ func (e *Evaluator) evalResourceBlocks(
 ) []ResolvedResource {
 	resources := make([]ResolvedResource, 0, len(resourceBlocks))
 	for _, rb := range resourceBlocks {
-		if len(rb.Labels) < 2 {
-			continue
-		}
-		// Skip resources with count = 0 or for_each = {}; Terraform creates no instances.
-		if isLiteralZero(rb.Body.Attributes["count"], evalCtx) {
-			continue
-		}
-		if isEmptyCollection(rb.Body.Attributes["for_each"], evalCtx) {
-			continue
-		}
-		resources = append(resources, ResolvedResource{
-			Type:          rb.Labels[0],
-			Name:          rb.Labels[1],
-			Attributes:    e.evalBody(rb.Body, evalCtx, nil),
+		resources = append(resources, e.expandResourceBlock(rb, evalCtx, addr, chain)...)
+	}
+	return resources
+}
+
+// expandResourceBlock emits zero, one, or N instances per block; known count/for_each
+// get count.index / each.* in a child context; unknown expansion uses one placeholder instance.
+func (e *Evaluator) expandResourceBlock(
+	rb *hclsyntax.Block,
+	evalCtx *hcl.EvalContext,
+	addr string,
+	chain []CallSite,
+) []ResolvedResource {
+	if len(rb.Labels) < 2 {
+		return nil
+	}
+	typeName, resName := rb.Labels[0], rb.Labels[1]
+
+	makeOne := func(name string, ctx *hcl.EvalContext) ResolvedResource {
+		return ResolvedResource{
+			Type:          typeName,
+			Name:          name,
+			Attributes:    e.evalBody(rb.Body, ctx, nil),
 			DefinedIn:     rb.TypeRange.Filename,
 			DefLine:       rb.TypeRange.Start.Line,
 			ModuleAddress: addr,
 			CallChain:     cloneChain(chain),
-		})
+		}
 	}
-	return resources
+
+	if out, ok := e.expandCountInstances(rb, resName, evalCtx, makeOne); ok {
+		return out
+	}
+	if out, ok := e.expandForEachInstances(rb, resName, evalCtx, makeOne); ok {
+		return out
+	}
+	return []ResolvedResource{makeOne(resName, evalCtx)}
+}
+
+func (e *Evaluator) expandCountInstances(
+	rb *hclsyntax.Block,
+	resName string,
+	evalCtx *hcl.EvalContext,
+	makeOne func(string, *hcl.EvalContext) ResolvedResource,
+) ([]ResolvedResource, bool) {
+	countAttr := rb.Body.Attributes["count"]
+	if countAttr == nil {
+		return nil, false
+	}
+	cv, diags := countAttr.Expr.Value(evalCtx)
+	if !diags.HasErrors() && cv.IsKnown() && !cv.IsNull() && cv.Type() == cty.Number {
+		f, _ := cv.AsBigFloat().Float64()
+		n := int(f)
+		if n <= 0 {
+			return nil, true
+		}
+		nExpand := n
+		if nExpand > maxCountExpansion {
+			nExpand = maxCountExpansion
+		}
+		out := make([]ResolvedResource, 0, nExpand)
+		for i := 0; i < nExpand; i++ {
+			child := evalCtx.NewChild()
+			child.Variables = map[string]cty.Value{
+				"count": cty.ObjectVal(map[string]cty.Value{
+					"index": cty.NumberIntVal(int64(i)),
+				}),
+			}
+			out = append(out, makeOne(fmt.Sprintf("%s[%d]", resName, i), child))
+		}
+		return out, true
+	}
+	child := evalCtx.NewChild()
+	child.Variables = map[string]cty.Value{
+		"count": cty.ObjectVal(map[string]cty.Value{
+			"index": cty.UnknownVal(cty.Number),
+		}),
+	}
+	return []ResolvedResource{makeOne(resName, child)}, true
+}
+
+func (e *Evaluator) expandForEachInstances(
+	rb *hclsyntax.Block,
+	resName string,
+	evalCtx *hcl.EvalContext,
+	makeOne func(string, *hcl.EvalContext) ResolvedResource,
+) ([]ResolvedResource, bool) {
+	feAttr := rb.Body.Attributes["for_each"]
+	if feAttr == nil {
+		return nil, false
+	}
+	fv, diags := feAttr.Expr.Value(evalCtx)
+	if !diags.HasErrors() && fv.IsKnown() && !fv.IsNull() {
+		t := fv.Type()
+		if t.IsObjectType() || t.IsMapType() || t.IsSetType() {
+			if fv.LengthInt() == 0 {
+				return nil, true
+			}
+			out := make([]ResolvedResource, 0)
+			i := 0
+			for it := fv.ElementIterator(); it.Next() && i < maxCountExpansion; i++ {
+				k, kv := it.Element()
+				keyStr := "__"
+				if k.Type() == cty.String && k.IsKnown() {
+					keyStr = k.AsString()
+				}
+				child := evalCtx.NewChild()
+				child.Variables = map[string]cty.Value{
+					"each": cty.ObjectVal(map[string]cty.Value{
+						"key":   k,
+						"value": kv,
+					}),
+				}
+				out = append(out, makeOne(fmt.Sprintf("%s[%q]", resName, keyStr), child))
+			}
+			return out, true
+		}
+	}
+	child := evalCtx.NewChild()
+	child.Variables = map[string]cty.Value{
+		"each": cty.ObjectVal(map[string]cty.Value{
+			"key":   cty.UnknownVal(cty.String),
+			"value": cty.UnknownVal(cty.DynamicPseudoType),
+		}),
+	}
+	return []ResolvedResource{makeOne(resName, child)}, true
+}
+
+// injectResourceRefs sets evalCtx.Variables[type][name] from resources; returns true if changed.
+// Count-expanded resources are exposed as ordered tuples so that x[0].attr resolves correctly;
+// for_each-expanded resources as keyed objects so that x["k"].attr resolves correctly.
+func injectResourceRefs(evalCtx *hcl.EvalContext, resources []ResolvedResource) bool {
+	type instBucket struct {
+		keys     []string
+		attrs    []map[string]cty.Value
+		isCount  bool
+		expanded bool // true when any instance has brackets (count or for_each)
+	}
+	byType := make(map[string]map[string]*instBucket)
+	for _, r := range resources {
+		base, key, isCount, expanded := parseResourceInstanceKey(r.Name)
+		if byType[r.Type] == nil {
+			byType[r.Type] = make(map[string]*instBucket)
+		}
+		b := byType[r.Type][base]
+		if b == nil {
+			b = &instBucket{isCount: isCount, expanded: expanded}
+			byType[r.Type][base] = b
+		} else if expanded {
+			b.expanded = true
+		}
+		b.keys = append(b.keys, key)
+		b.attrs = append(b.attrs, r.Attributes)
+	}
+	if len(byType) == 0 {
+		return false
+	}
+	progress := false
+	for typeName, nameMap := range byType {
+		typeAttrs := make(map[string]cty.Value, len(nameMap))
+		for baseName, b := range nameMap {
+			typeAttrs[baseName] = buildInstanceCtyVal(b.keys, b.attrs, b.isCount, b.expanded)
+		}
+		newVal := cty.ObjectVal(typeAttrs)
+		if existing, ok := evalCtx.Variables[typeName]; !ok || !existing.RawEquals(newVal) {
+			evalCtx.Variables[typeName] = newVal
+			progress = true
+		}
+	}
+	return progress
+}
+
+// buildInstanceCtyVal converts grouped resource instances into the cty value used for ref injection.
+// Non-expanded resources become plain objects. Count resources become ordered tuples (x[0]).
+// For_each resources become keyed objects (x["key"]), including the empty-string key case.
+func buildInstanceCtyVal(keys []string, attrsSlice []map[string]cty.Value, isCount, expanded bool) cty.Value {
+	if !expanded {
+		// Plain (non-indexed) resource: expose as a simple attribute object.
+		return objectOrEmpty(attrsSlice[0])
+	}
+	if isCount {
+		type indexed struct {
+			i     int
+			attrs map[string]cty.Value
+		}
+		items := make([]indexed, len(keys))
+		for i, k := range keys {
+			n, _ := strconv.Atoi(k)
+			items[i] = indexed{n, attrsSlice[i]}
+		}
+		sort.Slice(items, func(i, j int) bool { return items[i].i < items[j].i })
+		elems := make([]cty.Value, len(items))
+		for i, item := range items {
+			elems[i] = objectOrEmpty(item.attrs)
+		}
+		return cty.TupleVal(elems)
+	}
+	// for_each: expose as object keyed by string keys so x["key"].attr resolves.
+	// Empty-string keys ("") are valid Terraform for_each keys and are kept.
+	kvs := make(map[string]cty.Value, len(keys))
+	for i, k := range keys {
+		kvs[k] = objectOrEmpty(attrsSlice[i])
+	}
+	if len(kvs) == 0 {
+		return cty.EmptyObjectVal
+	}
+	return cty.ObjectVal(kvs)
 }
 
 // resolveVariables binds inputs to variables, falling back to the default then unknown.
@@ -342,18 +655,15 @@ func (e *Evaluator) evalExpr(expr hclsyntax.Expression, ctx *hcl.EvalContext) ct
 	return v
 }
 
-// preliminaryModuleOutputs runs a lightweight first pass over local module
-// blocks to collect their outputs. The results are installed into evalCtx
-// before the real evaluation loop so sibling module references (e.g.
-// module.a.out used as an input to module.b) resolve to known values.
-//
-// Uses a throw-away allVisited map so the main pass records accurate visited
-// dirs. The visiting set is copied to preserve cycle detection.
+// preliminaryModuleOutputs evaluates local modules once to fill module.* for sibling refs.
+// Passes the real chain so the cache key matches the main-loop evaluate calls, turning the
+// second evaluation into a cache hit. Copies visiting; uses a fresh allVisited.
 func (e *Evaluator) preliminaryModuleOutputs(
 	ctx context.Context,
 	moduleBlocks []*hclsyntax.Block,
 	evalCtx *hcl.EvalContext,
 	dir, addr string,
+	chain []CallSite,
 	depth int,
 	visiting map[string]bool,
 ) map[string]cty.Value {
@@ -379,10 +689,21 @@ func (e *Evaluator) preliminaryModuleOutputs(
 		}
 		childDir := resolveLocalDir(dir, source)
 		modInputs := e.evalBody(mb.Body, evalCtx, reservedModuleAttrs)
+		site := CallSite{
+			ModuleName: label,
+			Source:     source,
+			CalledFrom: mb.TypeRange.Filename,
+			CalledLine: mb.TypeRange.Start.Line,
+		}
 		childAddr := joinAddr(addr, "module."+label)
-		_, childOuts, _ := e.evaluate(ctx, childDir, modInputs, childAddr, nil, depth+1, tmpVisiting, map[string]bool{})
+		childChain := append(cloneChain(chain), site)
+		_, childOuts, _ := e.evaluate(ctx, childDir, modInputs, childAddr, childChain, depth+1, tmpVisiting, map[string]bool{})
 		if len(childOuts) > 0 {
 			out[label] = objectOrEmpty(childOuts)
+			// Make each module's outputs visible to subsequent siblings within this
+			// same pre-pass loop, so their inputs resolve to the same values that the
+			// main evaluation loop will compute — this keeps cache keys consistent.
+			evalCtx.Variables["module"] = cty.ObjectVal(out)
 		}
 	}
 	return out

--- a/pkg/parser/terraform/tfeval/evaluator_test.go
+++ b/pkg/parser/terraform/tfeval/evaluator_test.go
@@ -486,8 +486,6 @@ resource "aws_security_group" "this" {
 }
 
 func TestEvaluateModule_SiblingModuleOutputInInput(t *testing.T) {
-	// module.b uses module.a's output as an input; without the pre-pass,
-	// module.a.suffix would resolve to unknown when computing b's inputs.
 	root := t.TempDir()
 
 	writeModule(t, root, "naming", map[string]string{
@@ -531,6 +529,670 @@ module "bucket" {
 
 	r := findResource(t, resources, "aws_s3_bucket", "this")
 	requireString(t, r.Attributes, "bucket", "logs-prod")
+}
+
+func TestEvaluateModule_CountExpansion(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "this" {
+  count  = 3
+  bucket = "logs-${count.index}"
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	var got []ResolvedResource
+	for _, r := range resources {
+		if r.Type == "aws_s3_bucket" {
+			got = append(got, r)
+		}
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d aws_s3_bucket instances, want 3", len(got))
+	}
+	names := make(map[string]bool)
+	for _, r := range got {
+		v := r.Attributes["bucket"]
+		if v.IsKnown() && v.Type() == cty.String {
+			names[v.AsString()] = true
+		}
+	}
+	for _, want := range []string{"logs-0", "logs-1", "logs-2"} {
+		if !names[want] {
+			t.Fatalf("bucket %q not found in expanded instances; got %v", want, names)
+		}
+	}
+}
+
+func TestEvaluateModule_CountZeroSkipped(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "this" {
+  count  = 0
+  bucket = "never"
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	for _, r := range resources {
+		if r.Type == "aws_s3_bucket" && r.Name == "this" {
+			t.Fatal("count=0 resource should not be materialized")
+		}
+	}
+}
+
+func TestEvaluateModule_ForEachExpansion(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "this" {
+  for_each = { prod = "prod-bucket", staging = "staging-bucket" }
+  bucket   = each.value
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	var got []ResolvedResource
+	for _, r := range resources {
+		if r.Type == "aws_s3_bucket" {
+			got = append(got, r)
+		}
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d aws_s3_bucket instances, want 2", len(got))
+	}
+	buckets := make(map[string]bool)
+	for _, r := range got {
+		if v := r.Attributes["bucket"]; v.IsKnown() && v.Type() == cty.String {
+			buckets[v.AsString()] = true
+		}
+	}
+	for _, want := range []string{"prod-bucket", "staging-bucket"} {
+		if !buckets[want] {
+			t.Fatalf("bucket %q not found; got %v", want, buckets)
+		}
+	}
+}
+
+func TestEvaluateModule_ForEachEmptySkipped(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "this" {
+  for_each = {}
+  bucket   = each.key
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	for _, r := range resources {
+		if r.Type == "aws_s3_bucket" {
+			t.Fatal("for_each={} resource should not be materialized")
+		}
+	}
+}
+
+func TestEvaluateModule_CountInChildModuleExpanded(t *testing.T) {
+	root := t.TempDir()
+
+	writeModule(t, root, "bucket_mod", map[string]string{
+		"main.tf": `
+variable "prefix" { type = string }
+
+resource "aws_s3_bucket" "this" {
+  count  = 2
+  bucket = "${var.prefix}-${count.index}"
+}
+`,
+	})
+
+	rootDir := writeModule(t, root, "root", map[string]string{
+		"main.tf": `
+module "buckets" {
+  source = "../bucket_mod"
+  prefix = "logs"
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), rootDir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	var childBuckets []ResolvedResource
+	for _, r := range resources {
+		if r.Type == "aws_s3_bucket" && r.ModuleAddress != "" {
+			childBuckets = append(childBuckets, r)
+		}
+	}
+	if len(childBuckets) != 2 {
+		t.Fatalf("got %d child aws_s3_bucket instances, want 2", len(childBuckets))
+	}
+	names := make(map[string]bool)
+	for _, r := range childBuckets {
+		if v := r.Attributes["bucket"]; v.IsKnown() && v.Type() == cty.String {
+			names[v.AsString()] = true
+		}
+	}
+	for _, want := range []string{"logs-0", "logs-1"} {
+		if !names[want] {
+			t.Fatalf("bucket %q not found in child module instances; got %v", want, names)
+		}
+	}
+}
+
+func TestEvaluateModule_CrossResourceRef(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "aws_kms_key" "key" {
+  description = "my-key"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  kms_description = aws_kms_key.key.description
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "bucket")
+	requireString(t, r.Attributes, "kms_description", "my-key")
+}
+
+func TestEvaluateModule_CrossResourceRefViaLocal(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "aws_kms_key" "key" {
+  description = "via-local"
+}
+
+locals {
+  kms_desc = aws_kms_key.key.description
+}
+
+resource "aws_s3_bucket" "bucket" {
+  label = local.kms_desc
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "bucket")
+	requireString(t, r.Attributes, "label", "via-local")
+}
+
+func TestEvaluateModule_CrossResourceRefCountExpanded(t *testing.T) {
+	// A for_each resource that references a count-expanded sibling by index should
+	// resolve the attribute from the correct instance.
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "aws_kms_key" "k" {
+  count       = 2
+  description = "key-${count.index}"
+}
+
+resource "aws_s3_bucket" "b" {
+  kms_desc = aws_kms_key.k[0].description
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "b")
+	requireString(t, r.Attributes, "kms_desc", "key-0")
+}
+
+func TestEvaluateModule_CrossResourceRefForEachExpanded(t *testing.T) {
+	// A plain resource that references a for_each-expanded sibling by key should
+	// resolve the attribute from the correct instance.
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "aws_iam_role" "r" {
+  for_each = { dev = "arn:dev", prod = "arn:prod" }
+  arn      = each.value
+}
+
+resource "aws_s3_bucket" "b" {
+  role_arn = aws_iam_role.r["dev"].arn
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "b")
+	requireString(t, r.Attributes, "role_arn", "arn:dev")
+}
+
+func TestEvaluateModule_OutputResolvedAfterFinalRefPass(t *testing.T) {
+	// Output references a 3-hop chain a→b→c; the final ref pass resolves 'a' but
+	// the fix ensures that resolved value is in evalCtx before outputs are computed.
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "leaf" "c" {
+  value = "resolved"
+}
+
+resource "mid" "b" {
+  value = leaf.c.value
+}
+
+resource "top" "a" {
+  value = mid.b.value
+}
+
+output "o" { value = top.a.value }
+`,
+	})
+
+	_, outputs, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	v, ok := outputs["o"]
+	if !ok {
+		t.Fatal("output 'o' missing")
+	}
+	if !v.IsKnown() || v.Type() != cty.String || v.AsString() != "resolved" {
+		t.Fatalf("output 'o' = %v, want cty.StringVal(\"resolved\")", v)
+	}
+}
+
+func TestEvaluateModule_FourHopResourceChain(t *testing.T) {
+	// A 4-hop dependency chain (a→b→c→d) needs the final evalResourceBlocks pass
+	// so that d sees c's value after c was resolved on the last injection pass.
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "r" "a" { value = "x" }
+resource "r" "b" { value = r.a.value }
+resource "r" "c" { value = r.b.value }
+resource "r" "d" { value = r.c.value }
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	for _, want := range []string{"a", "b", "c", "d"} {
+		r := findResource(t, resources, "r", want)
+		requireString(t, r.Attributes, "value", "x")
+	}
+}
+
+func TestCanonicalInputsKey_NullTypeDistinct(t *testing.T) {
+	// cty.NullVal(cty.String) and cty.NullVal(cty.Number) must produce different
+	// cache keys; before the fix both encoded to "x=null\n".
+	k1 := canonicalInputsKey(map[string]cty.Value{"x": cty.NullVal(cty.String)})
+	k2 := canonicalInputsKey(map[string]cty.Value{"x": cty.NullVal(cty.Number)})
+	if k1 == k2 {
+		t.Errorf("null(string) and null(number) produced the same cache key: %q", k1)
+	}
+}
+
+func TestEvaluateModule_LaterSiblingForwardDepNotDropped(t *testing.T) {
+	// Module B (second) references module C (third, forward dep) as input.
+	// Module A (first) has no outputs. Without seeding moduleOutputs from the
+	// pre-pass, A's first iteration would drop C's pre-pass value from evalCtx,
+	// leaving B with an unknown input.
+	root := t.TempDir()
+
+	writeModule(t, root, "a", map[string]string{
+		"main.tf": `resource "r" "a" { value = "a-only" }`,
+	})
+	writeModule(t, root, "b", map[string]string{
+		"main.tf": `
+variable "x" {}
+resource "aws_s3_bucket" "r" { bucket = var.x }
+`,
+	})
+	writeModule(t, root, "c", map[string]string{
+		"main.tf": `output "val" { value = "concrete" }`,
+	})
+
+	dir := writeModule(t, root, "root", map[string]string{
+		"main.tf": `
+module "a" {
+  source = "../a"
+}
+module "b" {
+  source = "../b"
+  x      = module.c.val
+}
+module "c" {
+  source = "../c"
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	r := findResource(t, resources, "aws_s3_bucket", "r")
+	requireString(t, r.Attributes, "bucket", "concrete")
+}
+
+func TestEvaluateModule_SiblingModuleForwardDependency(t *testing.T) {
+	// Module A inputs reference module C's output (forward dependency).
+	// Module B inputs reference module A's output.
+	// Without incrementally updating evalCtx in evaluateLocalModuleBlocks, B
+	// sees the stale pre-pass value of module.a.val (unknown) and caches a
+	// stale result.
+	root := t.TempDir()
+
+	writeModule(t, root, "a", map[string]string{
+		"main.tf": `
+variable "x" {}
+output "val" { value = var.x }
+`,
+	})
+	writeModule(t, root, "b", map[string]string{
+		"main.tf": `
+variable "y" {}
+resource "aws_s3_bucket" "r" { bucket = var.y }
+`,
+	})
+	writeModule(t, root, "c", map[string]string{
+		"main.tf": `
+output "val" { value = "concrete" }
+`,
+	})
+
+	dir := writeModule(t, root, "root", map[string]string{
+		"main.tf": `
+module "a" {
+  source = "../a"
+  x      = module.c.val
+}
+module "b" {
+  source = "../b"
+  y      = module.a.val
+}
+module "c" {
+  source = "../c"
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	r := findResource(t, resources, "aws_s3_bucket", "r")
+	requireString(t, r.Attributes, "bucket", "concrete")
+}
+
+func TestEvaluateModule_FourHopOutputResolvesCorrectly(t *testing.T) {
+	// The final evalResourceBlocks result must be injected into evalCtx before
+	// outputs are computed, otherwise a 4-hop chain's last value is unknown.
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "r" "a" { value = "x" }
+resource "r" "b" { value = r.a.value }
+resource "r" "c" { value = r.b.value }
+resource "r" "d" { value = r.c.value }
+
+output "o" { value = r.d.value }
+`,
+	})
+
+	_, outputs, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	o, ok := outputs["o"]
+	if !ok {
+		t.Fatal("output 'o' not found")
+	}
+	if !o.IsKnown() || o.AsString() != "x" {
+		t.Errorf("output 'o' = %s, want 'x'", o.GoString())
+	}
+}
+
+func TestEvaluateModule_ModuleInputReferenceSiblingResource(t *testing.T) {
+	// module "child" { acl = aws_kms_key.key.description } — the module input
+	// references a sibling resource. Without the early pre-injection pass the input
+	// would evaluate to unknown and the child module's resource would never see it.
+	root := t.TempDir()
+
+	writeModule(t, root, "child", map[string]string{
+		"main.tf": `
+variable "acl" { type = string }
+
+resource "aws_s3_bucket_acl" "a" {
+  acl = var.acl
+}
+`,
+	})
+
+	dir := writeModule(t, root, "root", map[string]string{
+		"main.tf": `
+resource "aws_kms_key" "key" {
+  description = "sibling-value"
+}
+
+module "child" {
+  source = "../child"
+  acl    = aws_kms_key.key.description
+}
+`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket_acl", "a")
+	requireString(t, r.Attributes, "acl", "sibling-value")
+}
+
+func TestEvaluateModule_LocalResolvesAfterFinalRefPass(t *testing.T) {
+	// local.o = top.a.value, which only resolves on the last ref pass (3-hop chain).
+	// Without refreshing locals after the final injection, output "o" stays unknown.
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "leaf" "c" { value = "resolved" }
+resource "mid"  "b" { value = leaf.c.value }
+resource "top"  "a" { value = mid.b.value }
+
+locals {
+  o = top.a.value
+}
+
+output "o" { value = local.o }
+`,
+	})
+
+	_, outputs, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	v, ok := outputs["o"]
+	if !ok {
+		t.Fatal("output 'o' missing")
+	}
+	if !v.IsKnown() || v.Type() != cty.String || v.AsString() != "resolved" {
+		t.Fatalf("output 'o' = %v, want cty.StringVal(\"resolved\")", v)
+	}
+}
+
+func TestEvaluateModule_MemoizationSiblingPrepassAndMainLoop(t *testing.T) {
+	// When module B uses module A's output as an input the evaluator runs a
+	// sibling pre-pass and then a main loop. With memoization the pre-pass result
+	// is reused by the main loop: each child module is evaluated exactly once.
+	root := t.TempDir()
+
+	writeModule(t, root, "shared", map[string]string{
+		"main.tf": `
+variable "tag" { type = string }
+
+output "label" { value = "tag-${var.tag}" }
+
+resource "aws_s3_bucket" "b" {
+  bucket = "shared-${var.tag}"
+}
+`,
+	})
+
+	rootDir := writeModule(t, root, "root", map[string]string{
+		"main.tf": `
+module "a" {
+  source = "../shared"
+  tag    = "alpha"
+}
+
+module "b" {
+  source = "../shared"
+  tag    = module.a.label
+}
+`,
+	})
+
+	ev := New()
+	resources, _, _, err := ev.EvaluateModule(context.Background(), rootDir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	// Two module instances → two aws_s3_bucket resources with known values.
+	var buckets []string
+	for _, r := range resources {
+		if r.Type == "aws_s3_bucket" {
+			if v := r.Attributes["bucket"]; v.IsKnown() && v.Type() == cty.String {
+				buckets = append(buckets, v.AsString())
+			}
+		}
+	}
+	if len(buckets) != 2 {
+		t.Fatalf("got %d aws_s3_bucket resources, want 2: %v", len(buckets), buckets)
+	}
+
+	// The pre-pass updates evalCtx between siblings, so module.b's inputs are
+	// resolved the same way in both the pre-pass and the main loop → 2 child
+	// cache entries plus 1 for the root = 3 total. No duplicate evaluations.
+	if got := len(ev.cache); got != 3 {
+		t.Fatalf("cache size = %d, want 3 (2 child instances + root)", got)
+	}
+}
+
+func TestEvaluateModule_MemoizationAcrossRoots(t *testing.T) {
+	// Two root modules calling the same child with the same inputs share a cache
+	// entry; two roots with different inputs get independent correct results.
+	root := t.TempDir()
+
+	writeModule(t, root, "child", map[string]string{
+		"main.tf": `
+variable "name" { type = string }
+
+resource "aws_s3_bucket" "b" {
+  bucket = var.name
+}
+`,
+	})
+
+	rootA := writeModule(t, root, "rootA", map[string]string{
+		"main.tf": `
+module "m" {
+  source = "../child"
+  name   = "bucket-a"
+}
+`,
+	})
+
+	rootB := writeModule(t, root, "rootB", map[string]string{
+		"main.tf": `
+module "m" {
+  source = "../child"
+  name   = "bucket-b"
+}
+`,
+	})
+
+	ev := New()
+
+	resA, _, _, err := ev.EvaluateModule(context.Background(), rootA, nil)
+	if err != nil {
+		t.Fatalf("rootA: %v", err)
+	}
+	resB, _, _, err := ev.EvaluateModule(context.Background(), rootB, nil)
+	if err != nil {
+		t.Fatalf("rootB: %v", err)
+	}
+
+	findBucket := func(resources []ResolvedResource) string {
+		t.Helper()
+		for _, r := range resources {
+			if r.Type == "aws_s3_bucket" {
+				if v := r.Attributes["bucket"]; v.IsKnown() && v.Type() == cty.String {
+					return v.AsString()
+				}
+			}
+		}
+		t.Fatal("aws_s3_bucket not found")
+		return ""
+	}
+
+	if got := findBucket(resA); got != "bucket-a" {
+		t.Fatalf("rootA bucket = %q, want bucket-a", got)
+	}
+	if got := findBucket(resB); got != "bucket-b" {
+		t.Fatalf("rootB bucket = %q, want bucket-b", got)
+	}
+
+	// Two roots with different inputs → 2 child entries (no cross-root collision)
+	// plus 2 root entries = 4 cache entries total.
+	if got := len(ev.cache); got != 4 {
+		t.Fatalf("cache size = %d, want 4 (2 child + 2 root entries)", got)
+	}
 }
 
 func TestEvaluateModule_SingleNestedBlockIsSingletonTuple(t *testing.T) {

--- a/pkg/parser/terraform/tfeval/foreach_emptykey_ref_test.go
+++ b/pkg/parser/terraform/tfeval/foreach_emptykey_ref_test.go
@@ -1,0 +1,29 @@
+package tfeval
+
+import (
+	"context"
+	"testing"
+)
+
+func TestForEachEmptyStringKeyCrossRef(t *testing.T) {
+	root := t.TempDir()
+	// A plain resource references the empty-key instance via aws_s3_bucket.b[""].bucket
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "b" {
+  for_each = { "" = "val-empty" }
+  bucket   = each.value
+}
+
+resource "aws_iam_policy" "p" {
+  name = aws_s3_bucket.b[""].bucket
+}
+`,
+	})
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	r := findResource(t, resources, "aws_iam_policy", "p")
+	requireString(t, r.Attributes, "name", "val-empty")
+}

--- a/pkg/parser/terraform/tfeval/null_cache_test.go
+++ b/pkg/parser/terraform/tfeval/null_cache_test.go
@@ -1,0 +1,15 @@
+package tfeval
+
+import (
+	"testing"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestNullTypeCacheCollision(t *testing.T) {
+	// null string and null number produce the same cache key fragment
+	keyStr := canonicalInputsKey(map[string]cty.Value{"x": cty.NullVal(cty.String)})
+	keyNum := canonicalInputsKey(map[string]cty.Value{"x": cty.NullVal(cty.Number)})
+	if keyStr == keyNum {
+		t.Errorf("null-string and null-number produce the same cache key: %q", keyStr)
+	}
+}

--- a/pkg/parser/terraform/tfeval/parse.go
+++ b/pkg/parser/terraform/tfeval/parse.go
@@ -239,10 +239,12 @@ func parseResourceInstanceKey(name string) (base, key string, isCount, expanded 
 		}
 	}
 	// count: name ends with [N] where N is an integer
-	if idx := strings.LastIndex(name, "["); idx >= 0 {
-		inner := strings.TrimSuffix(name[idx+1:], "]")
-		if _, err := strconv.Atoi(inner); err == nil {
-			return name[:idx], inner, true, true
+	if strings.HasSuffix(name, "]") {
+		if idx := strings.LastIndex(name, "["); idx >= 0 {
+			inner := name[idx+1 : len(name)-1]
+			if _, err := strconv.Atoi(inner); err == nil {
+				return name[:idx], inner, true, true
+			}
 		}
 	}
 	return name, "", false, false

--- a/pkg/parser/terraform/tfeval/parse.go
+++ b/pkg/parser/terraform/tfeval/parse.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -217,6 +218,44 @@ func LoadRootVars(dir string) map[string]cty.Value {
 		}
 	}
 	return out
+}
+
+// parseResourceInstanceKey splits an expanded resource Name into its base label, instance key,
+// whether the key is a count index (true) vs a for_each string key (false), and whether the
+// name contained any expansion brackets at all.
+//   - "foo"        → ("foo", "",    false, false) — no expansion
+//   - "foo[0]"     → ("foo", "0",   true,  true)  — count
+//   - `foo["bar"]` → ("foo", "bar", false, true)  — for_each (including empty-string key)
+func parseResourceInstanceKey(name string) (base, key string, isCount, expanded bool) {
+	// for_each: name ends with `"]` and contains `["`
+	if strings.HasSuffix(name, `"]`) {
+		if idx := strings.LastIndex(name, `["`); idx >= 0 {
+			quoted := name[idx+1 : len(name)-1] // `"bar"`
+			unquoted, err := strconv.Unquote(quoted)
+			if err != nil {
+				unquoted = strings.Trim(quoted, `"`)
+			}
+			return name[:idx], unquoted, false, true
+		}
+	}
+	// count: name ends with [N] where N is an integer
+	if idx := strings.LastIndex(name, "["); idx >= 0 {
+		inner := strings.TrimSuffix(name[idx+1:], "]")
+		if _, err := strconv.Atoi(inner); err == nil {
+			return name[:idx], inner, true, true
+		}
+	}
+	return name, "", false, false
+}
+
+// ResourceBaseName strips any count/for_each instance suffix from a resource Name
+// (e.g. "k[0]" → "k", `k["dev"]` → "k"). Used by callers that need the bare label
+// for rule matching or source-line lookups.
+func ResourceBaseName(name string) string {
+	if idx := strings.IndexByte(name, '['); idx >= 0 {
+		return name[:idx]
+	}
+	return name
 }
 
 func blockLabel(b *hclsyntax.Block) string {


### PR DESCRIPTION
## Motivation

This builds on [PR #192](https://github.com/DataDog/datadog-iac-scanner/pull/192), which instantiates local Terraform modules into the scan payload. Two gaps from that rollout still weakened rules: known `count` / `for_each` only disabled the zero case while a single materialized block left `count.index` and `each.*` unknown, and sibling `resource` references such as `aws_kms_key.x.description` stayed unknown because nothing in the eval context represented evaluated resource attributes.

**Before / after.** A module with `count = 3` and `bucket = "logs-${count.index}"` used to yield one bucket attribute that stayed unknown; it now yields up to three instances with concrete names when the count is known. A resource that sets an attribute from another resource in the same file can resolve when that attribute is known from the prior evaluation pass.

**JIRA ticket:** [K9CODESEC-2307](https://datadoghq.atlassian.net/browse/K9CODESEC-2307)

## Changes

**tfeval (expansion).** Known numeric `count` expands into separate instances (cap 10) with per-instance `count.index` and names like `this[0]`. Known `for_each` over map/object/set expands one instance per element (same cap) with `each.key` / `each.value`. `count = 0` and `for_each = {}` still emit no instances. Unknown expansions keep one placeholder instance so attributes remain evaluable.

**tfeval (same-module references).** Up to three passes evaluate resources, inject resolved attributes under `evalCtx.Variables[<resource type>][<name>]`, then re-run the locals fixed-point so references and locals can pick up values from sibling blocks.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. Run `go test ./pkg/parser/terraform/tfeval/... ./pkg/engine/...`.
2. Optional: scan a fixture where a local module uses literal `count` or `for_each` and confirm instantiated synthetic resources reflect per-index or per-key values where rules read those attributes.

## Blast Radius

Terraform scans that use local module instantiation: synthetic documents may include more than one resolved resource per block and instance-style names in the inner resource map. Remote and registry `module` call sites and non-local-module paths are unchanged.

## Additional Notes

**Follow-ups / limits.** `data` sources are still not evaluated; `count` / `for_each` that are not known at eval time still use a single placeholder instance; expansion and ref passes are intentionally capped (`maxCountExpansion`, `resourceRefPasses`); reference lookup registers one object per bare resource name when multiple instances share a type and label.

I submit this contribution under the Apache-2.0 license.


[K9CODESEC-2307]: https://datadoghq.atlassian.net/browse/K9CODESEC-2307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ