### PR TITLE
Add per-phase CPU/MEM profiling instrumentation behind a --profiling flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,21 @@ make build
 ./bin/datadog-iac-scanner scan -p <path> -o <output-dir> -t Terraform
 ```
 
+## Profiling
+
+`--profiling` is a global flag (`CPU` or `MEM`). It profiles each major scan phase and writes a pprof file per phase to the system temp dir for `go tool pprof`. For `CPU` it logs the total CPU time per phase. For `MEM` it logs the live heap (`inuse_space`) at the moment each phase ends — a whole-process snapshot, so the numbers form a footprint high-water progression across the run rather than memory attributable to a phase alone.
+
+```bash
+./bin/datadog-iac-scanner --profiling CPU scan -p <path>   # or MEM
+```
+
+To isolate a single phase's contribution, diff its pprof file against the previous phase's (the file paths are printed at info level):
+
+```bash
+go tool pprof -base <prev-phase>.prof <cur-phase>.prof   # phase-only delta
+go tool pprof -sample_index=alloc_space <cur-phase>.prof # total allocations (churn)
+```
+
 ## Go lint (before commit or push)
 
 Any time you change Go code under `pkg/`, `cmd/`, or elsewhere in this module, **run golangci-lint locally before you commit or push**, using the same flags as the PR `lint` job (`.github/workflows/go-ci.yml`), so CI does not fail only after opening the PR.

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -237,6 +237,7 @@ core,github.com/google/go-cmp/cmp/internal/diff,BSD-3-Clause,Copyright (c) 2017 
 core,github.com/google/go-cmp/cmp/internal/flags,BSD-3-Clause,Copyright (c) 2017 The Go Authors. All rights reserved.
 core,github.com/google/go-cmp/cmp/internal/function,BSD-3-Clause,Copyright (c) 2017 The Go Authors. All rights reserved.
 core,github.com/google/go-cmp/cmp/internal/value,BSD-3-Clause,Copyright (c) 2017 The Go Authors. All rights reserved.
+core,github.com/google/pprof/profile,Apache-2.0,Andrew Hunter <andrewhhunter@gmail.com> | Google Inc. | Hyoun Kyu Cho <netforce@google.com> | Martin Spier <spiermar@gmail.com> | Raul Silvera <rsilvera@google.com> | Taco de Wolff <tacodewolff@gmail.com> | Tipp Moseley <tipp@google.com>
 core,github.com/google/shlex,Apache-2.0,Copyright 2012 Google Inc.
 core,github.com/google/uuid,BSD-3-Clause,"Copyright (c) 2009,2014 Google Inc. All rights reserved | Paul Borman <borman@google.com> | bmatsuo | cd1 | dansouza | dsymonds | jboverfelt | shawnps | theory | wallclockbuilder"
 core,github.com/gookit/color,MIT,Copyright (c) 2016 inhere

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/metrics"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	cli "github.com/urfave/cli/v3"
@@ -46,6 +47,10 @@ func main() {
 				Usage: "minimum log level to display (trace, debug, info, warn, error, fatal, panic, disable)",
 				Value: "error",
 			},
+			&cli.StringFlag{
+				Name:  "profiling",
+				Usage: "enables profiling; one of CPU or MEM (results logged at info level)",
+			},
 		},
 		Before: applyGlobalOptions,
 	}
@@ -72,6 +77,9 @@ func applyGlobalOptions(ctx context.Context, c *cli.Command) (context.Context, e
 		return nil, fmt.Errorf("error parsing the log level: %w", err)
 	}
 	zerolog.SetGlobalLevel(level)
+	if err := metrics.InitializeMetrics(c.String("profiling")); err != nil {
+		return nil, err
+	}
 	return log.Logger.WithContext(ctx), nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/emicklei/proto v1.14.3
 	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1
 	github.com/golang/mock v1.6.0
+	github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6
 	github.com/google/uuid v1.6.0
 	github.com/gookit/color v1.6.0
 	github.com/hashicorp/hcl v1.0.0

--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/DataDog/datadog-iac-scanner/internal/metrics"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/report"
 	"github.com/hashicorp/hcl"
@@ -80,6 +81,8 @@ func FileAnalyzer(path string) (string, error) {
 // them, matching the CLI counters and avoiding leaks into json/csv/gitlab/etc.
 func GenerateReport(ctx context.Context, path, filename string, body interface{}, formats []string, sciInfo *model.SCIInfo) error {
 	log.Debug().Msgf("helpers.GenerateReport()")
+	metrics.Metric.Start("generate_report")
+	defer metrics.Metric.Stop()
 
 	nonSarifBody := body
 	if summary, ok := body.(*model.Summary); ok {

--- a/internal/metrics/cpu_metric.go
+++ b/internal/metrics/cpu_metric.go
@@ -1,0 +1,65 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package metrics
+
+import (
+	"bytes"
+	"runtime/pprof"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+type cpuMetric struct {
+	close   func()
+	writer  *bytes.Buffer
+	idx     int
+	typeMap map[string]float64
+}
+
+var cpuMap = map[string]float64{
+	"ns":  float64(time.Nanosecond),
+	"us":  float64(time.Microsecond),
+	"ms":  float64(time.Millisecond),
+	"s":   float64(time.Second),
+	"hrs": float64(time.Hour),
+}
+
+// Start - start gathering metrics for CPU usage
+func (c *cpuMetric) start() {
+	c.idx = 1
+	c.typeMap = cpuMap
+
+	c.writer = bytes.NewBuffer([]byte{})
+
+	if err := pprof.StartCPUProfile(c.writer); err != nil {
+		log.Error().Msgf("failed to write cpu profile")
+	}
+	c.close = func() {
+		pprof.StopCPUProfile()
+	}
+}
+
+// Stop - stop gathering metrics for CPU usage. The collected buffer is written
+// to a file by Metrics.writeProfile.
+func (c *cpuMetric) stop() {
+	c.close()
+}
+
+// getWriter returns the profile buffer
+func (c *cpuMetric) getWriter() *bytes.Buffer {
+	return c.writer
+}
+
+// getIndex returns the cpu sample index
+func (c *cpuMetric) getIndex() int {
+	return c.idx
+}
+
+// getMap returns the map used to format total value
+func (c *cpuMetric) getMap() map[string]float64 {
+	return c.typeMap
+}

--- a/internal/metrics/mem_metric.go
+++ b/internal/metrics/mem_metric.go
@@ -43,9 +43,6 @@ func (c *memMetric) start() {
 	c.idx = 3 // inuse_space in the heap profile
 	c.typeMap = memoryMap
 
-	old := runtime.MemProfileRate
-	runtime.MemProfileRate = 4096
-
 	c.writer = bytes.NewBuffer([]byte{})
 	c.close = func() {
 		// Force a GC so inuse_space reflects live memory rather than uncollected
@@ -54,7 +51,6 @@ func (c *memMetric) start() {
 		if err := pprof.Lookup("heap").WriteTo(c.writer, 0); err != nil {
 			log.Error().Msgf("failed to write mem profile")
 		}
-		runtime.MemProfileRate = old
 	}
 }
 

--- a/internal/metrics/mem_metric.go
+++ b/internal/metrics/mem_metric.go
@@ -1,0 +1,80 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package metrics
+
+import (
+	"bytes"
+	"runtime"
+	"runtime/pprof"
+
+	"github.com/rs/zerolog/log"
+)
+
+type memMetric struct {
+	close   func()
+	writer  *bytes.Buffer
+	idx     int
+	typeMap map[string]float64
+}
+
+const (
+	b  = 1
+	kb = 10
+	mb = 20
+	gb = 30
+	tb = 40
+	pb = 50
+)
+
+var memoryMap = map[string]float64{
+	"B":  float64(b),
+	"kB": float64(b << kb),
+	"MB": float64(b << mb),
+	"GB": float64(b << gb),
+	"TB": float64(b << tb),
+	"PB": float64(b << pb),
+}
+
+// Start - start gathering metrics for Memory usage
+func (c *memMetric) start() {
+	c.idx = 3 // inuse_space in the heap profile
+	c.typeMap = memoryMap
+
+	old := runtime.MemProfileRate
+	runtime.MemProfileRate = 4096
+
+	c.writer = bytes.NewBuffer([]byte{})
+	c.close = func() {
+		// Force a GC so inuse_space reflects live memory rather than uncollected
+		// garbage at the moment the snapshot is taken.
+		runtime.GC()
+		if err := pprof.Lookup("heap").WriteTo(c.writer, 0); err != nil {
+			log.Error().Msgf("failed to write mem profile")
+		}
+		runtime.MemProfileRate = old
+	}
+}
+
+// Stop - stop gathering metrics for Memory usage. The collected buffer is
+// written to a file by Metrics.writeProfile.
+func (c *memMetric) stop() {
+	c.close()
+}
+
+// getWriter returns the profile buffer
+func (c *memMetric) getWriter() *bytes.Buffer {
+	return c.writer
+}
+
+// getIndex returns the memory sample index
+func (c *memMetric) getIndex() int {
+	return c.idx
+}
+
+// getMap returns the map used to format total value
+func (c *memMetric) getMap() map[string]float64 {
+	return c.typeMap
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -67,6 +68,9 @@ func InitializeMetrics(metric string) error {
 		Metric.metricsID = profileCPU
 		Metric.Disable = false
 	case profileMEM:
+		// Set once before any allocation so pprof can treat the rate as constant
+		// for the program lifetime, as the runtime docs require.
+		runtime.MemProfileRate = 4096
 		Metric.metric = &memMetric{}
 		Metric.metricsID = profileMEM
 		Metric.Disable = false

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,203 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package metrics
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/google/pprof/profile"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	profileCPU = "cpu"
+	profileMEM = "mem"
+)
+
+var (
+	// Metric is the global metrics object
+	Metric = &Metrics{
+		Disable: true,
+	}
+)
+
+// Start - starts gathering metrics based on the type of metrics and writes metrics to string
+// Stop - stops gathering metrics for the type of metrics specified
+type metricType interface {
+	start()
+	stop()
+	getWriter() *bytes.Buffer
+	getIndex() int
+	getMap() map[string]float64
+}
+
+// Metrics - structure to keep information relevant to the metrics calculation
+// Disable - disables metric calculations
+type Metrics struct {
+	metric    metricType
+	metricsID string
+	location  string
+	Disable   bool
+	total     int64
+
+	// The global pprof profiler permits only one active profile at a time, so
+	// Start/Stop are serialized and nested regions are subsumed by the
+	// outermost one. mu guards depth and the start/stop transitions.
+	mu    sync.Mutex
+	depth int
+}
+
+// InitializeMetrics - creates a new instance of a Metrics based on the type of
+// metrics specified.
+func InitializeMetrics(metric string) error {
+	Metric.total = 0
+	Metric.depth = 0
+
+	switch strings.ToLower(metric) {
+	case profileCPU:
+		Metric.metric = &cpuMetric{}
+		Metric.metricsID = profileCPU
+		Metric.Disable = false
+	case profileMEM:
+		Metric.metric = &memMetric{}
+		Metric.metricsID = profileMEM
+		Metric.Disable = false
+	case "":
+		Metric.Disable = true
+	default:
+		Metric.Disable = true
+		return fmt.Errorf("unknown metric: %s (available metrics: CPU, MEM)", metric)
+	}
+
+	return nil
+}
+
+// Start - starts gathering metrics for the location specified. A profile is only
+// started for the outermost region; nested Start calls are counted so the
+// matching Stop calls stay balanced but do not start a second profile.
+func (m *Metrics) Start(location string) {
+	if m.Disable {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.depth++
+	if m.depth > 1 {
+		log.Debug().Msgf("Skipping nested %s profiling for %s (already profiling %s)",
+			m.metricsID, location, m.location)
+		return
+	}
+
+	log.Debug().Msgf("Started %s profiling for %s", m.metricsID, location)
+	m.location = location
+	m.metric.start()
+}
+
+// Stop - stops gathering metrics and logs the result. Only the Stop that closes
+// the outermost region finalizes the profile.
+func (m *Metrics) Stop() {
+	if m.Disable {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.depth == 0 {
+		return // unbalanced Stop; nothing to finalize
+	}
+	m.depth--
+	if m.depth > 0 {
+		return // still inside an outer region
+	}
+
+	log.Debug().Msgf("Stopped %s profiling for %s", m.metricsID, m.location)
+	m.metric.stop()
+	m.writeProfile()
+
+	p, err := profile.Parse(m.metric.getWriter())
+	if err != nil {
+		log.Error().Msgf("failed to parse profile on %s: %s", m.location, err)
+		return
+	}
+	if err := p.CheckValid(); err != nil {
+		log.Error().Msgf("invalid profile on %s: %s", m.location, err)
+		return
+	}
+
+	total := getTotal(p, m.metric.getIndex())
+	formatted := m.formatTotal(total, m.metric.getMap())
+	// The MEM total is a whole-process live-heap snapshot taken when the phase
+	// ends, not memory attributable to the phase alone, so word it as "live heap
+	// after" rather than "usage for".
+	if m.metricsID == profileMEM {
+		log.Info().Msgf("Total MEM live heap after %s: %s", m.location, formatted)
+	} else {
+		log.Info().Msgf("Total %s usage for %s: %s", strings.ToUpper(m.metricsID), m.location, formatted)
+	}
+	m.total = total
+}
+
+// writeProfile writes the collected profile buffer to a file in the system temp
+// dir so it can be inspected with `go tool pprof`.
+func (m *Metrics) writeProfile() {
+	f, err := os.CreateTemp("", fmt.Sprintf("iac-%s-*.prof", m.metricsID))
+	if err != nil {
+		log.Error().Msgf("failed to create %s profile file: %s", m.metricsID, err)
+		return
+	}
+	name := f.Name()
+	_, writeErr := f.Write(m.metric.getWriter().Bytes())
+	closeErr := f.Close()
+	if writeErr != nil {
+		log.Error().Msgf("failed to write %s profile file: %s", m.metricsID, writeErr)
+		return
+	}
+	if closeErr != nil {
+		log.Error().Msgf("failed to close %s profile file: %s", m.metricsID, closeErr)
+		return
+	}
+	log.Info().Msgf("%s profile written to %s — view with: go tool pprof %s", m.metricsID, name, name)
+}
+
+// getTotal sums the sample values at idx for the whole profile: the total CPU
+// time for a CPU profile, or the live heap (inuse_space) for a MEM profile. Heap
+// sample values are non-negative, so a plain sum is the process-wide total.
+func getTotal(prof *profile.Profile, idx int) int64 {
+	var total int64
+	for _, sample := range prof.Sample {
+		total += sample.Value[idx]
+	}
+
+	return total
+}
+
+// formatTotal parses total value into a human readable way
+func (m *Metrics) formatTotal(b int64, typeMap map[string]float64) string {
+	value := float64(b)
+	var formatter float64
+	var measure string
+	for k, u := range typeMap {
+		if u >= formatter && (value/u) >= 1.0 {
+			formatter = u
+			measure = k
+		}
+	}
+
+	metric := value / formatter
+	if math.IsNaN(metric) {
+		metric = 0
+	}
+
+	return fmt.Sprintf("%.2f%s", metric, measure)
+}

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"unicode"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/metrics"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -299,6 +300,8 @@ var defaultConfigFiles = []string{"pnpm-lock.yaml"}
 func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 	contextLogger := logger.FromContext(ctx)
 	// start metrics for file analyzer
+	metrics.Metric.Start("file_type_analyzer")
+	defer metrics.Metric.Stop()
 	returnAnalyzedPaths := model.AnalyzedPaths{
 		Types:       make([]string, 0),
 		Exc:         make([]string, 0),

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -10,6 +10,7 @@ package scan
 import (
 	"context"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/metrics"
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
@@ -72,6 +73,7 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 
 	contextLogger.Info().Msgf("Preparing to inspect query source %v", querySource)
 
+	metrics.Metric.Start("get_queries")
 	inspector, err := engine.NewInspector(ctx,
 		querySource,
 		engine.DefaultVulnerabilityBuilder,
@@ -87,6 +89,7 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		c.ScanParams.KicsComputeNewSimID,
 		c.ScanParams.FlagEvaluator,
 	)
+	metrics.Metric.Stop()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/metrics"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/runner"
@@ -24,6 +25,7 @@ func PrepareAndScan(
 	services serviceSlice,
 	flagEvaluator featureflags.FlagEvaluator,
 ) error {
+	metrics.Metric.Start("prepare_sources")
 	var wg sync.WaitGroup
 	wgDone := make(chan bool)
 	errCh := make(chan error)
@@ -44,16 +46,21 @@ func PrepareAndScan(
 
 	select {
 	case <-ctx.Done():
+		metrics.Metric.Stop()
 		return ctx.Err()
 	case <-wgDone:
+		metrics.Metric.Stop()
 		return StartScan(ctx, scanID, services)
 	case err := <-errCh:
+		metrics.Metric.Stop()
 		return err
 	}
 }
 
 // StartScan will run concurrent scans by parser
 func StartScan(ctx context.Context, scanID string, services serviceSlice) error {
+	defer metrics.Metric.Stop()
+	metrics.Metric.Start("start_scan")
 	contextLogger := logger.FromContext(ctx)
 	var wg sync.WaitGroup
 	wgDone := make(chan bool)


### PR DESCRIPTION
## Motivation

Add KICS-aligned CPU and memory profiling support to help investigate scanner performance and memory footprint by scan phase.

JIRA Ticket [K9CODESEC-2331](https://datadoghq.atlassian.net/browse/K9CODESEC-2331)

## Changes

- Added global `--profiling CPU|MEM` support.
- Added profiling around major scan phases, including query loading, source preparation, scan execution, analysis, and report generation.
- Based the implementation on KICS metrics/profiling behavior.
- Improved on KICS by writing per-phase pprof files to the system temp directory for direct `go tool pprof` inspection.
- Improved MEM profiling clarity by logging live heap after each phase, since heap profiles are whole-process snapshots rather than phase-local allocation totals.
- Updated profiling documentation with `go tool pprof` examples.

## Author Checklist

- [x] I have reviewed my own PR.
- [X] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [X] I have updated any relevant documentation (if applicable).

## QA Instruction

Run a scan with profiling enabled:

```bash
./bin/datadog-iac-scanner --profiling CPU scan -p <path>
./bin/datadog-iac-scanner --profiling MEM scan -p <path>
```

Verify that phase totals are logged and that pprof files are written to the temp directory. For MEM, confirm logs say `Total MEM live heap after ...` and inspect profiles with `go tool pprof`.

## Blast Radius

Limited to Datadog IaC Scanner CLI profiling behavior and related documentation. Normal scans are unchanged unless `--profiling` is enabled.

## Additional Notes

No new unit tests were added; this change is exercised through CLI profiling runs and produces runtime pprof artifacts/log output.

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-2331]: https://datadoghq.atlassian.net/browse/K9CODESEC-2331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ