### PR TITLE
[Terraform plan] tfplan parser losing track of resources

### DIFF
--- a/pkg/parser/json/parser.go
+++ b/pkg/parser/json/parser.go
@@ -56,10 +56,15 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	jLine := initializeJSONLine(resolved)
 	jsonDoc := jLine.setLineInfo(r)
 
+	if !looksLikeTerraformPlan(fileContent) {
+		// JSON is not a tf plan
+		return resolved, []model.Document{jsonDoc}, nil, resolvedFiles, nil
+	}
+
 	// Try to parse JSON as Terraform plan
 	tfPlan, err := parseTFPlan(jsonDoc)
 	if err != nil {
-		// JSON is not a tf plan
+		// Fallback to regular json
 		return resolved, []model.Document{jsonDoc}, nil, resolvedFiles, nil
 	}
 

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -7,6 +7,7 @@ package json
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	hcl_plan "github.com/hashicorp/terraform-json"
@@ -66,18 +67,67 @@ func readPlan(plan *hcl_plan.Plan) model.Document {
 }
 
 // readModule will iterate over all planned_value getting the information required
+// It recursively processes all modules and accumulates resources without losing data
 func (kp *TFPlan) readModule(module *hcl_plan.StateModule) {
-	// initialize all the types interfaces
+	kp.readModuleWithAddress(module, "")
+}
+
+// readModuleWithAddress recursively processes a module and its children with full address path
+// to ensure unique resource identification across the module tree
+func (kp *TFPlan) readModuleWithAddress(module *hcl_plan.StateModule, moduleAddress string) {
+	// Process all resources in this module
 	for _, resource := range module.Resources {
-		convNamedRes := make(map[string]TFPlanNamedResource)
-		kp.Resource[resource.Type] = convNamedRes
-	}
-	// fill in all the types interfaces
-	for _, resource := range module.Resources {
-		kp.Resource[resource.Type][resource.Name] = resource.AttributeValues
+		// Ensure the resource type map exists - accumulate, don't reinitialize!
+		if kp.Resource[resource.Type] == nil {
+			kp.Resource[resource.Type] = make(map[string]TFPlanNamedResource)
+		}
+
+		// Build resource key with module path for child modules
+		// Root module resources keep simple names for backward compatibility
+		// Child module resources are prefixed with their module path
+		resourceKey := resource.Name
+		if moduleAddress != "" {
+			resourceKey = moduleAddress + "." + resource.Name
+		}
+
+		// Handle count and for_each: append the index to the resource key
+		// This ensures each instance gets a unique key
+		if resource.Index != nil {
+			resourceKey = formatResourceKeyWithIndex(resourceKey, resource.Index)
+		}
+
+		// Accumulate the resource into the existing type map
+		kp.Resource[resource.Type][resourceKey] = resource.AttributeValues
 	}
 
+	// Recursively process child modules with their full address path
 	for _, childModule := range module.ChildModules {
-		kp.readModule(childModule)
+		// The childModule.Address already contains the full path from root
+		// (e.g., "module.networking" or "module.networking.module.security")
+		// So we pass it directly without combining with parent
+		kp.readModuleWithAddress(childModule, childModule.Address)
+	}
+}
+
+// formatResourceKeyWithIndex formats a resource key to include count/for_each index
+// Examples:
+//   - count: "web" + 0 -> "web[0]"
+//   - count: "web" + 2 -> "web[2]"
+//   - for_each: "bucket" + "prod" -> "bucket[\"prod\"]"
+//   - for_each: "bucket" + "staging" -> "bucket[\"staging\"]"
+func formatResourceKeyWithIndex(baseName string, index interface{}) string {
+	switch idx := index.(type) {
+	case float64:
+		// Count index (JSON numbers are float64)
+		return fmt.Sprintf("%s[%d]", baseName, int(idx))
+	case int:
+		// Count index (in case it's already an int)
+		return fmt.Sprintf("%s[%d]", baseName, idx)
+	case string:
+		// For_each index with string key
+		return fmt.Sprintf("%s[%q]", baseName, idx)
+	default:
+		// Fallback: just use the base name if we don't recognize the index type
+		return baseName
 	}
 }

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -77,6 +77,427 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want:    model.Document{},
 			wantErr: true,
 		},
+		{
+			name: "test - multi-module with same resource type",
+			args: args{
+				doc: model.Document{
+					"format_version":    "1.2",
+					"terraform_version": "1.5.0",
+					"planned_values": map[string]interface{}{
+						"root_module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_s3_bucket.main",
+									"mode":    "managed",
+									"type":    "aws_s3_bucket",
+									"name":    "main",
+									"values": map[string]interface{}{
+										"bucket": "main-bucket",
+										"acl":    "private",
+									},
+								},
+								{
+									"address": "aws_instance.web",
+									"mode":    "managed",
+									"type":    "aws_instance",
+									"name":    "web",
+									"values": map[string]interface{}{
+										"instance_type": "t2.micro",
+									},
+								},
+							},
+							"child_modules": []map[string]interface{}{
+								{
+									"address": "module.storage",
+									"resources": []map[string]interface{}{
+										{
+											"address": "module.storage.aws_s3_bucket.backup",
+											"mode":    "managed",
+											"type":    "aws_s3_bucket",
+											"name":    "backup",
+											"values": map[string]interface{}{
+												"bucket": "backup-bucket",
+												"acl":    "private",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: model.Document{
+				"resource": map[string]interface{}{
+					"aws_s3_bucket": map[string]interface{}{
+						"main": map[string]interface{}{
+							"bucket": "main-bucket",
+							"acl":    "private",
+						},
+						"module.storage.backup": map[string]interface{}{
+							"bucket": "backup-bucket",
+							"acl":    "private",
+						},
+					},
+					"aws_instance": map[string]interface{}{
+						"web": map[string]interface{}{
+							"instance_type": "t2.micro",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test - same resource name in different modules",
+			args: args{
+				doc: model.Document{
+					"format_version":    "1.2",
+					"terraform_version": "1.5.0",
+					"planned_values": map[string]interface{}{
+						"root_module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_instance.web",
+									"mode":    "managed",
+									"type":    "aws_instance",
+									"name":    "web",
+									"values": map[string]interface{}{
+										"instance_type": "t2.large",
+										"tags": map[string]interface{}{
+											"Environment": "production",
+										},
+									},
+								},
+							},
+							"child_modules": []map[string]interface{}{
+								{
+									"address": "module.staging",
+									"resources": []map[string]interface{}{
+										{
+											"address": "module.staging.aws_instance.web",
+											"mode":    "managed",
+											"type":    "aws_instance",
+											"name":    "web",
+											"values": map[string]interface{}{
+												"instance_type": "t2.micro",
+												"tags": map[string]interface{}{
+													"Environment": "staging",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: model.Document{
+				"resource": map[string]interface{}{
+					"aws_instance": map[string]interface{}{
+						"web": map[string]interface{}{
+							"instance_type": "t2.large",
+							"tags": map[string]interface{}{
+								"Environment": "production",
+							},
+						},
+						"module.staging.web": map[string]interface{}{
+							"instance_type": "t2.micro",
+							"tags": map[string]interface{}{
+								"Environment": "staging",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test - deeply nested modules",
+			args: args{
+				doc: model.Document{
+					"format_version":    "1.2",
+					"terraform_version": "1.5.0",
+					"planned_values": map[string]interface{}{
+						"root_module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_vpc.main",
+									"mode":    "managed",
+									"type":    "aws_vpc",
+									"name":    "main",
+									"values": map[string]interface{}{
+										"cidr_block": "10.0.0.0/16",
+									},
+								},
+							},
+							"child_modules": []map[string]interface{}{
+								{
+									"address": "module.networking",
+									"resources": []map[string]interface{}{
+										{
+											"address": "module.networking.aws_subnet.public",
+											"mode":    "managed",
+											"type":    "aws_subnet",
+											"name":    "public",
+											"values": map[string]interface{}{
+												"cidr_block": "10.0.1.0/24",
+											},
+										},
+									},
+									"child_modules": []map[string]interface{}{
+										{
+											"address": "module.networking.module.security",
+											"resources": []map[string]interface{}{
+												{
+													"address": "module.networking.module.security.aws_security_group.web",
+													"mode":    "managed",
+													"type":    "aws_security_group",
+													"name":    "web",
+													"values": map[string]interface{}{
+														"description": "Web traffic",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: model.Document{
+				"resource": map[string]interface{}{
+					"aws_vpc": map[string]interface{}{
+						"main": map[string]interface{}{
+							"cidr_block": "10.0.0.0/16",
+						},
+					},
+					"aws_subnet": map[string]interface{}{
+						"module.networking.public": map[string]interface{}{
+							"cidr_block": "10.0.1.0/24",
+						},
+					},
+					"aws_security_group": map[string]interface{}{
+						"module.networking.module.security.web": map[string]interface{}{
+							"description": "Web traffic",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test - multiple sibling modules with same resource types",
+			args: args{
+				doc: model.Document{
+					"format_version":    "1.2",
+					"terraform_version": "1.5.0",
+					"planned_values": map[string]interface{}{
+						"root_module": map[string]interface{}{
+							"resources": []map[string]interface{}{},
+							"child_modules": []map[string]interface{}{
+								{
+									"address": "module.app1",
+									"resources": []map[string]interface{}{
+										{
+											"address": "module.app1.aws_s3_bucket.data",
+											"mode":    "managed",
+											"type":    "aws_s3_bucket",
+											"name":    "data",
+											"values": map[string]interface{}{
+												"bucket": "app1-data",
+											},
+										},
+									},
+								},
+								{
+									"address": "module.app2",
+									"resources": []map[string]interface{}{
+										{
+											"address": "module.app2.aws_s3_bucket.data",
+											"mode":    "managed",
+											"type":    "aws_s3_bucket",
+											"name":    "data",
+											"values": map[string]interface{}{
+												"bucket": "app2-data",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: model.Document{
+				"resource": map[string]interface{}{
+					"aws_s3_bucket": map[string]interface{}{
+						"module.app1.data": map[string]interface{}{
+							"bucket": "app1-data",
+						},
+						"module.app2.data": map[string]interface{}{
+							"bucket": "app2-data",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test - count creates multiple resource instances",
+			args: args{
+				doc: model.Document{
+					"format_version":    "1.2",
+					"terraform_version": "1.5.0",
+					"planned_values": map[string]interface{}{
+						"root_module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_instance.web[0]",
+									"mode":    "managed",
+									"type":    "aws_instance",
+									"name":    "web",
+									"index":   float64(0), // JSON numbers are float64
+									"values": map[string]interface{}{
+										"instance_type": "t2.micro",
+										"tags": map[string]interface{}{
+											"Name":  "web-0",
+											"Index": float64(0),
+										},
+									},
+								},
+								{
+									"address": "aws_instance.web[1]",
+									"mode":    "managed",
+									"type":    "aws_instance",
+									"name":    "web",
+									"index":   float64(1),
+									"values": map[string]interface{}{
+										"instance_type": "t2.micro",
+										"tags": map[string]interface{}{
+											"Name":  "web-1",
+											"Index": float64(1),
+										},
+									},
+								},
+								{
+									"address": "aws_instance.web[2]",
+									"mode":    "managed",
+									"type":    "aws_instance",
+									"name":    "web",
+									"index":   float64(2),
+									"values": map[string]interface{}{
+										"instance_type": "t2.micro",
+										"tags": map[string]interface{}{
+											"Name":  "web-2",
+											"Index": float64(2),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: model.Document{
+				"resource": map[string]interface{}{
+					"aws_instance": map[string]interface{}{
+						"web[0]": map[string]interface{}{
+							"instance_type": "t2.micro",
+							"tags": map[string]interface{}{
+								"Name":  "web-0",
+								"Index": float64(0),
+							},
+						},
+						"web[1]": map[string]interface{}{
+							"instance_type": "t2.micro",
+							"tags": map[string]interface{}{
+								"Name":  "web-1",
+								"Index": float64(1),
+							},
+						},
+						"web[2]": map[string]interface{}{
+							"instance_type": "t2.micro",
+							"tags": map[string]interface{}{
+								"Name":  "web-2",
+								"Index": float64(2),
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test - for_each creates multiple resource instances",
+			args: args{
+				doc: model.Document{
+					"format_version":    "1.2",
+					"terraform_version": "1.5.0",
+					"planned_values": map[string]interface{}{
+						"root_module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_s3_bucket.data[\"prod\"]",
+									"mode":    "managed",
+									"type":    "aws_s3_bucket",
+									"name":    "data",
+									"index":   "prod",
+									"values": map[string]interface{}{
+										"bucket": "prod-data-bucket",
+										"acl":    "private",
+									},
+								},
+								{
+									"address": "aws_s3_bucket.data[\"staging\"]",
+									"mode":    "managed",
+									"type":    "aws_s3_bucket",
+									"name":    "data",
+									"index":   "staging",
+									"values": map[string]interface{}{
+										"bucket": "staging-data-bucket",
+										"acl":    "private",
+									},
+								},
+								{
+									"address": "aws_s3_bucket.data[\"dev\"]",
+									"mode":    "managed",
+									"type":    "aws_s3_bucket",
+									"name":    "data",
+									"index":   "dev",
+									"values": map[string]interface{}{
+										"bucket": "dev-data-bucket",
+										"acl":    "private",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: model.Document{
+				"resource": map[string]interface{}{
+					"aws_s3_bucket": map[string]interface{}{
+						"data[\"prod\"]": map[string]interface{}{
+							"bucket": "prod-data-bucket",
+							"acl":    "private",
+						},
+						"data[\"staging\"]": map[string]interface{}{
+							"bucket": "staging-data-bucket",
+							"acl":    "private",
+						},
+						"data[\"dev\"]": map[string]interface{}{
+							"bucket": "dev-data-bucket",
+							"acl":    "private",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Motivation

PR #194 enables Terraform plan scanning behind the `--x-terraform-plan` flag, but the tfplan parser has critical bugs that cause resource loss in multi-module plans. These bugs prevent accurate scanning of real-world Terraform plans with modules, count, or for_each.

Related: #194

## Changes

### Bug Fixes

1. **Fixed module resource loss**: Resources from child modules were overwriting root module resources of the same type
   - Root cause: `readModule` was reinitializing `kp.Resource[resource.Type]` for each module, erasing previous resources
   - Solution: Check if map exists before creating (accumulate, don't reinitialize)
   - Disambiguation: Child module resources prefixed with module path (e.g., `module.networking.subnet`)
   - Backward compatibility: Root module resources keep simple names for existing Rego queries

2. **Fixed count/for_each resource loss**: Resources using `count` or `for_each` were overwriting each other
   - Root cause: Only `resource.Name` used as key, ignoring `Index` field
   - Solution: Format keys as `name[0]`, `name[1]` for count and `name["prod"]`, `name["dev"]` for for_each
   - Added `formatResourceKeyWithIndex` function to handle both numeric and string indexes

### Test Coverage

Added 6 comprehensive test cases in `tfplan_test.go`:
- Multi-module with same resource type
- Same resource name in different modules
- Deeply nested modules (3 levels deep)
- Multiple sibling modules with same resource types
- Count creates multiple instances (3 instances)
- For_each creates multiple instances (3 environments)

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

### Test the fixes:

1. **Module resource accumulation**:
```bash
go test -v ./pkg/parser/json/... -run "TestJson_parseTFPlan/test_-_multi-module"
go test -v ./pkg/parser/json/... -run "TestJson_parseTFPlan/test_-_same_resource_name"
go test -v ./pkg/parser/json/... -run "TestJson_parseTFPlan/test_-_deeply_nested"
```

2. **Count/for_each support**:
```bash
go test -v ./pkg/parser/json/... -run "TestJson_parseTFPlan/test_-_count"
go test -v ./pkg/parser/json/... -run "TestJson_parseTFPlan/test_-_for_each"
```

3. **Full test suite**:
```bash
go test ./pkg/parser/json/...
```

### Verify Rego query compatibility:

Existing Rego queries using `split(resource, ".")[1]` patterns continue to work because root module resources maintain simple names without module prefixes.

## Blast Radius

- **Impact**: Only affects Terraform plan JSON parsing (currently gated behind `--x-terraform-plan` experimental flag)
- **Scope**: Fixes prevent data loss in scans, enabling accurate security analysis of multi-module Terraform plans
- **Compatibility**: Backward compatible with existing Rego queries

## Additional Notes

### Key Implementation Details

**Resource key formats**:
- Root module: `resource_name` (no prefix for backward compatibility)
- Child module: `module.path.resource_name`
- Count: `resource_name[0]`, `resource_name[1]`, etc.
- For_each: `resource_name["prod"]`, `resource_name["staging"]`, etc.
- Combined: `module.app.web[0]`, `module.storage.bucket["prod"]`

**Before these fixes**:
```json
{
  "resource": {
    "aws_s3_bucket": {
      "backup": {...}  // Only last module's bucket survives
    }
  }
}
```

**After these fixes**:
```json
{
  "resource": {
    "aws_s3_bucket": {
      "main": {...},  // Root module bucket
      "module.storage.backup": {...}  // Child module bucket - both preserved!
    }
  }
}
```

I submit this contribution under the Apache-2.0 license.
