### PR TITLE
[K9VULN-16354] Differentiate local module findings per caller to prevent fingerprint collisions

### DIFF
--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -276,8 +276,9 @@ func (c *Inspector) Inspect(
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("engine.Inspect()")
 
-	// Instantiate local modules into synthetic resource docs; suppress duplicate module bodies.
-	moduleDocs := c.instantiateLocalModules(ctx, files)
+	// Local modules: append synthetic file rows (ids match docs) for attribution and fingerprints.
+	moduleDocs, syntheticFiles := c.instantiateLocalModules(ctx, files)
+	files = append(files, syntheticFiles...)
 
 	// Must run before Combine: instantiateLocalModules clears suppressed file bodies in place.
 	combinedFiles := files.Combine(ctx, false)

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -29,10 +29,15 @@ import (
 // only after evaluation succeeds (see resolveModulesSafely); a panic during
 // evaluation leaves the scan input untouched rather than removing coverage
 // without a synthetic replacement.
-func (c *Inspector) instantiateLocalModules(ctx context.Context, files model.FileMetadatas) []model.Document {
-	moduleDocs, suppressed, calledDirs, ok := c.resolveModulesSafely(ctx, files)
+// instantiateLocalModules returns synthetic docs and matching FileMetadata (call chain for fingerprints).
+// Caller must append the files before Combine/ToMap.
+func (c *Inspector) instantiateLocalModules(
+	ctx context.Context,
+	files model.FileMetadatas,
+) ([]model.Document, []*model.FileMetadata) {
+	moduleDocs, syntheticFiles, suppressed, calledDirs, ok := c.resolveModulesSafely(ctx, files)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	for _, f := range files {
 		if f == nil || !isTerraformFile(f.FilePath) {
@@ -55,7 +60,7 @@ func (c *Inspector) instantiateLocalModules(ctx context.Context, files model.Fil
 	} else {
 		contextLogger.Debug().Msg("Instantiated 0 local module resources")
 	}
-	return moduleDocs
+	return moduleDocs, syntheticFiles
 }
 
 // resolveModulesSafely runs the panic-prone module evaluation under a recover so
@@ -65,14 +70,14 @@ func (c *Inspector) instantiateLocalModules(ctx context.Context, files model.Fil
 func (c *Inspector) resolveModulesSafely(
 	ctx context.Context,
 	files model.FileMetadatas,
-) (moduleDocs []model.Document, suppressed, calledDirs map[string]bool, ok bool) {
+) (moduleDocs []model.Document, syntheticFiles []*model.FileMetadata, suppressed, calledDirs map[string]bool, ok bool) {
 	defer func() {
 		if r := recover(); r != nil {
 			contextLogger := logger.FromContext(ctx)
 			contextLogger.Error().Interface("panic", r).Msg(
 				"instantiateLocalModules: recovered from panic; skipping synthetic module docs",
 			)
-			moduleDocs, suppressed, calledDirs, ok = nil, nil, nil, false
+			moduleDocs, syntheticFiles, suppressed, calledDirs, ok = nil, nil, nil, nil, false
 		}
 	}()
 	return resolveModuleDocuments(ctx, files, c.repoPath)
@@ -91,10 +96,10 @@ func resolveModuleDocuments(
 	ctx context.Context,
 	files model.FileMetadatas,
 	repoPath string,
-) (extra []model.Document, suppressed, calledDirs map[string]bool, ok bool) {
+) (extra []model.Document, syntheticFiles []*model.FileMetadata, suppressed, calledDirs map[string]bool, ok bool) {
 	byAbsPath, filesByDir, dirsWithTf := indexTerraformFiles(ctx, files, repoPath)
 	if len(dirsWithTf) == 0 {
-		return nil, nil, nil, false
+		return nil, nil, nil, nil, false
 	}
 
 	// staticCalledDirs is used only to classify root vs. child dirs before evaluation.
@@ -127,13 +132,15 @@ func resolveModuleDocuments(
 		}
 		// evalRootDir distinguishes the same child module reached from different roots
 		// (different variable bindings) so synthetic documents are not incorrectly deduped.
-		extra = append(extra, instantiatedDocs(resources, byAbsPath, repoPath, seen, dir)...)
+		docs, syn := instantiatedDocs(resources, byAbsPath, repoPath, seen, dir)
+		extra = append(extra, docs...)
+		syntheticFiles = append(syntheticFiles, syn...)
 	}
 
 	// If every root evaluation failed, do not strip or suppress module bodies: that would
 	// remove coverage with no synthetic replacement.
 	if !rootEvalOK {
-		return nil, nil, nil, false
+		return nil, nil, nil, nil, false
 	}
 
 	suppressed = make(map[string]bool)
@@ -151,19 +158,18 @@ func resolveModuleDocuments(
 		}
 	}
 
-	return extra, suppressed, strippedDirs, true
+	return extra, syntheticFiles, suppressed, strippedDirs, true
 }
 
-// instantiatedDocs builds one synthetic document per resolved module resource (skips root
-// and out-of-scope). seen dedupes across eval roots; dedupe key includes type, name, line, module path.
+// instantiatedDocs builds one synthetic doc + FileMetadata per resolved module resource (skips root / out-of-scope).
+// seen dedupes across eval roots. Doc id is file id + call chain + instance; synthetic row carries ModuleCallChain for hashing.
 func instantiatedDocs(
 	resources []tfeval.ResolvedResource,
 	byAbsPath map[string]*model.FileMetadata,
 	repoPath string,
 	seen map[string]bool,
 	evalRootDir string,
-) []model.Document {
-	var docs []model.Document
+) (docs []model.Document, synthetic []*model.FileMetadata) {
 	for i := range resources {
 		r := &resources[i]
 		if r.ModuleAddress == "" {
@@ -180,10 +186,13 @@ func instantiatedDocs(
 		}
 		seen[key] = true
 
+		cck := callChainKey(r, repoPath)
+		docID := strings.Join([]string{fm.ID, cck, r.Name}, "\x00")
+
 		// Use the bare resource label (not the expanded name like k[0]) so that
 		// Rego rules matching input.document[_].resource.TYPE.NAME find the resource.
 		docs = append(docs, model.Document{
-			"id":   fm.ID,
+			"id":   docID,
 			"file": fm.FilePath,
 			"resource": map[string]interface{}{
 				r.Type: map[string]interface{}{
@@ -191,8 +200,31 @@ func instantiatedDocs(
 				},
 			},
 		})
+		synthetic = append(synthetic, newInstanceFileMetadata(fm, docID, cck))
 	}
-	return docs
+	return docs, synthetic
+}
+
+// newInstanceFileMetadata is a clone with empty Document (Combine skips it); same path/source/LineInfoDocument as fm for line detection; id and ModuleCallChain match the synthetic doc.
+func newInstanceFileMetadata(fm *model.FileMetadata, id, callChain string) *model.FileMetadata {
+	clone := *fm
+	clone.ID = id
+	clone.Document = model.Document{}
+	clone.ModuleCallChain = callChain
+	return &clone
+}
+
+// callChainKey is repo-relative outer caller + "|" + module address (no line numbers, to keep fingerprints stable).
+func callChainKey(r *tfeval.ResolvedResource, repoPath string) string {
+	if len(r.CallChain) == 0 {
+		return r.ModuleAddress
+	}
+	root := absPath(r.CallChain[0].CalledFrom, repoPath)
+	rel := root
+	if rp, err := filepath.Rel(repoPath, root); err == nil {
+		rel = rp
+	}
+	return filepath.ToSlash(rel) + "|" + r.ModuleAddress
 }
 
 // stripLocalModuleCalls drops local module blocks whose source dir is in calledDirs.

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -126,6 +126,77 @@ resource "aws_s3_bucket" "this" {
 	require.Greater(t, v.Line, 0, "line should be detected in the module file")
 }
 
+// Two roots call the same module with the same inputs: expect two findings and two distinct ModuleCallChain values.
+func TestInspect_TwoCallersGetDistinctCallChains(t *testing.T) {
+	root := t.TempDir()
+
+	modDir := filepath.Join(root, "modules", "bucket")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "stack-a"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "stack-b"), 0o755))
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+
+	aPath := filepath.Join(root, "stack-a", "main.tf")
+	bPath := filepath.Join(root, "stack-b", "main.tf")
+	modPath := filepath.Join(modDir, "main.tf")
+
+	require.NoError(t, os.WriteFile(aPath, []byte(`
+module "bucket" {
+  source = "../modules/bucket"
+  acl    = "public-read"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(bPath, []byte(`
+module "bucket" {
+  source = "../modules/bucket"
+  acl    = "public-read"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(modPath, []byte(`
+variable "acl" {
+  type = string
+}
+
+resource "aws_s3_bucket" "this" {
+  acl = var.acl
+}
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, aPath)...)
+	files = append(files, parseTerraform(t, bPath)...)
+	files = append(files, parseTerraform(t, modPath)...)
+
+	queries := []model.QueryMetadata{{
+		Query:       "acl_rule",
+		Content:     aclRule,
+		InputData:   "{}",
+		Platform:    "terraform",
+		Metadata:    map[string]interface{}{"id": "acl-rule"},
+		Aggregation: 1,
+	}}
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
+	})
+
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{root}, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries())
+
+	// Both callers pass the same (bad) value, yet we expect one finding per caller,
+	// each attributed to the module body but with a distinct call chain.
+	require.Len(t, vulns, 2, "expected one finding per module caller")
+	chains := map[string]bool{}
+	for _, v := range vulns {
+		require.Equal(t, modPath, v.FileName, "findings should be reported at the module resource definition")
+		require.NotEmpty(t, v.ModuleCallChain, "instantiated finding must carry a module call chain")
+		chains[v.ModuleCallChain] = true
+	}
+	require.Len(t, chains, 2, "the two callers must produce distinct module call chains")
+}
+
 // variableTypeRule fires on a variable declaration that has no type, mirroring
 // real rules that match non-resource blocks (variable/output/data/locals).
 const variableTypeRule = `package datadog
@@ -305,4 +376,3 @@ resource "aws_s3_bucket" "this" {
 	require.Len(t, vulns, 1, "legacy module branch must not fire alongside instantiated resource (no double-findings)")
 	require.Equal(t, "aws_s3_bucket", vulns[0].ResourceType, "finding must come from the resource branch, not the module branch")
 }
-

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -9,10 +9,17 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 )
+
+// docFileID is the prefix of synthetic doc ids: fileID\x00callChain\x00name.
+func docFileID(id interface{}) string {
+	s, _ := id.(string)
+	return strings.SplitN(s, "\x00", 2)[0]
+}
 
 // writeFile creates dir/name with content and returns the absolute path.
 func writeFile(t *testing.T, dir, name, content string) string {
@@ -58,7 +65,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", modFile),
 	}
 
-	extra, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
+	extra, synthetic, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
 	if !ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -67,8 +74,22 @@ resource "aws_s3_bucket" "this" {
 		t.Fatalf("expected 1 instantiated resource document, got %d: %#v", len(extra), extra)
 	}
 	doc := extra[0]
-	if doc["id"] != "mod-id" {
-		t.Fatalf("instantiated doc id = %v, want mod-id (resource definition file)", doc["id"])
+	if got := docFileID(doc["id"]); got != "mod-id" {
+		t.Fatalf("instantiated doc id prefix = %v, want mod-id (resource definition file)", got)
+	}
+
+	// A synthetic file backs the document under the same id and carries the call chain.
+	if len(synthetic) != 1 {
+		t.Fatalf("expected 1 synthetic file, got %d", len(synthetic))
+	}
+	if synthetic[0].ID != doc["id"] {
+		t.Fatalf("synthetic file id = %v, want doc id %v", synthetic[0].ID, doc["id"])
+	}
+	if synthetic[0].ModuleCallChain == "" {
+		t.Fatalf("synthetic file should carry a non-empty module call chain")
+	}
+	if len(synthetic[0].Document) != 0 {
+		t.Fatalf("synthetic file Document must be empty so Combine skips it")
 	}
 
 	resource, _ := doc["resource"].(map[string]interface{})
@@ -116,7 +137,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", filepath.Join("modules", "bucket", "main.tf")),
 	}
 
-	extra, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
+	extra, _, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
 	if !ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -124,8 +145,8 @@ resource "aws_s3_bucket" "this" {
 	if len(extra) != 1 {
 		t.Fatalf("expected 1 instantiated resource document, got %d: %#v", len(extra), extra)
 	}
-	if doc := extra[0]; doc["id"] != "mod-id" {
-		t.Fatalf("instantiated doc id = %v, want mod-id", doc["id"])
+	if doc := extra[0]; docFileID(doc["id"]) != "mod-id" {
+		t.Fatalf("instantiated doc id prefix = %v, want mod-id", docFileID(doc["id"]))
 	}
 	if !suppressed["mod-id"] || suppressed["root-id"] {
 		t.Fatalf("unexpected suppression map: %#v", suppressed)
@@ -173,7 +194,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", modFile),
 	}
 
-	extra, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
+	extra, synthetic, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
 	if !ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -181,10 +202,12 @@ resource "aws_s3_bucket" "this" {
 		t.Fatalf("want 2 instantiated bucket docs (one per root), got %d: %#v", len(extra), extra)
 	}
 	names := make(map[string]int)
+	docIDs := make(map[string]bool)
 	for _, doc := range extra {
-		if doc["id"] != "mod-id" {
-			t.Fatalf("doc id = %v, want mod-id", doc["id"])
+		if got := docFileID(doc["id"]); got != "mod-id" {
+			t.Fatalf("doc id prefix = %v, want mod-id", got)
 		}
+		docIDs[doc["id"].(string)] = true
 		res, _ := doc["resource"].(map[string]interface{})
 		bt, _ := res["aws_s3_bucket"].(map[string]interface{})
 		th, _ := bt["this"].(map[string]interface{})
@@ -193,6 +216,18 @@ resource "aws_s3_bucket" "this" {
 	}
 	if names["from-a"] != 1 || names["from-b"] != 1 {
 		t.Fatalf("bucket values = %#v, want one from-a and one from-b", names)
+	}
+	// The two callers must produce distinct document ids and distinct call chains
+	// so their findings get distinct fingerprints instead of collapsing.
+	if len(docIDs) != 2 {
+		t.Fatalf("want 2 distinct per-caller doc ids, got %d: %#v", len(docIDs), docIDs)
+	}
+	chains := make(map[string]bool)
+	for _, sf := range synthetic {
+		chains[sf.ModuleCallChain] = true
+	}
+	if len(chains) != 2 {
+		t.Fatalf("want 2 distinct module call chains (one per root), got %d: %#v", len(chains), chains)
 	}
 	if !suppressed["mod-id"] {
 		t.Fatalf("shared module file should be suppressed")
@@ -218,7 +253,7 @@ module "bucket" {
 		fileMeta("root-id", filepath.Join("stack", "main.tf")),
 	}
 
-	extra, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
+	extra, _, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
 	if ok {
 		t.Fatalf("resolveModuleDocuments ok = true, want false when all roots fail")
 	}
@@ -245,7 +280,7 @@ resource "aws_s3_bucket" "this" {
 
 	files := model.FileMetadatas{fileMeta("orphan-id", orphanFile)}
 
-	extra, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
+	extra, _, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
 	if !ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true for orphan root")
 	}
@@ -288,7 +323,7 @@ resource "aws_s3_bucket" "leaf" {
 		fileMeta("leaf-id", leafFile),
 	}
 
-	extra, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
+	extra, _, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
 	if !ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -297,8 +332,8 @@ resource "aws_s3_bucket" "leaf" {
 		t.Fatalf("expected 1 instantiated resource, got %d: %#v", len(extra), extra)
 	}
 	doc := extra[0]
-	if doc["id"] != "leaf-id" {
-		t.Fatalf("doc id = %v, want leaf-id", doc["id"])
+	if got := docFileID(doc["id"]); got != "leaf-id" {
+		t.Fatalf("doc id prefix = %v, want leaf-id", got)
 	}
 	resource, _ := doc["resource"].(map[string]interface{})
 	bucketType, _ := resource["aws_s3_bucket"].(map[string]interface{})
@@ -342,8 +377,8 @@ module "bucket" {
 	ins := newTestInspector(t, inspectorOpts{
 		repoPath: root,
 	})
-	if docs := ins.instantiateLocalModules(context.Background(), files); docs != nil {
-		t.Fatalf("instantiateLocalModules = %#v, want nil when resolve aborts", docs)
+	if docs, synthetic := ins.instantiateLocalModules(context.Background(), files); docs != nil || synthetic != nil {
+		t.Fatalf("instantiateLocalModules = (%#v, %#v), want nil when resolve aborts", docs, synthetic)
 	}
 	if _, has := rootFM.Document["module"]; !has {
 		t.Fatalf("expected module block preserved on root when evaluation failed")

--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -234,6 +234,7 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 		ResourceSource:        linesVulne.ResourceSource,
 		FileSource:            linesVulne.FileSource,
 		BlockLocation:         linesVulne.BlockLocation,
+		ModuleCallChain:       file.ModuleCallChain,
 		Frameworks: append(extractDefaultFrameworks(ctx, qCtx.Query.Metadata.Metadata, qCtx.FlagEvaluator),
 			extractCustomFrameworks(ctx, qCtx.Query.Metadata.Metadata, qCtx.FlagEvaluator)...),
 	}, nil

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -167,6 +167,8 @@ type FileMetadata struct {
 	ResolvedFiles     map[string]ResolvedFile
 	LinesOriginalData *[]string
 	IsMinified        bool
+	// ModuleCallChain: synthetic rows for instantiated local modules; used in SARIF fingerprint (Terraform only).
+	ModuleCallChain string
 }
 
 // QueryMetadata is a representation of general information about a query
@@ -232,6 +234,8 @@ type Vulnerability struct {
 	IsSuppressed             bool   `json:"isSuppressed,omitempty"`
 	SuppressionKind          string `json:"suppressionKind,omitempty"`
 	SuppressionJustification string `json:"suppressionJustification,omitempty"`
+	// ModuleCallChain: local-module instantiation path; empty for root resources; folded into fingerprint.
+	ModuleCallChain string `json:"moduleCallChain,omitempty"`
 }
 
 // Framework represents a framework mapping for a query

--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -52,6 +52,8 @@ type VulnerableFile struct {
 	IsSuppressed             bool   `json:"is_suppressed,omitempty"`
 	SuppressionKind          string `json:"suppression_kind,omitempty"`
 	SuppressionJustification string `json:"suppression_justification,omitempty"`
+	// ModuleCallChain: local-module call path; empty for root; included in fingerprint.
+	ModuleCallChain string `json:"module_call_chain,omitempty"`
 }
 
 // QueryResult contains a query that tested positive ID, name, severity and a list of files that tested vulnerable
@@ -302,6 +304,7 @@ func CreateSummary(ctx context.Context, counters Counters, vulnerabilities []Vul
 			IsSuppressed:             item.IsSuppressed,
 			SuppressionKind:          item.SuppressionKind,
 			SuppressionJustification: item.SuppressionJustification,
+			ModuleCallChain:          item.ModuleCallChain,
 		})
 
 		filePaths[resolvedPath] = item.FileName

--- a/pkg/parser/terraform/tfeval/cache.go
+++ b/pkg/parser/terraform/tfeval/cache.go
@@ -8,19 +8,31 @@ package tfeval
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
-// evalCacheKey identifies a unique module evaluation by directory, module address, and resolved inputs.
-// Including addr ensures two callers that reach the same dir via different paths (different addr
-// prefixes) are treated as separate entries whose resource ModuleAddress values are already distinct.
+// evalCacheKey: dir + addr + inputs + call chain. Chain splits identical-input callers; pre-pass and main loop share the same chain and hit the same entry.
 type evalCacheKey struct {
 	dir    string
 	addr   string
 	inputs string // canonical encoding of the resolved input map
+	chain  string // canonical encoding of the module call chain
+}
+
+// chainKey encodes each hop as calledFrom#line#module.name; joined by "/".
+func chainKey(chain []CallSite) string {
+	if len(chain) == 0 {
+		return ""
+	}
+	parts := make([]string, len(chain))
+	for i, s := range chain {
+		parts[i] = s.CalledFrom + "#" + strconv.Itoa(s.CalledLine) + "#module." + s.ModuleName
+	}
+	return strings.Join(parts, "/")
 }
 
 // evalCacheEntry holds the result of a completed module evaluation.

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -122,10 +122,8 @@ func (e *Evaluator) evaluate(
 		return nil, map[string]cty.Value{}, nil
 	}
 
-	// Cache lookup: after guard checks but before file I/O. The pre-pass and main loop
-	// call evaluate with identical (dir, addr, inputs, chain) once chain is threaded
-	// through, so the second call always hits the cache.
-	cacheKey := evalCacheKey{dir: dir, addr: addr, inputs: canonicalInputsKey(inputs)}
+	// Pre-pass and main loop share (dir, addr, inputs, chain); distinct callers differ in chain only.
+	cacheKey := evalCacheKey{dir: dir, addr: addr, inputs: canonicalInputsKey(inputs), chain: chainKey(chain)}
 	if entry, ok := e.cache[cacheKey]; ok {
 		for _, d := range entry.visitedDirs {
 			allVisited[d] = true

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
@@ -225,6 +226,7 @@ const (
 	scannedFileCountTag      = "DATADOG_SCANNED_FILE_COUNT:%d"
 
 	DOCKERFILE = "Dockerfile"
+	TERRAFORM  = "Terraform"
 )
 
 func initSarifTool() sarifTool {
@@ -591,6 +593,7 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 						resourceName,
 						queryID,
 						vulnerability.LineWithVulnerability,
+						vulnerability.ModuleCallChain,
 					),
 				},
 				Suppressions: buildSarifSuppressions(ctx, &vulnerability),
@@ -684,11 +687,48 @@ func (sr *sarifReport) AddTags(ctx context.Context, summary *model.Summary, diff
 }
 
 // nolint:gocritic
-func GetDatadogFingerprintHash(sciInfo model.SCIInfo, filePath, platform, resourceType, resourceName, ruleId, vulnline string) string {
-	if platform == DOCKERFILE {
-		return StringToHash(fmt.Sprintf("%s|%s|%s|%s|%s|%s", sciInfo.RepositoryCommitInfo.RepositoryUrl, filePath, resourceType, resourceName, ruleId, vulnline)) //nolint:lll
+func GetDatadogFingerprintHash(
+	sciInfo model.SCIInfo, filePath, platform, resourceType, resourceName, ruleId, vulnline, moduleCallChain string,
+) string {
+	segments := datadogFingerprintSegments(fingerprintInput{
+		repoURL:         sciInfo.RepositoryCommitInfo.RepositoryUrl,
+		filePath:        filePath,
+		platform:        platform,
+		resourceType:    resourceType,
+		resourceName:    resourceName,
+		ruleID:          ruleId,
+		vulnLine:        vulnline,
+		moduleCallChain: moduleCallChain,
+	})
+	return StringToHash(strings.Join(segments, "|"))
+}
+
+// fingerprintInput groups inputs to datadogFingerprintSegments.
+type fingerprintInput struct {
+	repoURL         string
+	filePath        string
+	platform        string
+	resourceType    string
+	resourceName    string
+	ruleID          string
+	vulnLine        string
+	moduleCallChain string
+}
+
+// datadogFingerprintSegments builds repo|file|type|name|rule, then platform-specific suffixes (Dockerfile: vuln line; Terraform: module chain when set).
+func datadogFingerprintSegments(in fingerprintInput) []string {
+	segments := []string{in.repoURL, in.filePath, in.resourceType, in.resourceName, in.ruleID}
+
+	switch in.platform {
+	case DOCKERFILE:
+		segments = append(segments, in.vulnLine)
+	case TERRAFORM:
+		if in.moduleCallChain != "" {
+			segments = append(segments, in.moduleCallChain)
+		}
 	}
-	return StringToHash(fmt.Sprintf("%s|%s|%s|%s|%s", sciInfo.RepositoryCommitInfo.RepositoryUrl, filePath, resourceType, resourceName, ruleId)) //nolint:lll
+
+	return segments
 }
 
 func logVulnerabilityLineEmpty(ctx context.Context, lineWithVulnerability, platform, queryName, fileName string, line int) {

--- a/pkg/report/model/sarif_test.go
+++ b/pkg/report/model/sarif_test.go
@@ -163,6 +163,7 @@ var sarifTests = []sarifTest{
 									"test_resource",
 									"1",
 									"",
+									"",
 								),
 							},
 						},
@@ -261,6 +262,7 @@ var sarifTests = []sarifTest{
 									"test_resource_type",
 									"test_resource_name",
 									"1",
+									"",
 									"",
 								),
 							},
@@ -456,6 +458,7 @@ var sarifTests = []sarifTest{
 									"test_resource_name",
 									"test",
 									"",
+									"",
 								),
 							},
 						},
@@ -492,6 +495,7 @@ var sarifTests = []sarifTest{
 									"test_resource_type_2",
 									"test_resource_name_2",
 									"test info",
+									"",
 									"",
 								),
 							},
@@ -635,6 +639,7 @@ var sarifTests = []sarifTest{
 									"test_resource_name",
 									"1",
 									"",
+									"",
 								),
 							},
 						},
@@ -772,6 +777,7 @@ var sarifTests = []sarifTest{
 									"test_resource_type",
 									"test_resource_name",
 									"1",
+									"",
 									"",
 								),
 							},
@@ -1151,4 +1157,27 @@ func TestBuildSarifIssueWithFrameworks(t *testing.T) {
 	require.Equal(t, "AMI shared with multiple accounts", result.ResultRuleID)
 	require.Equal(t, "note", result.ResultLevel) // MEDIUM maps to "note"
 	require.Equal(t, "main.tf", result.ResultLocations[0].PhysicalLocation.ArtifactLocation.ArtifactURI)
+}
+
+// Empty chain adds no segment; a chain changes the hash for Terraform and is ignored elsewhere.
+func TestGetDatadogFingerprintHash_ModuleCallChain(t *testing.T) {
+	sci := model.SCIInfo{RepositoryCommitInfo: model.RepositoryCommitInfo{RepositoryUrl: "repo"}}
+
+	// An empty chain appends nothing, so Terraform matches the plain base hash (no fingerprint churn).
+	base := GetDatadogFingerprintHash(sci, "modules/bucket/main.tf", "Kubernetes", "aws_s3_bucket", "this", "rule-1", "", "")
+	tfEmpty := GetDatadogFingerprintHash(sci, "modules/bucket/main.tf", TERRAFORM, "aws_s3_bucket", "this", "rule-1", "", "")
+	require.Equal(t, base, tfEmpty, "empty call chain must not change the fingerprint")
+
+	fromA := GetDatadogFingerprintHash(sci, "modules/bucket/main.tf", TERRAFORM, "aws_s3_bucket", "this", "rule-1", "", "stack-a/main.tf|module.bucket")
+	fromB := GetDatadogFingerprintHash(sci, "modules/bucket/main.tf", TERRAFORM, "aws_s3_bucket", "this", "rule-1", "", "stack-b/main.tf|module.bucket")
+
+	require.NotEqual(t, tfEmpty, fromA, "a non-empty call chain must change the fingerprint")
+	require.NotEqual(t, fromA, fromB, "distinct callers must produce distinct fingerprints")
+
+	fromAAgain := GetDatadogFingerprintHash(sci, "modules/bucket/main.tf", TERRAFORM, "aws_s3_bucket", "this", "rule-1", "", "stack-a/main.tf|module.bucket")
+	require.Equal(t, fromA, fromAAgain, "the same caller must produce a stable fingerprint")
+
+	// Non-Terraform platforms must ignore the module call chain.
+	k8sWithChain := GetDatadogFingerprintHash(sci, "modules/bucket/main.tf", "Kubernetes", "aws_s3_bucket", "this", "rule-1", "", "stack-a/main.tf|module.bucket")
+	require.Equal(t, base, k8sWithChain, "non-Terraform platforms must ignore the module call chain")
 }


### PR DESCRIPTION
## Motivation

When the same local Terraform module is instantiated from more than one caller, the resources it produces are attributed to the module body file and share the same finding fingerprint (repository, file path, resource type/name, rule id). Distinct module calls therefore collide and collapse into a single finding, hiding per-caller context and the per-call resolved values.

This stacks on top of #193 and folds the module call chain into the fingerprint so each caller yields its own finding.

JIRA Ticket: [K9VULN-16354](https://datadoghq.atlassian.net/browse/K9VULN-16354)

## Changes

- Each instantiated local-module resource now gets a per-caller synthetic document (id = file id + call chain + instance) backed by a lightweight synthetic file entry that carries the module call chain; the document keeps an empty body so it is not re-scanned.
- The call chain is propagated through the vulnerability and the SARIF `VulnerableFile`, and folded into the Datadog fingerprint via `GetDatadogFingerprintHash`. When the chain is empty (every non-module finding) the hash is byte-identical to before, so existing fingerprints are unchanged.
- The module evaluation cache is now keyed by the call chain in addition to dir/address/inputs, so two distinct callers passing identical inputs are evaluated separately instead of sharing the first caller's resolved resources and call chain.

## Author Checklist

- [ ] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Scan a repo where two root stacks call the same local module (even with identical inputs). Confirm two findings are produced, each attributed to the module body file with a distinct fingerprint, instead of a single collapsed finding. Confirm non-module findings keep their previous fingerprints. See `TestInspect_TwoCallersGetDistinctCallChains` and `TestGetDatadogFingerprintHash_ModuleCallChain`.

## Blast Radius

This only affects findings for resources instantiated from local Terraform modules: their document identity and fingerprint now include the call chain. Root resources and all non-module findings are unchanged (empty chain reproduces the previous hash).

## Additional Notes

Builds on #193; the call chain is used only for fingerprinting for now and is also carried on the finding so it can be surfaced to users in a follow-up.

I submit this contribution under the Apache-2.0 license.


[K9VULN-16354]: https://datadoghq.atlassian.net/browse/K9VULN-16354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ