### PR TITLE
[K9CODESEC-2398] Add RunCustomRegoQuery and ValidateCustomRegoQuery

### DIFF
--- a/cmd/scanner/custom.go
+++ b/cmd/scanner/custom.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/scan"
+	cli "github.com/urfave/cli/v3"
+)
+
+var customAction = &cli.Command{
+	Name:  "custom",
+	Usage: "Run or validate a custom Rego rule against an IaC file",
+	Commands: []*cli.Command{
+		evaluateCustomAction,
+		validateCustomAction,
+	},
+}
+
+type evaluateOutput struct {
+	Findings []customFinding            `json:"findings"`
+	Errors   []scan.RegoValidationError `json:"errors"`
+}
+
+type customFinding struct {
+	Resource     string `json:"resource"`
+	StartLine    int    `json:"start_line"`
+	EndLine      int    `json:"end_line"`
+	ResourceType string `json:"resource_type"`
+	ResourceName string `json:"resource_name"`
+	Message      string `json:"message"`
+}
+
+var evaluateCustomAction = &cli.Command{
+	Name:  "evaluate",
+	Usage: "Run a custom Rego rule against a sample IaC file; outputs JSON to stdout",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "platform", Required: true, Usage: "IaC platform (e.g. terraform, kubernetes)"},
+		&cli.StringFlag{Name: "rego", Required: true, Usage: "base64-encoded Rego rule content"},
+		&cli.StringFlag{Name: "file", Required: true, Usage: "base64-encoded IaC file content"},
+	},
+	Action: runEvaluateCustom,
+}
+
+func runEvaluateCustom(ctx context.Context, c *cli.Command) error {
+	platform := c.String("platform")
+
+	regoBytes, err := base64.StdEncoding.DecodeString(c.String("rego"))
+	if err != nil {
+		return fmt.Errorf("decoding --rego: %w", err)
+	}
+
+	fileBytes, err := base64.StdEncoding.DecodeString(c.String("file"))
+	if err != nil {
+		return fmt.Errorf("decoding --file: %w", err)
+	}
+
+	// Validate before scanning: compile errors would otherwise produce empty findings with no explanation.
+	validationErrs, err := scan.ValidateCustomRegoQuery(ctx, platform, string(regoBytes))
+	if err != nil {
+		return fmt.Errorf("validating custom query: %w", err)
+	}
+	if len(validationErrs) > 0 {
+		return writeJSON(evaluateOutput{Findings: []customFinding{}, Errors: validationErrs})
+	}
+
+	vulns, failedQueries, err := scan.RunCustomRegoQuery(ctx, platform, string(regoBytes), fileBytes)
+	if err != nil {
+		return fmt.Errorf("running custom query: %w", err)
+	}
+
+	findings := make([]customFinding, 0, len(vulns))
+	for i := range vulns {
+		v := &vulns[i]
+		startLine := v.VulnerabilityLocation.Start.Line
+		endLine := v.VulnerabilityLocation.End.Line
+		if startLine == 0 {
+			startLine = v.Line
+			endLine = v.Line
+		}
+		findings = append(findings, customFinding{
+			Resource:     v.SearchKey,
+			StartLine:    startLine,
+			EndLine:      endLine,
+			ResourceType: v.ResourceType,
+			ResourceName: v.ResourceName,
+			Message:      v.KeyExpectedValue,
+		})
+	}
+
+	runtimeErrs := make([]scan.RegoValidationError, 0, len(failedQueries))
+	for _, queryErr := range failedQueries {
+		runtimeErrs = append(runtimeErrs, scan.RegoValidationError{
+			Code:    "rego_runtime_error",
+			Message: queryErr.Error(),
+		})
+	}
+
+	return writeJSON(evaluateOutput{Findings: findings, Errors: runtimeErrs})
+}
+
+type validateOutput struct {
+	Errors []scan.RegoValidationError `json:"errors"`
+}
+
+var validateCustomAction = &cli.Command{
+	Name:  "validate",
+	Usage: "Compile-check a custom Rego rule; outputs JSON to stdout",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "platform", Required: true, Usage: "IaC platform (e.g. terraform, kubernetes)"},
+		&cli.StringFlag{Name: "rego", Required: true, Usage: "base64-encoded Rego rule content"},
+	},
+	Action: runValidateCustom,
+}
+
+func runValidateCustom(ctx context.Context, c *cli.Command) error {
+	regoBytes, err := base64.StdEncoding.DecodeString(c.String("rego"))
+	if err != nil {
+		return fmt.Errorf("decoding --rego: %w", err)
+	}
+
+	validationErrors, err := scan.ValidateCustomRegoQuery(ctx, c.String("platform"), string(regoBytes))
+	if err != nil {
+		return fmt.Errorf("validating custom query: %w", err)
+	}
+
+	if validationErrors == nil {
+		validationErrors = []scan.RegoValidationError{}
+	}
+
+	return writeJSON(validateOutput{Errors: validationErrors})
+}
+
+func writeJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -31,6 +31,7 @@ func main() {
 		Usage: "Scans your Infrastructure as Code configurations",
 		Commands: []*cli.Command{
 			scanAction,
+			customAction,
 			listPlatformsAction,
 			listQueriesAction,
 			showConfigAction,

--- a/pkg/engine/source/platforms.go
+++ b/pkg/engine/source/platforms.go
@@ -1,5 +1,7 @@
 package source
 
+import "strings"
+
 type supportedPlatforms map[string]string
 
 var supPlatforms = &supportedPlatforms{
@@ -26,4 +28,16 @@ func getPlatform(metadataPlatform string) string {
 		return p
 	}
 	return "unknown"
+}
+
+// LibraryName maps a user-facing platform name (case-insensitive) to the
+// embedded library file name under assets/libraries/. Returns the lower-cased
+// input unchanged when no specific mapping exists.
+func LibraryName(platform string) string {
+	for key, lib := range *supPlatforms {
+		if strings.EqualFold(key, platform) {
+			return lib
+		}
+	}
+	return strings.ToLower(platform)
 }

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -69,8 +69,12 @@ type Client struct {
 	Storage       *storage.MemoryStorage
 	Printer       *consolePrinter.Printer
 	FlagEvaluator featureflags.FlagEvaluator
-	// querySourceFactory overrides createQuerySource; set in tests only.
+	// querySourceFactory overrides createQuerySource; set in tests and custom scans.
 	querySourceFactory func(ctx context.Context, platforms []string) (source.QueriesSource, error)
+	// analyzerOverride skips the file-extension analyzer and returns a pre-known platform list.
+	// Set when the platform is already known (e.g. RunCustomRegoQuery) so the temp file name
+	// does not need to encode platform information.
+	analyzerOverride func(ctx context.Context) (model.AnalyzedPaths, error)
 }
 
 func GetDefaultParameters(ctx context.Context, rootPath string) (*Parameters, context.Context) {

--- a/pkg/scan/custom_scan.go
+++ b/pkg/scan/custom_scan.go
@@ -37,6 +37,7 @@ const (
 	scanTargetJSON     = "scan-target.json"
 	platformARM        = "azureresourcemanager"
 	codeMissingPackage = "missing_package"
+	datadogPackage     = "package datadog"
 )
 
 // platformTempFileName returns a temp filename whose extension the scanner's file-type
@@ -70,7 +71,7 @@ func RunCustomRegoQuery(
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	const ownerReadWritePerm = 0o600
+	const ownerReadWritePerm = 0600
 	tmpFile := filepath.Join(tmpDir, platformTempFileName(platform))
 	if err := os.WriteFile(tmpFile, fileContent, ownerReadWritePerm); err != nil {
 		return nil, nil, fmt.Errorf("writing temp file: %w", err)
@@ -87,7 +88,6 @@ func RunCustomRegoQuery(
 		Platform:                []string{platform},
 		ChangedDefaultQueryPath: true,
 		MaxFileSizeFlag:         5,
-		QueryExecTimeout:        10, // shorter than the CLI default; custom rules should be fast
 		ScanID:                  "console",
 		MaxResolverDepth:        15,
 		FlagEvaluator:           featureflags.NewLocalEvaluator(),
@@ -136,7 +136,7 @@ func ValidateCustomRegoQuery(
 	module, parseErrs := parseRegoModule(regoContent)
 	if module == nil {
 		if hasPackageExpectedError(parseErrs) {
-			if recoveredModule, _ := parseRegoModule("package datadog\n\n" + regoContent); recoveredModule != nil {
+			if recoveredModule, _ := parseRegoModule(datadogPackage + "\n\n" + regoContent); recoveredModule != nil {
 				recoveredErrs := staticChecks(recoveredModule)
 				shiftErrorLines(recoveredErrs, -2)
 				return append(parseErrs, recoveredErrs...), nil
@@ -219,10 +219,10 @@ func hasPackageExpectedError(errs []RegoValidationError) bool {
 func shiftErrorLines(errs []RegoValidationError, delta int) {
 	for i := range errs {
 		if errs[i].StartLine > 0 {
-			errs[i].StartLine += delta
+			errs[i].StartLine = max(1, errs[i].StartLine+delta)
 		}
 		if errs[i].EndLine > 0 {
-			errs[i].EndLine += delta
+			errs[i].EndLine = max(1, errs[i].EndLine+delta)
 		}
 	}
 }
@@ -599,7 +599,7 @@ func enrichParseErrors(regoContent string, errs []RegoValidationError) []RegoVal
 		switch {
 		case e.Code == ast.ParseErr && e.Message == "package expected":
 			e.Code = codeMissingPackage
-			e.Message = "expected `package datadog` at the start of the module."
+			e.Message = "expected `" + datadogPackage + "` at the start of the module."
 			result = append(result, e)
 		case e.Code == ast.ParseErr && e.Message == "unexpected identifier token: expected number":
 			rewriteMissingInputRoot(regoContent, &e)

--- a/pkg/scan/custom_scan.go
+++ b/pkg/scan/custom_scan.go
@@ -1,0 +1,911 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package scan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
+	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/printer"
+	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
+)
+
+// RegoValidationError is a compile-time or static-analysis error with source location.
+type RegoValidationError struct {
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	StartLine int    `json:"start_line"`
+	StartCol  int    `json:"start_col"`
+	EndLine   int    `json:"end_line"`
+	EndCol    int    `json:"end_col"`
+}
+
+const (
+	scanTargetJSON     = "scan-target.json"
+	platformARM        = "azureresourcemanager"
+	codeMissingPackage = "missing_package"
+)
+
+// platformTempFileName returns a temp filename whose extension the scanner's file-type
+// filter will accept for the given platform.
+func platformTempFileName(platform string) string {
+	switch strings.ToLower(platform) {
+	case "terraform":
+		return "scan-target.tf"
+	case "cloudformation", platformARM:
+		return scanTargetJSON
+	case "kubernetes", "ansible":
+		return "scan-target.yaml"
+	case "dockerfile":
+		return "Dockerfile"
+	default:
+		return scanTargetJSON
+	}
+}
+
+// RunCustomRegoQuery writes fileContent to a temp file and runs regoContent against it
+// using the same OPA setup as a normal scan.
+func RunCustomRegoQuery(
+	ctx context.Context,
+	platform string,
+	regoContent string,
+	fileContent []byte,
+) ([]model.Vulnerability, map[string]error, error) {
+	tmpDir, err := os.MkdirTemp("", "iac-custom-scan-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	const ownerReadWritePerm = 0o600
+	tmpFile := filepath.Join(tmpDir, platformTempFileName(platform))
+	if err := os.WriteFile(tmpFile, fileContent, ownerReadWritePerm); err != nil {
+		return nil, nil, fmt.Errorf("writing temp file: %w", err)
+	}
+
+	// LibrariesDefaultBasePath ("./assets/libraries") is CWD-relative; the CLI is
+	// always invoked from the repo root so this resolves correctly.
+	params := &Parameters{
+		Path:                    []string{tmpFile},
+		QueriesPath:             []string{"."},
+		LibrariesPath:           source.LibrariesDefaultBasePath,
+		PreviewLines:            3,
+		CloudProvider:           []string{""},
+		Platform:                []string{platform},
+		ChangedDefaultQueryPath: true,
+		MaxFileSizeFlag:         5,
+		QueryExecTimeout:        10, // shorter than the CLI default; custom rules should be fast
+		ScanID:                  "console",
+		MaxResolverDepth:        15,
+		FlagEvaluator:           featureflags.NewLocalEvaluator(),
+		ExcludeGitIgnore:        true,
+	}
+
+	c, err := NewClient(ctx, params, (*printer.Printer)(nil))
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating scan client: %w", err)
+	}
+
+	c.analyzerOverride = func(_ context.Context) (model.AnalyzedPaths, error) {
+		return model.AnalyzedPaths{Types: []string{platform}}, nil
+	}
+	c.querySourceFactory = func(_ context.Context, _ []string) (source.QueriesSource, error) {
+		return &customRegoSource{platform: platform, regoContent: regoContent}, nil
+	}
+
+	results, err := c.executeScan(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("executing scan: %w", err)
+	}
+
+	if results == nil {
+		return nil, nil, nil
+	}
+
+	narrowToAttributeLocation(results.Results)
+	return results.Results, results.FailedQueries, nil
+}
+
+// ValidateCustomRegoQuery runs three diagnostic phases against regoContent and returns
+// all errors in a single call — parse errors, static AST checks, and OPA compilation
+// errors are collected independently so no phase gates another:
+//
+//  1. Parse: syntax errors enriched with precise locations.
+//  2. Static checks: package name, rule name, result fields, sprintf arity, missing imports.
+//  3. OPA compile against platform libraries: type errors and unresolved references.
+//
+// Returns (nil, nil) on success, (errors, nil) on validation failure.
+func ValidateCustomRegoQuery(
+	ctx context.Context,
+	platform string,
+	regoContent string,
+) ([]RegoValidationError, error) {
+	module, parseErrs := parseRegoModule(regoContent)
+	if module == nil {
+		if hasPackageExpectedError(parseErrs) {
+			if recoveredModule, _ := parseRegoModule("package datadog\n\n" + regoContent); recoveredModule != nil {
+				recoveredErrs := staticChecks(recoveredModule)
+				shiftErrorLines(recoveredErrs, -2)
+				return append(parseErrs, recoveredErrs...), nil
+			}
+		}
+		return parseErrs, nil
+	}
+
+	allErrs := staticChecks(module)
+	fs := libraryFilesystemSource(ctx, platform)
+
+	commonLib, err := fs.GetQueryLibrary(ctx, "common")
+	if err != nil {
+		return nil, fmt.Errorf("loading common library: %w", err)
+	}
+
+	platformLib, err := fs.GetQueryLibrary(ctx, source.LibraryName(platform))
+	if err != nil {
+		return nil, fmt.Errorf("loading platform library: %w", err)
+	}
+
+	_, compileErr := rego.New(
+		rego.Query(utils.RegoQuery),
+		rego.SetRegoVersion(ast.RegoV1),
+		rego.Module("Common", commonLib.LibraryCode),
+		rego.Module("Generic", platformLib.LibraryCode),
+		rego.Module("query.rego", regoContent),
+		rego.UnsafeBuiltins(map[string]struct{}{
+			"http.send":   {},
+			"opa.runtime": {},
+		}),
+	).PrepareForEval(ctx)
+
+	if compileErr != nil {
+		compileErrs := regoValidationErrorsFrom(compileErr)
+		// Filter before enriching: enrichCompileErrors rewrites messages (e.g.
+		// "var tf_lib is unsafe" → "undefined variable..."), so isConsequentialCompileError
+		// must see the original OPA text to match correctly.
+		compileErrs = filterConsequentialCompileErrors(allErrs, compileErrs)
+		compileErrs = enrichCompileErrors(regoContent, compileErrs)
+		allErrs = append(allErrs, compileErrs...)
+	}
+
+	return allErrs, nil
+}
+
+// ValidateRegoStructure parses regoContent and runs every static check without loading
+// platform libraries — cheaper than ValidateCustomRegoQuery when library compilation
+// is not needed. Does not recover from a missing package declaration; use
+// ValidateCustomRegoQuery for full user-facing validation.
+func ValidateRegoStructure(regoContent string) []RegoValidationError {
+	module, parseErrs := parseRegoModule(regoContent)
+	if module == nil {
+		return parseErrs
+	}
+	return staticChecks(module)
+}
+
+// parseRegoModule parses and enriches parse errors. Returns (module, nil) on success.
+func parseRegoModule(regoContent string) (*ast.Module, []RegoValidationError) {
+	module, err := ast.ParseModuleWithOpts("query.rego", regoContent, ast.ParserOptions{
+		ProcessAnnotation: false,
+		RegoVersion:       ast.RegoV1,
+	})
+	if err != nil {
+		return nil, enrichParseErrors(regoContent, regoValidationErrorsFrom(err))
+	}
+	return module, nil
+}
+
+func hasPackageExpectedError(errs []RegoValidationError) bool {
+	for _, e := range errs {
+		if e.Code == codeMissingPackage {
+			return true
+		}
+	}
+	return false
+}
+
+func shiftErrorLines(errs []RegoValidationError, delta int) {
+	for i := range errs {
+		if errs[i].StartLine > 0 {
+			errs[i].StartLine += delta
+		}
+		if errs[i].EndLine > 0 {
+			errs[i].EndLine += delta
+		}
+	}
+}
+
+// enrichTypeErrors translates OPA's internal fully-qualified paths in type error
+// messages back to the import alias the user wrote. OPA always uses the qualified
+// form in errors regardless of how the user wrote it.
+func enrichTypeErrors(regoContent string, errs []RegoValidationError) []RegoValidationError {
+	aliases := parseImportAliases(regoContent)
+	for i := range errs {
+		e := &errs[i]
+		if e.Code != ast.TypeErr {
+			continue
+		}
+		const prefix = "undefined function "
+		if !strings.HasPrefix(e.Message, prefix) {
+			continue
+		}
+		fnFull := strings.TrimPrefix(e.Message, prefix)
+		for alias, qualPath := range aliases {
+			if strings.HasPrefix(fnFull, qualPath+".") {
+				e.Message = prefix + alias + "." + strings.TrimPrefix(fnFull, qualPath+".")
+				break
+			}
+		}
+	}
+	return errs
+}
+
+func enrichCompileErrors(regoContent string, errs []RegoValidationError) []RegoValidationError {
+	errs = enrichTypeErrors(regoContent, errs)
+	out := make([]RegoValidationError, 0, len(errs))
+	for _, e := range errs {
+		varName, ok := unsafeVarName(e)
+		if !ok {
+			out = append(out, e) // not an unsafe-var error; pass through
+			continue
+		}
+		if varName == resultVar {
+			continue // "result is unsafe" is always a cascade; skip it
+		}
+		if line, col, ok := findVariableUsage(regoContent, varName); ok {
+			e.StartLine = line
+			e.EndLine = line
+			e.StartCol = col
+			e.EndCol = col + len(varName)
+		}
+		e.Message = fmt.Sprintf("undefined variable %q. Define it before using it.", varName)
+		out = append(out, e)
+	}
+	return out
+}
+
+func unsafeVarName(e RegoValidationError) (string, bool) {
+	const prefix = "var "
+	const suffix = " is unsafe"
+	if e.Code != "rego_unsafe_var_error" ||
+		!strings.HasPrefix(e.Message, prefix) ||
+		!strings.HasSuffix(e.Message, suffix) {
+		return "", false
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(e.Message, prefix), suffix), true
+}
+
+func findVariableUsage(regoContent, varName string) (line, col int, ok bool) {
+	lines := strings.Split(regoContent, "\n")
+	for i, text := range lines {
+		searchFrom := 0
+		for {
+			idx := strings.Index(text[searchFrom:], varName)
+			if idx < 0 {
+				break
+			}
+			idx += searchFrom
+			if isIdentifierBoundary(text, idx-1) && isIdentifierBoundary(text, idx+len(varName)) {
+				return i + 1, idx + 1, true
+			}
+			searchFrom = idx + len(varName)
+		}
+	}
+	return 0, 0, false
+}
+
+func isIdentifierBoundary(s string, idx int) bool {
+	if idx < 0 || idx >= len(s) {
+		return true
+	}
+	ch := s[idx]
+	return (ch < 'a' || ch > 'z') && (ch < 'A' || ch > 'Z') && (ch < '0' || ch > '9') && ch != '_'
+}
+
+const datadogPolicyRule = "DatadogPolicy"
+
+const resultVar = "result"
+
+// staticChecks runs every AST-level check on a successfully parsed module; all checks
+// run regardless of what others find.
+func staticChecks(module *ast.Module) []RegoValidationError {
+	var errs []RegoValidationError
+
+	if module.Package.Path.String() != "data.datadog" {
+		e := RegoValidationError{
+			Code: "invalid_package",
+			Message: fmt.Sprintf(
+				"package must be 'datadog', got %q. The scanner evaluates data.datadog.DatadogPolicy.",
+				module.Package.Path.String(),
+			),
+		}
+		if loc := module.Package.Location; loc != nil {
+			pkgName := strings.TrimPrefix(module.Package.Path.String(), "data.")
+			nameCol := loc.Col + len("package ")
+			e.StartLine = loc.Row
+			e.EndLine = loc.Row
+			e.StartCol = nameCol
+			e.EndCol = nameCol + len(pkgName)
+		}
+		errs = append(errs, e)
+	}
+
+	hasPolicy := false
+	var firstOtherRule *ast.Rule
+	for _, rule := range module.Rules {
+		if rule.Head.Name == datadogPolicyRule {
+			hasPolicy = true
+			break
+		}
+		if firstOtherRule == nil {
+			firstOtherRule = rule
+		}
+	}
+	if !hasPolicy {
+		e := RegoValidationError{
+			Code: "missing_rule",
+			Message: "no '" + datadogPolicyRule + "' rule found. " +
+				"The scanner evaluates data.datadog.DatadogPolicy so the rule must use that exact name",
+		}
+		if firstOtherRule != nil && firstOtherRule.Location != nil {
+			loc := firstOtherRule.Location
+			ruleName := string(firstOtherRule.Head.Name)
+			e.StartLine = loc.Row
+			e.EndLine = loc.Row
+			e.StartCol = loc.Col
+			e.EndCol = loc.Col + len(ruleName)
+		}
+		errs = append(errs, e)
+	}
+
+	errs = append(errs, checkMissingImports(module)...)
+	errs = append(errs, checkSprintfArity(module)...)
+	errs = append(errs, checkResultFields(module)...)
+
+	return errs
+}
+
+var requiredResultFields = []string{
+	"documentId",
+	"resourceType",
+	"resourceName",
+	"searchKey",
+}
+
+var requiredImportAliases = map[string]string{
+	"common_lib": "import data.generic.common as common_lib",
+	"tf_lib":     "import data.generic.terraform as tf_lib",
+}
+
+// parseImportAliases scans regoContent for "import <path> as <alias>" lines and
+// returns a map of alias → qualified path. Used to translate OPA's internal paths
+// back to the alias the user actually wrote, covering all imported libraries.
+func parseImportAliases(regoContent string) map[string]string {
+	out := make(map[string]string)
+	for _, line := range strings.Split(regoContent, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "import ") {
+			continue
+		}
+		path, alias, ok := strings.Cut(strings.TrimPrefix(line, "import "), " as ")
+		if ok {
+			out[strings.TrimSpace(alias)] = strings.TrimSpace(path)
+		}
+	}
+	return out
+}
+
+func checkMissingImports(module *ast.Module) []RegoValidationError {
+	imported := make(map[string]bool, len(module.Imports))
+	for _, imp := range module.Imports {
+		imported[string(imp.Name())] = true
+	}
+
+	reported := make(map[string]bool)
+	var errs []RegoValidationError
+	ast.WalkTerms(module, func(term *ast.Term) bool {
+		ref, ok := term.Value.(ast.Ref)
+		if !ok || len(ref) == 0 {
+			return false
+		}
+
+		alias, ok := ref[0].Value.(ast.Var)
+		if !ok {
+			return false
+		}
+
+		aliasName := string(alias)
+		importStmt, required := requiredImportAliases[aliasName]
+		if !required || imported[aliasName] || reported[aliasName] {
+			return false
+		}
+
+		reported[aliasName] = true
+		loc := term.Location
+		errs = append(errs, RegoValidationError{
+			Code:      "missing_import",
+			Message:   fmt.Sprintf("missing import for %q. Add `%s`.", aliasName, importStmt),
+			StartLine: loc.Row,
+			StartCol:  loc.Col,
+			EndLine:   loc.Row,
+			EndCol:    loc.Col + len(aliasName),
+		})
+		return false
+	})
+
+	return errs
+}
+
+// checkResultFields reports missing required keys in literal result := { ... } assignments.
+func checkResultFields(module *ast.Module) []RegoValidationError {
+	var errs []RegoValidationError
+
+	ast.WalkRules(module, func(rule *ast.Rule) bool {
+		if string(rule.Head.Name) != datadogPolicyRule {
+			return false
+		}
+
+		ast.WalkExprs(rule, func(expr *ast.Expr) bool {
+			if !expr.IsAssignment() {
+				return false
+			}
+			terms, ok := expr.Terms.([]*ast.Term)
+			if !ok || len(terms) != 3 {
+				return false
+			}
+
+			lhs, ok := terms[1].Value.(ast.Var)
+			if !ok || string(lhs) != resultVar {
+				return false
+			}
+
+			obj, ok := terms[2].Value.(ast.Object)
+			if !ok {
+				return false
+			}
+
+			present := make(map[string]bool)
+			obj.Foreach(func(k, _ *ast.Term) {
+				if s, ok := k.Value.(ast.String); ok {
+					present[string(s)] = true
+				}
+			})
+
+			loc := terms[1].Location
+			for _, field := range requiredResultFields {
+				if !present[field] {
+					errs = append(errs, RegoValidationError{
+						Code: "missing_result_field",
+						Message: fmt.Sprintf(
+							"result object is missing required field %q. "+
+								"Findings without this field will have empty values in scan output",
+							field,
+						),
+						StartLine: loc.Row,
+						StartCol:  loc.Col,
+						EndLine:   loc.Row,
+						EndCol:    loc.Col + len(string(lhs)),
+					})
+				}
+			}
+			return false
+		})
+		return false
+	})
+
+	return errs
+}
+
+// checkSprintfArity reports sprintf calls whose verb count does not match the args slice.
+// OPA does not catch this at compile time.
+func checkSprintfArity(module *ast.Module) []RegoValidationError {
+	var errs []RegoValidationError
+
+	ast.WalkTerms(module, func(term *ast.Term) bool {
+		call, ok := term.Value.(ast.Call)
+		if !ok || len(call) < 3 {
+			return false
+		}
+
+		ref, ok := call[0].Value.(ast.Ref)
+		if !ok || ref.String() != "sprintf" {
+			return false
+		}
+
+		fmtStr, ok := call[1].Value.(ast.String)
+		if !ok {
+			return false
+		}
+
+		argsArr, ok := call[2].Value.(*ast.Array)
+		if !ok {
+			return false
+		}
+
+		verbCount := countFormatVerbs(string(fmtStr))
+		if verbCount != argsArr.Len() {
+			loc := term.Location
+			errs = append(errs, RegoValidationError{
+				Code: "sprintf_arity",
+				Message: fmt.Sprintf(
+					"sprintf: format string has %d verb(s) but %d argument(s) provided. "+
+						"This call returns undefined and the rule body will never unify, producing zero Findings",
+					verbCount, argsArr.Len(),
+				),
+				StartLine: loc.Row,
+				StartCol:  loc.Col,
+				EndLine:   loc.Row,
+				EndCol:    loc.Col + 1,
+			})
+		}
+		return false
+	})
+
+	return errs
+}
+
+func countFormatVerbs(s string) int {
+	count := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '%' {
+			i++
+			if i < len(s) && s[i] != '%' {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+// regoValidationErrorsFrom converts OPA errors to RegoValidationError.
+// ast.Errors is a slice type that errors.As cannot unwrap, so we assert it directly first.
+func regoValidationErrorsFrom(err error) []RegoValidationError {
+	var astErrs ast.Errors
+	switch e := err.(type) {
+	case ast.Errors:
+		astErrs = e
+	default:
+		if !errors.As(err, &astErrs) {
+			return []RegoValidationError{{Code: ast.CompileErr, Message: err.Error()}}
+		}
+	}
+	out := make([]RegoValidationError, 0, len(astErrs))
+	for _, e := range astErrs {
+		out = append(out, regoValidationErrorFromAST(e))
+	}
+	return out
+}
+
+// enrichParseErrors rewrites raw OPA parse messages into actionable diagnostics.
+// "non-terminated object" errors are replaced with a text scan that locates every
+// missing comma — OPA reports those at the object opener rather than the offending line.
+func enrichParseErrors(regoContent string, errs []RegoValidationError) []RegoValidationError {
+	result := make([]RegoValidationError, 0, len(errs))
+	var nonTerminated []RegoValidationError
+
+	for _, e := range errs {
+		switch {
+		case e.Code == ast.ParseErr && e.Message == "package expected":
+			e.Code = codeMissingPackage
+			e.Message = "expected `package datadog` at the start of the module."
+			result = append(result, e)
+		case e.Code == ast.ParseErr && e.Message == "unexpected identifier token: expected number":
+			rewriteMissingInputRoot(regoContent, &e)
+			result = append(result, e)
+		case e.Code == ast.ParseErr && e.Message == "unexpected eof token":
+			e.Message = "unexpected end of file. Check for an unclosed `{`, `[`, or `(`."
+			result = append(result, e)
+		case e.Code == ast.ParseErr && strings.HasPrefix(e.Message, "unexpected }"):
+			e.Message = "unexpected `}`. Check for an extra closing brace."
+			result = append(result, e)
+		case e.Code == ast.ParseErr && strings.Contains(e.Message, "non-terminated object"):
+			nonTerminated = append(nonTerminated, e)
+		default:
+			result = append(result, e)
+		}
+	}
+
+	if len(nonTerminated) > 0 {
+		textErrs := findAllMissingObjectFieldSeparators(regoContent)
+		if len(textErrs) == 0 {
+			textErrs = findUnclosedParentheses(regoContent)
+		}
+		if len(textErrs) > 0 {
+			result = append(result, textErrs...)
+		} else {
+			result = append(result, nonTerminated...) // text scan found nothing; keep OPA originals
+		}
+	}
+
+	return result
+}
+
+// rewriteMissingInputRoot updates err in-place when a bare `.document` reference is
+// found. If not found, err is left unchanged and the original OPA message is kept.
+func rewriteMissingInputRoot(regoContent string, err *RegoValidationError) {
+	line, col, ok := findMissingInputRoot(regoContent)
+	if !ok {
+		return
+	}
+	err.Message = "expected `input` before `.document`"
+	err.StartLine = line
+	err.EndLine = line
+	err.StartCol = col
+	err.EndCol = col + len(".document")
+}
+
+func findMissingInputRoot(regoContent string) (line, col int, ok bool) {
+	lines := strings.Split(regoContent, "\n")
+	for i, text := range lines {
+		idx := strings.Index(text, ".document")
+		if idx < 0 {
+			continue
+		}
+		if idx > 0 && !isIdentifierBoundary(text, idx-1) {
+			continue
+		}
+		return i + 1, idx + 1, true
+	}
+	return 0, 0, false
+}
+
+// findAllMissingObjectFieldSeparators scans the source line-by-line and returns a
+// diagnostic for every object field that is not followed by a comma when the next line
+// starts another field. OPA reports all such cases as a single "non-terminated object"
+// at the object opener; this scan localizes each one precisely.
+func findAllMissingObjectFieldSeparators(regoContent string) []RegoValidationError {
+	var errs []RegoValidationError
+	lines := strings.Split(regoContent, "\n")
+
+	for i := 0; i < len(lines)-1; i++ {
+		cur := strings.TrimSpace(lines[i])
+		next := strings.TrimSpace(lines[i+1])
+
+		if cur == "" || cur == "{" || cur == "}" {
+			continue
+		}
+		if !strings.Contains(cur, `":`) {
+			continue
+		}
+		if strings.HasSuffix(cur, ",") {
+			continue
+		}
+		if !strings.HasPrefix(next, `"`) {
+			continue
+		}
+
+		key := extractObjectKey(cur)
+		keyCol := strings.Index(lines[i], `"`)
+		if keyCol < 0 {
+			keyCol = 0
+		}
+
+		msg := "expected ',' or '}' after object field"
+		endCol := keyCol + 2 // at least past the opening quote
+		if key != "" {
+			msg = fmt.Sprintf("expected ',' after field %q", key)
+			endCol = keyCol + len(key) + 2 // "key"
+		}
+
+		errs = append(errs, RegoValidationError{
+			Code:      ast.ParseErr,
+			Message:   msg,
+			StartLine: i + 1,
+			EndLine:   i + 1,
+			StartCol:  keyCol + 1, // 1-indexed
+			EndCol:    endCol + 1,
+		})
+	}
+
+	return errs
+}
+
+// findUnclosedParentheses reports lines where '(' outnumber ')', for example a trailing
+// comma after sprintf(..., [name], when the closing ')' was removed.
+func findUnclosedParentheses(regoContent string) []RegoValidationError {
+	var errs []RegoValidationError
+	lines := strings.Split(regoContent, "\n")
+
+	for i, text := range lines {
+		if strings.Count(text, "(") <= strings.Count(text, ")") {
+			continue
+		}
+		col, name, ok := findUnclosedCallOnLine(text)
+		if !ok {
+			continue
+		}
+		endCol := col + 1
+		if name != "" {
+			endCol = col + len(name)
+		}
+		errs = append(errs, RegoValidationError{
+			Code:      ast.ParseErr,
+			Message:   "expected ')' to close function call",
+			StartLine: i + 1,
+			EndLine:   i + 1,
+			StartCol:  col + 1,
+			EndCol:    endCol + 1,
+		})
+	}
+
+	return errs
+}
+
+func findUnclosedCallOnLine(text string) (col int, name string, ok bool) {
+	lastOpen := strings.LastIndex(text, "(")
+	if lastOpen < 0 {
+		return 0, "", false
+	}
+
+	start := lastOpen - 1
+	for start >= 0 && (text[start] == ' ' || text[start] == '\t') {
+		start--
+	}
+	end := start
+	for start >= 0 && isIdentChar(text[start]) {
+		start--
+	}
+	if end > start {
+		return start + 1, text[start+1 : end+1], true
+	}
+	return lastOpen, "", true
+}
+
+func isIdentChar(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_'
+}
+
+func extractObjectKey(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, `"`) {
+		return ""
+	}
+	end := strings.Index(trimmed[1:], `"`)
+	if end < 0 {
+		return ""
+	}
+	return trimmed[1 : end+1]
+}
+
+// filterConsequentialCompileErrors drops OPA compile errors that are direct consequences
+// of structural issues we already reported via staticChecks. Showing both would be
+// noise, for example "undefined data.datadog.DatadogPolicy" when the user already sees
+// invalid_package.
+func filterConsequentialCompileErrors(structural, compile []RegoValidationError) []RegoValidationError {
+	summary := summarizeStructuralErrors(structural)
+	if !summary.hasInvalidPackage && !summary.hasMissingRule && len(summary.missingImportAliases) == 0 {
+		return compile
+	}
+
+	filtered := make([]RegoValidationError, 0, len(compile))
+	for _, e := range compile {
+		if isConsequentialCompileError(e, summary) {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	return filtered
+}
+
+type structuralErrorSummary struct {
+	hasInvalidPackage    bool
+	hasMissingRule       bool
+	missingImportAliases map[string]bool
+}
+
+func summarizeStructuralErrors(errs []RegoValidationError) structuralErrorSummary {
+	summary := structuralErrorSummary{missingImportAliases: map[string]bool{}}
+	for _, e := range errs {
+		switch e.Code {
+		case "invalid_package":
+			summary.hasInvalidPackage = true
+		case "missing_rule":
+			summary.hasMissingRule = true
+		case "missing_import":
+			for alias := range requiredImportAliases {
+				if strings.Contains(e.Message, alias) {
+					summary.missingImportAliases[alias] = true
+				}
+			}
+		}
+	}
+	return summary
+}
+
+func isConsequentialCompileError(e RegoValidationError, summary structuralErrorSummary) bool {
+	if summary.hasInvalidPackage && strings.Contains(e.Message, "data.datadog.DatadogPolicy") {
+		return true
+	}
+	if summary.hasMissingRule && strings.Contains(e.Message, "DatadogPolicy") {
+		return true
+	}
+	for alias := range summary.missingImportAliases {
+		if strings.Contains(e.Message, "undefined function "+alias+".") ||
+			strings.Contains(e.Message, "var "+alias+" is unsafe") {
+			return true
+		}
+	}
+	return false
+}
+
+func clampLocation(loc *model.ResourceLocation) {
+	loc.Start.Col = max(loc.Start.Col, 1)
+	if loc.End.Col < 1 {
+		loc.End.Col = loc.Start.Col
+	}
+}
+
+func narrowToAttributeLocation(vulns []model.Vulnerability) {
+	for i := range vulns {
+		v := &vulns[i]
+		clampLocation(&v.VulnerabilityLocation)
+		precise := v.RemediationLocation
+		if precise.Start.Line >= v.VulnerabilityLocation.Start.Line &&
+			precise.End.Line <= v.VulnerabilityLocation.End.Line {
+			v.VulnerabilityLocation = precise
+			clampLocation(&v.VulnerabilityLocation)
+		}
+	}
+}
+
+func libraryFilesystemSource(ctx context.Context, platform string) *source.FilesystemSource {
+	return source.NewFilesystemSource(ctx, []string{"."}, []string{platform}, []string{""}, source.LibrariesDefaultBasePath, false)
+}
+
+func regoValidationErrorFromAST(e *ast.Error) RegoValidationError {
+	ve := RegoValidationError{
+		Code:    e.Code,
+		Message: e.Message,
+	}
+	if e.Location != nil {
+		ve.StartLine = e.Location.Row
+		ve.StartCol = e.Location.Col
+		ve.EndLine = e.Location.Row
+		ve.EndCol = e.Location.Col + 1
+		if len(e.Location.Text) > 0 {
+			ve.EndCol = e.Location.Col + len(e.Location.Text)
+		}
+	}
+	return ve
+}
+
+// customRegoSource is an in-memory QueriesSource that injects a single custom Rego rule.
+type customRegoSource struct {
+	platform    string
+	regoContent string
+}
+
+func (s *customRegoSource) GetQueries(_ context.Context, _ *source.QueryInspectorParameters) ([]model.QueryMetadata, error) {
+	return []model.QueryMetadata{
+		{
+			Query:    "custom_rule",
+			Content:  s.regoContent,
+			Platform: s.platform,
+			Metadata: map[string]interface{}{
+				"id":            "custom-rule",
+				"queryName":     "Custom Rule",
+				"severity":      "HIGH",
+				"category":      "Custom",
+				"platform":      s.platform,
+				"cloudProvider": "",
+			},
+			Aggregation: 1,
+		},
+	}, nil
+}
+
+func (s *customRegoSource) GetQueryLibrary(ctx context.Context, libPlatform string) (source.RegoLibraries, error) {
+	return libraryFilesystemSource(ctx, s.platform).GetQueryLibrary(ctx, source.LibraryName(libPlatform))
+}

--- a/pkg/scan/custom_scan_test.go
+++ b/pkg/scan/custom_scan_test.go
@@ -1,0 +1,469 @@
+package scan
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validTerraformRego is a minimal DatadogPolicy rule that passes all validation phases.
+const validTerraformRego = `
+package datadog
+
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
+
+DatadogPolicy contains result if {
+	resource := input.document[i].resource.aws_s3_bucket[name]
+	resource.acl == "public-read"
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_s3_bucket",
+		"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),
+		"searchKey": sprintf("aws_s3_bucket[%s].acl", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'acl' should be 'private'",
+		"keyActualValue": sprintf("'acl' is '%s'", [resource.acl]),
+		"searchLine": common_lib.build_search_line(["resource", "aws_s3_bucket", name, "acl"], []),
+	}
+}
+`
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func errorCodes(errs []RegoValidationError) map[string]bool {
+	m := make(map[string]bool, len(errs))
+	for _, e := range errs {
+		m[e.Code] = true
+	}
+	return m
+}
+
+func errorLines(errs []RegoValidationError) []int {
+	lines := make([]int, 0, len(errs))
+	for _, e := range errs {
+		lines = append(lines, e.StartLine)
+	}
+	return lines
+}
+
+func firstWithCode(errs []RegoValidationError, code string) (RegoValidationError, bool) {
+	for _, e := range errs {
+		if e.Code == code {
+			return e, true
+		}
+	}
+	return RegoValidationError{}, false
+}
+
+// ── unit tests ────────────────────────────────────────────────────────────────
+
+func TestParseImportAliases(t *testing.T) {
+	src := `
+import data.generic.terraform as tf_lib
+import data.generic.common as common_lib
+import data.generic.kubernetes as k8s_lib
+`
+	got := parseImportAliases(src)
+	assert.Equal(t, "data.generic.terraform", got["tf_lib"])
+	assert.Equal(t, "data.generic.common", got["common_lib"])
+	assert.Equal(t, "data.generic.kubernetes", got["k8s_lib"])
+	assert.Len(t, got, 3, "only 'as'-aliased imports should be collected")
+}
+
+func TestParseImportAliases_NoAlias(t *testing.T) {
+	got := parseImportAliases(`import rego.v1`)
+	assert.Empty(t, got, "bare imports without 'as' should be ignored")
+}
+
+// ── parse phase ───────────────────────────────────────────────────────────────
+
+func TestValidateCustomRegoQuery_Valid(t *testing.T) {
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", validTerraformRego)
+	require.NoError(t, err)
+	assert.Empty(t, errs, "valid rule should produce no errors")
+}
+
+func TestValidateCustomRegoQuery_MissingPackage(t *testing.T) {
+	rego := strings.TrimPrefix(strings.Replace(validTerraformRego, "package datadog\n\n", "", 1), "\n")
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.NotEmpty(t, errs)
+	assert.Equal(t, codeMissingPackage, errs[0].Code)
+	assert.Contains(t, errs[0].Message, "package datadog")
+	assert.Equal(t, 1, errs[0].StartLine)
+}
+
+func TestValidateCustomRegoQuery_MissingPackageRecovery(t *testing.T) {
+	// Missing package + a missing result field: both should be reported thanks to
+	// the recovery path that prepends "package datadog" and re-runs static checks.
+	rego := strings.TrimPrefix(strings.Replace(validTerraformRego, "package datadog\n\n", "", 1), "\n")
+	rego = strings.Replace(rego, `"resourceType": "aws_s3_bucket",`+"\n", "", 1)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.NotEmpty(t, errs)
+
+	codes := errorCodes(errs)
+	assert.True(t, codes[codeMissingPackage], "missing package must be reported")
+	assert.True(t, codes["missing_result_field"], "static checks must still run after recovery")
+}
+
+func TestValidateCustomRegoQuery_MissingIf(t *testing.T) {
+	rego := strings.Replace(validTerraformRego, "DatadogPolicy contains result if {", "DatadogPolicy contains result {", 1)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.NotEmpty(t, errs, "missing 'if' should produce a parse error")
+
+	e := errs[0]
+	assert.Equal(t, "rego_parse_error", e.Code)
+	assert.Greater(t, e.StartLine, 0)
+}
+
+func TestValidateCustomRegoQuery_MissingInputRoot(t *testing.T) {
+	rego := strings.Replace(validTerraformRego,
+		"input.document[i].resource.aws_s3_bucket[name]",
+		".document[i].resource.aws_s3_bucket[name]",
+		1,
+	)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.NotEmpty(t, errs)
+
+	assert.Equal(t, "rego_parse_error", errs[0].Code)
+	assert.Equal(t, "expected `input` before `.document`", errs[0].Message)
+	assert.Equal(t, 8, errs[0].StartLine)
+	assert.Equal(t, 14, errs[0].StartCol)
+}
+
+func TestValidateCustomRegoQuery_MissingComma(t *testing.T) {
+	rego := strings.Replace(validTerraformRego,
+		`"documentId": input.document[i].id,`,
+		`"documentId": input.document[i].id`,
+		1,
+	)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.NotEmpty(t, errs)
+	assert.Contains(t, errs[0].Message, `expected ',' after field "documentId"`)
+	assert.Equal(t, 11, errs[0].StartLine)
+}
+
+func TestValidateCustomRegoQuery_MissingCommaAfterMiddleField(t *testing.T) {
+	rego := strings.Replace(validTerraformRego,
+		`"resourceType": "aws_s3_bucket",`,
+		`"resourceType": "aws_s3_bucket"`,
+		1,
+	)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.NotEmpty(t, errs)
+	assert.Contains(t, errs[0].Message, `expected ',' after field "resourceType"`)
+	assert.Equal(t, 12, errs[0].StartLine)
+}
+
+func TestValidateCustomRegoQuery_TwoMissingCommas(t *testing.T) {
+	rego := validTerraformRego
+	rego = strings.Replace(rego, `"documentId": input.document[i].id,`, `"documentId": input.document[i].id`, 1)
+	rego = strings.Replace(rego, `"resourceType": "aws_s3_bucket",`, `"resourceType": "aws_s3_bucket"`, 1)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(errs), 2, "all missing commas should be reported in one pass")
+	assert.Contains(t, errorLines(errs), 11)
+	assert.Contains(t, errorLines(errs), 12)
+}
+
+func TestValidateCustomRegoQuery_MissingClosingParen(t *testing.T) {
+	rego := strings.Replace(validTerraformRego,
+		`sprintf("aws_s3_bucket[%s].acl", [name]),`,
+		`sprintf("aws_s3_bucket[%s].acl", [name],`,
+		1,
+	)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.NotEmpty(t, errs)
+	assert.Equal(t, "rego_parse_error", errs[0].Code)
+	assert.Contains(t, errs[0].Message, ")")
+	assert.Equal(t, 14, errs[0].StartLine)
+}
+
+func TestValidateCustomRegoQuery_UnbalancedBrace(t *testing.T) {
+	rego := validTerraformRego[:strings.LastIndex(validTerraformRego, "}")]
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.NotEmpty(t, errs, "removing closing brace should produce a parse error")
+
+	e := errs[0]
+	assert.Equal(t, "rego_parse_error", e.Code)
+	assert.Contains(t, e.Message, "unclosed")
+	assert.Greater(t, e.StartLine, 0)
+}
+
+func TestValidateCustomRegoQuery_ExtraClosingBrace(t *testing.T) {
+	rego := validTerraformRego + "}\n"
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.NotEmpty(t, errs)
+
+	e := errs[0]
+	assert.Equal(t, "rego_parse_error", e.Code)
+	assert.Contains(t, e.Message, "unexpected `}`")
+	assert.Greater(t, e.StartLine, 0)
+}
+
+// ── static checks ─────────────────────────────────────────────────────────────
+
+func TestValidateCustomRegoQuery_WrongPackage(t *testing.T) {
+	rego := strings.Replace(validTerraformRego, "package datadog", "package mycompany", 1)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.NotEmpty(t, errs)
+
+	e, ok := firstWithCode(errs, "invalid_package")
+	require.True(t, ok, "invalid_package must be present")
+	assert.Greater(t, e.StartLine, 0, "must carry a line number")
+	assert.Greater(t, e.StartCol, 0, "must carry a column number")
+}
+
+func TestValidateCustomRegoQuery_WrongRuleName(t *testing.T) {
+	rego := strings.Replace(validTerraformRego, "DatadogPolicy", "MyPolicy", -1)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+
+	e, ok := firstWithCode(errs, "missing_rule")
+	require.True(t, ok, "missing_rule must be present")
+	assert.Greater(t, e.StartLine, 0, "must point to the misnamed rule")
+	assert.Contains(t, e.Message, "The scanner evaluates")
+}
+
+func TestValidateCustomRegoQuery_SprintfArityMismatch(t *testing.T) {
+	rego := strings.Replace(validTerraformRego,
+		`sprintf("aws_s3_bucket[%s].acl", [name])`,
+		`sprintf("aws_s3_bucket[%s].acl=%s", [name])`,
+		1,
+	)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+
+	e, ok := firstWithCode(errs, "sprintf_arity")
+	require.True(t, ok, "sprintf_arity must be reported")
+	assert.Contains(t, e.Message, "zero Findings")
+	assert.Greater(t, e.StartLine, 0)
+}
+
+func TestValidateCustomRegoQuery_MissingResultField(t *testing.T) {
+	rego := strings.Replace(validTerraformRego,
+		`"searchKey": sprintf("aws_s3_bucket[%s].acl", [name]),`+"\n",
+		"",
+		1,
+	)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+
+	e, ok := firstWithCode(errs, "missing_result_field")
+	require.True(t, ok)
+	assert.Contains(t, e.Message, "searchKey")
+	assert.Contains(t, e.Message, "Findings")
+	assert.Equal(t, 10, e.StartLine)
+	assert.Equal(t, 2, e.StartCol)
+}
+
+func TestValidateCustomRegoQuery_MultipleResultFieldsMissing(t *testing.T) {
+	rego := validTerraformRego
+	rego = strings.Replace(rego, `"resourceType": "aws_s3_bucket",`+"\n", "", 1)
+	rego = strings.Replace(rego, `"resourceName": tf_lib.resolve_s3_bucket_name(resource, name),`+"\n", "", 1)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+
+	missing := make([]string, 0)
+	for _, e := range errs {
+		if e.Code == "missing_result_field" {
+			missing = append(missing, e.Message)
+		}
+	}
+	require.Len(t, missing, 2, "both missing fields should be reported")
+	assert.True(t, strings.Contains(missing[0], "resourceType") || strings.Contains(missing[1], "resourceType"))
+	assert.True(t, strings.Contains(missing[0], "resourceName") || strings.Contains(missing[1], "resourceName"))
+}
+
+func TestValidateCustomRegoQuery_MissingTfLibImport(t *testing.T) {
+	rego := strings.Replace(validTerraformRego, "import data.generic.terraform as tf_lib\n", "", 1)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+
+	e, ok := firstWithCode(errs, "missing_import")
+	require.True(t, ok)
+	assert.Contains(t, e.Message, "tf_lib")
+	assert.Greater(t, e.StartLine, 0)
+	assert.Greater(t, e.StartCol, 0)
+
+	// Compile cascade should be filtered: no redundant "undefined function tf_lib." error.
+	for _, e := range errs {
+		assert.NotContains(t, e.Message, "undefined function tf_lib.")
+	}
+}
+
+func TestValidateCustomRegoQuery_MissingCommonLibImport(t *testing.T) {
+	rego := strings.Replace(validTerraformRego, "import data.generic.common as common_lib\n", "", 1)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+
+	e, ok := firstWithCode(errs, "missing_import")
+	require.True(t, ok)
+	assert.Contains(t, e.Message, "common_lib")
+	assert.Greater(t, e.StartLine, 0)
+
+	for _, e := range errs {
+		assert.NotContains(t, e.Message, "undefined function common_lib.")
+	}
+}
+
+// ── OPA compilation phase ─────────────────────────────────────────────────────
+
+func TestValidateCustomRegoQuery_UndefinedLibraryFunction(t *testing.T) {
+	// Call a function that does not exist in tf_lib; OPA reports the fully-qualified
+	// path, but enrichTypeErrors should translate it back to the alias the user wrote.
+	rego := strings.Replace(validTerraformRego,
+		"tf_lib.resolve_s3_bucket_name(resource, name)",
+		"tf_lib.no_such_fn(resource, name)",
+		1,
+	)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.NotEmpty(t, errs)
+
+	var typeErr *RegoValidationError
+	for i := range errs {
+		if errs[i].Code == "rego_type_error" {
+			typeErr = &errs[i]
+			break
+		}
+	}
+	require.NotNil(t, typeErr, "rego_type_error must be present")
+	assert.Contains(t, typeErr.Message, "tf_lib.no_such_fn",
+		"alias form must be used, not data.generic.terraform.no_such_fn")
+	assert.NotContains(t, typeErr.Message, "data.generic.terraform")
+}
+
+func TestValidateCustomRegoQuery_MissingResourceBinding(t *testing.T) {
+	rego := strings.Replace(validTerraformRego,
+		"\tresource := input.document[i].resource.aws_s3_bucket[name]\n",
+		"",
+		1,
+	)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.NotEmpty(t, errs)
+
+	// "result is unsafe" must not surface — it is always a cascade.
+	for _, e := range errs {
+		assert.NotContains(t, e.Message, "result is unsafe")
+	}
+
+	var hasResource, hasName bool
+	for _, e := range errs {
+		if e.Code != "rego_unsafe_var_error" {
+			continue
+		}
+		if strings.Contains(e.Message, `"resource"`) {
+			hasResource = true
+			assert.Equal(t, 8, e.StartLine)
+			assert.Equal(t, 2, e.StartCol)
+			assert.Equal(t, 10, e.EndCol)
+		}
+		if strings.Contains(e.Message, `"name"`) {
+			hasName = true
+			assert.Greater(t, e.StartCol, 0)
+		}
+	}
+	assert.True(t, hasResource, "resource usage must be flagged")
+	assert.True(t, hasName, "name usage must be flagged")
+}
+
+// ── all-at-once behaviour ─────────────────────────────────────────────────────
+
+func TestValidateCustomRegoQuery_AllErrorsInOneCall(t *testing.T) {
+	rego := validTerraformRego
+	rego = strings.Replace(rego, "package datadog", "package mycompany", 1)
+	rego = strings.Replace(rego, `sprintf("aws_s3_bucket[%s].acl", [name])`, `sprintf("aws_s3_bucket[%s].acl=%s", [name])`, 1)
+
+	errs, err := ValidateCustomRegoQuery(context.Background(), "terraform", rego)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(errs), 2)
+
+	codes := errorCodes(errs)
+	assert.True(t, codes["invalid_package"])
+	assert.True(t, codes["sprintf_arity"])
+}
+
+// ── platform support ──────────────────────────────────────────────────────────
+
+func TestValidateCustomRegoQuery_KubernetesPlatform(t *testing.T) {
+	// Verifies that "kubernetes" platform loads the k8s library correctly
+	// (libraryPlatform maps "kubernetes" → "k8s" to match the embedded asset).
+	const k8sRego = `
+package datadog
+
+import rego.v1
+
+DatadogPolicy contains result if {
+	pod := input.document[_]
+	result := {
+		"documentId":   pod.id,
+		"resourceType": "Pod",
+		"resourceName": "pod",
+		"searchKey":    "pod",
+	}
+}
+`
+	errs, err := ValidateCustomRegoQuery(context.Background(), "kubernetes", k8sRego)
+	require.NoError(t, err, "kubernetes platform must not fail with a library-load error")
+	// Content errors are fine; what matters is no internal "unable to get libraries" error.
+	for _, e := range errs {
+		assert.NotContains(t, e.Message, "unable to get libraries", "library must load correctly")
+	}
+}
+
+// ── ValidateRegoStructure ─────────────────────────────────────────────────────
+
+func TestValidateRegoStructure_Valid(t *testing.T) {
+	errs := ValidateRegoStructure(validTerraformRego)
+	assert.Empty(t, errs)
+}
+
+func TestValidateRegoStructure_WrongPackage(t *testing.T) {
+	rego := strings.Replace(validTerraformRego, "package datadog", "package mycompany", 1)
+	errs := ValidateRegoStructure(rego)
+	require.NotEmpty(t, errs)
+	assert.True(t, errorCodes(errs)["invalid_package"])
+}
+
+func TestValidateRegoStructure_MissingPackage(t *testing.T) {
+	rego := strings.TrimPrefix(strings.Replace(validTerraformRego, "package datadog\n\n", "", 1), "\n")
+	errs := ValidateRegoStructure(rego)
+	// Returns parse errors; does not attempt recovery (unlike ValidateCustomRegoQuery).
+	require.NotEmpty(t, errs)
+	assert.True(t, errorCodes(errs)[codeMissingPackage], "must return parse error, not recover")
+	assert.False(t, errorCodes(errs)["missing_result_field"], "recovery path must not run")
+}

--- a/pkg/scan/utils.go
+++ b/pkg/scan/utils.go
@@ -68,8 +68,13 @@ func (c *Client) prepareAndAnalyzePaths(ctx context.Context) (provider.Extracted
 		NumWorkers:        c.ScanParams.ParallelScanFlag,
 	}
 
-	pathTypes, errAnalyze := analyzePaths(ctx, a)
-
+	var pathTypes model.AnalyzedPaths
+	var errAnalyze error
+	if c.analyzerOverride != nil {
+		pathTypes, errAnalyze = c.analyzerOverride(ctx)
+	} else {
+		pathTypes, errAnalyze = analyzePaths(ctx, a)
+	}
 	if errAnalyze != nil {
 		return provider.ExtractedPath{}, errAnalyze
 	}


### PR DESCRIPTION
## Motivation

Custom rule authors writing Rego policies need to know immediately whether their code is valid, not after a failed deployment. This PR adds two new exported functions, `ValidateCustomRegoQuery` and `RunCustomRegoQuery`, that give callers IDE-quality diagnostics and evaluation results for custom Rego rules without running a full scan.

Related Ticket: [K9CODESEC-2398](https://datadoghq.atlassian.net/browse/K9CODESEC-2398?atlOrigin=eyJpIjoiNGVmMjAwMWU4Y2QwNDRiMjhjMmEwNmFmNTlmN2NhMmMiLCJwIjoiaiJ9)

## Changes

**Validation pipeline**

`ValidateCustomRegoQuery` runs three phases in a single call and returns all errors simultaneously, so authors see the full picture at once rather than fixing one error at a time:

1. **Parse**: OPA parse errors are rewritten into actionable messages. Bare `.document` references (missing `input` prefix), missing package declarations, missing commas inside objects, and unbalanced parentheses each get a precise line/column location and a human-readable explanation instead of OPA's internal error text.
2. **Static AST checks**: verifies that the package is `datadog`, that a `DatadogPolicy` rule is present, that all required result fields (`documentId`, `resourceType`, `resourceName`, `searchKey`) are assigned, that `sprintf` call matches its format string, and that any aliased library has a corresponding import statement.
3. **OPA compilation**: compiles the rule against the platform libraries and surfaces type errors and unresolved references. Errors that are purely a consequence of an earlier structural problem (wrong package, missing rule, missing import) are filtered out so they do not drown out the root cause.

If the module is missing its `package` declaration, validation recovers by temporarily prepending `package datadog`, runs the static checks on the recovered AST, and shifts error line numbers back so locations still point at the user's original code.

**Evaluation**

`RunCustomRegoQuery` writes the Rego content and the IaC file to temporary files with the correct platform-specific extension (`.tf`, `.yaml`, `.json`, …), runs the scan engine in-memory, and returns findings with precise resource locations alongside any runtime errors.

**CLI**

Two new subcommands are registered under `custom`:

`datadog-iac-scanner custom validate --platform <platform> --rego <base64>` — outputs JSON `{"errors": [...]}`.

`datadog-iac-scanner custom evaluate --platform <platform> --rego <base64> --file <base64>` — runs validation first; if errors are found they are returned without scanning. Otherwise outputs JSON `{"findings": [...], "errors": [...]}`.

Both commands accept base64-encoded inputs so binary-safe content can be passed from any calling process without shell escaping concerns.

> [!NOTE]
> I have a branch with an UI and a server, let me know if you need it to better test.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/scan/ -run TestValidateCustomRegoQuery -v` — all scenarios (missing package, wrong package, missing rule, missing result fields, missing imports, missing commas, unbalanced parens, missing `input`, undefined variables) should pass.
2. Build: `go build ./cmd/scanner/...`
3. Validate a known-good rule end-to-end:
```
REGO=$(base64 -i <path-to-valid-rule.rego>)
./bin/datadog-iac-scanner custom validate --platform terraform --rego "$REGO"
# expect: {"errors": []}
```
4. Introduce a deliberate error (remove `resourceType` from the result object) and re-run validate — expect a `missing_result_field` error with the correct line number.
5. Evaluate against a sample Terraform file:
```
FILE=$(base64 -i <path-to-sample.tf>)
./bin/datadog-iac-scanner custom evaluate --platform terraform --rego "$REGO" --file "$FILE"
# expect: {"findings": [...], "errors": []}
```

## Blast Radius

This PR only adds new exported functions and CLI subcommands. No existing scan logic, query loading, or result reporting paths are modified. The only change to existing files is wiring the new `custom` command into the CLI entry point and a minor fix to pass the IaC file path through the scan client.

## Additional Notes

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-2398]: https://datadoghq.atlassian.net/browse/K9CODESEC-2398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ