### PR TITLE
Add the queries-path flag to the scanner binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ By default, the output file is named `datadog-iac-scanner-result.sarif`. Use `--
 datadog-iac-scanner scan -p REPODIR -o OUTPUTDIR --output-name OUTPUTFILE.sarif
 ```
 
+You can run the scanner using your own local rules, written in the QUERYDIR directory, with the -q flag:
+
+```bash
+datadog-iac-scanner scan -p REPODIR -o OUTPUTDIR -q QUERYDIR
+```
+
+The rule directories in the QUERYDIR directory must contain a 'query.rego' and a 'metadata.json' file. You can also specify multiple paths:
+
+```bash
+datadog-iac-scanner scan -p REPODIR -o OUTPUTDIR -q QUERYDIR1 -q QUERYDIR2
+```
+
 Run `datadog-iac-scanner scan --help` to see all available flags.
 
 ### Configuring the scan

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -210,7 +210,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 	queriesPath := c.StringSlice("queries-path")
 	queriesPath, err = validateQueriesPaths(queriesPath)
 	if err != nil {
-		return errorWithExitCode(fmt.Errorf("Path parsing exited with error: %q", err), constants.InvalidConfigErrorCode)
+		return errorWithExitCode(fmt.Errorf("path parsing exited with error: %q", err), constants.InvalidConfigErrorCode)
 	}
 
 	changedDefaultQueryPath := len(queriesPath) > 0

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -91,6 +91,22 @@ var scanAction = &cli.Command{
 			Usage:  "(experimental, will be removed soon) scan terraform plans",
 			Value:  false,
 		},
+		&cli.StringSliceFlag{
+			Name:    "queries-path",
+			Aliases: []string{"q"},
+			Usage:   "a list of query directories paths",
+		},
+
+		// NOTE: --x-parallelparsing flag disabled due to pre-existing race conditions
+		// in concurrent query workers (SetupLogs shared state write, docker detector
+		// shallow slice copy) that cause non-deterministic violation counts.
+		// See K9VULN-13746 for the follow-up to fix and re-enable.
+		// &cli.BoolFlag{
+		// 	Name:   "x-parallelparsing",
+		// 	Hidden: true,
+		// 	Usage:  "(experimental, will be removed soon) parse files in parallel",
+		// 	Value:  false,
+		// },
 	},
 	Action: runScan,
 }
@@ -99,6 +115,24 @@ const (
 	filePerms = 0644
 	dirPerms  = 0755
 )
+
+func validateQueriesPaths(paths []string) ([]string, error) {
+	absolutePaths, err := getAbsolutePaths(paths)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, path := range absolutePaths {
+		info, err := os.Stat(path) // follows symlink
+		if err != nil {
+			return nil, fmt.Errorf("invalid queries path %q", path)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("queries path %q is not a directory", path)
+		}
+	}
+	return absolutePaths, nil
+}
 
 // nolint:gocyclo
 func runScan(ctx context.Context, c *cli.Command) error {
@@ -173,26 +207,38 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		cfg.RuleConfigs[ruleID] = rc
 	}
 
+	queriesPath := c.StringSlice("queries-path")
+	queriesPath, err = validateQueriesPaths(queriesPath)
+	if err != nil {
+		return errorWithExitCode(fmt.Errorf("Path parsing exited with error: %q", err), constants.InvalidConfigErrorCode)
+	}
+
+	changedDefaultQueryPath := len(queriesPath) > 0
+	if !changedDefaultQueryPath {
+		queriesPath = []string{"./assets/queries"}
+	}
+
 	params := &scan.Parameters{
-		CloudProvider:     []string{""},
-		OutputPath:        outputPath,
-		OutputName:        c.String("output-name"),
-		PreviewLines:      3,
-		RepoPath:          repoDir,
-		Path:              inputPaths,
-		QueriesPath:       []string{"./assets/queries"},
-		LibrariesPath:     "./assets/libraries",
-		ReportFormats:     []string{"sarif"},
-		Platform:          selectPlatforms(c.StringSlice("type")),
-		DisableSecrets:    true,
-		ScanID:            "console",
-		MaxFileSizeFlag:   c.Int("max-file-size"),
-		MaxResolverDepth:  c.Int("max-resolver-depth"),
-		PayloadPath:       payloadPath,
-		SCIInfo:           model.SCIInfo{RepositoryDir: repoDir, RepositoryCommitInfo: *repoInfo},
-		FlagEvaluator:     getFeatureFlagEvaluator(c),
-		Config:            *cfg,
-		ShouldScanTfPlans: c.Bool("x-terraform-plan"),
+		CloudProvider:           []string{""},
+		OutputPath:              outputPath,
+		OutputName:              c.String("output-name"),
+		PreviewLines:            3,
+		RepoPath:                repoDir,
+		Path:                    inputPaths,
+		QueriesPath:             queriesPath,
+		ChangedDefaultQueryPath: changedDefaultQueryPath,
+		LibrariesPath:           "./assets/libraries",
+		ReportFormats:           []string{"sarif"},
+		Platform:                selectPlatforms(c.StringSlice("type")),
+		DisableSecrets:          true,
+		ScanID:                  "console",
+		MaxFileSizeFlag:         c.Int("max-file-size"),
+		MaxResolverDepth:        c.Int("max-resolver-depth"),
+		PayloadPath:             payloadPath,
+		SCIInfo:                 model.SCIInfo{RepositoryDir: repoDir, RepositoryCommitInfo: *repoInfo},
+		FlagEvaluator:           getFeatureFlagEvaluator(c),
+		Config:                  *cfg,
+		ShouldScanTfPlans:       c.Bool("x-terraform-plan"),
 	}
 
 	metadata, err := console.ExecuteScan(ctx, params)

--- a/cmd/scanner/scan_test.go
+++ b/cmd/scanner/scan_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/scan"
 	"github.com/stretchr/testify/assert"
 	cli "github.com/urfave/cli/v3"
+	"github.com/stretchr/testify/require"
 )
 
 func TestApplyPlatformFilters(t *testing.T) {
@@ -36,10 +39,10 @@ func TestApplyPlatformFilters(t *testing.T) {
 			want:            []string{"Ansible", "CICD", "CloudFormation", "Kubernetes", "Terraform"},
 		},
 		{
-			name:            "case-insensitive only-platforms",
-			cliPlatforms:    all,
-			onlyPlatforms:   []string{"terraform"},
-			want:            []string{"Terraform"},
+			name:          "case-insensitive only-platforms",
+			cliPlatforms:  all,
+			onlyPlatforms: []string{"terraform"},
+			want:          []string{"Terraform"},
 		},
 		{
 			name:            "case-insensitive ignore-platforms",
@@ -103,6 +106,55 @@ func TestTerraformPlanFlag(t *testing.T) {
 			assert.True(t, foundFlag.Hidden, "x-terraform-plan flag should be hidden")
 			assert.Equal(t, false, foundFlag.Value, "x-terraform-plan flag should default to false")
 			assert.Contains(t, foundFlag.Usage, "experimental", "flag usage should indicate experimental status")
+		})
+	}
+}
+
+func TestValidateQueriesPaths(t *testing.T) {
+	tmp := t.TempDir()
+
+	validDir := filepath.Join(tmp, "queries")
+	require.NoError(t, os.Mkdir(validDir, 0o755))
+
+	missingPath := filepath.Join(tmp, "missing")
+
+	filePath := filepath.Join(tmp, "queries.rego")
+	require.NoError(t, os.WriteFile(filePath, []byte("package test"), 0o644))
+
+	tests := []struct {
+		name    string
+		paths   []string
+		wantErr string
+	}{
+		{
+			name:  "valid dir",
+			paths: []string{validDir},
+		},
+		{
+			name:    "non-existent path",
+			paths:   []string{missingPath},
+			wantErr: "invalid queries path",
+		},
+		{
+			name:    "path is a file",
+			paths:   []string{filePath},
+			wantErr: "is not a directory",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateQueriesPaths(tt.paths)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, got, len(tt.paths))
+			assert.True(t, filepath.IsAbs(got[0]))
 		})
 	}
 }

--- a/pkg/engine/source/filesystem.go
+++ b/pkg/engine/source/filesystem.go
@@ -286,28 +286,55 @@ func checkQueryFeatureFlagDisabled(ctx context.Context, metadata map[string]any,
 // GetQueries returns all queries found under the source paths registered in s.Source.
 // Rules are no longer embedded in the binary; provide local rule directories via s.Source.
 func (s *FilesystemSource) GetQueries(ctx context.Context, queryParameters *QueryInspectorParameters) ([]model.QueryMetadata, error) {
-	dirs := s.localQueryDirs(ctx)
+	dirs, err := s.localQueryDirs(ctx)
+	if err != nil {
+		return nil, err
+	}
 	queries := s.iterateQueryDirs(ctx, dirs, queryParameters)
 	return queries, nil
 }
 
-// localQueryDirs collects one-level-deep sub-directories from each path in s.Source.
-func (s *FilesystemSource) localQueryDirs(ctx context.Context) []string {
+// localQueryDirs recursively collects sub-directories from each path in s.Source.
+// It does not collect sub-directories that do not contain a query.rego and metadata.json file.
+func (s *FilesystemSource) localQueryDirs(ctx context.Context) ([]string, error) {
 	contextLogger := logger.FromContext(ctx)
 	var dirs []string
 	for _, src := range s.Source {
-		entries, err := os.ReadDir(src)
+		evaluated, err := filepath.EvalSymlinks(src)
 		if err != nil {
-			contextLogger.Debug().Msgf("localQueryDirs: skipping %s: %v", src, err)
-			continue
+			fmt.Println(err)
+			contextLogger.Debug().Msgf("localQueryDirs: error evaluating %s: %v", src, err)
+			return nil, err
 		}
-		for _, e := range entries {
-			if e.IsDir() {
-				dirs = append(dirs, filepath.Join(src, e.Name()))
+		err = filepath.WalkDir(evaluated, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				contextLogger.Debug().Msgf("localQueryDirs: error walking %s: %v", path, err)
+				return err
 			}
+			if !d.IsDir() {
+				return nil
+			}
+			queryPath := filepath.Join(path, QueryFileName)
+			metadataPath := filepath.Join(path, MetadataFileName)
+			if fileExists(queryPath) && fileExists(metadataPath) {
+				dirs = append(dirs, path)
+				return filepath.SkipDir
+			}
+			return nil
+		})
+		if err != nil {
+			contextLogger.Debug().Msgf("localQueryDirs: error walking %s: %v", src, err)
+			return nil, err
 		}
 	}
-	return dirs
+	if len(dirs) == 0 {
+		return nil, errors.New("no valid query directories found")
+	}
+	return dirs, nil
+}
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }
 
 // iterateQueryDirs iterates all query directories and reads the respective queries

--- a/pkg/engine/source/filesystem.go
+++ b/pkg/engine/source/filesystem.go
@@ -304,7 +304,7 @@ func (s *FilesystemSource) localQueryDirs(ctx context.Context) ([]string, error)
 		if err != nil {
 			fmt.Println(err)
 			contextLogger.Debug().Msgf("localQueryDirs: error evaluating %s: %v", src, err)
-			return nil, err
+			return nil, errors.New("unable to evaluate path: " + src)
 		}
 		err = filepath.WalkDir(evaluated, func(path string, d os.DirEntry, err error) error {
 			if err != nil {

--- a/pkg/engine/source/filesystem_test.go
+++ b/pkg/engine/source/filesystem_test.go
@@ -612,7 +612,7 @@ func TestFilesystemSource_localQueryDirs(t *testing.T) {
 		{
 			name: "non-existent path",
 			set: func(t *testing.T, root string) ([]string, []string, error) {
-				return []string{filepath.Join(root, "missing")}, nil, errors.New("no such file or directory")
+				return []string{filepath.Join(root, "missing")}, nil, errors.New("unable to evaluate path")
 			},
 		},
 		{
@@ -651,7 +651,7 @@ func TestFilesystemSource_localQueryDirs(t *testing.T) {
 			name: "error in one of multiple paths",
 			set: func(t *testing.T, root string) ([]string, []string, error) {
 				createQueryDir(t, root, "not_returned_valid_query_dir")
-				return []string{root, "non_existent_path"}, nil, errors.New("no such file or directory")
+				return []string{root, "non_existent_path"}, nil, errors.New("unable to evaluate path")
 			},
 		},
 		{

--- a/pkg/engine/source/filesystem_test.go
+++ b/pkg/engine/source/filesystem_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -568,6 +569,113 @@ func TestCheckQueryIncludeWithLegacyId(t *testing.T) {
 			}
 			result := checkQueryInclude(ctx, tt.metadata, queryParams)
 			assert.Equal(t, tt.expectedResult, result, tt.description)
+		})
+	}
+}
+
+func TestFilesystemSource_localQueryDirs(t *testing.T) {
+	ctx := context.Background()
+
+	normalizePaths := func(t *testing.T, paths []string) []string {
+		t.Helper()
+		out := make([]string, 0, len(paths))
+		for _, path := range paths {
+			evaluated, err := filepath.EvalSymlinks(path)
+			require.NoError(t, err)
+			out = append(out, evaluated)
+		}
+		return out
+	}
+
+	createQueryDir := func(t *testing.T, root, name string) string {
+		t.Helper()
+
+		queryDir := filepath.Join(root, name)
+		require.NoError(t, os.MkdirAll(queryDir, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(queryDir, QueryFileName), []byte("package test"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(queryDir, MetadataFileName), []byte(`{"id":"test","platform":"terraform"}`), 0o600))
+
+		return queryDir
+	}
+
+	tests := []struct {
+		name string
+		set  func(t *testing.T, root string) (source []string, want []string, err error)
+	}{
+		{
+			name: "valid dir",
+			set: func(t *testing.T, root string) ([]string, []string, error) {
+				queryDir := createQueryDir(t, root, "valid_query")
+				return []string{root}, []string{queryDir}, nil
+			},
+		},
+		{
+			name: "non-existent path",
+			set: func(t *testing.T, root string) ([]string, []string, error) {
+				return []string{filepath.Join(root, "missing")}, nil, errors.New("no such file or directory")
+			},
+		},
+		{
+			name: "path is a file",
+			set: func(t *testing.T, root string) ([]string, []string, error) {
+				filePath := filepath.Join(root, "queries.rego")
+				require.NoError(t, os.WriteFile(filePath, []byte("package test"), 0o600))
+				return []string{filePath}, nil, errors.New("no valid query directories found")
+			},
+		},
+		{
+			name: "symlink to dir",
+			set: func(t *testing.T, root string) ([]string, []string, error) {
+				target := filepath.Join(root, "target")
+				queryDir := createQueryDir(t, target, "linked_query")
+
+				link := filepath.Join(root, "queries-link")
+				require.NoError(t, os.Symlink(target, link))
+
+				return []string{link}, []string{queryDir}, nil
+			},
+		},
+		{
+			name: "recursive search",
+			set: func(t *testing.T, root string) ([]string, []string, error) {
+				recdir := filepath.Join(root, "recursive")
+				require.NoError(t, os.MkdirAll(recdir, 0o700))
+				queryDir := createQueryDir(t, recdir, "recursive_query")
+				queryDir2 := createQueryDir(t, recdir, "recursive_query2")
+				queryDir3 := createQueryDir(t, recdir, "recursive_query3")
+
+				return []string{root}, []string{queryDir, queryDir2, queryDir3}, nil
+			},
+		},
+		{
+			name: "error in one of multiple paths",
+			set: func(t *testing.T, root string) ([]string, []string, error) {
+				createQueryDir(t, root, "not_returned_valid_query_dir")
+				return []string{root, "non_existent_path"}, nil, errors.New("no such file or directory")
+			},
+		},
+		{
+			name: "no valid query directories",
+			set: func(t *testing.T, root string) ([]string, []string, error) {
+				return []string{root}, nil, errors.New("no valid query directories found")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			src, want, wantErr := tt.set(t, root)
+
+			source := NewFilesystemSource(ctx, src, []string{""}, []string{""}, "", true)
+
+			got, err := source.localQueryDirs(ctx)
+			assert.ElementsMatch(t, normalizePaths(t, want), got)
+			if wantErr != nil {
+				require.ErrorContains(t, err, wantErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -40,7 +40,7 @@ func createServices(types, cloudProviders []string) (serviceSlice, *storage.Memo
 	if err != nil {
 		return nil, nil, err
 	}
-	querySource := source.NewFilesystemSource(ctx, []string{}, types, cloudProviders, filepath.FromSlash("../../assets/libraries"), true)
+	querySource := source.NewFilesystemSource(ctx, []string{"../../test"}, types, cloudProviders, filepath.FromSlash("../../assets/libraries"), true)
 
 	inspector, err := engine.NewInspector(context.Background(),
 		querySource, engine.DefaultVulnerabilityBuilder,


### PR DESCRIPTION
## Motivation

This PR allows the user to define a local directory from which the IaC rules are fetched. This is useful for testing purposes when changing the rules.

## Changes

- Added a --queries-path flag
- Changed the values of QueriesPath and ChangedDefaultQueryPath scan parameters if the flag is used
- Modified the README.md to reflect previous changes 

## Author Checklist

- [x] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- Run a scan on your chosen repository
- Clone the [datadog-iac-scanner-default-rules](https://github.com/DataDog/datadog-iac-scanner-default-rules)
- Either do some relevant changes to a rule, or choose a subdirectory from the rules repo (not containing every rules that flagged a violation in the first scan)
- Rerun the scan using -q QUERYDIR
- Verify that the findings are in line with the flag you just used
## Blast Radius

This change impacts the query fetching of the IaC scanner

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
