### PR TITLE
feat(common): add is_iam_policy_principal_scoped_by_condition helper

### DIFF
--- a/assets/libraries/common.rego
+++ b/assets/libraries/common.rego
@@ -494,14 +494,17 @@ condition_keys_scoping_principal := {
 #   1. The operator must be affirmative — negating operators (containing "not")
 #      or conditional-presence operators ("...ifexists") do not restrict access.
 #   2. The condition key must be in the recognized scoping-key allowlist.
-#   3. The value must not itself be a wildcard ("*"), which would restrict nothing.
+#   3. No value in the (possibly array) condition value is a wildcard ("*") or an
+#      unrestricted CIDR ("0.0.0.0/0", "::/0"), either of which would restrict nothing.
 is_iam_policy_principal_scoped_by_condition(statement) if {
 	valid_key(statement, conditions[idx])
 	value := statement[conditions[idx]][op][key]
 	not contains(lower(op), "not")
 	not endswith(lower(op), "ifexists")
 	lower(key) == lower(condition_keys_scoping_principal[_])
-	value != "*"
+	values := as_array(value)
+	not "*" in values
+	every v in values { not is_unrestricted(v) }
 }
 
 is_cross_account(statement) if {

--- a/assets/libraries/common.rego
+++ b/assets/libraries/common.rego
@@ -464,6 +464,46 @@ is_access_limited_to_an_account_id(statement) if {
 	lower(key) == lower(condition_keys_limiting_access_to_account_id[_])
 }
 
+# Global condition keys that scope a wildcard principal down to specific
+# callers or source resources (e.g. AWS service integrations such as
+# S3/CloudTrail -> SNS event notifications). A statement carrying one of these
+# is not effectively public. Superset of
+# condition_keys_limiting_access_to_account_id (which only covers account-id
+# scoping); this also covers source-resource, VPC, network and org scoping.
+condition_keys_scoping_principal := {
+	"aws:SourceArn",
+	"aws:SourceAccount",
+	"aws:SourceOwner",
+	"aws:SourceOrgID",
+	"aws:SourceOrgPaths",
+	"aws:SourceVpc",
+	"aws:SourceVpce",
+	"aws:SourceIp",
+	"aws:VpcSourceIp",
+	"aws:ResourceAccount",
+	"aws:PrincipalArn",
+	"aws:PrincipalAccount",
+	"aws:PrincipalOrgID",
+	"aws:PrincipalOrgPaths",
+	"aws:VpceAccount",
+}
+
+# verifies whether an IAM policy statement scopes its principal down via a
+# recognized Condition key so that a wildcard ("*") principal is not effectively
+# public. Three checks are combined:
+#   1. The operator must be affirmative — negating operators (containing "not")
+#      or conditional-presence operators ("...ifexists") do not restrict access.
+#   2. The condition key must be in the recognized scoping-key allowlist.
+#   3. The value must not itself be a wildcard ("*"), which would restrict nothing.
+is_iam_policy_principal_scoped_by_condition(statement) if {
+	valid_key(statement, conditions[idx])
+	value := statement[conditions[idx]][op][key]
+	not contains(lower(op), "not")
+	not endswith(lower(op), "ifexists")
+	lower(key) == lower(condition_keys_scoping_principal[_])
+	value != "*"
+}
+
 is_cross_account(statement) if {
 	is_string(statement.Principal.AWS)
 	regex.match("(^[0-9]{12}$)|(^arn:aws:(iam|sts)::[0-9]{12})", statement.Principal.AWS)

--- a/assets/libraries/test/common_test.rego
+++ b/assets/libraries/test/common_test.rego
@@ -703,3 +703,42 @@ test_is_iam_policy_principal_scoped_wildcard_value if {
 	}
 	not is_iam_policy_principal_scoped_by_condition(statement)
 }
+
+test_is_iam_policy_principal_scoped_array_wildcard_value if {
+	# Terraform aws_iam_policy_document emits condition values as arrays; ["*"] is still a wildcard
+	statement := {
+		"Effect": "Allow",
+		"Principal": "*",
+		"Condition": {"ArnLike": {"aws:SourceArn": ["*"]}},
+	}
+	not is_iam_policy_principal_scoped_by_condition(statement)
+}
+
+test_is_iam_policy_principal_scoped_unrestricted_cidr if {
+	# 0.0.0.0/0 on aws:SourceIp restricts nothing
+	statement := {
+		"Effect": "Allow",
+		"Principal": "*",
+		"Condition": {"IpAddress": {"aws:SourceIp": "0.0.0.0/0"}},
+	}
+	not is_iam_policy_principal_scoped_by_condition(statement)
+}
+
+test_is_iam_policy_principal_scoped_unrestricted_ipv6 if {
+	statement := {
+		"Effect": "Allow",
+		"Principal": "*",
+		"Condition": {"IpAddress": {"aws:SourceIp": "::/0"}},
+	}
+	not is_iam_policy_principal_scoped_by_condition(statement)
+}
+
+test_is_iam_policy_principal_scoped_specific_cidr if {
+	# A specific CIDR is a real restriction
+	statement := {
+		"Effect": "Allow",
+		"Principal": "*",
+		"Condition": {"IpAddress": {"aws:SourceIp": "10.0.0.0/8"}},
+	}
+	is_iam_policy_principal_scoped_by_condition(statement)
+}

--- a/assets/libraries/test/common_test.rego
+++ b/assets/libraries/test/common_test.rego
@@ -628,3 +628,78 @@ test_get_encryption_unencrypted if {
 	result := get_encryption_if_exists(resource)
 	result == "unencrypted"
 }
+
+# Test is_iam_policy_principal_scoped_by_condition function
+test_is_iam_policy_principal_scoped_source_arn if {
+	statement := {
+		"Effect": "Allow",
+		"Principal": "*",
+		"Action": "sns:Publish",
+		"Condition": {"ArnLike": {"aws:SourceArn": "arn:aws:s3:::my-bucket"}},
+	}
+	is_iam_policy_principal_scoped_by_condition(statement)
+}
+
+test_is_iam_policy_principal_scoped_source_account if {
+	statement := {
+		"Effect": "Allow",
+		"Principal": "*",
+		"Condition": {"StringEquals": {"aws:SourceAccount": "123456789012"}},
+	}
+	is_iam_policy_principal_scoped_by_condition(statement)
+}
+
+test_is_iam_policy_principal_scoped_lowercase_key if {
+	# condition key matching is case-insensitive
+	statement := {
+		"Effect": "Allow",
+		"Principal": "*",
+		"Condition": {"ArnLike": {"AWS:sourcearn": "arn:aws:s3:::my-bucket"}},
+	}
+	is_iam_policy_principal_scoped_by_condition(statement)
+}
+
+test_is_iam_policy_principal_scoped_non_scoping_key if {
+	# aws:SecureTransport restricts HOW, not WHO — not scoped
+	statement := {
+		"Effect": "Allow",
+		"Principal": "*",
+		"Condition": {"Bool": {"aws:SecureTransport": "true"}},
+	}
+	not is_iam_policy_principal_scoped_by_condition(statement)
+}
+
+test_is_iam_policy_principal_scoped_no_condition if {
+	statement := {"Effect": "Allow", "Principal": "*", "Action": "sns:Publish"}
+	not is_iam_policy_principal_scoped_by_condition(statement)
+}
+
+test_is_iam_policy_principal_scoped_negating_operator if {
+	# StringNotEquals means "everyone EXCEPT this account" — still public
+	statement := {
+		"Effect": "Allow",
+		"Principal": "*",
+		"Condition": {"StringNotEquals": {"aws:SourceAccount": "123456789012"}},
+	}
+	not is_iam_policy_principal_scoped_by_condition(statement)
+}
+
+test_is_iam_policy_principal_scoped_ifexists_operator if {
+	# ArnLikeIfExists passes when the key is absent — does not reliably restrict
+	statement := {
+		"Effect": "Allow",
+		"Principal": "*",
+		"Condition": {"ArnLikeIfExists": {"aws:SourceArn": "arn:aws:s3:::my-bucket"}},
+	}
+	not is_iam_policy_principal_scoped_by_condition(statement)
+}
+
+test_is_iam_policy_principal_scoped_wildcard_value if {
+	# aws:SourceArn set to "*" restricts nothing
+	statement := {
+		"Effect": "Allow",
+		"Principal": "*",
+		"Condition": {"ArnLike": {"aws:SourceArn": "*"}},
+	}
+	not is_iam_policy_principal_scoped_by_condition(statement)
+}


### PR DESCRIPTION
Adds is_iam_policy_principal_scoped_by_condition and the supporting condition_keys_scoping_principal set to the shared library.

The helper returns true when an IAM policy statement's Condition block genuinely restricts the caller — covering source-resource (aws:SourceArn), account/org, VPC, network, and principal-identity keys. Three checks prevent false negatives:

  - Negating operators (containing "not") are rejected, so StringNotEquals:SourceAccount("X") still reads as "public to everyone except X".
  - ...IfExists operators are rejected; they pass silently when the key is absent, providing no guaranteed restriction.
  - A wildcard value ("*") is rejected; aws:SourceArn:"*" restricts nothing.

This is a superset of is_access_limited_to_an_account_id (account-id scoping only, presence-based) and is intended for rules that need to avoid false positives on legitimate AWS service-integration patterns such as S3/CloudTrail -> SNS event notifications.

Resources checked in the condition: 

| Family | Keys | What they restrict |
  |---|---|---|
  | Source resource | `aws:SourceArn`, `aws:SourceOwner` | Only a specific AWS resource (like one S3 bucket) can trigger the action |
  | Source account/org | `aws:SourceAccount`, `aws:SourceOrgID`, `aws:SourceOrgPaths`,`aws:ResourceAccount`,`aws:VpceAccount` | Only a specific AWS account or org can call |
  | Network | `aws:SourceVpc`, `aws:SourceVpce`, `aws:SourceIp`, `aws:VpcSourceIp` | Only calls from a specific VPC or IP range |
  | Principal identity | `aws:PrincipalArn`, `aws:PrincipalAccount`, `aws:PrincipalOrgID`,`aws:PrincipalOrgPaths` | Only calls from a specific IAM principal or org |
