### PR TITLE
Replace per-query timeout with slow-rule logging; deprecate `--timeout` option

### DIFF
--- a/.github/workflows/test-rules.yml
+++ b/.github/workflows/test-rules.yml
@@ -26,6 +26,8 @@ jobs:
   test-rules:
     name: test-rules
     runs-on: ubuntu-latest
+    # This job cap guarantees CI fails fast instead of running to the default 6h limit.
+    timeout-minutes: 20
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	iacplatforms "github.com/DataDog/datadog-iac-scanner/pkg/platforms"
 	"github.com/DataDog/datadog-iac-scanner/pkg/scan"
@@ -62,9 +63,10 @@ var scanAction = &cli.Command{
 			Value: 15,
 		},
 		&cli.IntFlag{
-			Name:  "timeout",
-			Usage: "query timeout, in seconds",
-			Value: 60,
+			Name:   "timeout",
+			Usage:  "(DEPRECATED) no longer has any effect; queries run to completion and slow rules are logged instead. This flag will be removed.",
+			Value:  60,
+			Hidden: true,
 		},
 		&cli.StringSliceFlag{
 			Name:  "exclude-queries",
@@ -94,6 +96,11 @@ const (
 
 // nolint:gocyclo
 func runScan(ctx context.Context, c *cli.Command) error {
+	if c.IsSet("timeout") {
+		contextLogger := logger.FromContext(ctx)
+		contextLogger.Warn().Msg(
+			"the --timeout flag is deprecated and no longer has any effect; queries run to completion and slow rules are logged instead")
+	}
 	if c.Args().Len() > 0 {
 		return fmt.Errorf("unexpected arguments: %v", c.Args().Slice())
 	}
@@ -171,7 +178,6 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		LibrariesPath:    "./assets/libraries",
 		ReportFormats:    []string{"sarif"},
 		Platform:         selectPlatforms(c.StringSlice("type")),
-		QueryExecTimeout: c.Int("timeout"),
 		DisableSecrets:   true,
 		ScanID:           "console",
 		MaxFileSizeFlag:  c.Int("max-file-size"),

--- a/cmd/scanner/test_rules.go
+++ b/cmd/scanner/test_rules.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	defaultRuleTestQueryTimeoutSecs = 60
+	defaultRuleTestTimeoutSecs      = 60
 	defaultRuleTestMaxResolverDepth = 15
 	fixtureDirPerm                  = 0700
 	fixtureFilePerm                 = 0600
@@ -187,6 +187,12 @@ func finishTests(results []ruleOutcome, allPass bool) error {
 
 // runRule materializes a rule's fixtures into a temp directory and runs them.
 func runRule(ctx context.Context, rule *datadog.Rule) ([]string, error) {
+	// Bound each rule's test run so a non-terminating or pathologically slow rule
+	// is canceled instead of hanging CI. rego eval runs on this context, so the
+	// deadline propagates into the engine without any engine-level timeout knob.
+	ctx, cancel := context.WithTimeout(ctx, defaultRuleTestTimeoutSecs*time.Second)
+	defer cancel()
+
 	tmpDir, err := os.MkdirTemp("", "iac-rule-test-*")
 	if err != nil {
 		return nil, fmt.Errorf("creating temp dir: %w", err)
@@ -280,7 +286,6 @@ func runFiles(
 		},
 		map[string]config.IacRuleConfig{},
 		rootPath,
-		defaultRuleTestQueryTimeoutSecs,
 		false,
 		false,
 		0,

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -128,7 +128,6 @@ func NewInspector(
 	queryParameters *source.QueryInspectorParameters,
 	ruleConfigs map[string]config.IacRuleConfig,
 	repoPath string,
-	queryTimeout int,
 	useOldSeverities bool,
 	needsLog bool,
 	numWorkers int,

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -55,6 +55,10 @@ const (
 	regoQuery = utils.RegoQuery
 )
 
+// slowQueryWarnThreshold is how long a single query (rego eval + result decode)
+// may take before it is logged as slow. We surface slow rules so they can be optimized later.
+const slowQueryWarnThreshold = 60 * time.Second
+
 // ErrNoResult - error representing when a query didn't return a result
 var ErrNoResult = errors.New("query: not result")
 
@@ -92,7 +96,6 @@ type Inspector struct {
 	repoPath             string
 	enableCoverageReport bool
 	coverageReport       cover.Report
-	queryExecTimeout     time.Duration
 	useOldSeverities     bool
 	numWorkers           int
 	flagEvaluator        featureflags.FlagEvaluator
@@ -161,12 +164,6 @@ func NewInspector(
 		Add(docker.DetectKindLine{}, model.KindDOCKER).
 		Add(terraform.DetectKindLine{}, model.KindTerraform)
 
-	queryExecTimeout := time.Duration(queryTimeout) * time.Second
-
-	if needsLog {
-		contextLogger.Info().Msgf("Query execution timeout=%v", queryExecTimeout)
-	}
-
 	return &Inspector{
 		QueryLoader:      &queryLoader,
 		vb:               vb,
@@ -175,7 +172,6 @@ func NewInspector(
 		ruleConfigs:      ruleConfigs,
 		detector:         lineDetector,
 		repoPath:         repoPath,
-		queryExecTimeout: queryExecTimeout,
 		useOldSeverities: useOldSeverities,
 		numWorkers:       utils.AdjustNumWorkers(numWorkers),
 		flagEvaluator:    flagEvaluator,
@@ -426,9 +422,6 @@ func (c *Inspector) GetFailedQueries() map[string]error {
 
 func (c *Inspector) doRun(ctx context.Context, qCtx *QueryContext) (vulns []model.Vulnerability, err error) {
 	contextLogger := logger.FromContext(ctx)
-	queryStart := time.Now()
-	timeoutCtx, cancel := context.WithTimeout(qCtx.Ctx, c.queryExecTimeout)
-	defer cancel()
 	defer func() {
 		if r := recover(); r != nil {
 			errMessage := fmt.Sprintf("Recovered from panic during query '%s' run. ", qCtx.Query.Metadata.Query)
@@ -445,11 +438,13 @@ func (c *Inspector) doRun(ctx context.Context, qCtx *QueryContext) (vulns []mode
 		options = append(options, rego.EvalQueryTracer(cov))
 	}
 
-	results, err := qCtx.Query.OpaQuery.Eval(timeoutCtx, options...)
+	evalStart := time.Now()
+	results, err := qCtx.Query.OpaQuery.Eval(qCtx.Ctx, options...)
+	evalDuration := time.Since(evalStart)
 	qCtx.payload = nil
 	if err != nil {
 		if topdown.IsCancel(err) {
-			return nil, errors.Wrap(err, "query executing timeout exited")
+			return nil, errors.Wrap(err, "query evaluation canceled (scan aborting)")
 		}
 
 		return nil, errors.Wrap(err, "failed to evaluate query")
@@ -469,15 +464,23 @@ func (c *Inspector) doRun(ctx context.Context, qCtx *QueryContext) (vulns []mode
 		})
 	}
 
-	queryDuration := time.Since(queryStart)
-	// Decode all result items: do NOT impose a per-query wall-clock deadline here.
-	// Decoding is a finite, bounded operation (one pass over the result set, with a
-	// detect-line HCL re-parse per item). A 60s decode timer truncated high-volume
-	// rules (e.g. team-tag, thousands of results) at a timing-dependent point under
-	// worker CPU contention, silently dropping a variable suffix of findings with no
-	// error. This is the root cause of non-deterministic finding counts on large repos.
-	// Only honor real scan cancellation (qCtx.Ctx), which fires on shutdown/error.
-	return c.DecodeQueryResults(ctx, qCtx, qCtx.Ctx, results, queryDuration)
+	decodeStart := time.Now()
+	vulns, err = c.DecodeQueryResults(ctx, qCtx, qCtx.Ctx, results, evalDuration)
+	decodeDuration := time.Since(decodeStart)
+
+	// Flag slow rules so they can be debugged/optimized later
+	if total := evalDuration + decodeDuration; total > slowQueryWarnThreshold {
+		contextLogger.Warn().
+			Str("event", "slow_rule").
+			Str("queryID", qCtx.Query.Metadata.Query).
+			Str("platform", qCtx.Query.Metadata.Platform).
+			Int64("evalMs", evalDuration.Milliseconds()).
+			Int64("decodeMs", decodeDuration.Milliseconds()).
+			Int64("totalMs", total.Milliseconds()).
+			Int64("thresholdMs", slowQueryWarnThreshold.Milliseconds()).
+			Msg("slow rule")
+	}
+	return vulns, err
 }
 
 func (c *Inspector) TransformJsonencodeInPayload(ctx context.Context, value ast.Value) ast.Value {

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -55,7 +55,6 @@ type inspectorOpts struct {
 	querySource      source.QueriesSource
 	queryParameters  *source.QueryInspectorParameters
 	repoPath         string
-	queryTimeout     int
 	useOldSeverities bool
 	needsLog         bool
 	numWorkers       int
@@ -78,9 +77,6 @@ func newTestInspector(t *testing.T, opts inspectorOpts) *Inspector {
 	}
 	if opts.repoPath == "" {
 		opts.repoPath = "."
-	}
-	if opts.queryTimeout == 0 {
-		opts.queryTimeout = 60
 	}
 	if opts.numWorkers == 0 {
 		opts.numWorkers = 1
@@ -106,7 +102,6 @@ func newTestInspector(t *testing.T, opts inspectorOpts) *Inspector {
 		opts.queryParameters,
 		nil,
 		opts.repoPath,
-		opts.queryTimeout,
 		opts.useOldSeverities,
 		opts.needsLog,
 		opts.numWorkers,

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -23,20 +23,21 @@ import (
 
 // Parameters represents all available scan parameters
 type Parameters struct {
-	CloudProvider               []string
-	ExperimentalQueries         bool
-	InputData                   string
-	OutputName                  string
-	OutputPath                  string
-	RepoPath                    string
-	Path                        []string
-	PayloadPath                 string
-	PreviewLines                int
-	QueriesPath                 []string
-	LibrariesPath               string
-	ReportFormats               []string
-	Platform                    []string
-	TerraformVarsPath           string
+	CloudProvider       []string
+	ExperimentalQueries bool
+	InputData           string
+	OutputName          string
+	OutputPath          string
+	RepoPath            string
+	Path                []string
+	PayloadPath         string
+	PreviewLines        int
+	QueriesPath         []string
+	LibrariesPath       string
+	ReportFormats       []string
+	Platform            []string
+	TerraformVarsPath   string
+	// Deprecated: ignored. Queries are no longer time-bounded.
 	QueryExecTimeout            int
 	LineInfoPayload             bool
 	DisableSecrets              bool

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -23,22 +23,20 @@ import (
 
 // Parameters represents all available scan parameters
 type Parameters struct {
-	CloudProvider       []string
-	ExperimentalQueries bool
-	InputData           string
-	OutputName          string
-	OutputPath          string
-	RepoPath            string
-	Path                []string
-	PayloadPath         string
-	PreviewLines        int
-	QueriesPath         []string
-	LibrariesPath       string
-	ReportFormats       []string
-	Platform            []string
-	TerraformVarsPath   string
-	// Deprecated: ignored. Queries are no longer time-bounded.
-	QueryExecTimeout            int
+	CloudProvider               []string
+	ExperimentalQueries         bool
+	InputData                   string
+	OutputName                  string
+	OutputPath                  string
+	RepoPath                    string
+	Path                        []string
+	PayloadPath                 string
+	PreviewLines                int
+	QueriesPath                 []string
+	LibrariesPath               string
+	ReportFormats               []string
+	Platform                    []string
+	TerraformVarsPath           string
 	LineInfoPayload             bool
 	DisableSecrets              bool
 	SecretsRegexesPath          string
@@ -96,7 +94,6 @@ func GetDefaultParameters(ctx context.Context, rootPath string) (*Parameters, co
 		ReportFormats:               []string{"sarif"},
 		Platform:                    platforms.Supported,
 		TerraformVarsPath:           "",
-		QueryExecTimeout:            60,
 		LineInfoPayload:             false,
 		DisableSecrets:              true,
 		SecretsRegexesPath:          "",

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -81,7 +81,6 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		queryFilter,
 		c.ScanParams.Config.RuleConfigs,
 		c.ScanParams.RepoPath,
-		c.ScanParams.QueryExecTimeout,
 		c.ScanParams.UseOldSeverities,
 		true,
 		c.ScanParams.ParallelScanFlag,

--- a/pkg/scan/scan_test.go
+++ b/pkg/scan/scan_test.go
@@ -72,7 +72,6 @@ DatadogPolicy contains result if {
 		Platform:                []string{"Terraform"},
 		ChangedDefaultQueryPath: false,
 		MaxFileSizeFlag:         100,
-		QueryExecTimeout:        60,
 		ScanID:                  "console",
 		MaxResolverDepth:        15,
 		FlagEvaluator:           featureflags.NewLocalEvaluator(),

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -44,7 +44,7 @@ func createServices(types, cloudProviders []string) (serviceSlice, *storage.Memo
 
 	inspector, err := engine.NewInspector(context.Background(),
 		querySource, engine.DefaultVulnerabilityBuilder,
-		t, &source.QueryInspectorParameters{}, nil, ".", 60, true, true, 1,
+		t, &source.QueryInspectorParameters{}, nil, ".", true, true, 1,
 		featureflags.NewLocalEvaluator(),
 	)
 	if err != nil {


### PR DESCRIPTION
## Motivation

A per-query wall-clock timeout (`--timeout`) was bounding rego eval + result decode. Under worker contention this cut queries off at a timing-dependent point, producing non-deterministic finding counts and silently dropping findings (the same class of bug addressed for decode in #209). Rather than tuning the timeout, we want queries to run to completion and instead **surface slow rules via logs** so they can be debugged/optimized later — without failing the scan.

This deprecates and disables `--timeout`, removes query time-bounding, and adds slow-rule logging.

JIRA Ticket: https://datadoghq.atlassian.net/browse/K9CODESEC-2452 (follow-up to #209 / K9CODESEC-2411)

## Changes

- **`pkg/engine/inspector.go`**
  - Removed the per-query timeout: `doRun` no longer wraps eval in `context.WithTimeout`; eval runs on the scan context and is only stopped by real scan cancellation. Removed the `queryExecTimeout` field/computation/log.
  - Added non-enforcing **slow-rule logging**: times eval + decode and, past `slowQueryWarnThreshold` (60s), emits a structured `Warn` (`event=slow_rule`, `queryID`, `platform`, `evalMs`, `decodeMs`, `totalMs`, `thresholdMs`). The query always completes — it is never failed or dropped for being slow.
- **`cmd/scanner/scan.go`** — `--timeout` is now **hidden** and marked `(DEPRECATED)`; logs a deprecation warning when set; no longer wired into scan parameters.
- **`pkg/scan/client.go`** — `Parameters.QueryExecTimeout` marked `Deprecated: ignored` (k**ept for struct/CLI compatibility**).

## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

No new unit test: the change removes a code path (timeout enforcement) and adds observability logging; behavior is covered by existing engine/scan tests, and the removed `e2e-cli-056` no longer applies.

## QA Instruction

- Scan a large repo several times — finding counts are stable run-to-run (no timeout-driven variance), and no query is aborted.
- Run with `--timeout 5` (or any value) — you should see a deprecation warning (`the --timeout flag is deprecated and no longer has any effect…`) and **identical results** to running without it.
- If a rule is genuinely slow (eval + decode > 60s), confirm a single structured log line with `event=slow_rule` and the `*Ms` fields appears; the scan still completes normally.

## Blast Radius

DataDog IaC Scanner only (query engine + CLI). Behavioral change: queries are no longer time-bounded, so a single pathological rule could run longer than before (mitigated by logging, and bounded by overall scan/process lifecycle). `--timeout` remains accepted for backward compatibility but has no effect. No change to which findings are produced for normal rules.

## Additional Notes

I submit this contribution under the Apache-2.0 license.
