### PR TITLE
Add a long-lived `serve` HTTP server

### DIFF
--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	"github.com/DataDog/datadog-iac-scanner/internal/metrics"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -27,8 +28,9 @@ func main() {
 		debug.SetGCPercent(gcPercent)
 	}
 	cmd := &cli.Command{
-		Name:  "datadog-iac-scanner",
-		Usage: "Scans your Infrastructure as Code configurations",
+		Name:    "datadog-iac-scanner",
+		Usage:   "Scans your Infrastructure as Code configurations",
+		Version: constants.GetVersion(),
 		Commands: []*cli.Command{
 			scanAction,
 			customAction,
@@ -36,6 +38,7 @@ func main() {
 			listQueriesAction,
 			showConfigAction,
 			testRulesAction,
+			serveAction,
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/scanner/serve.go
+++ b/cmd/scanner/serve.go
@@ -34,6 +34,11 @@ var serveAction = &cli.Command{
 			Value: false,
 			Usage: "allow POST/GET /shutdown to stop the server",
 		},
+		&cli.IntFlag{
+			Name:  "max-concurrent-analyze",
+			Value: 4,
+			Usage: "maximum concurrent /analyze scans before returning 503 (must be > 0)",
+		},
 		&cli.BoolFlag{
 			Name:  "use-rules-cache",
 			Value: false,
@@ -58,12 +63,13 @@ func serve(ctx context.Context, c *cli.Command) error {
 	defer stop()
 
 	cfg := server.Config{
-		Address:          c.String("address"),
-		Port:             c.Int("port"),
-		KeepAliveTimeout: time.Duration(c.Int("keep-alive-timeout")) * time.Second,
-		EnableShutdown:   c.Bool("enable-shutdown"),
-		LibrariesPath:    c.String("libraries-path"),
-		QueriesPath:      c.String("queries-path"),
+		Address:              c.String("address"),
+		Port:                 c.Int("port"),
+		KeepAliveTimeout:     time.Duration(c.Int("keep-alive-timeout")) * time.Second,
+		EnableShutdown:       c.Bool("enable-shutdown"),
+		LibrariesPath:        c.String("libraries-path"),
+		QueriesPath:          c.String("queries-path"),
+		MaxConcurrentAnalyze: c.Int("max-concurrent-analyze"),
 	}
 	return server.New(&cfg).ListenAndServe(ctx)
 }

--- a/cmd/scanner/serve.go
+++ b/cmd/scanner/serve.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/server"
+	cli "github.com/urfave/cli/v3"
+)
+
+var serveAction = &cli.Command{
+	Name:  "serve",
+	Usage: "Runs a long-lived HTTP server that analyzes IaC files on demand",
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name:  "port",
+			Value: 8000,
+			Usage: "port to listen on",
+		},
+		&cli.StringFlag{
+			Name:  "address",
+			Value: "127.0.0.1",
+			Usage: "address to bind to",
+		},
+		&cli.IntFlag{
+			Name:  "keep-alive-timeout",
+			Value: 90,
+			Usage: "seconds without a request before auto-shutdown (0 disables)",
+		},
+		&cli.BoolFlag{
+			Name:  "enable-shutdown",
+			Value: false,
+			Usage: "allow POST/GET /shutdown to stop the server",
+		},
+		&cli.BoolFlag{
+			Name:  "use-rules-cache",
+			Value: false,
+			Usage: "accepted for compatibility with the static-analyzer server contract; currently a no-op",
+		},
+		&cli.IntFlag{
+			Name:  "rule-timeout-ms",
+			Value: 0,
+			Usage: "per-query evaluation timeout in milliseconds (0 uses the default of 60s)",
+		},
+		&cli.StringFlag{
+			Name:  "libraries-path",
+			Value: "./assets/libraries",
+			Usage: "path to the Rego support libraries",
+		},
+		&cli.StringFlag{
+			Name:  "queries-path",
+			Value: "./assets/queries",
+			Usage: "path to the default rule corpus (used only when a request omits its own rules)",
+		},
+	},
+	Action: serve,
+}
+
+const msPerSecond = 1000
+
+func serve(ctx context.Context, c *cli.Command) error {
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// Mirror the static-analyzer server's --rule-timeout-ms flag onto the IaC
+	// engine's per-query timeout (which is expressed in seconds).
+	queryExecTimeout := 60
+	if ms := c.Int("rule-timeout-ms"); ms > 0 {
+		queryExecTimeout = max(ms/msPerSecond, 1)
+	}
+
+	cfg := server.Config{
+		Address:          c.String("address"),
+		Port:             c.Int("port"),
+		KeepAliveTimeout: time.Duration(c.Int("keep-alive-timeout")) * time.Second,
+		EnableShutdown:   c.Bool("enable-shutdown"),
+		LibrariesPath:    c.String("libraries-path"),
+		QueriesPath:      c.String("queries-path"),
+		QueryExecTimeout: queryExecTimeout,
+	}
+	return server.New(&cfg).ListenAndServe(ctx)
+}

--- a/cmd/scanner/serve.go
+++ b/cmd/scanner/serve.go
@@ -39,11 +39,6 @@ var serveAction = &cli.Command{
 			Value: false,
 			Usage: "accepted for compatibility with the static-analyzer server contract; currently a no-op",
 		},
-		&cli.IntFlag{
-			Name:  "rule-timeout-ms",
-			Value: 0,
-			Usage: "per-query evaluation timeout in milliseconds (0 uses the default of 60s)",
-		},
 		&cli.StringFlag{
 			Name:  "libraries-path",
 			Value: "./assets/libraries",
@@ -58,18 +53,9 @@ var serveAction = &cli.Command{
 	Action: serve,
 }
 
-const msPerSecond = 1000
-
 func serve(ctx context.Context, c *cli.Command) error {
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-
-	// Mirror the static-analyzer server's --rule-timeout-ms flag onto the IaC
-	// engine's per-query timeout (which is expressed in seconds).
-	queryExecTimeout := 60
-	if ms := c.Int("rule-timeout-ms"); ms > 0 {
-		queryExecTimeout = max(ms/msPerSecond, 1)
-	}
 
 	cfg := server.Config{
 		Address:          c.String("address"),
@@ -78,7 +64,6 @@ func serve(ctx context.Context, c *cli.Command) error {
 		EnableShutdown:   c.Bool("enable-shutdown"),
 		LibrariesPath:    c.String("libraries-path"),
 		QueriesPath:      c.String("queries-path"),
-		QueryExecTimeout: queryExecTimeout,
 	}
 	return server.New(&cfg).ListenAndServe(ctx)
 }

--- a/cmd/scanner/test_rules.go
+++ b/cmd/scanner/test_rules.go
@@ -30,6 +30,7 @@ import (
 	yamlParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/default"
 	"github.com/DataDog/datadog-iac-scanner/pkg/runner"
 	scanUtils "github.com/DataDog/datadog-iac-scanner/pkg/utils"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/google/uuid"
 	cli "github.com/urfave/cli/v3"
 )
@@ -290,6 +291,7 @@ func runFiles(
 		false,
 		0,
 		featureflags.NewLocalEvaluator(),
+		vfs.DiskFS{},
 	)
 	if err != nil {
 		return nil, nil, err

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -33,6 +33,27 @@ func MatchesPath(pattern, filePath string) bool {
 	return false
 }
 
+// Excluded reports whether filePath should be dropped given ignore-paths and
+// only-paths lists. A file is excluded if it matches any ignorePaths pattern;
+// otherwise, when onlyPaths is non-empty, it is excluded unless it matches one
+// of them. Patterns use MatchesPath semantics.
+func Excluded(filePath string, ignorePaths, onlyPaths []string) bool {
+	for _, pattern := range ignorePaths {
+		if MatchesPath(pattern, filePath) {
+			return true
+		}
+	}
+	if len(onlyPaths) == 0 {
+		return false
+	}
+	for _, pattern := range onlyPaths {
+		if MatchesPath(pattern, filePath) {
+			return false
+		}
+	}
+	return true
+}
+
 // matchDoublestar matches a pre-split path against a pre-split pattern where
 // "**" matches zero or more path segments.
 func matchDoublestar(pat, filePath []string) bool {

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -37,3 +37,25 @@ func TestMatchesPath(t *testing.T) {
 		})
 	}
 }
+
+func TestExcluded(t *testing.T) {
+	tests := []struct {
+		name        string
+		file        string
+		ignorePaths []string
+		onlyPaths   []string
+		want        bool
+	}{
+		{"no filters", "infra/main.tf", nil, nil, false},
+		{"ignored by glob", "infra/main.tf", []string{"infra/**"}, nil, true},
+		{"not ignored", "src/main.tf", []string{"infra/**"}, nil, false},
+		{"only-paths match", "src/main.tf", nil, []string{"src/**"}, false},
+		{"only-paths excludes others", "infra/main.tf", nil, []string{"src/**"}, true},
+		{"ignore wins over only", "src/main.tf", []string{"src/**"}, []string{"src/**"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Excluded(tt.file, tt.ignorePaths, tt.onlyPaths))
+		})
+	}
+}

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -120,6 +120,18 @@ var (
 	listKeywordsAnsibleHots = []string{"hosts", "children"}
 )
 
+// PossibleFileTypes returns the sorted set of file extensions and filenames the
+// scanner can analyze. Exposed so the server's supported-files endpoint can
+// stay in sync with the scanner's capabilities.
+func PossibleFileTypes() []string {
+	out := make([]string, 0, len(possibleFileTypes))
+	for k := range possibleFileTypes {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
 const (
 	cdkTf        = "cdkTf"
 	yml          = ".yml"

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -113,6 +114,10 @@ type Inspector struct {
 	useOldSeverities     bool
 	numWorkers           int
 	flagEvaluator        featureflags.FlagEvaluator
+	// fsys is the filesystem used for Terraform module resolution. Defaults to
+	// the real disk; the HTTP server injects an in-memory FS built from pushed
+	// content.
+	fsys vfs.FS
 }
 
 // QueryContext contains the context where the query is executed, which scan it belongs, basic information of query,
@@ -146,9 +151,14 @@ func NewInspector(
 	needsLog bool,
 	numWorkers int,
 	flagEvaluator featureflags.FlagEvaluator,
+	fsys vfs.FS,
 ) (*Inspector, error) {
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("engine.NewInspector()")
+
+	if fsys == nil {
+		fsys = vfs.DiskFS{}
+	}
 
 	queries, err := queriesSource.GetQueries(ctx, queryParameters)
 	if err != nil {
@@ -191,6 +201,7 @@ func NewInspector(
 		useOldSeverities: useOldSeverities,
 		numWorkers:       utils.AdjustNumWorkers(numWorkers),
 		flagEvaluator:    flagEvaluator,
+		fsys:             fsys,
 	}, nil
 }
 
@@ -298,7 +309,7 @@ func (c *Inspector) Inspect(
 	vulnerabilities := make([]model.Vulnerability, 0)
 
 	// Step 1: Parse Terraform modules
-	parsedModules, err := tfmodules.ParseTerraformModules(ctx, files, c.numWorkers)
+	parsedModules, err := tfmodules.ParseTerraformModules(ctx, c.fsys, files, c.numWorkers)
 	if err != nil {
 		contextLogger.Warn().Err(err).Msg("Failed to parse Terraform modules")
 	}
@@ -306,7 +317,7 @@ func (c *Inspector) Inspect(
 
 	// Step 2: Enrich modules with parsed variables
 	rootDir := c.repoPath
-	enrichedModules := tfmodules.ParseAllModuleVariables(ctx, parsedModules, rootDir)
+	enrichedModules := tfmodules.ParseAllModuleVariables(ctx, c.fsys, parsedModules, rootDir)
 
 	// Convert combined documents directly to OPA AST, skipping the
 	// json.Marshal -> UnmarshalJSON round-trip to avoid intermediate copies.

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -708,20 +708,7 @@ func lookupRuleConfig(ruleConfigs map[string]config.IacRuleConfig, queryID, lega
 // rulePathExcluded returns true if the file should be dropped for a given rule
 // based on its ignore-paths and only-paths lists.
 func rulePathExcluded(filePath string, ignorePaths, onlyPaths []string) bool {
-	for _, pattern := range ignorePaths {
-		if pathutil.MatchesPath(pattern, filePath) {
-			return true
-		}
-	}
-	if len(onlyPaths) == 0 {
-		return false
-	}
-	for _, pattern := range onlyPaths {
-		if pathutil.MatchesPath(pattern, filePath) {
-			return false
-		}
-	}
-	return true
+	return pathutil.Excluded(filePath, ignorePaths, onlyPaths)
 }
 
 // markSuppressed records the first suppression decision; later gates are

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
@@ -107,6 +108,7 @@ func newTestInspector(t *testing.T, opts inspectorOpts) *Inspector {
 		opts.needsLog,
 		opts.numWorkers,
 		opts.flagEvaluator,
+		vfs.DiskFS{},
 	)
 	require.NoError(t, err)
 	return ins

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -92,6 +92,7 @@ func NewFileSystemSourceProvider(ctx context.Context, paths, excludes, onlyPaths
 func (s *FileSystemSourceProvider) addExcluded(ctx context.Context, excludePaths []string) error {
 	contextLogger := logger.FromContext(ctx)
 	for _, excludePath := range excludePaths {
+		excludePath = filepath.Clean(excludePath)
 		info, err := os.Stat(excludePath)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/pkg/engine/provider/memory.go
+++ b/pkg/engine/provider/memory.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/pathutil"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
@@ -29,17 +30,21 @@ import (
 // and is unsupported in content-push mode. Pushed Helm templates fall through to
 // raw-YAML scanning.
 type MemorySourceProvider struct {
-	fsys  vfs.FS
-	paths []string
+	fsys        vfs.FS
+	paths       []string
+	ignorePaths []string
+	onlyPaths   []string
 }
 
 // NewMemorySourceProvider builds a provider over the given paths, reading each
 // file's content from fsys (the same in-memory FS used for cross-file
-// resolution, so content is stored once).
-func NewMemorySourceProvider(fsys vfs.FS, paths []string) *MemorySourceProvider {
+// resolution, so content is stored once). ignorePaths/onlyPaths are the config's
+// global path filters; they apply the same ignore-paths/only-paths semantics the
+// disk source provider applies, so server-mode scans honor them too.
+func NewMemorySourceProvider(fsys vfs.FS, paths, ignorePaths, onlyPaths []string) *MemorySourceProvider {
 	sorted := append([]string(nil), paths...)
 	sort.Strings(sorted)
-	return &MemorySourceProvider{fsys: fsys, paths: sorted}
+	return &MemorySourceProvider{fsys: fsys, paths: sorted, ignorePaths: ignorePaths, onlyPaths: onlyPaths}
 }
 
 // GetBasePaths returns the synthetic root the pushed (workspace-relative) paths
@@ -53,6 +58,9 @@ func (m *MemorySourceProvider) GetSources(ctx context.Context,
 	contextLogger := logger.FromContext(ctx)
 	for _, p := range m.paths {
 		if !extensions.Include(memExtension(p)) {
+			continue
+		}
+		if pathutil.Excluded(p, m.ignorePaths, m.onlyPaths) {
 			continue
 		}
 		content, err := m.fsys.ReadFile(p)

--- a/pkg/engine/provider/memory.go
+++ b/pkg/engine/provider/memory.go
@@ -1,0 +1,90 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package provider
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"path/filepath"
+	"sort"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+)
+
+// MemorySourceProvider serves a fixed set of files (pushed over HTTP) to the
+// scan pipeline, reading their content through a vfs.FS. It replaces the
+// disk-walking FileSystemSourceProvider in the server's content-push path, so
+// there is no filesystem walk, no symlink/SameFile handling, and no Helm chart
+// discovery.
+//
+// The resolverSink (used by FileSystemSourceProvider to render Helm charts) is
+// intentionally never invoked: Helm rendering needs a real on-disk chart path
+// and is unsupported in content-push mode. Pushed Helm templates fall through to
+// raw-YAML scanning.
+type MemorySourceProvider struct {
+	fsys  vfs.FS
+	paths []string
+}
+
+// NewMemorySourceProvider builds a provider over the given paths, reading each
+// file's content from fsys (the same in-memory FS used for cross-file
+// resolution, so content is stored once).
+func NewMemorySourceProvider(fsys vfs.FS, paths []string) *MemorySourceProvider {
+	sorted := append([]string(nil), paths...)
+	sort.Strings(sorted)
+	return &MemorySourceProvider{fsys: fsys, paths: sorted}
+}
+
+// GetBasePaths returns the synthetic root the pushed (workspace-relative) paths
+// are reported against.
+func (m *MemorySourceProvider) GetBasePaths() []string { return []string{"."} }
+
+// GetSources feeds each pushed file whose extension a parser supports into the
+// sink, reading its content through the vfs.FS.
+func (m *MemorySourceProvider) GetSources(ctx context.Context,
+	extensions model.Extensions, sink Sink, _ ResolverSink) error {
+	contextLogger := logger.FromContext(ctx)
+	for _, p := range m.paths {
+		if !extensions.Include(memExtension(p)) {
+			continue
+		}
+		content, err := m.fsys.ReadFile(p)
+		if err != nil {
+			contextLogger.Warn().Msgf("memory source provider: could not read pushed file %s: %v", p, err)
+			continue
+		}
+		if err := sink(ctx, p, io.NopCloser(bytes.NewReader(content))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetParallelSources has no I/O to parallelize over in-memory content, so it
+// delegates to GetSources.
+func (m *MemorySourceProvider) GetParallelSources(ctx context.Context,
+	extensions model.Extensions, sink Sink, resolverSink ResolverSink) error {
+	return m.GetSources(ctx, extensions, sink, resolverSink)
+}
+
+// memExtension determines a pushed file's extension token from its path alone
+// (no disk access), mirroring the dotted form parsers declare in
+// SupportedExtensions (".tf", ".yaml", …). Extensionless files fall back to
+// their base name so filename-keyed types like "Dockerfile" still match. Unlike
+// utils.GetExtension it never stats the file, since pushed content has no
+// on-disk presence.
+func memExtension(p string) string {
+	if ext := filepath.Ext(p); ext != "" {
+		return ext
+	}
+	return filepath.Base(p)
+}
+
+var _ SourceProvider = (*MemorySourceProvider)(nil)

--- a/pkg/engine/provider/memory_test.go
+++ b/pkg/engine/provider/memory_test.go
@@ -22,7 +22,7 @@ func TestMemorySourceProvider_GetSources_FiltersByExtension(t *testing.T) {
 		"k8s/deploy.yaml": []byte("yaml-content"),
 		"Dockerfile":      []byte("FROM scratch"),
 	})
-	p := NewMemorySourceProvider(mem, mem.Paths())
+	p := NewMemorySourceProvider(mem, mem.Paths(), nil, nil)
 
 	got := collect(t, p, model.Extensions{".tf": {}})
 	if len(got) != 1 || got["infra/main.tf"] != "tf-content" {
@@ -40,8 +40,34 @@ func TestMemorySourceProvider_GetSources_FiltersByExtension(t *testing.T) {
 	}
 }
 
+func TestMemorySourceProvider_GetSources_FiltersByPath(t *testing.T) {
+	files := map[string][]byte{
+		"infra/main.tf": []byte("infra-tf"),
+		"src/main.tf":   []byte("src-tf"),
+	}
+	tfOnly := model.Extensions{".tf": {}}
+
+	t.Run("ignore-paths skips matching files", func(t *testing.T) {
+		mem := vfs.NewMemFS(files)
+		p := NewMemorySourceProvider(mem, mem.Paths(), []string{"infra/**"}, nil)
+		got := collect(t, p, tfOnly)
+		if len(got) != 1 || got["src/main.tf"] != "src-tf" {
+			t.Errorf("with ignore-paths infra/**, emitted %v, want just src/main.tf", got)
+		}
+	})
+
+	t.Run("only-paths restricts to matching files", func(t *testing.T) {
+		mem := vfs.NewMemFS(files)
+		p := NewMemorySourceProvider(mem, mem.Paths(), nil, []string{"infra/**"})
+		got := collect(t, p, tfOnly)
+		if len(got) != 1 || got["infra/main.tf"] != "infra-tf" {
+			t.Errorf("with only-paths infra/**, emitted %v, want just infra/main.tf", got)
+		}
+	})
+}
+
 func TestMemorySourceProvider_GetBasePaths(t *testing.T) {
-	p := NewMemorySourceProvider(vfs.NewMemFS(nil), nil)
+	p := NewMemorySourceProvider(vfs.NewMemFS(nil), nil, nil, nil)
 	if got := p.GetBasePaths(); len(got) != 1 || got[0] != "." {
 		t.Errorf("GetBasePaths = %v, want [.]", got)
 	}

--- a/pkg/engine/provider/memory_test.go
+++ b/pkg/engine/provider/memory_test.go
@@ -1,0 +1,65 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package provider
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+)
+
+func TestMemorySourceProvider_GetSources_FiltersByExtension(t *testing.T) {
+	mem := vfs.NewMemFS(map[string][]byte{
+		"infra/main.tf":   []byte("tf-content"),
+		"infra/notes.md":  []byte("md-content"),
+		"k8s/deploy.yaml": []byte("yaml-content"),
+		"Dockerfile":      []byte("FROM scratch"),
+	})
+	p := NewMemorySourceProvider(mem, mem.Paths())
+
+	got := collect(t, p, model.Extensions{".tf": {}})
+	if len(got) != 1 || got["infra/main.tf"] != "tf-content" {
+		t.Errorf("with .tf only, emitted %v, want just infra/main.tf", got)
+	}
+
+	gotDocker := collect(t, p, model.Extensions{"Dockerfile": {}})
+	if len(gotDocker) != 1 || gotDocker["Dockerfile"] != "FROM scratch" {
+		t.Errorf("with Dockerfile only, emitted %v, want just Dockerfile", gotDocker)
+	}
+
+	gotMulti := collect(t, p, model.Extensions{".tf": {}, ".yaml": {}})
+	if len(gotMulti) != 2 {
+		t.Errorf("with .tf+.yaml, emitted %v, want 2 files", gotMulti)
+	}
+}
+
+func TestMemorySourceProvider_GetBasePaths(t *testing.T) {
+	p := NewMemorySourceProvider(vfs.NewMemFS(nil), nil)
+	if got := p.GetBasePaths(); len(got) != 1 || got[0] != "." {
+		t.Errorf("GetBasePaths = %v, want [.]", got)
+	}
+}
+
+// collect runs GetSources and returns the emitted filename -> content map.
+func collect(t *testing.T, p *MemorySourceProvider, exts model.Extensions) map[string]string {
+	t.Helper()
+	got := map[string]string{}
+	sink := func(_ context.Context, filename string, content io.ReadCloser) error {
+		b, _ := io.ReadAll(content)
+		_ = content.Close()
+		got[filename] = string(b)
+		return nil
+	}
+	noopResolver := func(_ context.Context, _ string) ([]string, error) { return nil, nil }
+	if err := p.GetSources(context.Background(), exts, sink, noopResolver); err != nil {
+		t.Fatalf("GetSources: %v", err)
+	}
+	return got
+}

--- a/pkg/engine/source/filesystem.go
+++ b/pkg/engine/source/filesystem.go
@@ -283,6 +283,32 @@ func checkQueryFeatureFlagDisabled(ctx context.Context, metadata map[string]any,
 	return false
 }
 
+// FilterQueries returns the subset of queries whose metadata passes the
+// include/exclude filters in queryParameters (use-rules, ignore-rules,
+// severity/category filters, TRACE/BoM gating, and feature-flag exclusions),
+// plus the experimental gate. It lets query sources that don't read from disk
+// (e.g. the server's pushed-rule source) apply the same filtering the
+// filesystem source applies via iterateQueryDirs. A nil queryParameters returns
+// the queries unchanged.
+func FilterQueries(ctx context.Context, queries []model.QueryMetadata,
+	queryParameters *QueryInspectorParameters) []model.QueryMetadata {
+	if queryParameters == nil {
+		return queries
+	}
+	out := make([]model.QueryMetadata, 0, len(queries))
+	for _, query := range queries {
+		if query.Experimental && !queryParameters.ExperimentalQueries {
+			continue
+		}
+		if !checkQueryInclude(ctx, query.Metadata, queryParameters) ||
+			checkQueryExclude(ctx, query.Metadata, queryParameters) {
+			continue
+		}
+		out = append(out, query)
+	}
+	return out
+}
+
 // GetQueries returns all queries found under the source paths registered in s.Source.
 // Rules are no longer embedded in the binary; provide local rule directories via s.Source.
 func (s *FilesystemSource) GetQueries(ctx context.Context, queryParameters *QueryInspectorParameters) ([]model.QueryMetadata, error) {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 )
 
 type kindParser interface {
@@ -30,6 +31,7 @@ type kindParser interface {
 // Builder is a representation of parsers that will be construct
 type Builder struct {
 	parsers []kindParser
+	fsys    vfs.FS
 }
 
 // NewBuilder creates a new Builder's reference
@@ -37,6 +39,16 @@ func NewBuilder(ctx context.Context) *Builder {
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("parser.NewBuilder()")
 	return &Builder{}
+}
+
+// WithFS sets the filesystem used for extension detection during parsing. The
+// CLI omits it (defaults to the real disk); the HTTP server injects an in-memory
+// FS so pushed content (not on disk) is recognized. A nil fsys is ignored.
+func (b *Builder) WithFS(fsys vfs.FS) *Builder {
+	if fsys != nil {
+		b.fsys = fsys
+	}
+	return b
 }
 
 // Add is a function that adds a new parser to the caller and returns it
@@ -63,6 +75,7 @@ func (b *Builder) Build(types, cloudProviders []string) ([]*Parser, error) {
 				Parsers:    parser,
 				extensions: extensions,
 				Platform:   platforms,
+				fsys:       b.fsys,
 			})
 		}
 	}
@@ -80,6 +93,7 @@ type Parser struct {
 	extensions model.Extensions
 	Platform   []string
 	SCIInfo    model.SCIInfo
+	fsys       vfs.FS
 }
 
 // ParsedDocument is a struct containing data retrieved from parsing
@@ -193,7 +207,11 @@ func contains(types []string, supportedTypes map[string]bool) bool {
 }
 
 func (c *Parser) isValidExtension(ctx context.Context, filePath string) bool {
-	ext, _ := utils.GetExtension(ctx, filePath)
+	fsys := c.fsys
+	if fsys == nil {
+		fsys = vfs.DiskFS{}
+	}
+	ext, _ := utils.GetExtensionWithFS(ctx, fsys, filePath)
 	_, ok := c.extensions[ext]
 	return ok
 }

--- a/pkg/parser/terraform/data_source.go
+++ b/pkg/parser/terraform/data_source.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/functions"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -78,9 +79,9 @@ type convertedPolicy struct {
 	Version   string                     `json:"Version,omitempty"`
 }
 
-func getDataSourcePolicy(ctx context.Context, currentPath string, inputVariables converter.VariableMap) converter.VariableMap {
+func getDataSourcePolicy(ctx context.Context, fsys vfs.FS, currentPath string, inputVariables converter.VariableMap) converter.VariableMap {
 	contextLogger := logger.FromContext(ctx)
-	tfFiles, err := filepath.Glob(filepath.Join(currentPath, "*.tf"))
+	tfFiles, err := fsys.Glob(filepath.Join(currentPath, "*.tf"))
 	if err != nil {
 		contextLogger.Error().Msg("Error getting .tf files to parse data source")
 		return inputVariables
@@ -90,7 +91,7 @@ func getDataSourcePolicy(ctx context.Context, currentPath string, inputVariables
 	}
 	jsonMap := make(map[string]map[string]string)
 	for _, tfFile := range tfFiles {
-		parsedFile, parseErr := parseFile(tfFile, true)
+		parsedFile, parseErr := parseFile(fsys, tfFile, true)
 		if parseErr != nil {
 			contextLogger.Debug().Msgf("Error trying to parse file %s for data source.", tfFile)
 			continue

--- a/pkg/parser/terraform/data_source_test.go
+++ b/pkg/parser/terraform/data_source_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
@@ -20,7 +21,7 @@ func Test_getDataSourcePolicy(t *testing.T) {
 	type args struct {
 		currentPath  string
 		resourceName string
-		inputVars converter.VariableMap // nil means empty map
+		inputVars    converter.VariableMap // nil means empty map
 	}
 	tests := []struct {
 		name string
@@ -75,7 +76,7 @@ func Test_getDataSourcePolicy(t *testing.T) {
 			if inputVars == nil {
 				inputVars = make(converter.VariableMap)
 			}
-			result := getDataSourcePolicy(ctx, tt.args.currentPath, inputVars)
+			result := getDataSourcePolicy(ctx, vfs.DiskFS{}, tt.args.currentPath, inputVars)
 			data, ok := result["data"]
 			if !ok {
 				t.FailNow()

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -15,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/cespare/xxhash/v2"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -185,6 +185,7 @@ func collectLocalsAndVars(body *hclsyntax.Body, localsMap, varsMap map[string]st
 
 func extractModuleBlocks(
 	ctx context.Context,
+	fsys vfs.FS,
 	filePath string,
 	body *hclsyntax.Body,
 	localsMap, varsMap map[string]string,
@@ -211,12 +212,12 @@ func extractModuleBlocks(
 				if mod.IsLocal {
 					absPath := filepath.Join(baseDir, strings.TrimPrefix(resolved, "file://"))
 					var err error
-					mod.AbsSource, err = filepath.Abs(absPath)
+					mod.AbsSource, err = fsys.Abs(absPath)
 					if err != nil {
 						contextLogger.Warn().Msgf("Could not compute absolute path name for %v: %v", absPath, err)
 						mod.AbsSource = filepath.Clean(absPath)
 					}
-					err = validateModuleSource(ctx, mod.AbsSource)
+					err = validateModuleSource(ctx, fsys, mod.AbsSource)
 					if err != nil {
 						contextLogger.Warn().Msgf("Invalid local module source %q: %v", mod.Source, err)
 						continue
@@ -243,7 +244,7 @@ func extractModuleBlocks(
 
 // ParseTerraformModules parses HCL content and extracts module source/version.
 // numWorkers: 0 means auto-detect (GOMAXPROCS).
-func ParseTerraformModules(ctx context.Context, files model.FileMetadatas, numWorkers int) (map[string]ParsedModule, error) {
+func ParseTerraformModules(ctx context.Context, fsys vfs.FS, files model.FileMetadatas, numWorkers int) (map[string]ParsedModule, error) {
 	parsedBodies := parseHCLBodies(ctx, files, numWorkers)
 	modules := make(map[string]ParsedModule)
 
@@ -272,16 +273,16 @@ func ParseTerraformModules(ctx context.Context, files model.FileMetadatas, numWo
 			collectLocalsAndVars(e.body, localsMap, varsMap)
 		}
 		for _, e := range entries {
-			extractModuleBlocks(ctx, e.file.FilePath, e.body, localsMap, varsMap, modules)
+			extractModuleBlocks(ctx, fsys, e.file.FilePath, e.body, localsMap, varsMap, modules)
 		}
 	}
 	return modules, nil
 }
 
-func validateModuleSource(ctx context.Context, absPath string) error {
+func validateModuleSource(ctx context.Context, fsys vfs.FS, absPath string) error {
 	contextLogger := logger.FromContext(ctx)
 	// Attempt to read the directory contents
-	entries, err := os.ReadDir(absPath)
+	entries, err := fsys.ReadDir(absPath)
 	if err != nil {
 		err := fmt.Errorf("module source path %q is not accessible: %w", absPath, err)
 		contextLogger.Error().Msg(err.Error())
@@ -593,7 +594,7 @@ func DetectModuleSourceType(source string) (string, string) {
 	return stringUnknown, ""
 }
 
-func ParseAllModuleVariables(ctx context.Context, modules map[string]ParsedModule, rootDir string) []ParsedModule {
+func ParseAllModuleVariables(ctx context.Context, fsys vfs.FS, modules map[string]ParsedModule, rootDir string) []ParsedModule {
 	contextLogger := logger.FromContext(ctx)
 	numWorkers := 4
 
@@ -622,7 +623,7 @@ func ParseAllModuleVariables(ctx context.Context, modules map[string]ParsedModul
 					}
 					modulePath := resolveModulePath(mod.AbsSource, rootDir)
 
-					attributesData, err := generateEquivalentMap(ctx, modulePath)
+					attributesData, err := generateEquivalentMap(ctx, fsys, modulePath)
 					if err != nil {
 						contextLogger.Warn().Msg("Failed to generate equivalent map")
 					} else {
@@ -671,12 +672,12 @@ func ParseAllModuleVariables(ctx context.Context, modules map[string]ParsedModul
 	}
 }
 
-func generateEquivalentMap(ctx context.Context, modulePath string) (map[string]ModuleAttributesInfo, error) {
+func generateEquivalentMap(ctx context.Context, fsys vfs.FS, modulePath string) (map[string]ModuleAttributesInfo, error) {
 	contextLogger := logger.FromContext(ctx)
 	equivalentMap := make(map[string]ModuleAttributesInfo)
 	resourceTypesMap := make(map[string]map[string]bool)
 
-	entries, err := os.ReadDir(modulePath)
+	entries, err := fsys.ReadDir(modulePath)
 	if err != nil {
 		contextLogger.Error().Msgf("Failed to read module source directory: %s", modulePath)
 		return nil, err
@@ -695,7 +696,7 @@ func generateEquivalentMap(ctx context.Context, modulePath string) (map[string]M
 			continue
 		}
 
-		contents, err := os.ReadFile(filepath.Clean(path))
+		contents, err := fsys.ReadFile(filepath.Clean(path))
 		if err != nil {
 			contextLogger.Error().Msgf("Failed to read file: %s", path)
 			return nil, err

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/require"
@@ -53,7 +54,7 @@ module "local_bucket" {
 		},
 	}
 
-	gotMap, err := ParseTerraformModules(ctx, files, 0)
+	gotMap, err := ParseTerraformModules(ctx, vfs.DiskFS{}, files, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -322,7 +323,7 @@ module "three" {
 					}},
 			}
 
-			gotMap, err := ParseTerraformModules(ctx, files, 0)
+			gotMap, err := ParseTerraformModules(ctx, vfs.DiskFS{}, files, 0)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -7,7 +7,6 @@ package terraform
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -19,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/utils"
 	masterUtils "github.com/DataDog/datadog-iac-scanner/pkg/utils"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pkg/errors"
@@ -39,6 +39,11 @@ type Parser struct {
 	terraformVarsPath string
 	sciInfo           model.SCIInfo
 
+	// fsys is the filesystem used for cross-file resolution (sibling .tf files,
+	// .tfvars, data sources). Defaults to the real disk; the HTTP server injects
+	// an in-memory FS populated from pushed content.
+	fsys vfs.FS
+
 	// dirVarsCache memoizes per-directory variable/locals resolution (O(N²) without
 	// it). Scoped to the Parser instance, which is created once per scan.
 	dirVarsCache sync.Map // dir -> converter.VariableMap
@@ -50,12 +55,16 @@ func NewDefault() *Parser {
 	return &Parser{
 		numOfRetries: RetriesDefaultValue,
 		convertFunc:  converter.DefaultConverted,
+		fsys:         vfs.DiskFS{},
 	}
 }
 
 // nolint:gocritic
-func NewDefaultWithParams(terraformVarsPath string, sciInfo model.SCIInfo) *Parser {
+func NewDefaultWithParams(fsys vfs.FS, terraformVarsPath string, sciInfo model.SCIInfo) *Parser {
 	parser := NewDefault()
+	if fsys != nil {
+		parser.fsys = fsys
+	}
 	parser.terraformVarsPath = terraformVarsPath
 	parser.sciInfo = sciInfo
 	return parser
@@ -81,16 +90,16 @@ func (p *Parser) Resolve(ctx context.Context,
 // are resolved per-file (uncached) because their result depends on file content.
 func (p *Parser) resolveDirVars(ctx context.Context, dir string, fileContent []byte) converter.VariableMap {
 	if p.terraformVarsPath == "" && strings.Contains(string(fileContent), terraformVarsPathDirective) {
-		inputVars := getInputVariables(ctx, dir, string(fileContent), p.terraformVarsPath)
-		return getDataSourcePolicy(ctx, dir, inputVars)
+		inputVars := getInputVariables(ctx, p.fsys, dir, string(fileContent), p.terraformVarsPath)
+		return getDataSourcePolicy(ctx, p.fsys, dir, inputVars)
 	}
 
 	if v, ok := p.dirVarsCache.Load(dir); ok {
 		return cloneVariableMap(v.(converter.VariableMap))
 	}
 	v, _, _ := p.dirVarsSF.Do(dir, func() (interface{}, error) {
-		inputVars := getInputVariables(ctx, dir, string(fileContent), p.terraformVarsPath)
-		vars := getDataSourcePolicy(ctx, dir, inputVars)
+		inputVars := getInputVariables(ctx, p.fsys, dir, string(fileContent), p.terraformVarsPath)
+		vars := getDataSourcePolicy(ctx, p.fsys, dir, inputVars)
 		p.dirVarsCache.Store(dir, vars)
 		return vars, nil
 	})
@@ -200,8 +209,8 @@ func addExtraInfo(ctx context.Context, json []model.Document, path string) ([]mo
 	return json, nil
 }
 
-func parseFile(filename string, shouldReplaceDataSource bool) (*hcl.File, error) {
-	file, err := os.ReadFile(filepath.Clean(filename))
+func parseFile(fsys vfs.FS, filename string, shouldReplaceDataSource bool) (*hcl.File, error) {
+	file, err := fsys.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/parser/terraform/terraform_test.go
+++ b/pkg/parser/terraform/terraform_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -379,7 +380,7 @@ data "aws_iam_policy_document" "test_destination_policy" {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parsedFile, err := parseFile(tt.filename, tt.shouldReplaceDataSource)
+			parsedFile, err := parseFile(vfs.DiskFS{}, tt.filename, tt.shouldReplaceDataSource)
 			if tt.wantErr {
 				require.NotNil(t, err)
 				require.Nil(t, parsedFile)

--- a/pkg/parser/terraform/variables.go
+++ b/pkg/parser/terraform/variables.go
@@ -7,13 +7,13 @@ package terraform
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
@@ -29,8 +29,8 @@ func mergeMaps(baseMap, newItems converter.VariableMap) {
 }
 
 // nolint:gocyclo
-func getInputVariablesFromFile(filename string) (converter.VariableMap, error) {
-	src, err := os.ReadFile(filepath.Clean(filename))
+func getInputVariablesFromFile(fsys vfs.FS, filename string) (converter.VariableMap, error) {
+	src, err := fsys.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +86,8 @@ func getInputVariablesFromFile(filename string) (converter.VariableMap, error) {
 	return variables, nil
 }
 
-func getInputLocalsFromFile(filename string) (converter.VariableMap, error) {
-	src, err := os.ReadFile(filepath.Clean(filename))
+func getInputLocalsFromFile(fsys vfs.FS, filename string) (converter.VariableMap, error) {
+	src, err := fsys.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, err
 	}
@@ -147,12 +147,12 @@ func sanitizeCtyMap(in map[string]cty.Value) map[string]cty.Value {
 	return out
 }
 
-func getInputVariables(ctx context.Context, currentPath, fileContent, terraformVarsPath string) converter.VariableMap {
+func getInputVariables(ctx context.Context, fsys vfs.FS, currentPath, fileContent, terraformVarsPath string) converter.VariableMap {
 	contextLogger := logger.FromContext(ctx)
 	variablesMap := make(converter.VariableMap)
 	localsMap := make(converter.VariableMap)
 
-	tfFiles, err := filepath.Glob(filepath.Join(currentPath, "*.tf"))
+	tfFiles, err := fsys.Glob(filepath.Join(currentPath, "*.tf"))
 	if err != nil {
 		contextLogger.Error().Msg("Error getting .tf files")
 	}
@@ -160,7 +160,7 @@ func getInputVariables(ctx context.Context, currentPath, fileContent, terraformV
 	// Parse all .tf files for variables and locals
 	for _, tfFile := range tfFiles {
 		// Get variables
-		vars, errVars := getInputVariablesFromFile(tfFile)
+		vars, errVars := getInputVariablesFromFile(fsys, tfFile)
 		if errVars != nil {
 			contextLogger.Error().Msgf("Error getting default values from %s", tfFile)
 			contextLogger.Err(errVars)
@@ -169,7 +169,7 @@ func getInputVariables(ctx context.Context, currentPath, fileContent, terraformV
 		}
 
 		// Get locals
-		locals, errLocals := getInputLocalsFromFile(tfFile)
+		locals, errLocals := getInputLocalsFromFile(fsys, tfFile)
 		if errLocals != nil {
 			contextLogger.Error().Msgf("Error getting locals from %s", tfFile)
 			contextLogger.Err(errLocals)
@@ -179,18 +179,18 @@ func getInputVariables(ctx context.Context, currentPath, fileContent, terraformV
 	}
 
 	// Parse *.auto.tfvars files
-	tfVarsFiles, err := filepath.Glob(filepath.Join(currentPath, "*.auto.tfvars"))
+	tfVarsFiles, err := fsys.Glob(filepath.Join(currentPath, "*.auto.tfvars"))
 	if err != nil {
 		contextLogger.Error().Msg("Error getting .auto.tfvars files")
 	}
 
 	// Add terraform.tfvars if it exists
-	if _, err := os.Stat(filepath.Join(currentPath, "terraform.tfvars")); err == nil {
+	if _, err := fsys.Stat(filepath.Join(currentPath, "terraform.tfvars")); err == nil {
 		tfVarsFiles = append(tfVarsFiles, filepath.Join(currentPath, "terraform.tfvars"))
 	}
 
 	for _, tfVarsFile := range tfVarsFiles {
-		vars, errInput := getInputVariablesFromFile(tfVarsFile)
+		vars, errInput := getInputVariablesFromFile(fsys, tfVarsFile)
 		if errInput != nil {
 			contextLogger.Error().Msgf("Error getting values from %s", tfVarsFile)
 			contextLogger.Err(errInput)
@@ -211,8 +211,8 @@ func getInputVariables(ctx context.Context, currentPath, fileContent, terraformV
 	}
 
 	if terraformVarsPath != "" {
-		if _, err := os.Stat(terraformVarsPath); err == nil {
-			vars, errInput := getInputVariablesFromFile(terraformVarsPath)
+		if _, err := fsys.Stat(terraformVarsPath); err == nil {
+			vars, errInput := getInputVariablesFromFile(fsys, terraformVarsPath)
 			if errInput != nil {
 				contextLogger.Error().Msgf("Error getting values from %s", terraformVarsPath)
 				contextLogger.Err(errInput)

--- a/pkg/parser/terraform/variables_test.go
+++ b/pkg/parser/terraform/variables_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -36,7 +37,7 @@ type inputVarTest struct {
 }
 
 func setInputVariablesDefaultValues(filename string) (converter.VariableMap, error) {
-	parsedFile, err := parseFile(filename, false)
+	parsedFile, err := parseFile(vfs.DiskFS{}, filename, false)
 	if err != nil || parsedFile == nil {
 		return nil, err
 	}
@@ -174,7 +175,7 @@ func TestGetInputVariablesFromFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inputVars, err := getInputVariablesFromFile(tt.filename)
+			inputVars, err := getInputVariablesFromFile(vfs.DiskFS{}, tt.filename)
 			if tt.wantErr {
 				require.NotNil(t, err)
 			} else {
@@ -230,7 +231,7 @@ func TestGetInputVariables(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fileContent, _ := os.ReadFile(tt.filename)
-			result := getInputVariables(ctx, tt.filename, string(fileContent), "../../../test/fixtures/test_terraform_variables/varsToUse/varsToUse.tf")
+			result := getInputVariables(ctx, vfs.DiskFS{}, tt.filename, string(fileContent), "../../../test/fixtures/test_terraform_variables/varsToUse/varsToUse.tf")
 			require.Equal(t, tt.want, result)
 		})
 	}

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/platforms"
 	consolePrinter "github.com/DataDog/datadog-iac-scanner/pkg/printer"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/rs/zerolog/log"
 )
 
@@ -75,6 +76,46 @@ type Client struct {
 	// Set when the platform is already known (e.g. RunCustomRegoQuery) so the temp file name
 	// does not need to encode platform information.
 	analyzerOverride func(ctx context.Context) (model.AnalyzedPaths, error)
+	// fsys is the filesystem used for cross-file resolution. Defaults to the real
+	// disk (CLI); the HTTP server injects an in-memory FS built from pushed
+	// content via WithFS.
+	fsys vfs.FS
+	// inMemory marks a server (content-push) scan: initScan builds its file set
+	// from inMemoryPaths instead of walking the disk via the analyzer.
+	inMemory      bool
+	inMemoryPaths []string
+}
+
+// ClientOption customizes a Client at construction time.
+type ClientOption func(*Client)
+
+// WithQuerySourceFactory injects a factory that supplies the engine's queries,
+// bypassing the default Datadog/filesystem source. The HTTP server uses this to
+// serve rules pushed in the request body. Promotes the previously test-only
+// querySourceFactory seam to a first-class production option.
+func WithQuerySourceFactory(f func(ctx context.Context, platforms []string) (source.QueriesSource, error)) ClientOption {
+	return func(c *Client) { c.querySourceFactory = f }
+}
+
+// WithFS sets the filesystem used for cross-file resolution. The CLI uses the
+// default (real disk); the HTTP server injects an in-memory FS built from pushed
+// content. A nil fsys is ignored.
+func WithFS(fsys vfs.FS) ClientOption {
+	return func(c *Client) {
+		if fsys != nil {
+			c.fsys = fsys
+		}
+	}
+}
+
+// WithInMemoryScan marks the scan as content-push: initScan builds its file set
+// from the given paths (the keys of the pushed content) instead of walking the
+// disk. Used together with WithFS.
+func WithInMemoryScan(paths []string) ClientOption {
+	return func(c *Client) {
+		c.inMemory = true
+		c.inMemoryPaths = paths
+	}
 }
 
 func GetDefaultParameters(ctx context.Context, rootPath string) (*Parameters, context.Context) {
@@ -115,8 +156,10 @@ func GetDefaultParameters(ctx context.Context, rootPath string) (*Parameters, co
 	}, logCtx
 }
 
-// NewClient initializes the client with all the required parameters
-func NewClient(ctx context.Context, params *Parameters, customPrint *consolePrinter.Printer) (*Client, error) {
+// NewClient initializes the client with all the required parameters. Optional
+// ClientOptions (WithFS, WithQuerySourceFactory, WithInMemoryScan) configure the
+// HTTP server's content-push path; the CLI passes none.
+func NewClient(ctx context.Context, params *Parameters, customPrint *consolePrinter.Printer, opts ...ClientOption) (*Client, error) {
 	contextLogger := logger.FromContext(ctx)
 	t, err := tracker.NewTracker(params.PreviewLines)
 	if err != nil {
@@ -126,13 +169,26 @@ func NewClient(ctx context.Context, params *Parameters, customPrint *consolePrin
 
 	store := storage.NewMemoryStorage()
 
-	return &Client{
+	client := &Client{
 		ScanParams:    params,
 		Tracker:       t,
 		Storage:       store,
 		Printer:       customPrint,
 		FlagEvaluator: params.FlagEvaluator,
-	}, nil
+		fsys:          vfs.DiskFS{},
+	}
+	for _, opt := range opts {
+		opt(client)
+	}
+	return client, nil
+}
+
+// Scan runs the scan pipeline in memory and returns the results without writing
+// SARIF, reading git, or calling the network. It is the entry point used by the
+// HTTP server; the CLI uses PerformScan (which additionally produces reports).
+func (c *Client) Scan(ctx context.Context) (*Results, error) {
+	c.ScanStartTime = time.Now()
+	return c.executeScan(ctx)
 }
 
 // PerformScan executes executeScan and postScan

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -256,7 +256,8 @@ func (c *Client) createService(
 		// Content-push mode: serve the pushed files from the in-memory FS instead
 		// of walking the disk. No symlink/SameFile handling and no Helm chart
 		// discovery occur (the resolverSink is never invoked).
-		filesSource = provider.NewMemorySourceProvider(c.fsys, paths)
+		filesSource = provider.NewMemorySourceProvider(c.fsys, paths,
+			c.ScanParams.Config.IgnorePaths, c.ScanParams.Config.OnlyPaths)
 	} else {
 		fsSource, err := c.getFileSystemSourceProvider(ctx, paths)
 		if err != nil {

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -52,10 +52,20 @@ type executeScanParameters struct {
 func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 	contextLogger := logger.FromContext(ctx)
 
-	extractedPaths, err := c.prepareAndAnalyzePaths(ctx)
-	if err != nil {
-		contextLogger.Err(err).Msgf("failed to prepare and analyze paths %v", err)
-		return nil, err
+	var extractedPaths provider.ExtractedPath
+	if c.inMemory {
+		// Content-push (server) mode: the file set is the pushed paths. Skip the
+		// disk walk + analyzer.Analyze the CLI path runs (it reads the repo from
+		// disk and mutates ScanParams.Platform). Platforms come from the request
+		// (ScanParams.Platform); content is read through c.fsys.
+		extractedPaths = provider.ExtractedPath{Path: c.inMemoryPaths}
+	} else {
+		paths, err := c.prepareAndAnalyzePaths(ctx)
+		if err != nil {
+			contextLogger.Err(err).Msgf("failed to prepare and analyze paths %v", err)
+			return nil, err
+		}
+		extractedPaths = paths
 	}
 
 	if len(extractedPaths.Path) == 0 {
@@ -86,6 +96,7 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		true,
 		c.ScanParams.ParallelScanFlag,
 		c.ScanParams.FlagEvaluator,
+		c.fsys,
 	)
 	metrics.Metric.Stop()
 	if err != nil {
@@ -240,14 +251,24 @@ func (c *Client) createService(
 	types []string,
 	cloudProviders []string,
 	flagEvaluator featureflags.FlagEvaluator) ([]*runner.Service, error) {
-	filesSource, err := c.getFileSystemSourceProvider(ctx, paths)
-	if err != nil {
-		return nil, err
+	var filesSource provider.SourceProvider
+	if c.inMemory {
+		// Content-push mode: serve the pushed files from the in-memory FS instead
+		// of walking the disk. No symlink/SameFile handling and no Helm chart
+		// discovery occur (the resolverSink is never invoked).
+		filesSource = provider.NewMemorySourceProvider(c.fsys, paths)
+	} else {
+		fsSource, err := c.getFileSystemSourceProvider(ctx, paths)
+		if err != nil {
+			return nil, err
+		}
+		filesSource = fsSource
 	}
 
 	combinedParserBuilder := parser.NewBuilder(ctx).
+		WithFS(c.fsys).
 		Add(&yamlParser.Parser{}).
-		Add(terraformParser.NewDefaultWithParams(c.ScanParams.TerraformVarsPath, c.ScanParams.SCIInfo)).
+		Add(terraformParser.NewDefaultWithParams(c.fsys, c.ScanParams.TerraformVarsPath, c.ScanParams.SCIInfo)).
 		Add(&bicepParser.Parser{}).
 		Add(&cicdParser.Parser{}).
 		Add(&dockerParser.Parser{}).

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser"
 	"github.com/DataDog/datadog-iac-scanner/pkg/resolver"
 	"github.com/DataDog/datadog-iac-scanner/pkg/runner"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/stretchr/testify/require"
 
 	jsonParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/json"
@@ -46,6 +47,7 @@ func createServices(types, cloudProviders []string) (serviceSlice, *storage.Memo
 		querySource, engine.DefaultVulnerabilityBuilder,
 		t, &source.QueryInspectorParameters{}, nil, ".", true, true, 1,
 		featureflags.NewLocalEvaluator(),
+		vfs.DiskFS{},
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -176,7 +176,6 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 		LibrariesPath:    s.cfg.LibrariesPath,
 		PreviewLines:     3,
 		Platform:         plats,
-		QueryExecTimeout: s.cfg.QueryExecTimeout,
 		DisableSecrets:   true,
 		ScanID:           "serve",
 		MaxFileSizeFlag:  100,

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -160,7 +160,11 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 		if err != nil {
 			return nil, err
 		}
-		cfg = *parsed
+		// ParseConfig returns (nil, nil) for a valid config that has no `iac`
+		// section. Keep the empty IaC config in that case.
+		if parsed != nil {
+			cfg = *parsed
+		}
 	}
 
 	plats := req.Platform
@@ -248,8 +252,11 @@ type requestQuerySource struct {
 	libraries source.QueriesSource
 }
 
-func (r *requestQuerySource) GetQueries(_ context.Context, _ *source.QueryInspectorParameters) ([]model.QueryMetadata, error) {
-	return r.queries, nil
+func (r *requestQuerySource) GetQueries(ctx context.Context, params *source.QueryInspectorParameters) ([]model.QueryMetadata, error) {
+	// Apply the same use-rules/ignore-rules, severity/category, and feature-flag
+	// filters the filesystem source applies, so config-disabled rules stay
+	// suppressed even when the caller pushes them in the request.
+	return source.FilterQueries(ctx, r.queries, params), nil
 }
 
 func (r *requestQuerySource) GetQueryLibrary(ctx context.Context, platform string) (source.RegoLibraries, error) {

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -76,6 +76,18 @@ type analyzeResponse struct {
 func (s *Server) handleAnalyze(w http.ResponseWriter, r *http.Request) {
 	contextLogger := logger.FromContext(r.Context())
 
+	// Bound concurrent scans before buffering the body or spinning up the
+	// engine. Acquire-or-503 so a burst (reachable cross-origin) can't exhaust
+	// memory/goroutines; the caller is expected to retry.
+	select {
+	case s.analyzeSem <- struct{}{}:
+		defer func() { <-s.analyzeSem }()
+	default:
+		w.Header().Set("Retry-After", "1")
+		writeError(w, http.StatusServiceUnavailable, "server busy: too many concurrent analyses")
+		return
+	}
+
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBytes)
 	var req analyzeRequest
 	// Deliberately not DisallowUnknownFields: tolerating unknown fields lets a

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -1,0 +1,298 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"maps"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/config"
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
+	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/platforms"
+	consolePrinter "github.com/DataDog/datadog-iac-scanner/pkg/printer"
+	"github.com/DataDog/datadog-iac-scanner/pkg/scan"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+)
+
+const (
+	// maxFiles / maxRules bound a single analyze request. The default rule corpus
+	// is ~1200 rules; the limits are generous headroom, not a tuning knob.
+	maxFiles = 5000
+	maxRules = 10000
+	// metadataDefaultKeys is the number of fixed keys setDefault injects in
+	// toQueryMetadata (id, legacyId, queryName, severity, platform, category).
+	metadataDefaultKeys = 6
+)
+
+// analyzeFile is a single pushed file: a workspace-relative path and its raw
+// (possibly unsaved) content.
+type analyzeFile struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+// analyzeRule is a single Rego rule supplied by the caller. Mirrors the shape
+// the extension already builds for the engine.
+type analyzeRule struct {
+	ID        string         `json:"id"`
+	Platform  string         `json:"platform"`
+	Content   string         `json:"content"`
+	InputData string         `json:"inputData,omitempty"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+// analyzeRequest is the body of POST /ide/v1/iac/analyze. Content is raw (not
+// base64). Rules are pushed by the extension; an empty list falls back to the
+// embedded corpus. Config is the raw YAML of the unified config's iac section.
+type analyzeRequest struct {
+	Files    []analyzeFile `json:"files"`
+	Rules    []analyzeRule `json:"rules"`
+	Config   string        `json:"config,omitempty"`
+	Platform []string      `json:"platform,omitempty"`
+}
+
+// analyzeResponse is the body of a successful analyze. Findings are the engine's
+// full vulnerability records (the extension's converter picks the fields it
+// needs). MissingFiles drives the hybrid escalation: paths the engine referenced
+// but that were not pushed.
+type analyzeResponse struct {
+	Findings      []model.Vulnerability `json:"findings"`
+	MissingFiles  []string              `json:"missing_files"`
+	FailedQueries map[string]string     `json:"failed_queries,omitempty"`
+}
+
+func (s *Server) handleAnalyze(w http.ResponseWriter, r *http.Request) {
+	contextLogger := logger.FromContext(r.Context())
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBytes)
+	var req analyzeRequest
+	// Deliberately not DisallowUnknownFields: tolerating unknown fields lets a
+	// newer extension talk to an older binary (forward compatibility).
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+
+	if err := validateAnalyzeRequest(&req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	out, err := s.analyze(r.Context(), &req)
+	if err != nil {
+		contextLogger.Err(err).Msg("analyze failed")
+		writeError(w, http.StatusInternalServerError, "analysis failed: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func validateAnalyzeRequest(req *analyzeRequest) error {
+	if len(req.Files) == 0 {
+		return errors.New("at least one file is required")
+	}
+	if len(req.Files) > maxFiles {
+		return errors.New("too many files")
+	}
+	if len(req.Rules) > maxRules {
+		return errors.New("too many rules")
+	}
+	for _, f := range req.Files {
+		if err := validateFilePath(f.Path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateFilePath rejects paths that are empty, absolute, contain a NUL byte,
+// or escape the workspace root via "..".
+func validateFilePath(p string) error {
+	if p == "" {
+		return errors.New("empty file path")
+	}
+	if strings.ContainsRune(p, 0) {
+		return errors.New("file path contains NUL byte")
+	}
+	// filepath.IsAbs is OS-dependent; also reject Unix-style absolute paths on
+	// Windows (e.g. "/etc/passwd" is not absolute per Windows rules).
+	if filepath.IsAbs(p) || strings.HasPrefix(p, "/") {
+		return errors.New("file path must be workspace-relative, got absolute: " + p)
+	}
+	clean := filepath.ToSlash(filepath.Clean(p))
+	if clean == ".." || strings.HasPrefix(clean, "../") {
+		return errors.New("file path escapes the workspace: " + p)
+	}
+	return nil
+}
+
+// analyze runs the content-push scan: build an in-memory FS from the pushed
+// files, serve the request's rules, and run the engine with no disk, git, or
+// network access. It returns the findings plus the list of files the engine
+// referenced but did not receive.
+func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResponse, error) {
+	files := make(map[string][]byte, len(req.Files))
+	for _, f := range req.Files {
+		files[f.Path] = []byte(f.Content)
+	}
+	memfs := vfs.NewMemFS(files)
+
+	cfg := config.IacConfig{}
+	if strings.TrimSpace(req.Config) != "" {
+		parsed, err := config.ParseConfig([]byte(req.Config))
+		if err != nil {
+			return nil, err
+		}
+		cfg = *parsed
+	}
+
+	plats := req.Platform
+	if len(plats) == 0 {
+		plats = platforms.Supported
+	}
+
+	params := &scan.Parameters{
+		CloudProvider:    []string{""},
+		Path:             memfs.Paths(),
+		RepoPath:         "", // no git in server mode
+		QueriesPath:      []string{s.cfg.QueriesPath},
+		LibrariesPath:    s.cfg.LibrariesPath,
+		PreviewLines:     3,
+		Platform:         plats,
+		QueryExecTimeout: s.cfg.QueryExecTimeout,
+		DisableSecrets:   true,
+		ScanID:           "serve",
+		MaxFileSizeFlag:  100,
+		MaxResolverDepth: 15,
+		// Helm rendering shells out to a chart on disk, which content-push mode
+		// has no way to materialize, so disable the resolver. Parallel file
+		// parsing is pointless for in-memory content.
+		FlagEvaluator: featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
+			featureflags.IacEnableKicsHelmResolver:        false,
+			featureflags.IaCEnableKicsParallelFileParsing: false,
+		}),
+		Config: cfg,
+	}
+
+	client, err := scan.NewClient(ctx, params, &consolePrinter.Printer{},
+		scan.WithFS(memfs),
+		scan.WithInMemoryScan(memfs.Paths()),
+		scan.WithQuerySourceFactory(s.querySourceFactory(params, req.Rules)),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.Scan(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &analyzeResponse{
+		Findings:     []model.Vulnerability{},
+		MissingFiles: memfs.MissingFiles(),
+	}
+	if res == nil {
+		// No analyzable content for the requested platforms.
+		return resp, nil
+	}
+	if len(res.Results) > 0 {
+		resp.Findings = res.Results
+	}
+	if len(res.FailedQueries) > 0 {
+		resp.FailedQueries = make(map[string]string, len(res.FailedQueries))
+		for q, e := range res.FailedQueries {
+			resp.FailedQueries[q] = e.Error()
+		}
+	}
+	return resp, nil
+}
+
+// querySourceFactory returns a factory that serves the request's rules (with
+// libraries loaded from the embedded corpus). When no rules are pushed it falls
+// back to the filesystem corpus directly — never the network-backed Datadog
+// source, keeping the request path pure.
+func (s *Server) querySourceFactory(
+	params *scan.Parameters, rules []analyzeRule,
+) func(context.Context, []string) (source.QueriesSource, error) {
+	return func(ctx context.Context, plats []string) (source.QueriesSource, error) {
+		fsSource := source.NewFilesystemSource(ctx, params.QueriesPath, plats,
+			params.CloudProvider, params.LibrariesPath, params.ExperimentalQueries)
+		if len(rules) == 0 {
+			return fsSource, nil
+		}
+		return &requestQuerySource{queries: toQueryMetadata(rules), libraries: fsSource}, nil
+	}
+}
+
+// requestQuerySource serves the request's rules as queries while delegating
+// library loading to the embedded filesystem source.
+type requestQuerySource struct {
+	queries   []model.QueryMetadata
+	libraries source.QueriesSource
+}
+
+func (r *requestQuerySource) GetQueries(_ context.Context, _ *source.QueryInspectorParameters) ([]model.QueryMetadata, error) {
+	return r.queries, nil
+}
+
+func (r *requestQuerySource) GetQueryLibrary(ctx context.Context, platform string) (source.RegoLibraries, error) {
+	return r.libraries.GetQueryLibrary(ctx, platform)
+}
+
+// toQueryMetadata converts request rules into engine query metadata, filling the
+// metadata fields the vulnerability builder expects when the caller omits them.
+func toQueryMetadata(rules []analyzeRule) []model.QueryMetadata {
+	out := make([]model.QueryMetadata, 0, len(rules))
+	for _, rule := range rules {
+		inputData := rule.InputData
+		if inputData == "" {
+			inputData = "{}"
+		}
+		// Copy the caller's metadata into a fresh map so this function never
+		// mutates the request value (which may be shared/read concurrently).
+		metadata := make(map[string]any, len(rule.Metadata)+metadataDefaultKeys)
+		maps.Copy(metadata, rule.Metadata)
+		setDefault(metadata, "id", rule.ID)
+		setDefault(metadata, "legacyId", rule.ID)
+		setDefault(metadata, "queryName", rule.ID)
+		setDefault(metadata, "severity", "INFO")
+		setDefault(metadata, "platform", rule.Platform)
+		setDefault(metadata, "category", "Best Practices")
+
+		out = append(out, model.QueryMetadata{
+			Query:     rule.ID,
+			Content:   rule.Content,
+			InputData: inputData,
+			Platform:  rule.Platform,
+			Metadata:  metadata,
+		})
+	}
+	return out
+}
+
+func setDefault(m map[string]any, key string, value any) {
+	if _, ok := m[key]; !ok {
+		m[key] = value
+	}
+}
+
+// compile-time assertion that requestQuerySource satisfies the engine interface.
+var _ source.QueriesSource = (*requestQuerySource)(nil)

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -306,6 +306,80 @@ func TestAnalyze_Concurrent(t *testing.T) {
 	}
 }
 
+// TestAnalyze_ConfigWithoutIacSection guards against a nil-pointer panic when
+// the caller pushes a valid config that has no `iac` section (e.g. a workspace
+// configured only for secrets). ParseConfig returns (nil, nil) there; analyze
+// must fall back to the empty IaC config rather than dereferencing nil.
+func TestAnalyze_ConfigWithoutIacSection(t *testing.T) {
+	s := newTestServer(t)
+	rule := teamTagRule(t)
+
+	req := analyzeRequest{
+		Files:    []analyzeFile{{Path: "infra/main.tf", Content: `resource "aws_s3_bucket" "b" { bucket = "x" }`}},
+		Rules:    []analyzeRule{rule},
+		Platform: []string{"terraform"},
+		Config:   "schema-version: v1.3\nsecrets:\n  enabled: true\n",
+	}
+
+	out, _ := postAnalyze(t, s, req) // must not panic
+	if len(out.Findings) == 0 {
+		t.Errorf("expected findings with an iac-less config (empty config fallback), got none")
+	}
+}
+
+// TestAnalyze_ConfigIgnoreRulePushedRule verifies that ignore-rules in config
+// suppresses a rule even when the caller pushes that rule in the request — the
+// pushed-rule source must apply the same query filters the filesystem source
+// applies.
+func TestAnalyze_ConfigIgnoreRulePushedRule(t *testing.T) {
+	s := newTestServer(t)
+	rule := teamTagRule(t)
+
+	req := analyzeRequest{
+		Files:    []analyzeFile{{Path: "infra/main.tf", Content: `resource "aws_s3_bucket" "b" { bucket = "x" }`}},
+		Rules:    []analyzeRule{rule},
+		Platform: []string{"terraform"},
+		Config:   "schema-version: v1.3\niac:\n  ignore-rules:\n    - terraform-aws-team-tag-not-present\n",
+	}
+
+	out, _ := postAnalyze(t, s, req)
+	for _, f := range out.Findings {
+		if f.QueryID == "terraform-aws-team-tag-not-present" {
+			t.Errorf("ignore-rules should have suppressed the pushed rule, but it fired: %+v", f)
+		}
+	}
+}
+
+// TestAnalyze_ConfigIgnorePaths verifies that global ignore-paths in config
+// suppresses findings for matching pushed files in the in-memory (server) scan
+// path, mirroring the disk scanner's behavior.
+func TestAnalyze_ConfigIgnorePaths(t *testing.T) {
+	s := newTestServer(t)
+	rule := teamTagRule(t)
+	body := `resource "aws_s3_bucket" "b" { bucket = "x" }`
+
+	// Baseline: without filters the rule fires on infra/main.tf.
+	base, _ := postAnalyze(t, s, analyzeRequest{
+		Files:    []analyzeFile{{Path: "infra/main.tf", Content: body}},
+		Rules:    []analyzeRule{rule},
+		Platform: []string{"terraform"},
+	})
+	if len(base.Findings) == 0 {
+		t.Fatalf("baseline expected findings, got none")
+	}
+
+	// With ignore-paths covering infra/, the file is skipped → no findings.
+	out, _ := postAnalyze(t, s, analyzeRequest{
+		Files:    []analyzeFile{{Path: "infra/main.tf", Content: body}},
+		Rules:    []analyzeRule{rule},
+		Platform: []string{"terraform"},
+		Config:   "schema-version: v1.3\niac:\n  global-config:\n    ignore-paths:\n      - \"infra/**\"\n",
+	})
+	if len(out.Findings) != 0 {
+		t.Errorf("ignore-paths should have skipped infra/main.tf, got findings: %+v", out.Findings)
+	}
+}
+
 func readAll(resp *http.Response) ([]byte, error) {
 	defer resp.Body.Close()
 	var buf bytes.Buffer

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // repoRoot returns the module root relative to this package (pkg/server).
@@ -377,6 +378,60 @@ func TestAnalyze_ConfigIgnorePaths(t *testing.T) {
 	})
 	if len(out.Findings) != 0 {
 		t.Errorf("ignore-paths should have skipped infra/main.tf, got findings: %+v", out.Findings)
+	}
+}
+
+// TestKeepAlive_NotShutdownWhileInFlight verifies the keep-alive monitor does
+// not shut the server down while a request is being handled, even after the
+// idle window has elapsed — then shuts down once the request completes and the
+// server is genuinely idle.
+func TestKeepAlive_NotShutdownWhileInFlight(t *testing.T) {
+	s := New(&Config{KeepAliveTimeout: 15 * time.Millisecond})
+	s.pollInterval = 2 * time.Millisecond
+	// Look idle for far longer than the keep-alive window.
+	s.lastRequestNanos.Store(time.Now().Add(-time.Hour).UnixNano())
+	// But a request is in flight.
+	s.inFlight.Add(1)
+
+	go s.keepAliveMonitor(t.Context())
+
+	select {
+	case <-s.shutdownCh:
+		t.Fatal("server shut down while a request was in flight")
+	case <-time.After(60 * time.Millisecond):
+	}
+
+	// Request completes; server is now idle past the window → must shut down.
+	s.inFlight.Add(-1)
+	s.lastRequestNanos.Store(time.Now().Add(-time.Hour).UnixNano())
+	select {
+	case <-s.shutdownCh:
+	case <-time.After(time.Second):
+		t.Fatal("server did not shut down after the request completed and idle elapsed")
+	}
+}
+
+// TestAnalyze_ConcurrencyLimit verifies /analyze returns 503 once the
+// concurrency limit is saturated, without running a scan.
+func TestAnalyze_ConcurrencyLimit(t *testing.T) {
+	s := New(&Config{MaxConcurrentAnalyze: 1})
+	ts := httptest.NewServer(s.http.Handler)
+	defer ts.Close()
+
+	// Saturate the single slot so the next request is rejected.
+	s.analyzeSem <- struct{}{}
+
+	resp, err := http.Post(ts.URL+"/ide/v1/iac/analyze", "application/json",
+		strings.NewReader(`{"files":[{"path":"a.tf","content":"x"}]}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503 when concurrency limit is saturated", resp.StatusCode)
+	}
+	if resp.Header.Get("Retry-After") == "" {
+		t.Errorf("expected a Retry-After header on the 503 response")
 	}
 }
 

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -38,9 +38,8 @@ func newTestServer(t *testing.T) *Server {
 		t.Skipf("assets/libraries not found (%v); skipping engine-backed test", err)
 	}
 	return New(&Config{
-		LibrariesPath:    libs,
-		QueriesPath:      filepath.Join(root, "assets", "queries"),
-		QueryExecTimeout: 60,
+		LibrariesPath: libs,
+		QueriesPath:   filepath.Join(root, "assets", "queries"),
 	})
 }
 
@@ -181,7 +180,7 @@ resource "aws_s3_bucket" "b" { bucket = "x" }`}},
 
 // TestAnalyze_Validation exercises the request validation rules.
 func TestAnalyze_Validation(t *testing.T) {
-	s := New(&Config{QueryExecTimeout: 60})
+	s := New(&Config{})
 	ts := httptest.NewServer(s.http.Handler)
 	defer ts.Close()
 
@@ -213,7 +212,7 @@ func TestAnalyze_Validation(t *testing.T) {
 // returns "pong", standard + CORS headers are present, and /shutdown is gated by
 // --enable-shutdown.
 func TestLifecycle_Contract(t *testing.T) {
-	s := New(&Config{QueryExecTimeout: 60}) // EnableShutdown defaults false
+	s := New(&Config{}) // EnableShutdown defaults false
 	ts := httptest.NewServer(s.http.Handler)
 	defer ts.Close()
 

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -1,0 +1,315 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// repoRoot returns the module root relative to this package (pkg/server).
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Join(wd, "..", "..")
+}
+
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	root := repoRoot(t)
+	libs := filepath.Join(root, "assets", "libraries")
+	if _, err := os.Stat(libs); err != nil {
+		t.Skipf("assets/libraries not found (%v); skipping engine-backed test", err)
+	}
+	return New(&Config{
+		LibrariesPath:    libs,
+		QueriesPath:      filepath.Join(root, "assets", "queries"),
+		QueryExecTimeout: 60,
+	})
+}
+
+// teamTagRule loads the real Terraform "Team tag" rule from the e2e fixtures so
+// the test exercises a production-shaped rule without a network fetch.
+func teamTagRule(t *testing.T) analyzeRule {
+	t.Helper()
+	root := repoRoot(t)
+	regoPath := filepath.Join(root, "test", "e2e", "testdata", "rules", "terraform", "team_tag_not_present", "query.rego")
+	content, err := os.ReadFile(regoPath)
+	if err != nil {
+		t.Skipf("rule fixture not found (%v); skipping", err)
+	}
+	return analyzeRule{
+		ID:       "terraform-aws-team-tag-not-present",
+		Platform: "terraform",
+		Content:  string(content),
+		Metadata: map[string]any{
+			"id":        "terraform-aws-team-tag-not-present",
+			"queryName": "Team tag missing on AWS resource",
+			"severity":  "LOW",
+			"platform":  "Terraform",
+			"category":  "Best Practices",
+		},
+	}
+}
+
+func postAnalyze(t *testing.T, s *Server, req analyzeRequest) (*analyzeResponse, int) {
+	t.Helper()
+	out, err := s.analyze(context.Background(), &req)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	return out, http.StatusOK
+}
+
+// TestAnalyze_ContentPush_TerraformFinding verifies the full content-push path:
+// a pushed Terraform file plus its sibling variables file are scanned in memory
+// (no disk), a real rule fires, and same-directory siblings resolve without
+// being reported missing.
+func TestAnalyze_ContentPush_TerraformFinding(t *testing.T) {
+	s := newTestServer(t)
+	rule := teamTagRule(t)
+
+	req := analyzeRequest{
+		Files: []analyzeFile{
+			{Path: "infra/main.tf", Content: `resource "aws_s3_bucket" "b" {
+  bucket = var.bucket_name
+}`},
+			{Path: "infra/variables.tf", Content: `variable "bucket_name" { default = "my-bucket" }`},
+		},
+		Rules:    []analyzeRule{rule},
+		Platform: []string{"terraform"},
+	}
+
+	out, _ := postAnalyze(t, s, req)
+
+	if len(out.Findings) == 0 {
+		t.Fatalf("expected at least one finding for an AWS resource missing a Team tag, got none")
+	}
+	var found bool
+	for _, f := range out.Findings {
+		if f.QueryID == "terraform-aws-team-tag-not-present" {
+			found = true
+			if f.FileName != "infra/main.tf" {
+				t.Errorf("finding fileName = %q, want infra/main.tf", f.FileName)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected the team-tag rule to fire; findings = %+v", out.Findings)
+	}
+	// Same-directory siblings resolve via the in-memory glob, so nothing is
+	// reported missing.
+	if len(out.MissingFiles) != 0 {
+		t.Errorf("expected no missing files for same-dir siblings, got %v", out.MissingFiles)
+	}
+}
+
+// TestAnalyze_MissingModuleEscalation verifies a Terraform module pointing at a
+// directory that was not pushed is reported in missing_files as a clean
+// workspace-relative path (the hybrid escalation signal).
+func TestAnalyze_MissingModuleEscalation(t *testing.T) {
+	s := newTestServer(t)
+	rule := teamTagRule(t)
+
+	req := analyzeRequest{
+		Files: []analyzeFile{
+			{Path: "infra/main.tf", Content: `module "net" {
+  source = "../modules/networking"
+}
+resource "aws_s3_bucket" "b" { bucket = "x" }`},
+		},
+		Rules:    []analyzeRule{rule},
+		Platform: []string{"terraform"},
+	}
+
+	out, _ := postAnalyze(t, s, req)
+
+	var sawModule bool
+	for _, m := range out.MissingFiles {
+		if m == "modules/networking" {
+			sawModule = true
+		}
+		if filepath.IsAbs(m) {
+			t.Errorf("missing path should be workspace-relative, got absolute: %q", m)
+		}
+	}
+	if !sawModule {
+		t.Errorf("expected modules/networking in missing_files, got %v", out.MissingFiles)
+	}
+}
+
+// TestAnalyze_MissingFilesCWDIndependent proves missing_files are
+// workspace-relative regardless of the server process's working directory. A
+// single server serves many IDE workspaces/windows, so the result must not
+// depend on where the binary was launched.
+func TestAnalyze_MissingFilesCWDIndependent(t *testing.T) {
+	s := newTestServer(t) // resolves an absolute libraries path before we chdir
+	rule := teamTagRule(t)
+	req := analyzeRequest{
+		Files: []analyzeFile{{Path: "infra/main.tf", Content: `module "net" {
+  source = "../modules/networking"
+}
+resource "aws_s3_bucket" "b" { bucket = "x" }`}},
+		Rules:    []analyzeRule{rule},
+		Platform: []string{"terraform"},
+	}
+
+	// Move CWD somewhere unrelated to the (virtual) workspace.
+	t.Chdir(t.TempDir())
+
+	out, _ := postAnalyze(t, s, req)
+	if len(out.MissingFiles) != 1 || out.MissingFiles[0] != "modules/networking" {
+		t.Errorf("missing_files = %v, want [modules/networking] (workspace-relative, CWD-independent)", out.MissingFiles)
+	}
+}
+
+// TestAnalyze_Validation exercises the request validation rules.
+func TestAnalyze_Validation(t *testing.T) {
+	s := New(&Config{QueryExecTimeout: 60})
+	ts := httptest.NewServer(s.http.Handler)
+	defer ts.Close()
+
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"empty files", `{"files":[],"rules":[]}`, http.StatusBadRequest},
+		{"path traversal", `{"files":[{"path":"../escape.tf","content":"x"}],"rules":[]}`, http.StatusBadRequest},
+		{"absolute path", `{"files":[{"path":"/etc/passwd","content":"x"}],"rules":[]}`, http.StatusBadRequest},
+		{"malformed json", `{`, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := http.Post(ts.URL+"/ide/v1/iac/analyze", "application/json", strings.NewReader(tc.body))
+			if err != nil {
+				t.Fatalf("post: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != tc.want {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tc.want)
+			}
+		})
+	}
+}
+
+// TestLifecycle_Contract checks the SAST-mirrored lifecycle contract: /ping
+// returns "pong", standard + CORS headers are present, and /shutdown is gated by
+// --enable-shutdown.
+func TestLifecycle_Contract(t *testing.T) {
+	s := New(&Config{QueryExecTimeout: 60}) // EnableShutdown defaults false
+	ts := httptest.NewServer(s.http.Handler)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/ping")
+	if err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+	body, _ := readAll(resp)
+	if resp.StatusCode != http.StatusOK || string(body) != "pong" {
+		t.Errorf("/ping = %d %q, want 200 pong", resp.StatusCode, body)
+	}
+	for _, h := range []string{"X-Iac-Scanner-Server-Version", "Access-Control-Allow-Origin", "X-Request-Id"} {
+		if resp.Header.Get(h) == "" {
+			t.Errorf("missing response header %s", h)
+		}
+	}
+
+	// Shutdown is disabled by default → 403.
+	sresp, err := http.Post(ts.URL+"/shutdown", "", nil)
+	if err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+	defer sresp.Body.Close()
+	if sresp.StatusCode != http.StatusForbidden {
+		t.Errorf("/shutdown (disabled) = %d, want 403", sresp.StatusCode)
+	}
+
+	// Supported-files returns the strategy map.
+	fresp, err := http.Get(ts.URL + "/ide/v1/iac/supported-files")
+	if err != nil {
+		t.Fatalf("supported-files: %v", err)
+	}
+	defer fresp.Body.Close()
+	var entries []SupportedFileEntry
+	if err := json.NewDecoder(fresp.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode supported-files: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Errorf("supported-files returned no entries")
+	}
+}
+
+// TestAnalyze_Concurrent runs many analyze requests in parallel — each spawning
+// a multi-worker inspector over several documents — to exercise the engine's
+// shared per-request state (notably the failedQueries map written by worker
+// goroutines). Run with `go test -race` to surface data races.
+func TestAnalyze_Concurrent(t *testing.T) {
+	s := newTestServer(t)
+	rule := teamTagRule(t)
+
+	files := make([]analyzeFile, 0, 6)
+	for i := range 6 {
+		files = append(files, analyzeFile{
+			Path:    fmt.Sprintf("infra/r%d.tf", i),
+			Content: fmt.Sprintf(`resource "aws_s3_bucket" "b%d" { bucket = "x%d" }`, i, i),
+		})
+	}
+	// Replicate the rule under distinct IDs so the inspector runs several queries
+	// across multiple worker goroutines, producing findings concurrently — this
+	// exercises the shared per-request engine state (failedQueries, the shared
+	// line detector) that earlier raced under -race.
+	rules := make([]analyzeRule, 0, 8)
+	for i := range 8 {
+		r := rule
+		r.ID = fmt.Sprintf("%s-%d", rule.ID, i)
+		rules = append(rules, r)
+	}
+	req := analyzeRequest{Files: files, Rules: rules, Platform: []string{"terraform"}}
+
+	const n = 12
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for range n {
+		// Each goroutine builds its own client/inspector; the request value is
+		// read-only and safe to share.
+		wg.Go(func() {
+			out, err := s.analyze(context.Background(), &req)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if len(out.Findings) == 0 {
+				errs <- fmt.Errorf("expected findings, got none")
+			}
+		})
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent analyze: %v", err)
+	}
+}
+
+func readAll(resp *http.Response) ([]byte, error) {
+	defer resp.Body.Close()
+	var buf bytes.Buffer
+	_, err := buf.ReadFrom(resp.Body)
+	return buf.Bytes(), err
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,0 +1,286 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+// Package server implements a long-lived HTTP server that analyzes IaC files on
+// demand. It mirrors the contract of the Rust datadog-static-analyzer-server so
+// the Datadog VS Code extension can manage both binaries through the same
+// lifecycle (keep-alive ping, graceful shutdown, version discovery).
+//
+// The server is a pure engine: it never reads git, calls the Datadog API, or
+// writes SARIF. Rules and file content are pushed over HTTP by the extension.
+//
+// Lifecycle endpoints (this file):
+//
+//	GET  /ping      health / keep-alive (resets the idle timer), returns "pong"
+//	GET  /version   running binary version (plain text)
+//	GET  /revision  running binary commit (plain text)
+//	POST /shutdown  graceful shutdown (204 when --enable-shutdown, else 403)
+//	GET  /shutdown  same as POST
+//
+// IaC endpoints (GET /ide/v1/iac/supported-files, POST /ide/v1/iac/analyze) are
+// registered here and implemented in sibling files.
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/DataDog/datadog-iac-scanner/internal/constants"
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// readHeaderTimeout / readTimeout are explicit slowloris guards
+	readHeaderTimeout = 10 * time.Second
+	readTimeout       = 60 * time.Second
+	// shutdownGraceTimeout matches the static-analyzer server: its keep-alive
+	// loop notifies a graceful shutdown, then allows 10s before escalating to
+	// process abort. We give in-flight requests the same window via http.Server.Shutdown.
+	shutdownGraceTimeout = 10 * time.Second
+	// keepAlivePollInterval matches the static-analyzer server's idle-check
+	// cadence: it polls for inactivity every 5s.
+	keepAlivePollInterval = 5 * time.Second
+	// maxRequestBytes caps a single request body (applied by body-reading
+	// handlers via http.MaxBytesReader). 32 MiB comfortably fits a directory of
+	// IaC files plus the pushed rule corpus.
+	maxRequestBytes = 32 << 20
+)
+
+// Config holds the server's runtime settings, populated from the serve command's
+// flags.
+type Config struct {
+	Address          string        // bind address (default 127.0.0.1)
+	Port             int           // listen port (default 8000)
+	KeepAliveTimeout time.Duration // idle timeout; 0 disables auto-shutdown
+	EnableShutdown   bool          // gate for the /shutdown endpoint
+	LibrariesPath    string        // Rego support libraries
+	QueriesPath      string        // default rule corpus (used only when a request omits rules)
+	QueryExecTimeout int           // per-query evaluation timeout, seconds
+}
+
+// Server is the IaC analysis HTTP server.
+type Server struct {
+	cfg  Config
+	http *http.Server
+
+	// lastRequestNanos is the UnixNano timestamp of the most recent request,
+	// updated by middleware and read by the keep-alive monitor.
+	lastRequestNanos atomic.Int64
+
+	// shutdownCh is closed exactly once to trigger graceful shutdown (by
+	// /shutdown, the keep-alive monitor, or a canceled context).
+	shutdownCh   chan struct{}
+	shutdownOnce sync.Once
+}
+
+// New builds a server from cfg, applying defaults for any zero-valued field.
+func New(cfg *Config) *Server {
+	if cfg.Address == "" {
+		cfg.Address = "127.0.0.1"
+	}
+	if cfg.Port == 0 {
+		cfg.Port = 8000
+	}
+	if cfg.LibrariesPath == "" {
+		cfg.LibrariesPath = "./assets/libraries"
+	}
+	if cfg.QueriesPath == "" {
+		cfg.QueriesPath = "./assets/queries"
+	}
+	if cfg.QueryExecTimeout == 0 {
+		cfg.QueryExecTimeout = 60
+	}
+
+	s := &Server{cfg: *cfg, shutdownCh: make(chan struct{})}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /ping", s.handlePing)
+	mux.HandleFunc("GET /version", s.handleVersion)
+	mux.HandleFunc("GET /revision", s.handleRevision)
+	mux.HandleFunc("POST /shutdown", s.handleShutdown)
+	mux.HandleFunc("GET /shutdown", s.handleShutdown)
+	// CORS preflight: a path-wildcard pattern scoped to OPTIONS so it never
+	// shadows the method-specific routes above.
+	mux.HandleFunc("OPTIONS /", s.handleOptions)
+	// IaC endpoints (implemented in sibling files):
+	mux.HandleFunc("GET /ide/v1/iac/supported-files", s.handleSupportedFiles)
+	mux.HandleFunc("POST /ide/v1/iac/analyze", s.handleAnalyze)
+
+	s.http = &http.Server{
+		Addr:              net.JoinHostPort(cfg.Address, strconv.Itoa(cfg.Port)),
+		Handler:           s.middleware(mux),
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		// No WriteTimeout: a cold scan recompiles the rule corpus and can take
+		// several seconds until the prepared-query cache lands.
+	}
+	return s
+}
+
+// ListenAndServe starts the server and blocks until it is shut down (via
+// /shutdown, a canceled ctx, or the keep-alive timeout). A clean shutdown
+// returns nil.
+func (s *Server) ListenAndServe(ctx context.Context) error {
+	contextLogger := logger.FromContext(ctx)
+	s.lastRequestNanos.Store(time.Now().UnixNano())
+
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-s.shutdownCh:
+		}
+		s.gracefulShutdown()
+	}()
+
+	if s.cfg.KeepAliveTimeout > 0 {
+		go s.keepAliveMonitor(ctx)
+	}
+
+	contextLogger.Info().Msgf("IaC analysis server listening on %s", s.http.Addr)
+	if err := s.http.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+// keepAliveMonitor shuts the server down after KeepAliveTimeout elapses with no
+// requests, mirroring the SAST server's idle-exit behavior.
+func (s *Server) keepAliveMonitor(ctx context.Context) {
+	contextLogger := logger.FromContext(ctx)
+	ticker := time.NewTicker(keepAlivePollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.shutdownCh:
+			return
+		case <-ticker.C:
+			last := time.Unix(0, s.lastRequestNanos.Load())
+			if time.Since(last) > s.cfg.KeepAliveTimeout {
+				contextLogger.Info().Msg("keep-alive timeout reached; shutting down")
+				s.triggerShutdown()
+				return
+			}
+		}
+	}
+}
+
+func (s *Server) triggerShutdown() {
+	s.shutdownOnce.Do(func() { close(s.shutdownCh) })
+}
+
+func (s *Server) gracefulShutdown() {
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownGraceTimeout)
+	defer cancel()
+	_ = s.http.Shutdown(ctx)
+}
+
+// --- lifecycle handlers ---
+
+func (s *Server) handlePing(w http.ResponseWriter, _ *http.Request) {
+	writeText(w, http.StatusOK, "pong")
+}
+
+func (s *Server) handleVersion(w http.ResponseWriter, _ *http.Request) {
+	writeText(w, http.StatusOK, constants.Version)
+}
+
+func (s *Server) handleRevision(w http.ResponseWriter, _ *http.Request) {
+	writeText(w, http.StatusOK, constants.SCMCommit)
+}
+
+func (s *Server) handleShutdown(w http.ResponseWriter, _ *http.Request) {
+	if !s.cfg.EnableShutdown {
+		writeError(w, http.StatusForbidden, "shutdown is disabled")
+		return
+	}
+	// Flush the response before tearing the listener down; the actual shutdown
+	// runs off the request goroutine so Shutdown does not wait on this handler.
+	w.WriteHeader(http.StatusNoContent)
+	s.triggerShutdown()
+}
+
+func (s *Server) handleOptions(w http.ResponseWriter, _ *http.Request) {
+	// CORS headers are already set by middleware; just acknowledge the preflight.
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- middleware ---
+
+// middleware updates the keep-alive timestamp, sets the standard response and
+// CORS headers, attaches the global logger to the request context (so the scan
+// pipeline's logger.FromContext works), and recovers from handler panics.
+func (s *Server) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.lastRequestNanos.Store(time.Now().UnixNano())
+
+		h := w.Header()
+		h.Set("X-iac-scanner-server-version", constants.Version)
+		h.Set("X-iac-scanner-server-revision", constants.SCMCommit)
+		h.Set("X-iac-scanner-server-shutdown-enabled", strconv.FormatBool(s.cfg.EnableShutdown))
+		h.Set("X-iac-scanner-server-keepalive-enabled", strconv.FormatBool(s.cfg.KeepAliveTimeout > 0))
+		reqID := r.Header.Get("X-Request-Id")
+		if reqID == "" {
+			reqID = newRequestID()
+		}
+		h.Set("X-Request-Id", reqID)
+
+		h.Set("Access-Control-Allow-Origin", "*")
+		h.Set("Access-Control-Allow-Methods", "POST, GET, PATCH, OPTIONS")
+		h.Set("Access-Control-Allow-Headers", "*")
+		h.Set("Access-Control-Allow-Credentials", "true")
+
+		ctx := log.Logger.WithContext(r.Context())
+		contextLogger := logger.FromContext(ctx)
+
+		defer func() {
+			if rec := recover(); rec != nil {
+				contextLogger.Error().Msgf("panic serving %s %s: %v", r.Method, r.URL.Path, rec)
+				// Best-effort; if the handler already wrote a status this is a no-op.
+				writeError(w, http.StatusInternalServerError, "internal server error")
+			}
+		}()
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// --- helpers ---
+
+func writeText(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(body))
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+func newRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "unknown"
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -46,6 +46,9 @@ const (
 	// readHeaderTimeout / readTimeout are explicit slowloris guards
 	readHeaderTimeout = 10 * time.Second
 	readTimeout       = 60 * time.Second
+	// idleTimeout bounds how long an idle keep-alive TCP connection is held open
+	// between requests, so abandoned connections don't accumulate.
+	idleTimeout = 120 * time.Second
 	// shutdownGraceTimeout matches the static-analyzer server: its keep-alive
 	// loop notifies a graceful shutdown, then allows 10s before escalating to
 	// process abort. We give in-flight requests the same window via http.Server.Shutdown.
@@ -57,6 +60,10 @@ const (
 	// handlers via http.MaxBytesReader). 32 MiB comfortably fits a directory of
 	// IaC files plus the pushed rule corpus.
 	maxRequestBytes = 32 << 20
+	// defaultMaxConcurrentAnalyze bounds how many /analyze scans run at once.
+	// Each scan buffers up to maxRequestBytes and spins worker goroutines, so an
+	// unbounded burst could exhaust memory/goroutines.
+	defaultMaxConcurrentAnalyze = 4
 )
 
 // Config holds the server's runtime settings, populated from the serve command's
@@ -68,6 +75,9 @@ type Config struct {
 	EnableShutdown   bool          // gate for the /shutdown endpoint
 	LibrariesPath    string        // Rego support libraries
 	QueriesPath      string        // default rule corpus (used only when a request omits rules)
+	// MaxConcurrentAnalyze caps simultaneous /analyze scans. <= 0 applies
+	// defaultMaxConcurrentAnalyze.
+	MaxConcurrentAnalyze int
 }
 
 // Server is the IaC analysis HTTP server.
@@ -75,9 +85,23 @@ type Server struct {
 	cfg  Config
 	http *http.Server
 
-	// lastRequestNanos is the UnixNano timestamp of the most recent request,
-	// updated by middleware and read by the keep-alive monitor.
+	// lastRequestNanos is the UnixNano timestamp of the most recent request
+	// boundary (start and completion), updated by middleware and read by the
+	// keep-alive monitor.
 	lastRequestNanos atomic.Int64
+
+	// inFlight counts requests currently being handled. The keep-alive monitor
+	// never shuts down while this is non-zero, so a long scan with no concurrent
+	// /ping is not mistaken for an idle server and killed mid-flight.
+	inFlight atomic.Int64
+
+	// analyzeSem bounds concurrent /analyze scans (acquire-or-503). Buffered to
+	// cfg.MaxConcurrentAnalyze.
+	analyzeSem chan struct{}
+
+	// pollInterval is the keep-alive monitor's check cadence; defaults to
+	// keepAlivePollInterval and is overridable in tests.
+	pollInterval time.Duration
 
 	// shutdownCh is closed exactly once to trigger graceful shutdown (by
 	// /shutdown, the keep-alive monitor, or a canceled context).
@@ -99,7 +123,15 @@ func New(cfg *Config) *Server {
 	if cfg.QueriesPath == "" {
 		cfg.QueriesPath = "./assets/queries"
 	}
-	s := &Server{cfg: *cfg, shutdownCh: make(chan struct{})}
+	if cfg.MaxConcurrentAnalyze <= 0 {
+		cfg.MaxConcurrentAnalyze = defaultMaxConcurrentAnalyze
+	}
+	s := &Server{
+		cfg:          *cfg,
+		analyzeSem:   make(chan struct{}, cfg.MaxConcurrentAnalyze),
+		pollInterval: keepAlivePollInterval,
+		shutdownCh:   make(chan struct{}),
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /ping", s.handlePing)
@@ -119,6 +151,7 @@ func New(cfg *Config) *Server {
 		Handler:           s.middleware(mux),
 		ReadHeaderTimeout: readHeaderTimeout,
 		ReadTimeout:       readTimeout,
+		IdleTimeout:       idleTimeout,
 		// No WriteTimeout: a cold scan recompiles the rule corpus and can take
 		// several seconds until the prepared-query cache lands.
 	}
@@ -155,7 +188,11 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 // requests, mirroring the SAST server's idle-exit behavior.
 func (s *Server) keepAliveMonitor(ctx context.Context) {
 	contextLogger := logger.FromContext(ctx)
-	ticker := time.NewTicker(keepAlivePollInterval)
+	interval := s.pollInterval
+	if interval <= 0 {
+		interval = keepAlivePollInterval
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -164,6 +201,11 @@ func (s *Server) keepAliveMonitor(ctx context.Context) {
 		case <-s.shutdownCh:
 			return
 		case <-ticker.C:
+			// A request in flight means the server is busy, not idle — never
+			// shut down underneath an active scan.
+			if s.inFlight.Load() > 0 {
+				continue
+			}
 			last := time.Unix(0, s.lastRequestNanos.Load())
 			if time.Since(last) > s.cfg.KeepAliveTimeout {
 				contextLogger.Info().Msg("keep-alive timeout reached; shutting down")
@@ -222,6 +264,13 @@ func (s *Server) handleOptions(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.lastRequestNanos.Store(time.Now().UnixNano())
+		s.inFlight.Add(1)
+		defer func() {
+			s.inFlight.Add(-1)
+			// Restamp on completion so the idle window starts when the request
+			// finishes, not when it began.
+			s.lastRequestNanos.Store(time.Now().UnixNano())
+		}()
 
 		h := w.Header()
 		h.Set("X-iac-scanner-server-version", constants.Version)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -68,7 +68,6 @@ type Config struct {
 	EnableShutdown   bool          // gate for the /shutdown endpoint
 	LibrariesPath    string        // Rego support libraries
 	QueriesPath      string        // default rule corpus (used only when a request omits rules)
-	QueryExecTimeout int           // per-query evaluation timeout, seconds
 }
 
 // Server is the IaC analysis HTTP server.
@@ -100,10 +99,6 @@ func New(cfg *Config) *Server {
 	if cfg.QueriesPath == "" {
 		cfg.QueriesPath = "./assets/queries"
 	}
-	if cfg.QueryExecTimeout == 0 {
-		cfg.QueryExecTimeout = 60
-	}
-
 	s := &Server{cfg: *cfg, shutdownCh: make(chan struct{})}
 
 	mux := http.NewServeMux()

--- a/pkg/server/supported_files.go
+++ b/pkg/server/supported_files.go
@@ -1,0 +1,78 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package server
+
+import (
+	"net/http"
+	"sort"
+)
+
+// fileStrategy tells the IDE how to assemble the scan unit for a file type.
+type fileStrategy string
+
+const (
+	// strategyDirectory: the file may reference siblings, so the IDE should push
+	// the containing directory's candidate files on the first shot.
+	strategyDirectory fileStrategy = "directory"
+	// strategySingleFile: the file is self-contained; push only the open file.
+	strategySingleFile fileStrategy = "single_file"
+)
+
+// SupportedFileEntry maps a set of file patterns to a resolution strategy. This
+// is the IaC analog of the static analyzer's GET /languages.
+type SupportedFileEntry struct {
+	Patterns []string     `json:"patterns"`
+	Strategy fileStrategy `json:"strategy"`
+}
+
+// strategyByPattern is the single source of truth for the resolution strategy of
+// every supported file type. "directory" applies to Terraform (always needs
+// var/local/module context), the ambiguous .yaml/.yml/.json family (whose
+// platform is decided by server-side content heuristics, so the IDE
+// conservatively sends the directory), .bicep, and Ansible config. "single_file"
+// applies to self-contained types (Dockerfile, gRPC proto, Buildah .sh).
+//
+// Keys are the IDE-facing patterns (dotted extensions, or full filenames like
+// "Dockerfile"). TestSupportedFiles_NoDrift asserts this covers every
+// analyzer.PossibleFileTypes() entry so a newly supported type can't be missed.
+var strategyByPattern = map[string]fileStrategy{
+	".tf":         strategyDirectory,
+	".tfvars":     strategyDirectory,
+	".yaml":       strategyDirectory,
+	".yml":        strategyDirectory,
+	".json":       strategyDirectory,
+	".bicep":      strategyDirectory,
+	".cfg":        strategyDirectory,
+	".conf":       strategyDirectory,
+	".ini":        strategyDirectory,
+	"Dockerfile":  strategySingleFile,
+	".dockerfile": strategySingleFile,
+	".ubi8":       strategySingleFile,
+	".debian":     strategySingleFile,
+	".proto":      strategySingleFile,
+	".sh":         strategySingleFile,
+}
+
+// supportedFiles builds the supported-files response: one entry per pattern,
+// sorted for deterministic output.
+func supportedFiles() []SupportedFileEntry {
+	patterns := make([]string, 0, len(strategyByPattern))
+	for p := range strategyByPattern {
+		patterns = append(patterns, p)
+	}
+	sort.Strings(patterns)
+
+	entries := make([]SupportedFileEntry, 0, len(patterns))
+	for _, p := range patterns {
+		entries = append(entries, SupportedFileEntry{Patterns: []string{p}, Strategy: strategyByPattern[p]})
+	}
+	return entries
+}
+
+func (s *Server) handleSupportedFiles(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, supportedFiles())
+}

--- a/pkg/server/supported_files_test.go
+++ b/pkg/server/supported_files_test.go
@@ -1,0 +1,60 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/analyzer"
+)
+
+// normalizePattern converts an analyzer file-type key into the IDE-facing
+// pattern used as a strategyByPattern key.
+func normalizePattern(fileType string) string {
+	if fileType == "" || strings.HasPrefix(fileType, ".") {
+		return fileType
+	}
+	if fileType[0] >= 'A' && fileType[0] <= 'Z' {
+		return fileType
+	}
+	return "." + fileType
+}
+
+// TestSupportedFiles_NoDrift ensures every file type the scanner can analyze has
+// a declared resolution strategy, so a newly supported type can't be silently
+// omitted from the supported-files endpoint.
+func TestSupportedFiles_NoDrift(t *testing.T) {
+	for _, ft := range analyzer.PossibleFileTypes() {
+		pattern := normalizePattern(ft)
+		if _, ok := strategyByPattern[pattern]; !ok {
+			t.Errorf("analyzer file type %q (pattern %q) has no strategy in strategyByPattern", ft, pattern)
+		}
+	}
+}
+
+// TestSupportedFiles_Entries checks the response shape and a couple of
+// well-known strategies.
+func TestSupportedFiles_Entries(t *testing.T) {
+	entries := supportedFiles()
+	if len(entries) != len(strategyByPattern) {
+		t.Fatalf("expected %d entries, got %d", len(strategyByPattern), len(entries))
+	}
+	got := make(map[string]fileStrategy, len(entries))
+	for _, e := range entries {
+		if len(e.Patterns) != 1 {
+			t.Errorf("expected single-pattern entries, got %v", e.Patterns)
+		}
+		got[e.Patterns[0]] = e.Strategy
+	}
+	if got[".tf"] != strategyDirectory {
+		t.Errorf(".tf should be %q, got %q", strategyDirectory, got[".tf"])
+	}
+	if got["Dockerfile"] != strategySingleFile {
+		t.Errorf("Dockerfile should be %q, got %q", strategySingleFile, got["Dockerfile"])
+	}
+}

--- a/pkg/utils/get_extension.go
+++ b/pkg/utils/get_extension.go
@@ -9,20 +9,28 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"golang.org/x/tools/godoc/util"
 )
 
-// GetExtension gets the extension of a file path
+// GetExtension gets the extension of a file path on the real filesystem.
 func GetExtension(ctx context.Context, path string) (string, error) {
+	return GetExtensionWithFS(ctx, vfs.DiskFS{}, path)
+}
+
+// GetExtensionWithFS gets the extension of a file path, reading file metadata
+// and content through fsys. The HTTP server passes an in-memory FS so extension
+// detection works for pushed content that never touches disk; the CLI passes the
+// real disk (the default, via GetExtension), preserving existing behavior.
+func GetExtensionWithFS(ctx context.Context, fsys vfs.FS, path string) (string, error) {
 	contextLogger := logger.FromContext(ctx)
 	targets := []string{"tfvars", "Dockerfile", "possibleDockerfile"}
 
 	// Get file information
-	fileInfo, err := os.Stat(path)
+	fileInfo, err := fsys.Stat(path)
 	if err != nil {
 		err = fmt.Errorf("file %s not found", path)
 		contextLogger.Error().Msg(err.Error())
@@ -41,7 +49,7 @@ func GetExtension(ctx context.Context, path string) (string, error) {
 		if Contains(base, targets) {
 			ext = base
 		} else {
-			isText, err := isTextFile(ctx, path)
+			isText, err := isTextFile(ctx, fsys, path)
 
 			if err != nil {
 				return "", err
@@ -58,9 +66,9 @@ func GetExtension(ctx context.Context, path string) (string, error) {
 	return ext, nil
 }
 
-func isTextFile(ctx context.Context, path string) (bool, error) {
+func isTextFile(ctx context.Context, fsys vfs.FS, path string) (bool, error) {
 	contextLogger := logger.FromContext(ctx)
-	info, err := os.Stat(path)
+	info, err := fsys.Stat(path)
 	if err != nil {
 		contextLogger.Error().Msgf("failed to get file info: %s", err)
 		return false, err
@@ -70,7 +78,7 @@ func isTextFile(ctx context.Context, path string) (bool, error) {
 		return false, nil
 	}
 
-	content, err := os.ReadFile(filepath.Clean(path))
+	content, err := fsys.ReadFile(filepath.Clean(path))
 	if err != nil {
 		contextLogger.Error().Msgf("failed to analyze file: %s", err)
 		return false, err

--- a/pkg/vfs/memfs.go
+++ b/pkg/vfs/memfs.go
@@ -1,0 +1,250 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package vfs
+
+import (
+	"io/fs"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	memDirMode  fs.FileMode = fs.ModeDir | 0o555
+	memFileMode fs.FileMode = 0o444
+)
+
+// MemFS is an in-memory FS built from content pushed over HTTP. Keys are
+// normalized (cleaned, forward-slash) paths. It is request-scoped: a fresh
+// instance is built per analyze request, so the missing-file set it accumulates
+// belongs to exactly one scan and never leaks across requests.
+//
+// Concurrency: Terraform module enrichment runs reader goroutines, so all access
+// is guarded by a mutex.
+type MemFS struct {
+	mu      sync.Mutex
+	files   map[string][]byte
+	missing map[string]struct{}
+}
+
+// NewMemFS builds a MemFS from a path -> content map. Keys are normalized so
+// they match the paths the Terraform readers compute via filepath.Join/Dir.
+func NewMemFS(files map[string][]byte) *MemFS {
+	m := &MemFS{
+		files:   make(map[string][]byte, len(files)),
+		missing: make(map[string]struct{}),
+	}
+	for p, c := range files {
+		m.files[normalize(p)] = c
+	}
+	return m
+}
+
+// normalize makes a path comparable: OS-cleaned then forward-slashed, mirroring
+// how FileSystemSourceProvider normalizes the paths it emits.
+func normalize(p string) string {
+	return filepath.ToSlash(filepath.Clean(p))
+}
+
+func notExist(op, name string) error {
+	return &fs.PathError{Op: op, Path: name, Err: syscall.ENOENT}
+}
+
+// ReadFile returns a copy of the named file's content, or fs.ErrNotExist if it
+// was not pushed (recording the miss for the escalation list).
+func (m *MemFS) ReadFile(name string) ([]byte, error) {
+	key := normalize(name)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if content, ok := m.files[key]; ok {
+		out := make([]byte, len(content))
+		copy(out, content)
+		return out, nil
+	}
+	m.missing[key] = struct{}{}
+	return nil, notExist("open", name)
+}
+
+// Stat reports whether the named file was pushed. A miss is NOT recorded: Stat
+// is only used for speculative existence probes (terraform.tfvars, an optional
+// vars file), so recording it would produce false escalations for files that
+// legitimately do not exist.
+func (m *MemFS) Stat(name string) (fs.FileInfo, error) {
+	key := normalize(name)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if content, ok := m.files[key]; ok {
+		return memFileInfo{name: path.Base(key), size: int64(len(content))}, nil
+	}
+	return nil, notExist("stat", name)
+}
+
+// ReadDir returns the immediate children of a directory synthesized from the
+// pushed file keys. A miss (no file lives under the directory) is recorded: an
+// absent directory is the primary escalation signal (a Terraform module whose
+// source directory was not pushed).
+func (m *MemFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	dir := normalize(name)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type childInfo struct {
+		isDir bool
+		size  int64
+	}
+	children := make(map[string]childInfo)
+	for p, content := range m.files {
+		var rel string
+		if dir == "." {
+			rel = p
+		} else if r, ok := underDir(p, dir); ok {
+			rel = r
+		} else {
+			continue
+		}
+		if rel == "" {
+			continue
+		}
+		if seg, _, found := strings.Cut(rel, "/"); found {
+			// A descendant: its first path segment is an immediate subdirectory.
+			if _, ok := children[seg]; !ok {
+				children[seg] = childInfo{isDir: true}
+			}
+			continue
+		}
+		children[rel] = childInfo{size: int64(len(content))}
+	}
+
+	if len(children) == 0 {
+		m.missing[dir] = struct{}{}
+		return nil, notExist("readdir", name)
+	}
+	names := make([]string, 0, len(children))
+	for n := range children {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	entries := make([]fs.DirEntry, 0, len(names))
+	for _, n := range names {
+		ci := children[n]
+		entries = append(entries, memDirEntry{name: n, dir: ci.isDir, size: ci.size})
+	}
+	return entries, nil
+}
+
+// Glob returns pushed paths matching pattern (filepath.Glob semantics over the
+// single directory level the Terraform readers use, e.g. "<dir>/*.tf"). A
+// non-match is never recorded — an empty glob is legal, exactly as on disk.
+func (m *MemFS) Glob(pattern string) ([]string, error) {
+	pat := filepath.ToSlash(pattern)
+	if _, err := path.Match(pat, ""); err != nil {
+		return nil, err
+	}
+	dir, base := path.Split(pat)
+	cleanDir := path.Clean(dir)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []string
+	for p := range m.files {
+		pdir, pbase := path.Split(p)
+		if path.Clean(pdir) != cleanDir {
+			continue
+		}
+		if ok, _ := path.Match(base, pbase); ok {
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// Abs keeps the path workspace-relative. This keeps Terraform module
+// and missing-file paths relative to the request's own workspace, which is
+// correct even when a single server process serves many IDE workspaces.
+func (m *MemFS) Abs(name string) (string, error) {
+	return normalize(name), nil
+}
+
+// Paths returns the sorted set of pushed file paths (used to seed the scan's
+// file set in server mode).
+func (m *MemFS) Paths() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, 0, len(m.files))
+	for p := range m.files {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// MissingFiles returns the sorted set of paths the scan referenced but that were
+// not pushed — the escalation list returned to the IDE.
+func (m *MemFS) MissingFiles() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, 0, len(m.missing))
+	for p := range m.missing {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// underDir returns the path of p relative to dir if p is a strict descendant of
+// dir (a non-empty remainder after the "dir/" prefix).
+func underDir(p, dir string) (string, bool) {
+	if after, ok := strings.CutPrefix(p, dir+"/"); ok && after != "" {
+		return after, true
+	}
+	return "", false
+}
+
+// memFileInfo is a minimal fs.FileInfo for in-memory entries.
+type memFileInfo struct {
+	name string
+	size int64
+	dir  bool
+}
+
+func (fi memFileInfo) Name() string { return fi.name }
+func (fi memFileInfo) Size() int64  { return fi.size }
+func (fi memFileInfo) Mode() fs.FileMode {
+	if fi.dir {
+		return memDirMode
+	}
+	return memFileMode
+}
+func (fi memFileInfo) ModTime() time.Time { return time.Time{} }
+func (fi memFileInfo) IsDir() bool        { return fi.dir }
+func (fi memFileInfo) Sys() any           { return nil }
+
+// memDirEntry is a minimal fs.DirEntry for in-memory directory listings.
+type memDirEntry struct {
+	name string
+	size int64
+	dir  bool
+}
+
+func (de memDirEntry) Name() string { return de.name }
+func (de memDirEntry) IsDir() bool  { return de.dir }
+func (de memDirEntry) Type() fs.FileMode {
+	if de.dir {
+		return fs.ModeDir
+	}
+	return 0
+}
+func (de memDirEntry) Info() (fs.FileInfo, error) {
+	return memFileInfo(de), nil
+}
+
+var _ FS = (*MemFS)(nil)

--- a/pkg/vfs/memfs_test.go
+++ b/pkg/vfs/memfs_test.go
@@ -1,0 +1,170 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package vfs
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func newTestMemFS() *MemFS {
+	return NewMemFS(map[string][]byte{
+		"infra/main.tf":             []byte(`resource "aws_s3_bucket" "b" {}`),
+		"infra/variables.tf":        []byte(`variable "name" {}`),
+		"infra/prod.auto.tfvars":    []byte(`name = "prod"`),
+		"infra/modules/net/main.tf": []byte(`resource "x" "y" {}`),
+		"./root.tf":                 []byte(`# root`),
+	})
+}
+
+func TestMemFS_ReadFile(t *testing.T) {
+	m := newTestMemFS()
+
+	got, err := m.ReadFile("infra/main.tf")
+	if err != nil {
+		t.Fatalf("ReadFile hit: unexpected error %v", err)
+	}
+	if string(got) != `resource "aws_s3_bucket" "b" {}` {
+		t.Errorf("ReadFile content = %q", got)
+	}
+
+	// Normalization: a dot-prefixed push is reachable by its clean key.
+	if _, err := m.ReadFile("root.tf"); err != nil {
+		t.Errorf("ReadFile normalized key: unexpected error %v", err)
+	}
+
+	// Miss is recorded and reports fs.ErrNotExist.
+	if _, err := m.ReadFile("infra/absent.tf"); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("ReadFile miss err = %v, want ErrNotExist", err)
+	}
+	if got := m.MissingFiles(); !reflect.DeepEqual(got, []string{"infra/absent.tf"}) {
+		t.Errorf("MissingFiles after ReadFile miss = %v", got)
+	}
+}
+
+func TestMemFS_StatDoesNotRecordMiss(t *testing.T) {
+	m := newTestMemFS()
+
+	if _, err := m.Stat("infra/main.tf"); err != nil {
+		t.Errorf("Stat hit: unexpected error %v", err)
+	}
+	// terraform.tfvars is a speculative probe; a miss must NOT be recorded.
+	if _, err := m.Stat("infra/terraform.tfvars"); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("Stat miss err = %v, want ErrNotExist", err)
+	}
+	if got := m.MissingFiles(); len(got) != 0 {
+		t.Errorf("Stat miss must not be recorded, got MissingFiles = %v", got)
+	}
+}
+
+func TestMemFS_Glob(t *testing.T) {
+	m := newTestMemFS()
+
+	tf, err := m.Glob(filepath.Join("infra", "*.tf"))
+	if err != nil {
+		t.Fatalf("Glob *.tf: %v", err)
+	}
+	want := []string{"infra/main.tf", "infra/variables.tf"}
+	if !reflect.DeepEqual(tf, want) {
+		t.Errorf("Glob infra/*.tf = %v, want %v (must not recurse into subdirs)", tf, want)
+	}
+
+	auto, _ := m.Glob(filepath.Join("infra", "*.auto.tfvars"))
+	if !reflect.DeepEqual(auto, []string{"infra/prod.auto.tfvars"}) {
+		t.Errorf("Glob *.auto.tfvars = %v", auto)
+	}
+
+	// Root-level single file.
+	root, _ := m.Glob("*.tf")
+	if !reflect.DeepEqual(root, []string{"root.tf"}) {
+		t.Errorf("Glob *.tf at root = %v", root)
+	}
+
+	// A non-matching glob returns empty and records nothing.
+	none, _ := m.Glob(filepath.Join("nowhere", "*.tf"))
+	if len(none) != 0 {
+		t.Errorf("Glob non-match = %v, want empty", none)
+	}
+	if got := m.MissingFiles(); len(got) != 0 {
+		t.Errorf("Glob must never record misses, got %v", got)
+	}
+}
+
+func TestMemFS_ReadDir(t *testing.T) {
+	m := newTestMemFS()
+
+	entries, err := m.ReadDir("infra")
+	if err != nil {
+		t.Fatalf("ReadDir infra: %v", err)
+	}
+	got := map[string]bool{}
+	for _, e := range entries {
+		got[e.Name()] = e.IsDir()
+	}
+	want := map[string]bool{"main.tf": false, "variables.tf": false, "prod.auto.tfvars": false, "modules": true}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ReadDir infra = %v, want %v", got, want)
+	}
+
+	// An absent module directory is recorded (the escalation signal).
+	if _, err := m.ReadDir("infra/missingmod"); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("ReadDir miss err = %v, want ErrNotExist", err)
+	}
+	if got := m.MissingFiles(); !reflect.DeepEqual(got, []string{"infra/missingmod"}) {
+		t.Errorf("MissingFiles after ReadDir miss = %v", got)
+	}
+}
+
+func TestMemFS_Paths(t *testing.T) {
+	m := newTestMemFS()
+	want := []string{"infra/main.tf", "infra/modules/net/main.tf", "infra/prod.auto.tfvars", "infra/variables.tf", "root.tf"}
+	if got := m.Paths(); !reflect.DeepEqual(got, want) {
+		t.Errorf("Paths = %v, want %v", got, want)
+	}
+}
+
+// TestMemFS_DiskParity asserts MemFS matches DiskFS for the read operations the
+// Terraform resolver relies on, so the content-push path produces the same
+// results as the CLI for an equivalent file set.
+func TestMemFS_DiskParity(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "main.tf"), `resource "x" "y" {}`)
+	mustWrite(t, filepath.Join(dir, "vars.tf"), `variable "v" {}`)
+
+	disk := DiskFS{}
+	mem := NewMemFS(map[string][]byte{
+		filepath.Join(dir, "main.tf"): []byte(`resource "x" "y" {}`),
+		filepath.Join(dir, "vars.tf"): []byte(`variable "v" {}`),
+	})
+
+	dGlob, _ := disk.Glob(filepath.Join(dir, "*.tf"))
+	mGlob, _ := mem.Glob(filepath.Join(dir, "*.tf"))
+	// DiskFS returns OS-separated absolute paths; MemFS returns slash-normalized.
+	if len(dGlob) != len(mGlob) {
+		t.Errorf("Glob count: disk=%d mem=%d", len(dGlob), len(mGlob))
+	}
+
+	dContent, derr := disk.ReadFile(filepath.Join(dir, "main.tf"))
+	mContent, merr := mem.ReadFile(filepath.Join(dir, "main.tf"))
+	if derr != nil || merr != nil {
+		t.Fatalf("ReadFile errors: disk=%v mem=%v", derr, merr)
+	}
+	if string(dContent) != string(mContent) {
+		t.Errorf("ReadFile content mismatch: disk=%q mem=%q", dContent, mContent)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -1,0 +1,63 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+// Package vfs abstracts the file-reading operations the scanner performs during
+// cross-file resolution (Terraform sibling/variable globs, module directory
+// reads, $ref includes). The CLI uses DiskFS — a thin passthrough to the real
+// filesystem, behaviorally identical to direct os.* calls. The HTTP server uses
+// an in-memory implementation built from content pushed over the wire, so it can
+// resolve unsaved editor buffers and browser web-shell files that never touch
+// disk.
+//
+// The interface deliberately mirrors os/filepath (absolute OS paths, filepath
+// glob semantics) rather than io/fs.FS, because the readers it serves operate on
+// absolute paths and use filepath.Glob.
+package vfs
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// FS is the set of read operations the cross-file resolution code performs.
+type FS interface {
+	// ReadFile reads the named file and returns its contents.
+	ReadFile(name string) ([]byte, error)
+	// Stat returns file info for the named file.
+	Stat(name string) (fs.FileInfo, error)
+	// ReadDir reads the named directory, returning its entries.
+	ReadDir(name string) ([]fs.DirEntry, error)
+	// Glob returns the names matching pattern (filepath.Glob semantics).
+	Glob(pattern string) ([]string, error)
+	// Abs resolves name against the filesystem's root.
+	Abs(name string) (string, error)
+}
+
+// DiskFS is the real-filesystem implementation used by the CLI. Each method is a
+// direct passthrough to os/filepath, so threading DiskFS through the resolution
+// code is behavior-preserving.
+type DiskFS struct{}
+
+// ReadFile reads the named file from disk.
+func (DiskFS) ReadFile(name string) ([]byte, error) { return os.ReadFile(name) } //nolint:gosec
+
+// Stat stats the named file on disk.
+func (DiskFS) Stat(name string) (fs.FileInfo, error) { return os.Stat(name) }
+
+// ReadDir reads the named directory from disk.
+func (DiskFS) ReadDir(name string) ([]fs.DirEntry, error) { return os.ReadDir(name) }
+
+// Glob returns the files on disk matching pattern.
+func (DiskFS) Glob(pattern string) ([]string, error) { return filepath.Glob(pattern) }
+
+// Abs resolves name against the process working directory.
+func (DiskFS) Abs(name string) (string, error) { return filepath.Abs(name) }
+
+// Default returns the filesystem used when none is injected (the real disk).
+func Default() FS { return DiskFS{} }
+
+var _ FS = DiskFS{}


### PR DESCRIPTION
## Motivation

Bring IaC scanning into the Datadog IDE extensions, the same way SAST and secret scanning already work.

Today the scanner is a one-shot CLI (requires a git remote, fetches rules from the API per scan, reads files from disk, writes SARIF) — unsuitable for an IDE. The extension needs a long-lived, **pure-engine** HTTP server it can drive by pushing rules + file content over HTTP, mirroring the `datadog-static-analyzer-server` contract so it can reuse the same binary-manager lifecycle (keep-alive ping, graceful shutdown, version discovery).

JIRA Ticket: [K9CODESEC-2453](https://datadoghq.atlassian.net/browse/K9CODESEC-2453)

## Changes

`serve` is purely additive. The `scan` CLI is unchanged, and the virtual-FS refactor is behavior-preserving (the CLI uses a `DiskFS` passthrough).

- **`serve` command + lifecycle** mirroring the static-analyzer server: flags `--port` / `--address` / `--keep-alive-timeout` / `--enable-shutdown` (`--use-rules-cache` accepted as a no-op); `GET /ping`→`pong`, `GET /version` & `/revision`, `GET|POST /shutdown` (204/403), keep-alive idle-exit goroutine, `X-iac-scanner-server-*` + CORS headers.
- **`GET /ide/v1/iac/supported-files`** — static `{patterns, strategy}` map (directory vs single_file), derived from `analyzer.PossibleFileTypes()` with a drift test.
- **`POST /ide/v1/iac/analyze`** — content-push scan. Request `{files:[{path,content}], rules, config}` (raw content); response `{findings, missing_files, failed_queries}`. No git, no network, no SARIF.
- **Content-push + virtual FS** — new `pkg/vfs` (`FS` / `DiskFS` / `MemFS`). `MemFS` resolves Terraform siblings, vars, and local modules in memory and records referenced-but-unpushed paths as workspace-relative `missing_files` (the hybrid-escalation signal; CWD-independent, so one server can serve many workspaces). New `MemorySourceProvider` feeds pushed files to the engine instead of walking disk. `vfs.FS` is threaded through the Terraform parser/data-source/modules, the inspector, and extension detection.
- **`scan.Client` seams** — `Client.Scan(ctx)` (in-memory results) plus `WithFS` / `WithQuerySourceFactory` / `WithInMemoryScan` options, and an in-memory `initScan` branch that bypasses the disk analyzer.

## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

The server needs the Rego support libraries on disk; rules and file content are pushed per request.

```
go build -o /tmp/iac-scanner ./cmd/scanner
/tmp/iac-scanner serve --port 49200 --enable-shutdown --libraries-path ./assets/libraries
```

- `curl 127.0.0.1:49200/ping` → `pong`; `GET /ide/v1/iac/supported-files` → the `{patterns,strategy}` array.
- `POST /ide/v1/iac/analyze`: fetch rules anonymously from `GET https://api.datadoghq.com/api/v2/static-analysis/iac/rulesets/default-ruleset` (base64-decode each `rego_query`, lowercase `platform`). Push a Terraform `main.tf` that uses `var.x` defined in a sibling `variables.tf` → expect findings, with `var.x` resolved (proves in-memory sibling resolution). Push a `module { source = "../mod" }` whose directory you *don't* send → expect `"mod"` to appear in `missing_files` as a workspace-relative path.
- **CLI regression**: `datadog-iac-scanner scan …` SARIF output must be unchanged (DiskFS path is behavior-preserving).
- **Concurrency**: `go build -race`, then fire several parallel `/analyze` requests — no `DATA RACE` in the log and the process must not exit `66`.

## Blast Radius

**Only `datadog-iac-scanner`.** `serve` is additive; the `scan` CLI and its SARIF output are unchanged (the `vfs` refactor is a DiskFS passthrough, covered by the existing suite). No backend/API changes.

## Additional Notes

- **Deferred**: Helm rendering is disabled in content-push mode (the Helm SDK needs a real chart directory) — pushed charts fall back to raw-YAML scanning; the `$ref`/include resolver isn't virtualized yet (niche OpenAPI/Ansible cross-file refs).

I submit this contribution under the Apache-2.0 license.


[K9CODESEC-2453]: https://datadoghq.atlassian.net/browse/K9CODESEC-2453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ