### PR TITLE
Fix data race on `Inspector.failedQueries` (concurrent map writes -> fatal crash)

### DIFF
--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
 	"runtime/debug"
 	"strings"
@@ -86,8 +87,13 @@ type Inspector struct {
 	vb            VulnerabilityBuilder
 	tracker       Tracker
 	failedQueries map[string]error
-	ruleConfigs   map[string]config.IacRuleConfig
-	detector      *detector.DetectLine
+	// failedQueriesMu guards failedQueries. Inspect writes it from two places
+	// concurrently: the collector goroutine (processResult, on a query error)
+	// and every worker goroutine (getVulnerabilitiesFromQuery, on a
+	// vulnerability-build error)
+	failedQueriesMu sync.Mutex
+	ruleConfigs     map[string]config.IacRuleConfig
+	detector        *detector.DetectLine
 
 	repoPath             string
 	enableCoverageReport bool
@@ -368,7 +374,9 @@ func processResult(ctx context.Context, result *QueryResult,
 	queries []model.QueryMetadata, c *Inspector) {
 	contextLogger := logger.FromContext(ctx)
 	if result.err != nil {
+		c.failedQueriesMu.Lock()
 		c.failedQueries[queries[result.queryID].Query] = result.err
+		c.failedQueriesMu.Unlock()
 		return
 	}
 
@@ -419,9 +427,13 @@ func (c *Inspector) GetCoverageReport() cover.Report {
 	return c.coverageReport
 }
 
-// GetFailedQueries returns a map of failed queries and the associated error
+// GetFailedQueries returns a map of failed queries and the associated error.
+// It returns a copy taken under failedQueriesMu so callers can read the result
+// safely even if a scan is still writing to the underlying map.
 func (c *Inspector) GetFailedQueries() map[string]error {
-	return c.failedQueries
+	c.failedQueriesMu.Lock()
+	defer c.failedQueriesMu.Unlock()
+	return maps.Clone(c.failedQueries)
 }
 
 func (c *Inspector) doRun(ctx context.Context, qCtx *QueryContext) (vulns []model.Vulnerability, err error) {
@@ -593,9 +605,11 @@ func getVulnerabilitiesFromQuery(ctx context.Context, qCtx *QueryContext, c *Ins
 		return nil, false
 	}
 	if err != nil {
+		c.failedQueriesMu.Lock()
 		if _, ok := c.failedQueries[qCtx.Query.Metadata.Query]; !ok {
 			c.failedQueries[qCtx.Query.Metadata.Query] = err
 		}
+		c.failedQueriesMu.Unlock()
 
 		return nil, false
 	}

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -1058,4 +1059,66 @@ func TestRulePathExcluded(t *testing.T) {
 			assert.Equal(t, tt.want, rulePathExcluded(tt.filePath, tt.ignorePaths, tt.onlyPaths))
 		})
 	}
+}
+
+// TestInspector_FailedQueriesConcurrentWrites reproduces the data race on
+// Inspector.failedQueries.
+func TestInspector_FailedQueriesConcurrentWrites(t *testing.T) {
+	buildErr := fmt.Errorf("vulnerability build failed")
+
+	ins := newTestInspector(t, inspectorOpts{
+		// vb always errors (and never with ErrNoResult), forcing the
+		// worker-side failedQueries write in getVulnerabilitiesFromQuery.
+		vb: func(_ context.Context, _ *QueryContext, _ Tracker, _ interface{},
+			_ *detector.DetectLine, _ bool, _ time.Duration) (*model.Vulnerability, error) {
+			return nil, buildErr
+		},
+	})
+
+	ctx := context.Background()
+
+	const goroutines = 64
+	queries := make([]model.QueryMetadata, goroutines)
+	for i := range queries {
+		queries[i] = model.QueryMetadata{Query: fmt.Sprintf("query-%d", i)}
+	}
+
+	var wg sync.WaitGroup
+	// start gates every goroutine so the writes overlap instead of running
+	// serially as each goroutine is scheduled.
+	start := make(chan struct{})
+
+	for i := 0; i < goroutines; i++ {
+		i := i
+
+		// Worker path: getVulnerabilitiesFromQuery writes failedQueries on a vb error.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			qCtx := &QueryContext{
+				Ctx:   ctx,
+				Query: &PreparedQuery{Metadata: queries[i]},
+				Files: map[string]*model.FileMetadata{},
+			}
+			<-start
+			getVulnerabilitiesFromQuery(ctx, qCtx, ins, struct{}{}, 0)
+		}()
+
+		// Collector path: processResult writes failedQueries on a query error.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			vulns := make([]model.Vulnerability, 0)
+			moduleVulns := make(map[string]int)
+			result := QueryResult{err: buildErr, queryID: i}
+			<-start
+			processResult(ctx, &result, &vulns, &moduleVulns, queries, ins)
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	// Sanity: the failures were actually recorded
+	require.NotEmpty(t, ins.GetFailedQueries())
 }


### PR DESCRIPTION
## Motivation

`Inspector.failedQueries` (`pkg/engine/inspector.go`) is a plain `map[string]error` written concurrently during `Inspect` with no synchronization: the collector goroutine writes it on a query error (`processResult`), while N worker goroutines write it on a vulnerability-build failure (`getVulnerabilitiesFromQuery`). In Go, concurrent map writes are not a "maybe corrupt" race, the runtime throws an unrecoverable `fatal error: concurrent map writes` that crashes the whole process.

It stayed hidden because the map is only written on failures, so it's empty on healthy scans — which is why `-race` never caught it across the parallel real-repo runs. 

JIRA Ticket https://datadoghq.atlassian.net/browse/K9CODESEC-2487

## Changes

- Added `failedQueriesMu sync.Mutex` to `Inspector` to guard `failedQueries`.
- Guarded both writers (`processResult` and `getVulnerabilitiesFromQuery`); the lock is only taken on the failure path, so healthy scans pay nothing.
- `GetFailedQueries` now returns a locked copy via `maps.Clone` so callers can read safely while a scan is still running.
- Added `TestInspector_FailedQueriesConcurrentWrites`, which drives both writer paths concurrently and reproduces the data race under `-race` on the unfixed code.

## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- Run the new test against the **fix reverted**: `go test -race -run TestInspector_FailedQueriesConcurrentWrites ./pkg/engine/` should report `WARNING: DATA RACE` pointing at `inspector.go:371` (`processResult`) and `inspector.go:596-597` (`getVulnerabilitiesFromQuery`).
- With the fix in place: `go test -race ./pkg/engine/` passes cleanly (exit 0).
- Confirm `failed_queries` output is unchanged, no vb-build errors are dropped (we kept the worker-side write rather than deleting it).

## Blast Radius

DataDog IaC Scanner only, specifically `pkg/engine`. No public API or output-format change; the lock is on the failure path only, so the happy path is unaffected. Removes an unrecoverable process crash that affects the CLI (under parallel parsing) and, more severely, server mode (one panic takes down all in-flight requests).

I submit this contribution under the Apache-2.0 license.
