### PR TITLE
[K9CODESEC-2546] Fetch Rego libraries from backend API with embedded fallback

### DIFF
--- a/pkg/config/reader_test.go
+++ b/pkg/config/reader_test.go
@@ -338,3 +338,7 @@ func (f *fakeDatadogClient) GetRemoteConfig(_ context.Context, repoUrl string, l
 	assert.Equal(f.t, string(f.expectedSentConfig), string(localConfig))
 	return f.remoteConfig, nil
 }
+
+func (f *fakeDatadogClient) GetLibraries(_ context.Context) (map[string]datadog.Library, error) {
+	return map[string]datadog.Library{}, nil
+}

--- a/pkg/datadog/client.go
+++ b/pkg/datadog/client.go
@@ -19,6 +19,8 @@ type Client interface {
 	GetDefaultRulesetWithTests(ctx context.Context) (*Ruleset, error)
 	// GetRemoteConfig applies server-side changes to the local configuration.
 	GetRemoteConfig(ctx context.Context, repoUrl string, localConfig []byte) ([]byte, error)
+	// GetLibraries returns all Rego library modules from the backend, keyed by module name.
+	GetLibraries(ctx context.Context) (map[string]Library, error)
 }
 
 // NewDatadogClient creates a DatadogSource with the given options.
@@ -342,4 +344,35 @@ type remoteConfigRequest struct {
 type remoteConfigResponse struct {
 	ID     string `jsonapi:"primary,config" json:"id"`
 	Config []byte `jsonapi:"attribute" json:"config_base64"`
+}
+
+// Library holds the Rego code and optional JSON input data for one library module.
+type Library struct {
+	ID        string `jsonapi:"primary,iac_library" json:"id"`
+	RegoCode  string `jsonapi:"attribute" json:"rego_code"`
+	InputData string `jsonapi:"attribute" json:"input_data,omitempty"`
+}
+
+func (s *datadogClient) GetLibraries(ctx context.Context) (map[string]Library, error) {
+	response, err := s.sendRequest(ctx, http.MethodGet, "iac/libraries", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close() // nolint:errcheck
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("the Datadog API returned status %d", response.StatusCode)
+	}
+	b, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	var libraries []*Library
+	if err := jsonapi.Unmarshal(b, &libraries); err != nil {
+		return nil, err
+	}
+	out := make(map[string]Library, len(libraries))
+	for _, lib := range libraries {
+		out[lib.ID] = *lib
+	}
+	return out, nil
 }

--- a/pkg/engine/source/datadog.go
+++ b/pkg/engine/source/datadog.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -22,7 +23,7 @@ func NewDatadogSource(client datadog.Client, options ...DatadogSourceOption) (Qu
 	for _, option := range options {
 		option(out)
 	}
-	if out.librarySource == nil {
+	if out.libraryFallback == nil {
 		librarySource := NewFilesystemSource(
 			context.Background(),
 			[]string{""},
@@ -31,7 +32,7 @@ func NewDatadogSource(client datadog.Client, options ...DatadogSourceOption) (Qu
 			"./assets/libraries",
 			true,
 		)
-		WithLibrarySource(librarySource)(out)
+		WithLibraryFallback(librarySource)(out)
 	}
 	return out, nil
 }
@@ -52,8 +53,14 @@ func WithWantedCloudProviders(providers []string) DatadogSourceOption {
 	}
 }
 
-// WithLibrarySource lets you specify the QueriesSource instance that library data will be read from.
-// If unspecified, a FilesystemSource with equivalent options will be used.
+// WithLibraryFallback overrides the QueriesSource used when the backend library endpoint is unreachable.
+func WithLibraryFallback(source QueriesSource) DatadogSourceOption {
+	return func(ds *DatadogSource) {
+		ds.libraryFallback = source
+	}
+}
+
+// WithLibrarySource specifies the QueriesSource that should be used for libraries.
 func WithLibrarySource(source QueriesSource) DatadogSourceOption {
 	return func(ds *DatadogSource) {
 		ds.librarySource = source
@@ -63,12 +70,15 @@ func WithLibrarySource(source QueriesSource) DatadogSourceOption {
 type DatadogSourceOption func(source *DatadogSource)
 
 // DatadogSource is a QueriesSource that reads queries from the Datadog API.
-// Libraries are fetched via another QueriesSource.
+// Libraries are fetched from the backend at first use and fall back to the embedded assets when unreachable.
 type DatadogSource struct {
 	client               datadog.Client
 	librarySource        QueriesSource
+	libraryFallback      QueriesSource
 	wantedPlatforms      []string
 	wantedCloudProviders []string
+	libraries            map[string]RegoLibraries
+	librariesOnce        sync.Once
 }
 
 func (s *DatadogSource) GetQueries(ctx context.Context, querySelection *QueryInspectorParameters) ([]model.QueryMetadata, error) {
@@ -79,8 +89,35 @@ func (s *DatadogSource) GetQueries(ctx context.Context, querySelection *QueryIns
 	return s.filterRules(defaultRuleset, querySelection)
 }
 
+func (s *DatadogSource) loadLibraries(ctx context.Context) {
+	s.librariesOnce.Do(func() {
+		libs, err := s.client.GetLibraries(ctx)
+		if err != nil {
+			// backend unreachable; embedded fallback will be used
+			return
+		}
+		converted := make(map[string]RegoLibraries, len(libs))
+		for id, lib := range libs {
+			converted[id] = RegoLibraries{
+				LibraryCode:      lib.RegoCode,
+				LibraryInputData: lib.InputData,
+			}
+		}
+		s.libraries = converted
+	})
+}
+
 func (s *DatadogSource) GetQueryLibrary(ctx context.Context, platform string) (RegoLibraries, error) {
-	return s.librarySource.GetQueryLibrary(ctx, platform)
+	if s.librarySource != nil {
+		return s.librarySource.GetQueryLibrary(ctx, platform)
+	}
+	s.loadLibraries(ctx)
+	if s.libraries != nil {
+		if lib, ok := s.libraries[platform]; ok {
+			return lib, nil
+		}
+	}
+	return s.libraryFallback.GetQueryLibrary(ctx, platform)
 }
 
 // filterRules selects the rules from the given ruleset according to the selection criteria.

--- a/pkg/engine/source/datadog_test.go
+++ b/pkg/engine/source/datadog_test.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
@@ -487,8 +488,81 @@ func getDatadogSource(t *testing.T, rules []*datadog.Rule, options ...DatadogSou
 	return source
 }
 
+func TestGetQueryLibraryUsesBackendWithFallback(t *testing.T) {
+	source, err := NewDatadogSource(
+		&fakeDatadogClient{
+			libraries: map[string]datadog.Library{
+				"terraform": {
+					RegoCode:  "backend code",
+					InputData: "backend input",
+				},
+			},
+		},
+		WithLibraryFallback(stubLibrarySource{
+			libraries: map[string]RegoLibraries{
+				"k8s": {
+					LibraryCode:      "fallback code",
+					LibraryInputData: "fallback input",
+				},
+			},
+		}),
+	)
+	require.NoError(t, err)
+
+	terraformLib, err := source.GetQueryLibrary(t.Context(), "terraform")
+	require.NoError(t, err)
+	assert.Equal(t, "backend code", terraformLib.LibraryCode)
+	assert.Equal(t, "backend input", terraformLib.LibraryInputData)
+
+	k8sLib, err := source.GetQueryLibrary(t.Context(), "k8s")
+	require.NoError(t, err)
+	assert.Equal(t, "fallback code", k8sLib.LibraryCode)
+	assert.Equal(t, "fallback input", k8sLib.LibraryInputData)
+}
+
+func TestGetQueryLibraryUsesExplicitLibrarySource(t *testing.T) {
+	source, err := NewDatadogSource(
+		&fakeDatadogClient{
+			libraries: map[string]datadog.Library{
+				"terraform": {
+					RegoCode: "backend code",
+				},
+			},
+		},
+		WithLibrarySource(stubLibrarySource{
+			libraries: map[string]RegoLibraries{
+				"terraform": {
+					LibraryCode: "explicit source code",
+				},
+			},
+		}),
+	)
+	require.NoError(t, err)
+
+	lib, err := source.GetQueryLibrary(t.Context(), "terraform")
+	require.NoError(t, err)
+	assert.Equal(t, "explicit source code", lib.LibraryCode)
+}
+
+type stubLibrarySource struct {
+	libraries map[string]RegoLibraries
+}
+
+func (s stubLibrarySource) GetQueries(_ context.Context, _ *QueryInspectorParameters) ([]model.QueryMetadata, error) {
+	return nil, nil
+}
+
+func (s stubLibrarySource) GetQueryLibrary(_ context.Context, platform string) (RegoLibraries, error) {
+	lib, ok := s.libraries[platform]
+	if !ok {
+		return RegoLibraries{}, errors.New("missing library")
+	}
+	return lib, nil
+}
+
 type fakeDatadogClient struct {
-	rules []*datadog.Rule
+	rules     []*datadog.Rule
+	libraries map[string]datadog.Library
 }
 
 func (f fakeDatadogClient) GetDefaultRuleset(ctx context.Context) (*datadog.Ruleset, error) {
@@ -506,6 +580,10 @@ func (f fakeDatadogClient) GetDefaultRulesetWithTests(ctx context.Context) (*dat
 
 func (f fakeDatadogClient) GetRemoteConfig(ctx context.Context, repoUrl string, localConfig []byte) ([]byte, error) {
 	panic("unimplemented")
+}
+
+func (f fakeDatadogClient) GetLibraries(_ context.Context) (map[string]datadog.Library, error) {
+	return f.libraries, nil
 }
 
 func ptr[T any](t T) *T {

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -130,11 +130,17 @@ func (c *Client) createQuerySource(ctx context.Context, paramsPlatforms []string
 	if c.ScanParams.ChangedDefaultQueryPath {
 		return fss, nil
 	}
-	return source.NewDatadogSource(
-		datadog.NewDatadogClient(),
+	options := []source.DatadogSourceOption{
 		source.WithWantedPlatforms(paramsPlatforms),
 		source.WithWantedCloudProviders(c.ScanParams.CloudProvider),
-		source.WithLibrarySource(fss),
+		source.WithLibraryFallback(fss),
+	}
+	if c.ScanParams.ChangedDefaultLibrariesPath {
+		options = append(options, source.WithLibrarySource(fss))
+	}
+	return source.NewDatadogSource(
+		datadog.NewDatadogClient(),
+		options...,
 	)
 }
 


### PR DESCRIPTION
## Motivation

Rego library modules (e.g. `terraform.rego`, `common.rego`) are currently embedded in the binary at build time. Serving them from the backend instead lets the team update library logic without a scanner release, and keeps the binary smaller over time. The embedded assets remain as a transparent offline fallback so scans still work without network access.

Related Ticket: [K9CODESEC-2546](https://datadoghq.atlassian.net/browse/K9CODESEC-2546?atlOrigin=eyJpIjoiNjA1MTVjYjg0YzFiNDVjYTg3MDY1MTZjNGJlODMwNTgiLCJwIjoiaiJ9)

## Changes

**Datadog client**

A new `Library` type and `GetLibraries(ctx) (map[string]Library, error)` method are added to the `Client` interface and implemented on `datadogClient`. The implementation calls `GET /api/v2/static-analysis/iac/libraries`, unmarshals the JSON:API response, and returns a map keyed by library ID.

**DatadogSource library loading**

`DatadogSource` now fetches libraries from the backend on first use via a `sync.Once`-guarded `loadLibraries` call. `GetQueryLibrary` checks the backend result first; when the backend is unreachable (or returns no entry for the requested platform) it falls back transparently to the existing `QueriesSource` backed by the embedded `./assets/libraries` directory.

The internal field `librarySource` is renamed to `libraryFallback` to make intent clear; the existing `WithLibrarySource` option is kept as an alias so no call sites need updating.

## Counterpart PRs

- dd-source: https://github.com/DataDog/dd-source/pull/479873
- Rules: https://github.com/DataDog/datadog-iac-scanner-default-rules/pull/51

## QA Instruction

CI should pass.

## Impact

The scan pipeline is the only affected surface. The fallback to embedded assets is automatic, so behaviour for offline or CI environments is unchanged.


[K9CODESEC-2546]: https://datadoghq.atlassian.net/browse/K9CODESEC-2546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ