### PR TITLE
Nathan.gallet/helm deterministic rendering

### DIFF
--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -190,35 +190,54 @@ func newClient(ctx context.Context) *action.Install {
 	return client
 }
 
-// deterministicPatterns maps each non-deterministic sprig function regex to a replacement generator.
-// The generator receives the line number of the match.
-var deterministicPatterns = []struct {
+// deterministicPattern represents a non-deterministic sprig function to replace.
+type deterministicPattern struct {
 	re      *regexp.Regexp
 	replace func(lineNum int) string
-}{
+	// guard is an optional function that can reject a match. Returns true to accept, false to skip.
+	// If nil, all matches are accepted.
+	guard func(s string, matchStart int) bool
+}
+
+// deterministicPatterns maps each non-deterministic sprig function regex to a replacement generator.
+// The generator receives the line number of the match.
+var deterministicPatterns = []deterministicPattern{
 	{
 		re:      regexp.MustCompile(`\brandAlphaNum\s+\d+`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
+		guard:   nil,
 	},
 	{
 		re:      regexp.MustCompile(`\brandAlpha\s+\d+`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
+		guard:   nil,
 	},
 	{
 		re:      regexp.MustCompile(`\brandAscii\s+\d+`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
+		guard:   nil,
 	},
 	{
 		re:      regexp.MustCompile(`\brandNumeric\s+\d+`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"%08d"`, lineNum) },
+		guard:   nil,
 	},
 	{
 		re:      regexp.MustCompile(`\buuidv4\b`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"00000000-0000-0000-%04d-%012d"`, lineNum, lineNum) },
+		guard:   nil,
 	},
 	{
 		re:      regexp.MustCompile(`\bnow\b`),
 		replace: func(_ int) string { return `(toDate "2006-01-02" "2000-01-01")` },
+		guard: func(s string, matchStart int) bool {
+			// Skip matches preceded by $ or . (variable/field references)
+			if matchStart == 0 {
+				return true
+			}
+			prev := s[matchStart-1]
+			return prev != '$' && prev != '.'
+		},
 	},
 }
 
@@ -235,19 +254,12 @@ func applyDeterministicSubstitutions(data []byte) []byte {
 	s := string(data)
 	var replacements []replacement
 
-	for patternIdx, p := range deterministicPatterns {
+	for _, p := range deterministicPatterns {
 		matches := p.re.FindAllStringIndex(s, -1)
 		for _, m := range matches {
-			// For the "now" pattern, skip matches preceded by $ or .
-			// These are variable references ($now) or field accesses (.Values.now),
-			// not function calls.
-			if patternIdx == 5 { // Index of the "now" pattern in deterministicPatterns
-				if m[0] > 0 {
-					prev := s[m[0]-1]
-					if prev == '$' || prev == '.' {
-						continue // Skip this match
-					}
-				}
+			// Check guard if present
+			if p.guard != nil && !p.guard(s, m[0]) {
+				continue
 			}
 
 			lineNum := strings.Count(s[:m[0]], "\n") + 1

--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -266,10 +266,7 @@ func makeDeterministic(ch *chart.Chart) *chart.Chart {
 		temp.Data = applyDeterministicSubstitutions(temp.Data)
 	}
 	for _, dep := range ch.Dependencies() {
-		dep = makeDeterministic(dep)
-		if dep != nil {
-			continue
-		}
+		makeDeterministic(dep)
 	}
 	return ch
 }

--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -190,6 +190,49 @@ func newClient(ctx context.Context) *action.Install {
 	return client
 }
 
+// templateActionRE matches Helm/Go template action delimiters including trim markers.
+var templateActionRE = regexp.MustCompile(`(?s)\{\{-?.*?-?\}\}`)
+
+// templateActionSpans returns the [start, end) byte ranges of all {{ ... }} blocks in s.
+// The returned slice is sorted by start (FindAllStringIndex guarantees this).
+func templateActionSpans(s string) [][2]int {
+	matches := templateActionRE.FindAllStringIndex(s, -1)
+	spans := make([][2]int, len(matches))
+	for i, m := range matches {
+		spans[i] = [2]int{m[0], m[1]}
+	}
+	return spans
+}
+
+// inAnySpan reports whether pos falls within any of the sorted, non-overlapping spans.
+func inAnySpan(pos int, spans [][2]int) bool {
+	// Binary search for the last span with start <= pos.
+	lo, hi := 0, len(spans)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if spans[mid][0] <= pos {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	if lo == 0 {
+		return false
+	}
+	span := spans[lo-1]
+	return pos < span[1]
+}
+
+// notPrecededByQuoteVarOrField rejects matches that are string arguments, variable
+// references ($name), or field accesses (.field) rather than bare function calls.
+func notPrecededByQuoteVarOrField(s string, pos int) bool {
+	if pos == 0 {
+		return true
+	}
+	prev := s[pos-1]
+	return prev != '"' && prev != '$' && prev != '.'
+}
+
 // deterministicPattern represents a non-deterministic sprig function to replace.
 type deterministicPattern struct {
 	re      *regexp.Regexp
@@ -205,39 +248,32 @@ var deterministicPatterns = []deterministicPattern{
 	{
 		re:      regexp.MustCompile(`\brandAlphaNum\s+\d+`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
-		guard:   nil,
+		guard:   notPrecededByQuoteVarOrField,
 	},
 	{
 		re:      regexp.MustCompile(`\brandAlpha\s+\d+`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
-		guard:   nil,
+		guard:   notPrecededByQuoteVarOrField,
 	},
 	{
 		re:      regexp.MustCompile(`\brandAscii\s+\d+`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
-		guard:   nil,
+		guard:   notPrecededByQuoteVarOrField,
 	},
 	{
 		re:      regexp.MustCompile(`\brandNumeric\s+\d+`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"%08d"`, lineNum) },
-		guard:   nil,
+		guard:   notPrecededByQuoteVarOrField,
 	},
 	{
 		re:      regexp.MustCompile(`\buuidv4\b`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"00000000-0000-0000-%04d-%012d"`, lineNum, lineNum) },
-		guard:   nil,
+		guard:   notPrecededByQuoteVarOrField,
 	},
 	{
 		re:      regexp.MustCompile(`\bnow\b`),
 		replace: func(_ int) string { return `(toDate "2006-01-02" "2000-01-01")` },
-		guard: func(s string, matchStart int) bool {
-			// Skip matches preceded by $ or . (variable/field references)
-			if matchStart == 0 {
-				return true
-			}
-			prev := s[matchStart-1]
-			return prev != '$' && prev != '.'
-		},
+		guard:   notPrecededByQuoteVarOrField,
 	},
 }
 
@@ -254,9 +290,18 @@ func applyDeterministicSubstitutions(data []byte) []byte {
 	s := string(data)
 	var replacements []replacement
 
+	// Pre-compute the spans of all {{ ... }} action blocks so we only substitute
+	// inside them, not in literal text (e.g. shell scripts in ConfigMap data).
+	spans := templateActionSpans(s)
+
 	for _, p := range deterministicPatterns {
 		matches := p.re.FindAllStringIndex(s, -1)
 		for _, m := range matches {
+			// Only substitute inside {{ ... }} action blocks.
+			if !inAnySpan(m[0], spans) {
+				continue
+			}
+
 			// Check guard if present
 			if p.guard != nil && !p.guard(s, m[0]) {
 				continue

--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -223,14 +223,45 @@ func inAnySpan(pos int, spans [][2]int) bool {
 	return pos < span[1]
 }
 
-// notPrecededByQuoteVarOrField rejects matches that are string arguments, variable
-// references ($name), or field accesses (.field) rather than bare function calls.
-func notPrecededByQuoteVarOrField(s string, pos int) bool {
+// notPrecededByVarOrField rejects matches that are variable references ($name) or
+// field accesses (.field). Quoted-string detection is handled separately by
+// insideQuotedStringInSpan, which is more accurate than a single-byte check.
+func notPrecededByVarOrField(s string, pos int) bool {
 	if pos == 0 {
 		return true
 	}
 	prev := s[pos-1]
-	return prev != '"' && prev != '$' && prev != '.'
+	return prev != '$' && prev != '.'
+}
+
+// insideQuotedStringInSpan reports whether pos is inside a Go template string literal
+// within the action span that contains it. It counts unescaped double-quotes from the
+// span's opening {{ to pos; an odd count means we are inside a string.
+func insideQuotedStringInSpan(s string, pos int, spans [][2]int) bool {
+	lo, hi := 0, len(spans)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if spans[mid][0] <= pos {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	if lo == 0 {
+		return false
+	}
+	span := spans[lo-1]
+	if pos >= span[1] {
+		return false
+	}
+	text := s[span[0]:pos]
+	quoteCount := 0
+	for i := 0; i < len(text); i++ {
+		if text[i] == '"' && (i == 0 || text[i-1] != '\\') {
+			quoteCount++
+		}
+	}
+	return quoteCount%2 == 1
 }
 
 // deterministicPattern represents a non-deterministic sprig function to replace.
@@ -248,32 +279,32 @@ var deterministicPatterns = []deterministicPattern{
 	{
 		re:      regexp.MustCompile(`\brandAlphaNum\s+\d+`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
-		guard:   notPrecededByQuoteVarOrField,
+		guard:   notPrecededByVarOrField,
 	},
 	{
 		re:      regexp.MustCompile(`\brandAlpha\s+\d+`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
-		guard:   notPrecededByQuoteVarOrField,
+		guard:   notPrecededByVarOrField,
 	},
 	{
 		re:      regexp.MustCompile(`\brandAscii\s+\d+`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
-		guard:   notPrecededByQuoteVarOrField,
+		guard:   notPrecededByVarOrField,
 	},
 	{
 		re:      regexp.MustCompile(`\brandNumeric\s+\d+`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"%08d"`, lineNum) },
-		guard:   notPrecededByQuoteVarOrField,
+		guard:   notPrecededByVarOrField,
 	},
 	{
 		re:      regexp.MustCompile(`\buuidv4\b`),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"00000000-0000-0000-%04d-%012d"`, lineNum, lineNum) },
-		guard:   notPrecededByQuoteVarOrField,
+		guard:   notPrecededByVarOrField,
 	},
 	{
 		re:      regexp.MustCompile(`\bnow\b`),
 		replace: func(_ int) string { return `(toDate "2006-01-02" "2000-01-01")` },
-		guard:   notPrecededByQuoteVarOrField,
+		guard:   notPrecededByVarOrField,
 	},
 }
 
@@ -302,7 +333,12 @@ func applyDeterministicSubstitutions(data []byte) []byte {
 				continue
 			}
 
-			// Check guard if present
+			// Skip matches inside string literals within the action (e.g. printf "...now...").
+			if insideQuotedStringInSpan(s, m[0], spans) {
+				continue
+			}
+
+			// Check guard if present (variable/field references).
 			if p.guard != nil && !p.guard(s, m[0]) {
 				continue
 			}

--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -193,13 +193,24 @@ func newClient(ctx context.Context) *action.Install {
 // templateActionRE matches Helm/Go template action delimiters including trim markers.
 var templateActionRE = regexp.MustCompile(`(?s)\{\{-?.*?-?\}\}`)
 
-// templateActionSpans returns the [start, end) byte ranges of all {{ ... }} blocks in s.
+// templateCommentRE matches Helm template comment blocks: {{/* ... */}} (with optional trim markers).
+var templateCommentRE = regexp.MustCompile(`(?s)\{\{-?\s*/\*.*?\*/\s*-?\}\}`)
+
+// templateActionSpans returns the [start, end) byte ranges of all {{ ... }} blocks in s,
+// excluding comment blocks ({{/* ... */}}).
 // The returned slice is sorted by start (FindAllStringIndex guarantees this).
 func templateActionSpans(s string) [][2]int {
-	matches := templateActionRE.FindAllStringIndex(s, -1)
-	spans := make([][2]int, len(matches))
-	for i, m := range matches {
-		spans[i] = [2]int{m[0], m[1]}
+	allMatches := templateActionRE.FindAllStringIndex(s, -1)
+	commentMatches := templateCommentRE.FindAllStringIndex(s, -1)
+	commentSet := make(map[[2]int]bool, len(commentMatches))
+	for _, m := range commentMatches {
+		commentSet[[2]int{m[0], m[1]}] = true
+	}
+	spans := make([][2]int, 0, len(allMatches))
+	for _, m := range allMatches {
+		if !commentSet[[2]int{m[0], m[1]}] {
+			spans = append(spans, [2]int{m[0], m[1]})
+		}
 	}
 	return spans
 }
@@ -275,25 +286,34 @@ type deterministicPattern struct {
 
 // deterministicPatterns maps each non-deterministic sprig function regex to a replacement generator.
 // The generator receives the line number of the match.
+// templateArgRE matches a Sprig function argument: a numeric literal, a .Values.foo
+// field path, or a $variable reference.
+const templateArgRE = `[\w$.]+`
+
 var deterministicPatterns = []deterministicPattern{
 	{
-		re:      regexp.MustCompile(`\brandAlphaNum\s+\d+`),
+		re:      regexp.MustCompile(`\brandAlphaNum\s+` + templateArgRE),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
 		guard:   notPrecededByVarOrField,
 	},
 	{
-		re:      regexp.MustCompile(`\brandAlpha\s+\d+`),
+		re:      regexp.MustCompile(`\brandAlpha\s+` + templateArgRE),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
 		guard:   notPrecededByVarOrField,
 	},
 	{
-		re:      regexp.MustCompile(`\brandAscii\s+\d+`),
+		re:      regexp.MustCompile(`\brandAscii\s+` + templateArgRE),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
 		guard:   notPrecededByVarOrField,
 	},
 	{
-		re:      regexp.MustCompile(`\brandNumeric\s+\d+`),
+		re:      regexp.MustCompile(`\brandNumeric\s+` + templateArgRE),
 		replace: func(lineNum int) string { return fmt.Sprintf(`"%08d"`, lineNum) },
+		guard:   notPrecededByVarOrField,
+	},
+	{
+		re:      regexp.MustCompile(`\brandBytes\s+` + templateArgRE),
+		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
 		guard:   notPrecededByVarOrField,
 	},
 	{

--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -235,9 +235,21 @@ func applyDeterministicSubstitutions(data []byte) []byte {
 	s := string(data)
 	var replacements []replacement
 
-	for _, p := range deterministicPatterns {
+	for patternIdx, p := range deterministicPatterns {
 		matches := p.re.FindAllStringIndex(s, -1)
 		for _, m := range matches {
+			// For the "now" pattern, skip matches preceded by $ or .
+			// These are variable references ($now) or field accesses (.Values.now),
+			// not function calls.
+			if patternIdx == 5 { // Index of the "now" pattern in deterministicPatterns
+				if m[0] > 0 {
+					prev := s[m[0]-1]
+					if prev == '$' || prev == '.' {
+						continue // Skip this match
+					}
+				}
+			}
+
 			lineNum := strings.Count(s[:m[0]], "\n") + 1
 			replacements = append(replacements, replacement{
 				start: m[0],

--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -137,6 +139,7 @@ func runInstall(ctx context.Context, args []string, client *action.Install,
 
 	excluded := getExcluded(ctx, chartRequested, cp)
 
+	chartRequested = makeDeterministic(chartRequested)
 	chartRequested = setID(chartRequested)
 
 	if instErr := checkIfInstallable(chartRequested); instErr != nil {
@@ -185,6 +188,90 @@ func newClient(ctx context.Context) *action.Install {
 		client.DryRun, client.ClientOnly, client.IncludeCRDs, client.ReleaseName)
 
 	return client
+}
+
+// deterministicPatterns maps each non-deterministic sprig function regex to a replacement generator.
+// The generator receives the line number of the match.
+var deterministicPatterns = []struct {
+	re      *regexp.Regexp
+	replace func(lineNum int) string
+}{
+	{
+		re:      regexp.MustCompile(`\brandAlphaNum\s+\d+`),
+		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
+	},
+	{
+		re:      regexp.MustCompile(`\brandAlpha\s+\d+`),
+		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
+	},
+	{
+		re:      regexp.MustCompile(`\brandAscii\s+\d+`),
+		replace: func(lineNum int) string { return fmt.Sprintf(`"ddscan%04d"`, lineNum) },
+	},
+	{
+		re:      regexp.MustCompile(`\brandNumeric\s+\d+`),
+		replace: func(lineNum int) string { return fmt.Sprintf(`"%08d"`, lineNum) },
+	},
+	{
+		re:      regexp.MustCompile(`\buuidv4\b`),
+		replace: func(lineNum int) string { return fmt.Sprintf(`"00000000-0000-0000-%04d-%012d"`, lineNum, lineNum) },
+	},
+	{
+		re:      regexp.MustCompile(`\bnow\b`),
+		replace: func(_ int) string { return `(toDate "2006-01-02" "2000-01-01")` },
+	},
+}
+
+// replacement is a single pending substitution collected before applying back-to-front.
+type replacement struct {
+	start int
+	end   int
+	text  string
+}
+
+// applyDeterministicSubstitutions replaces non-deterministic sprig function calls in a Helm
+// template with stable, line-number-seeded stubs so that repeated renders produce identical output.
+func applyDeterministicSubstitutions(data []byte) []byte {
+	s := string(data)
+	var replacements []replacement
+
+	for _, p := range deterministicPatterns {
+		matches := p.re.FindAllStringIndex(s, -1)
+		for _, m := range matches {
+			lineNum := strings.Count(s[:m[0]], "\n") + 1
+			replacements = append(replacements, replacement{
+				start: m[0],
+				end:   m[1],
+				text:  p.replace(lineNum),
+			})
+		}
+	}
+
+	// Apply back-to-front so earlier offsets remain valid.
+	sort.Slice(replacements, func(i, j int) bool {
+		return replacements[i].start > replacements[j].start
+	})
+
+	b := []byte(s)
+	for _, r := range replacements {
+		b = append(b[:r.start], append([]byte(r.text), b[r.end:]...)...)
+	}
+	return b
+}
+
+// makeDeterministic replaces all non-deterministic sprig calls in every template of the chart
+// and its dependencies, making repeated renders produce identical manifests.
+func makeDeterministic(ch *chart.Chart) *chart.Chart {
+	for _, temp := range ch.Templates {
+		temp.Data = applyDeterministicSubstitutions(temp.Data)
+	}
+	for _, dep := range ch.Dependencies() {
+		dep = makeDeterministic(dep)
+		if dep != nil {
+			continue
+		}
+	}
+	return ch
 }
 
 // setID will add auxiliary lines for each template as well as its dependencies

--- a/pkg/resolver/helm/helm_deterministic_test.go
+++ b/pkg/resolver/helm/helm_deterministic_test.go
@@ -68,6 +68,18 @@ func TestApplyDeterministicSubstitutions(t *testing.T) {
 			input:    "name: {{ .Values.myName }}\nport: 80\n",
 			contains: "name: {{ .Values.myName }}\nport: 80\n",
 		},
+		{
+			name:     "randAlphaNum outside action block",
+			input:    "data:\n  script: randAlphaNum 8\n",
+			contains: "randAlphaNum 8",
+			absent:   "ddscan",
+		},
+		{
+			name:     "uuidv4 as template-include string arg",
+			input:    `{{ include "uuidv4" . }}`,
+			contains: `"uuidv4"`,
+			absent:   "00000000",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/resolver/helm/helm_deterministic_test.go
+++ b/pkg/resolver/helm/helm_deterministic_test.go
@@ -52,6 +52,18 @@ func TestApplyDeterministicSubstitutions(t *testing.T) {
 			absent:   "now",
 		},
 		{
+			name:     "$now variable should NOT be substituted",
+			input:    "name: {{ $now }}\n",
+			contains: "$now",
+			absent:   "$(toDate",
+		},
+		{
+			name:     ".Values.now field should NOT be substituted",
+			input:    "value: {{ .Values.now }}\n",
+			contains: ".Values.now",
+			absent:   "toDate",
+		},
+		{
 			name:     "no match leaves template unchanged",
 			input:    "name: {{ .Values.myName }}\nport: 80\n",
 			contains: "name: {{ .Values.myName }}\nport: 80\n",

--- a/pkg/resolver/helm/helm_deterministic_test.go
+++ b/pkg/resolver/helm/helm_deterministic_test.go
@@ -92,6 +92,45 @@ func TestApplyDeterministicSubstitutions(t *testing.T) {
 			contains: "prefix randAlphaNum 8",
 			absent:   "ddscan",
 		},
+		// Variable-argument forms.
+		{
+			name:     "randAlphaNum with .Values arg replaced",
+			input:    "name: {{ randAlphaNum .Values.suffixLen }}\n",
+			contains: `"ddscan0001"`,
+			absent:   "randAlphaNum",
+		},
+		{
+			name:     "randAlphaNum with $var arg replaced",
+			input:    "name: {{ randAlphaNum $len }}\n",
+			contains: `"ddscan0001"`,
+			absent:   "randAlphaNum",
+		},
+		// randBytes.
+		{
+			name:     "randBytes with literal arg replaced",
+			input:    "token: {{ randBytes 16 }}\n",
+			contains: `"ddscan0001"`,
+			absent:   "randBytes",
+		},
+		{
+			name:     "randBytes with .Values arg replaced",
+			input:    "token: {{ randBytes .Values.len }}\n",
+			contains: `"ddscan0001"`,
+			absent:   "randBytes",
+		},
+		// Helm template comments — must not be modified.
+		{
+			name:     "Helm comment block not substituted",
+			input:    "{{/* randAlphaNum 8 is documented here */}}\nname: {{ .Values.name }}\n",
+			contains: "randAlphaNum 8 is documented here",
+			absent:   "ddscan",
+		},
+		{
+			name:     "Helm comment block with trim markers not substituted",
+			input:    "{{- /* randBytes 16 */ -}}\nname: {{ .Values.name }}\n",
+			contains: "randBytes 16",
+			absent:   "ddscan",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/resolver/helm/helm_deterministic_test.go
+++ b/pkg/resolver/helm/helm_deterministic_test.go
@@ -1,0 +1,89 @@
+package helm
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyDeterministicSubstitutions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		contains string // substring that must appear in output
+		absent   string // substring that must NOT appear in output (optional)
+	}{
+		{
+			name:     "randAlphaNum replaced with ddscan stub",
+			input:    "name: {{ randAlphaNum 8 | lower }}\n",
+			contains: `"ddscan0001"`,
+			absent:   "randAlphaNum",
+		},
+		{
+			name:     "randAlpha replaced with ddscan stub",
+			input:    "name: {{ randAlpha 5 }}\n",
+			contains: `"ddscan0001"`,
+			absent:   "randAlpha",
+		},
+		{
+			name:     "randNumeric replaced with digit-only stub",
+			input:    "port-seed: {{ randNumeric 4 }}\n",
+			contains: `"00000001"`,
+			absent:   "randNumeric",
+		},
+		{
+			name:     "uuidv4 replaced with UUID-shaped stub",
+			input:    "scan-id: {{ uuidv4 }}\n",
+			contains: `"00000000-0000-0000-0001-000000000001"`,
+			absent:   "uuidv4",
+		},
+		{
+			name:     "now replaced with static toDate call",
+			input:    "created: {{ now | htmlDate }}\n",
+			contains: `(toDate "2006-01-02" "2000-01-01")`,
+			absent:   "now",
+		},
+		{
+			name:     "no match leaves template unchanged",
+			input:    "name: {{ .Values.myName }}\nport: 80\n",
+			contains: "name: {{ .Values.myName }}\nport: 80\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := string(applyDeterministicSubstitutions([]byte(tt.input)))
+			require.Contains(t, out, tt.contains)
+			if tt.absent != "" {
+				require.NotContains(t, out, tt.absent)
+			}
+		})
+	}
+}
+
+func TestApplyDeterministicSubstitutions_TwoCallsDifferentLines(t *testing.T) {
+	// Two randAlphaNum calls on different lines must produce different stubs.
+	input := "line1: {{ randAlphaNum 8 }}\nline2: {{ randAlphaNum 8 }}\n"
+	out := string(applyDeterministicSubstitutions([]byte(input)))
+	require.Contains(t, out, `"ddscan0001"`, "first call should embed line 1")
+	require.Contains(t, out, `"ddscan0002"`, "second call should embed line 2")
+	require.NotContains(t, out, "randAlphaNum")
+}
+
+func TestHelm_DeterministicRendering(t *testing.T) {
+	res := &Resolver{}
+	ctx := context.Background()
+
+	fixturePath := filepath.FromSlash("../../../test/fixtures/test_helm_nondeterministic")
+
+	first, err := res.Resolve(ctx, fixturePath)
+	require.NoError(t, err)
+	require.NotEmpty(t, first.File, "first render must produce at least one file")
+
+	second, err := res.Resolve(ctx, fixturePath)
+	require.NoError(t, err)
+
+	require.Equal(t, first.File, second.File, "helm rendering must be deterministic")
+}

--- a/pkg/resolver/helm/helm_deterministic_test.go
+++ b/pkg/resolver/helm/helm_deterministic_test.go
@@ -28,6 +28,12 @@ func TestApplyDeterministicSubstitutions(t *testing.T) {
 			absent:   "randAlpha",
 		},
 		{
+			name:     "randAscii replaced with ddscan stub",
+			input:    "apiVersion: v1\nname: {{ randAscii 6 }}\n",
+			contains: `"ddscan0002"`,
+			absent:   "randAscii",
+		},
+		{
 			name:     "randNumeric replaced with digit-only stub",
 			input:    "port-seed: {{ randNumeric 4 }}\n",
 			contains: `"00000001"`,

--- a/pkg/resolver/helm/helm_deterministic_test.go
+++ b/pkg/resolver/helm/helm_deterministic_test.go
@@ -80,6 +80,18 @@ func TestApplyDeterministicSubstitutions(t *testing.T) {
 			contains: `"uuidv4"`,
 			absent:   "00000000",
 		},
+		{
+			name:     "now inside quoted string in action — not substituted",
+			input:    "name: {{ required \"set this now\" .Values.foo }}\n",
+			contains: "set this now",
+			absent:   "toDate",
+		},
+		{
+			name:     "randAlphaNum inside quoted string in action — not substituted",
+			input:    "x: {{ printf \"prefix randAlphaNum 8\" }}\n",
+			contains: "prefix randAlphaNum 8",
+			absent:   "ddscan",
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/fixtures/test_helm_nondeterministic/Chart.yaml
+++ b/test/fixtures/test_helm_nondeterministic/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: test_helm_nondeterministic
+description: Helm chart fixture with non-deterministic Sprig functions for testing deterministic rendering
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/test/fixtures/test_helm_nondeterministic/templates/_helpers.tpl
+++ b/test/fixtures/test_helm_nondeterministic/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "test_helm_nondeterministic.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/test/fixtures/test_helm_nondeterministic/templates/job.yaml
+++ b/test/fixtures/test_helm_nondeterministic/templates/job.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "test_helm_nondeterministic.fullname" . }}-{{ randAlphaNum 8 | lower }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    scan-id: {{ uuidv4 }}
+    created-date: {{ now | htmlDate }}
+spec:
+  template:
+    spec:
+      containers:
+        - name: worker
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+      restartPolicy: Never

--- a/test/fixtures/test_helm_nondeterministic/templates/service.yaml
+++ b/test/fixtures/test_helm_nondeterministic/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "test_helm_nondeterministic.fullname" . }}
+  annotations:
+    port-seed: {{ randNumeric 4 }}
+spec:
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/test/fixtures/test_helm_nondeterministic/values.yaml
+++ b/test/fixtures/test_helm_nondeterministic/values.yaml
@@ -1,0 +1,5 @@
+replicaCount: 1
+
+image:
+  repository: nginx
+  tag: latest


### PR DESCRIPTION
## Summary

Helm charts using non-deterministic Sprig functions (`randAlphaNum`, `uuidv4`, `now`, etc.) in resource names produce a different rendered name on every scan, generating a new `DATADOG_FINGERPRINT` each time and re-reporting the same finding as new indefinitely.

**Root cause:** `engine.Engine` (used internally by `action.Install.Run`) pulls its funcmap from `sprig.TxtFuncMap()` with no injection point — `funcMap()` and `initFunMap()` are unexported, and `Engine` has no `FuncMap` field.

**Fix:** Pre-process each chart template's raw bytes before rendering, replacing non-deterministic function calls with stable, line-number-seeded stubs:

| Function | Stub format |
|---|---|
| `randAlphaNum N`, `randAlpha N`, `randAscii N` | `"ddscan{lineNum:04d}"` |
| `randNumeric N` | `"{lineNum:08d}"` |
| `uuidv4` | `"00000000-0000-0000-{lineNum:04d}-{lineNum:012d}"` |
| `now` | `(toDate "2006-01-02" "2000-01-01")` — returns `time.Time`, works in any pipeline |

Stubs are seeded by line number so two resources in the same file using the same function produce distinct, stable names across every scan. Replacements are applied back-to-front by byte offset so earlier match positions stay valid during mutation. The `now` guard skips matches preceded by `$` or `.` to avoid corrupting `$now` variable declarations and `.Values.now` field accesses.

Crypto functions (`genSignedCert`, `genCA`, etc.) are deferred — they return structs, not strings, and rarely appear in resource names.

## Changes

- `pkg/resolver/helm/helm.go` — adds `deterministicPattern` struct, `deterministicPatterns` table, `applyDeterministicSubstitutions`, and `makeDeterministic` (mirrors `setID` pattern, recurses into sub-charts). `makeDeterministic` is called before `setID` in `runInstall`.
- `pkg/resolver/helm/helm_deterministic_test.go` — unit tests for each function type + two-lines distinctness + no-match passthrough; integration test calls `Resolve` twice and asserts byte-identical output.
- `test/fixtures/test_helm_nondeterministic/` — minimal fixture chart exercising all covered function types.

## Testing

```sh
go test ./pkg/resolver/helm/... -v -run "TestApplyDeterministic|TestHelm_"
```

All existing `TestHelm_Resolve` cases remain green. `TestHelm_DeterministicRendering` calls `Resolve` twice on the new fixture and asserts `require.Equal(first.File, second.File)`.