### PR TITLE
Resolve Terraform plan line numbers from searchKey

### DIFF
--- a/pkg/detector/default_detect.go
+++ b/pkg/detector/default_detect.go
@@ -17,7 +17,19 @@ import (
 
 const (
 	undetectedVulnerabilityLine = -1
+	// resource, type, name, and at least one attribute segment.
+	tfPlanMinAttributePathLen = 4
+	// resource, type, and name — used for types where plan line metadata
+	// lives on the resource object rather than a specific attribute.
+	tfPlanMinResourcePathLen = 3
 )
+
+// tfPlanResourceLevelTypes are Terraform resource types whose plan JSON line
+// metadata is anchored on the resource object (not an attribute). Text matching
+// on the plan address field is wrong for these; resolve structurally instead.
+var tfPlanResourceLevelTypes = map[string]struct{}{
+	"aws_api_gateway_deployment": {},
+}
 
 type defaultDetectLine struct {
 }
@@ -34,14 +46,23 @@ func (d defaultDetectLine) DetectLine(ctx context.Context, file *model.FileMetad
 		ResolvedFiles:   d.prepareResolvedFiles(file.ResolvedFiles),
 	}
 
+	lines := *file.LinesOriginalData
+
+	// Terraform plan JSON is remapped under a top-level "resource" key, so the
+	// resource block has no source text to match. Resolve the searchKey path
+	// structurally (mirroring the legacy searchLine) before any text matching.
+	if file.Kind == model.KindTerraformPlan {
+		if result := detectTerraformPlanLine(searchKey, file, detector.ResolvedFile, outputLines, lines); result != nil {
+			return *result
+		}
+	}
+
 	var extractedString [][]string
 	extractedString = GetBracketValues(searchKey, extractedString, "")
 	sanitizedSubstring := searchKey
 	for idx, str := range extractedString {
 		sanitizedSubstring = strings.ReplaceAll(sanitizedSubstring, str[0], `{{`+strconv.Itoa(idx)+`}}`)
 	}
-
-	lines := *file.LinesOriginalData
 	splitSanitized := strings.Split(sanitizedSubstring, ".")
 
 	// Re-join $ref segments split by dot (e.g. "$ref=#/schemas/v1.0.Foo" → ["v1","0","Foo"])
@@ -101,6 +122,85 @@ func (d defaultDetectLine) DetectLine(ctx context.Context, file *model.FileMetad
 		VulnLines:    &[]model.CodeLine{},
 		ResolvedFile: detector.ResolvedFile,
 	}
+}
+
+// detectTerraformPlanLine resolves a plan searchKey (e.g. "type[name].attr")
+// against the remapped "resource.type.name" document. Returns nil when the path
+// cannot be resolved so the caller can fall back to text matching.
+func detectTerraformPlanLine(
+	searchKey string,
+	file *model.FileMetadata,
+	resolvedFile string,
+	outputLines int,
+	lines []string,
+) *model.VulnerabilityLines {
+	path := terraformPlanPath(searchKey)
+	if len(path) < tfPlanMinResourcePathLen {
+		return nil
+	}
+	if len(path) < tfPlanMinAttributePathLen {
+		if _, ok := tfPlanResourceLevelTypes[path[1]]; !ok {
+			return nil
+		}
+	}
+	lineNr, err := GetLineBySearchLine(path, file)
+	// lineNr == 1 means _dd_lines were computed from minified (single-line) JSON;
+	// the plan opening "{" sits on line 1 so that value is never a real attribute
+	// line. Fall through to text matching, which runs on the pretty-printed content.
+	if err != nil || lineNr <= 1 || lineNr > len(lines) {
+		return nil
+	}
+	return &model.VulnerabilityLines{
+		Line:         lineNr,
+		VulnLines:    GetAdjacentVulnLines(lineNr-1, outputLines, lines),
+		ResolvedFile: resolvedFile,
+		VulnerablilityLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: lineNr},
+			End:   model.ResourceLine{Line: lineNr},
+		},
+	}
+}
+
+// terraformPlanPath turns a plan searchKey into structural path components for
+// GetLineBySearchLine. It expands bracket groups ("type[name]" -> type, name;
+// "list[0]" -> list, 0), drops value anchors (key=value -> key), and ensures the
+// path is rooted at the plan's top-level "resource" key.
+func terraformPlanPath(searchKey string) []string {
+	// Drop the value anchor (key=value) up front; the value may contain dots.
+	if eq := strings.Index(searchKey, "="); eq >= 0 {
+		searchKey = searchKey[:eq]
+	}
+	var comps []string
+	for _, seg := range strings.Split(searchKey, ".") {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		for seg != "" {
+			open := strings.Index(seg, "[")
+			if open < 0 {
+				if seg != "" {
+					comps = append(comps, seg)
+				}
+				break
+			}
+			if head := seg[:open]; head != "" {
+				comps = append(comps, head)
+			}
+			closeIdx := strings.Index(seg, "]")
+			if closeIdx < 0 || closeIdx < open {
+				break
+			}
+			if inner := seg[open+1 : closeIdx]; inner != "" {
+				comps = append(comps, inner)
+			}
+			seg = seg[closeIdx+1:]
+		}
+	}
+	if len(comps) > 0 && comps[0] == "resource" {
+		comps = comps[1:]
+	}
+	return append([]string{"resource"}, comps...)
 }
 
 // handleArrayIndex handles paths that contain numeric segments. It first attempts a

--- a/pkg/detector/default_detect.go
+++ b/pkg/detector/default_detect.go
@@ -19,17 +19,7 @@ const (
 	undetectedVulnerabilityLine = -1
 	// resource, type, name, and at least one attribute segment.
 	tfPlanMinAttributePathLen = 4
-	// resource, type, and name — used for types where plan line metadata
-	// lives on the resource object rather than a specific attribute.
-	tfPlanMinResourcePathLen = 3
 )
-
-// tfPlanResourceLevelTypes are Terraform resource types whose plan JSON line
-// metadata is anchored on the resource object (not an attribute). Text matching
-// on the plan address field is wrong for these; resolve structurally instead.
-var tfPlanResourceLevelTypes = map[string]struct{}{
-	"aws_api_gateway_deployment": {},
-}
 
 type defaultDetectLine struct {
 }
@@ -79,7 +69,15 @@ func (d defaultDetectLine) DetectLine(ctx context.Context, file *model.FileMetad
 	// source file, so the text-matcher cannot advance through them. handleArrayIndex
 	// tries a structured gjson lookup first; on failure it strips numerics and falls
 	// back to the text-matcher.
-	if result, remaining := handleArrayIndex(splitSanitized, extractedString, file, detector.ResolvedFile, outputLines, lines); result != nil {
+	if result, remaining := handleArrayIndex(
+		splitSanitized,
+		extractedString,
+		file,
+		detector.ResolvedFile,
+		outputLines,
+		lines,
+		file.Kind == model.KindTerraformPlan,
+	); result != nil {
 		return *result
 	} else if remaining != nil {
 		splitSanitized = remaining
@@ -134,14 +132,9 @@ func detectTerraformPlanLine(
 	outputLines int,
 	lines []string,
 ) *model.VulnerabilityLines {
-	path := terraformPlanPath(searchKey)
-	if len(path) < tfPlanMinResourcePathLen {
+	path, explicitResourcePath := terraformPlanPath(searchKey)
+	if len(path) < tfPlanMinAttributePathLen && !explicitResourcePath {
 		return nil
-	}
-	if len(path) < tfPlanMinAttributePathLen {
-		if _, ok := tfPlanResourceLevelTypes[path[1]]; !ok {
-			return nil
-		}
 	}
 	lineNr, err := GetLineBySearchLine(path, file)
 	// lineNr == 1 means _dd_lines were computed from minified (single-line) JSON;
@@ -165,7 +158,7 @@ func detectTerraformPlanLine(
 // GetLineBySearchLine. It expands bracket groups ("type[name]" -> type, name;
 // "list[0]" -> list, 0), drops value anchors (key=value -> key), and ensures the
 // path is rooted at the plan's top-level "resource" key.
-func terraformPlanPath(searchKey string) []string {
+func terraformPlanPath(searchKey string) ([]string, bool) {
 	// Drop the value anchor (key=value) up front; the value may contain dots.
 	if eq := strings.Index(searchKey, "="); eq >= 0 {
 		searchKey = searchKey[:eq]
@@ -197,10 +190,11 @@ func terraformPlanPath(searchKey string) []string {
 			seg = seg[closeIdx+1:]
 		}
 	}
-	if len(comps) > 0 && comps[0] == "resource" {
+	explicitResourcePath := len(comps) > 0 && comps[0] == "resource"
+	if explicitResourcePath {
 		comps = comps[1:]
 	}
-	return append([]string{"resource"}, comps...)
+	return append([]string{"resource"}, comps...), explicitResourcePath
 }
 
 // handleArrayIndex handles paths that contain numeric segments. It first attempts a
@@ -214,6 +208,7 @@ func handleArrayIndex(
 	resolvedFile string,
 	outputLines int,
 	lines []string,
+	skipStructuredLookup bool,
 ) (result *model.VulnerabilityLines, remaining []string) {
 	hasNumeric := false
 	for _, seg := range splitSanitized {
@@ -226,21 +221,23 @@ func handleArrayIndex(
 		return nil, nil
 	}
 
-	// Strip value anchors (key=value → key) so gjson receives a pure key path.
-	// Paths with mid-path anchors (e.g. "meta.name={{pod}}.spec...") resolve to a
-	// nonexistent gjson path and return -1, falling through to the text-matcher.
-	structPath := extractStructuralPath(splitSanitized, extractedString)
-	if lineNr, err := GetLineBySearchLine(structPath, file); err == nil && lineNr > 0 && lineNr <= len(lines) {
-		result := model.VulnerabilityLines{
-			Line:         lineNr,
-			VulnLines:    GetAdjacentVulnLines(lineNr-1, outputLines, lines),
-			ResolvedFile: resolvedFile,
-			VulnerablilityLocation: model.ResourceLocation{
-				Start: model.ResourceLine{Line: lineNr},
-				End:   model.ResourceLine{Line: lineNr},
-			},
+	if !skipStructuredLookup {
+		// Strip value anchors (key=value → key) so gjson receives a pure key path.
+		// Paths with mid-path anchors (e.g. "meta.name={{pod}}.spec...") resolve to a
+		// nonexistent gjson path and return -1, falling through to the text-matcher.
+		structPath := extractStructuralPath(splitSanitized, extractedString)
+		if lineNr, err := GetLineBySearchLine(structPath, file); err == nil && lineNr > 0 && lineNr <= len(lines) {
+			result := model.VulnerabilityLines{
+				Line:         lineNr,
+				VulnLines:    GetAdjacentVulnLines(lineNr-1, outputLines, lines),
+				ResolvedFile: resolvedFile,
+				VulnerablilityLocation: model.ResourceLocation{
+					Start: model.ResourceLine{Line: lineNr},
+					End:   model.ResourceLine{Line: lineNr},
+				},
+			}
+			return &result, nil
 		}
-		return &result, nil
 	}
 
 	filtered := splitSanitized[:0]

--- a/pkg/detector/default_detect_test.go
+++ b/pkg/detector/default_detect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	jsonParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/json"
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/DataDog/datadog-iac-scanner/test"
 	"github.com/stretchr/testify/require"
@@ -353,6 +354,133 @@ func Test_detectLineK8s(t *testing.T) { //nolint
 			}
 		})
 	}
+}
+
+func Test_terraformPlanPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		searchKey string
+		want      []string
+	}{
+		{
+			name:      "resource_and_attribute",
+			searchKey: "alicloud_db_instance[example].address",
+			want:      []string{"resource", "alicloud_db_instance", "example", "address"},
+		},
+		{
+			name:      "already_prefixed",
+			searchKey: "resource.aws_s3_bucket[b].acl",
+			want:      []string{"resource", "aws_s3_bucket", "b", "acl"},
+		},
+		{
+			name:      "array_index_and_value_anchor",
+			searchKey: "aws_security_group[sg].ingress[0].cidr_blocks=0.0.0.0/0",
+			want:      []string{"resource", "aws_security_group", "sg", "ingress", "0", "cidr_blocks"},
+		},
+		{
+			name:      "resource_only",
+			searchKey: "azurerm_sql_firewall_rule[positive1]",
+			want:      []string{"resource", "azurerm_sql_firewall_rule", "positive1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := terraformPlanPath(tt.searchKey); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("terraformPlanPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+var OriginalDataTFPlan = `{
+  "format_version": "1.0",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "alicloud_db_instance.example",
+          "mode": "managed",
+          "type": "alicloud_db_instance",
+          "name": "example",
+          "values": {
+            "engine": "MySQL",
+            "address": "0.0.0.0/0"
+          }
+        }
+      ]
+    }
+  }
+}`
+
+// Test_detectLineTerraformPlan verifies attribute-level and allowlisted resource-level plan searchKeys.
+func Test_detectLineTerraformPlan(t *testing.T) {
+	p := &jsonParser.Parser{}
+	_, docs, _, _, err := p.Parse(context.Background(), []byte(OriginalDataTFPlan), "plan.json", false, 1)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	file := &model.FileMetadata{
+		ScanID:            "scanID",
+		ID:                "Test",
+		Kind:              model.KindTerraformPlan,
+		OriginalData:      OriginalDataTFPlan,
+		LineInfoDocument:  docs[0],
+		LinesOriginalData: utils.SplitLines(OriginalDataTFPlan),
+	}
+
+	d := defaultDetectLine{}
+	got := d.DetectLine(context.Background(), file, "alicloud_db_instance[example].address", 0)
+	require.Equal(t, 13, got.Line)
+}
+
+func Test_detectLineTerraformPlanResourceLevel(t *testing.T) {
+	plan := `{
+  "planned_values": {
+    "root_module": {
+      "resources": [{
+        "address": "aws_api_gateway_deployment.positive1",
+        "type": "aws_api_gateway_deployment",
+        "name": "positive1",
+        "values": {
+          "rest_api_id": "some rest api id",
+          "stage_name": "some name"
+        }
+      }]
+    }
+  }
+}`
+	p := &jsonParser.Parser{}
+	_, docs, _, _, err := p.Parse(context.Background(), []byte(plan), "plan.json", false, 1)
+	require.NoError(t, err)
+
+	file := &model.FileMetadata{
+		Kind:              model.KindTerraformPlan,
+		LineInfoDocument:  docs[0],
+		LinesOriginalData: utils.SplitLines(plan),
+	}
+	got := defaultDetectLine{}.DetectLine(context.Background(), file, "aws_api_gateway_deployment[positive1]", 0)
+	require.Equal(t, 5, got.Line)
+}
+
+func Test_detectLineTerraformPlanMinified(t *testing.T) {
+	// terraform show -json produces minified output; _dd_lines are all 1.
+	// After StringifyContent pretty-prints, LinesOriginalData is multi-line.
+	// Structural lookup must fall through to text matching.
+	minified := `{"format_version":"1.0","planned_values":{"root_module":{"resources":[{"address":"alicloud_db_instance.example","type":"alicloud_db_instance","name":"example","values":{"address":"0.0.0.0/0"}}]}}}`
+	p := &jsonParser.Parser{}
+	// Parse computes _dd_lines from the minified bytes.
+	_, docs, _, _, err := p.Parse(context.Background(), []byte(minified), "plan.json", false, 1)
+	require.NoError(t, err)
+	// Simulate what StringifyContent produces for LinesOriginalData.
+	prettified, _ := p.StringifyContent([]byte(minified))
+	file := &model.FileMetadata{
+		Kind:              model.KindTerraformPlan,
+		LineInfoDocument:  docs[0],
+		LinesOriginalData: utils.SplitLines(prettified),
+	}
+	got := defaultDetectLine{}.DetectLine(context.Background(), file, "alicloud_db_instance[example].address", 0)
+	// Must not return line 1 (the opening "{" from minified _dd_lines).
+	require.Greater(t, got.Line, 1)
 }
 
 var content = []byte(

--- a/pkg/detector/default_detect_test.go
+++ b/pkg/detector/default_detect_test.go
@@ -385,7 +385,8 @@ func Test_terraformPlanPath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := terraformPlanPath(tt.searchKey); !reflect.DeepEqual(got, tt.want) {
+			got, _ := terraformPlanPath(tt.searchKey)
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("terraformPlanPath() = %v, want %v", got, tt.want)
 			}
 		})
@@ -412,7 +413,7 @@ var OriginalDataTFPlan = `{
   }
 }`
 
-// Test_detectLineTerraformPlan verifies attribute-level and allowlisted resource-level plan searchKeys.
+// Test_detectLineTerraformPlan verifies attribute-level plan searchKeys.
 func Test_detectLineTerraformPlan(t *testing.T) {
 	p := &jsonParser.Parser{}
 	_, docs, _, _, err := p.Parse(context.Background(), []byte(OriginalDataTFPlan), "plan.json", false, 1)
@@ -458,7 +459,7 @@ func Test_detectLineTerraformPlanResourceLevel(t *testing.T) {
 		LineInfoDocument:  docs[0],
 		LinesOriginalData: utils.SplitLines(plan),
 	}
-	got := defaultDetectLine{}.DetectLine(context.Background(), file, "aws_api_gateway_deployment[positive1]", 0)
+	got := defaultDetectLine{}.DetectLine(context.Background(), file, "resource.aws_api_gateway_deployment[positive1]", 0)
 	require.Equal(t, 5, got.Line)
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -17,18 +17,19 @@ import (
 
 // Constants to describe what kind of file refers
 const (
-	KindTerraform FileKind = "TF"
-	KindBICEP     FileKind = "BICEP"
-	KindDOCKER    FileKind = "DOCKER"
-	KindJSON      FileKind = "JSON"
-	KindYAML      FileKind = "YAML"
-	KindYML       FileKind = "YML"
-	KindPROTO     FileKind = "PROTO"
-	KindCOMMON    FileKind = "*"
-	KindHELM      FileKind = "HELM"
-	KindBUILDAH   FileKind = "SH"
-	KindCFG       FileKind = "CFG"
-	KindINI       FileKind = "INI"
+	KindTerraform     FileKind = "TF"
+	KindTerraformPlan FileKind = "TFPLAN"
+	KindBICEP         FileKind = "BICEP"
+	KindDOCKER        FileKind = "DOCKER"
+	KindJSON          FileKind = "JSON"
+	KindYAML          FileKind = "YAML"
+	KindYML           FileKind = "YML"
+	KindPROTO         FileKind = "PROTO"
+	KindCOMMON        FileKind = "*"
+	KindHELM          FileKind = "HELM"
+	KindBUILDAH       FileKind = "SH"
+	KindCFG           FileKind = "CFG"
+	KindINI           FileKind = "INI"
 )
 
 // Constants to describe commands given from comments

--- a/pkg/parser/json/parser.go
+++ b/pkg/parser/json/parser.go
@@ -79,7 +79,7 @@ func (p *Parser) GetKind() model.FileKind {
 // KindForContent overrides the static kind for Terraform plan JSON so line
 // detection can resolve plan resources structurally instead of by text match.
 func (p *Parser) KindForContent(content []byte) (model.FileKind, bool) {
-	if contentIsTerraformPlan(content) {
+	if looksLikeTerraformPlan(content) {
 		return model.KindTerraformPlan, true
 	}
 	return "", false
@@ -104,7 +104,7 @@ func (p *Parser) GetCommentToken() string {
 
 // StringifyContent converts original content into string formatted version
 func (p *Parser) StringifyContent(content []byte) (string, error) {
-	if contentIsTerraformPlan(content) {
+	if looksLikeTerraformPlan(content) {
 		var out bytes.Buffer
 		if err := json.Indent(&out, content, "", "  "); err != nil {
 			return "", err
@@ -114,21 +114,11 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 	return string(content), nil
 }
 
-// contentIsTerraformPlan reports whether content parses as a Terraform plan,
-// using the same check as Parse. Stateless and per-call. Recovers from panics
-// in plan parsing (malformed/partial plans) and treats them as "not a plan".
-func contentIsTerraformPlan(content []byte) (isPlan bool) {
-	defer func() {
-		if recover() != nil {
-			isPlan = false
-		}
-	}()
-	var doc model.Document
-	if err := json.Unmarshal(content, &doc); err != nil {
-		return false
-	}
-	if _, err := parseTFPlan(doc); err != nil {
-		return false
-	}
-	return true
+// looksLikeTerraformPlan is a fast byte-level heuristic that avoids a full
+// JSON parse. Both keys are required by the Terraform plan JSON spec, so their
+// co-presence is a reliable signal. Used by KindForContent and StringifyContent
+// where a full parseTFPlan call would be redundant (Parse already does it).
+func looksLikeTerraformPlan(content []byte) bool {
+	return bytes.Contains(content, []byte(`"format_version"`)) &&
+		bytes.Contains(content, []byte(`"planned_values"`))
 }

--- a/pkg/parser/json/parser.go
+++ b/pkg/parser/json/parser.go
@@ -76,6 +76,15 @@ func (p *Parser) GetKind() model.FileKind {
 	return model.KindJSON
 }
 
+// KindForContent overrides the static kind for Terraform plan JSON so line
+// detection can resolve plan resources structurally instead of by text match.
+func (p *Parser) KindForContent(content []byte) (model.FileKind, bool) {
+	if contentIsTerraformPlan(content) {
+		return model.KindTerraformPlan, true
+	}
+	return "", false
+}
+
 // SupportedTypes returns types supported by this parser, which are cloudFormation
 func (p *Parser) SupportedTypes() map[string]bool {
 	return map[string]bool{

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -16,6 +16,12 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 )
 
+// contentKindParser is an optional parser capability to refine the file kind
+// based on the resolved content (e.g. JSON that is actually a Terraform plan).
+type contentKindParser interface {
+	KindForContent(content []byte) (model.FileKind, bool)
+}
+
 type kindParser interface {
 	GetKind() model.FileKind
 	GetCommentToken() string
@@ -152,9 +158,16 @@ func (c *Parser) Parse(
 			cont = string(fileContent)
 		}
 
+		kind := c.Parsers.GetKind()
+		if ck, ok := c.Parsers.(contentKindParser); ok {
+			if refined, override := ck.KindForContent(resolved); override {
+				kind = refined
+			}
+		}
+
 		return ParsedDocument{
 			Docs:          obj,
-			Kind:          c.Parsers.GetKind(),
+			Kind:          kind,
 			Content:       cont,
 			IgnoreLines:   igLines,
 			CountLines:    bytes.Count(resolved, []byte{'\n'}) + 1,


### PR DESCRIPTION
## Motivation

Terraform plan JSON is remapped under a top-level `resource` key, so line detection cannot rely on text matching for attribute-level findings. Rules today duplicate location hints via a `searchLine` field alongside `searchKey`. This change lets plan files resolve lines from `searchKey` alone so rules can drop `searchLine` for attribute-level paths.

## Changes

**File kind**

Introduce `KindTerraformPlan` and set it when the JSON parser recognizes Terraform plan content, so plan files are routed to the correct line-detection path.

**Line detection**

For `KindTerraformPlan`, convert bracket-style `searchKey` values (e.g. `aws_s3_bucket[b].acl`) into a structural path under `resource.<type>.<name>.<attr>` and resolve the line via the existing gjson `_dd_lines` lookup. Attribute-level keys are resolved structurally; resource-only keys (no attribute segment) still fall back to text matching so existing expected lines are preserved.

**Tests**

Add unit tests for path conversion and an integration test that parses a minimal plan and asserts the resolved line.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/detector/... ./pkg/parser/...`
2. `go test ./...`
3. Point the default-rules repo at this branch (`go mod edit -replace github.com/DataDog/datadog-iac-scanner=../datadog-iac-scanner`) and run `./tool.sh test`.
4. Remove `searchLine` from a Terraform rule with a plan JSON fixture (e.g. `terraform-alicloud-rds-instance-address-publicly-accessible`) and confirm plan line numbers still match expected results.

## Blast Radius

Datadog IaC Scanner line detection for Terraform plan JSON files. No change to `.tf` HCL detection, CloudFormation, Kubernetes, or other JSON/YAML formats.

## Additional Notes

This PR does not read the rego `searchLine` field. The engine still honors `searchLine` when rules provide it (`searchLineCalculator` in `vulnerability_builder.go`); follow-up work in the default-rules repo can remove those fields once this ships. Resource-only `searchKey` values on plans continue to use text matching rather than structural lookup.

I submit this contribution under the Apache-2.0 license.