### PR TITLE
Add simple json report

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -96,6 +96,11 @@ var scanAction = &cli.Command{
 			Aliases: []string{"q"},
 			Usage:   "a list of query directories paths",
 		},
+		&cli.StringSliceFlag{
+			Name:  "report-format",
+			Usage: "output report formats (valid: sarif, simple-json)",
+			Value: []string{"sarif"},
+		},
 
 		// NOTE: --x-parallelparsing flag disabled due to pre-existing race conditions
 		// in concurrent query workers (SetupLogs shared state write, docker detector
@@ -115,6 +120,24 @@ const (
 	filePerms = 0644
 	dirPerms  = 0755
 )
+
+var validReportFormats = []string{
+	"sarif", "simple-json",
+}
+
+func validateReportFormats(formats []string) error {
+	valid := map[string]struct{}{}
+	for _, f := range validReportFormats {
+		valid[f] = struct{}{}
+	}
+	for _, f := range formats {
+		if _, ok := valid[strings.ToLower(f)]; !ok {
+			return fmt.Errorf("unknown report format %q; valid formats: %s",
+				f, strings.Join(validReportFormats, ", "))
+		}
+	}
+	return nil
+}
 
 func validateQueriesPaths(paths []string) ([]string, error) {
 	absolutePaths, err := getAbsolutePaths(paths)
@@ -207,6 +230,11 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		cfg.RuleConfigs[ruleID] = rc
 	}
 
+	reportFormats := c.StringSlice("report-format")
+	if err := validateReportFormats(reportFormats); err != nil {
+		return errorWithExitCode(err, constants.InvalidConfigErrorCode)
+	}
+
 	queriesPath := c.StringSlice("queries-path")
 	queriesPath, err = validateQueriesPaths(queriesPath)
 	if err != nil {
@@ -228,7 +256,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		QueriesPath:             queriesPath,
 		ChangedDefaultQueryPath: changedDefaultQueryPath,
 		LibrariesPath:           "./assets/libraries",
-		ReportFormats:           []string{"sarif"},
+		ReportFormats:           reportFormats,
 		Platform:                selectPlatforms(c.StringSlice("type")),
 		DisableSecrets:          true,
 		ScanID:                  "console",

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/console"
+	"github.com/DataDog/datadog-iac-scanner/internal/console/helpers"
 	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
@@ -121,12 +122,9 @@ const (
 	dirPerms  = 0755
 )
 
-var validReportFormats = []string{
-	"sarif", "simple-json",
-}
-
 func validateReportFormats(formats []string) error {
 	valid := map[string]struct{}{}
+	validReportFormats := helpers.GetSupportedReportFormats()
 	for _, f := range validReportFormats {
 		valid[f] = struct{}{}
 	}

--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -42,6 +42,10 @@ var reportGenerators = map[string]func(ctx context.Context, path, filename strin
 	"simple-json": report.PrintSimpleJSONReport,
 }
 
+func GetSupportedReportFormats() []string {
+	return []string{"sarif, simple-json"}
+}
+
 // FileAnalyzer determines the type of extension in the passed config file by its content
 func FileAnalyzer(path string) (string, error) {
 	rc, err := os.ReadFile(filepath.Clean(path))

--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -39,6 +39,7 @@ var reportGenerators = map[string]func(ctx context.Context, path, filename strin
 	"asff":        report.PrintASFFReport,
 	"csv":         report.PrintCSVReport,
 	"codeclimate": report.PrintCodeClimateReport,
+	"simple-json": report.PrintSimpleJSONReport,
 }
 
 // FileAnalyzer determines the type of extension in the passed config file by its content

--- a/internal/console/helpers/helpers_test.go
+++ b/internal/console/helpers/helpers_test.go
@@ -191,6 +191,136 @@ func TestHelpers_GenerateReport(t *testing.T) {
 	}
 }
 
+// TestHelpers_GenerateReport_SimpleJSON covers registry wiring for the simple-json format.
+func TestHelpers_GenerateReport_SimpleJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	require.NoError(t, GenerateReport(ctx, tmpDir, "result", test.SummaryMock, []string{"simple-json"}, &model.SCIInfo{}))
+
+	raw, err := os.ReadFile(filepath.Join(tmpDir, "result.simple.json"))
+	require.NoError(t, err)
+
+	var findings []map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &findings))
+	require.NotEmpty(t, findings)
+
+	for i, f := range findings {
+		require.Contains(t, f, "queryID", "finding %d missing queryID", i)
+		require.Contains(t, f, "queryName", "finding %d missing queryName", i)
+		require.Contains(t, f, "severity", "finding %d missing severity", i)
+		require.Contains(t, f, "fileName", "finding %d missing fileName", i)
+		require.Contains(t, f, "line", "finding %d missing line", i)
+		require.Contains(t, f, "fingerPrint", "finding %d missing fingerPrint", i)
+	}
+}
+
+// TestHelpers_GenerateReport_SimpleJSON_FiltersSuppressed ensures suppressed findings
+// are excluded from simple-json output (same filtering as other non-SARIF formats).
+func TestHelpers_GenerateReport_SimpleJSON_FiltersSuppressed(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	loc := model.ResourceLocation{
+		Start: model.ResourceLine{Line: 1, Col: 1},
+		End:   model.ResourceLine{Line: 1, Col: 1},
+	}
+	summary := &model.Summary{
+		Queries: model.QueryResultSlice{
+			{
+				QueryID:   "active-rule",
+				QueryName: "active-rule",
+				Severity:  model.SeverityHigh,
+				Files: []model.VulnerableFile{
+					{FileName: "active.tf", Line: 10, ResourceLocation: loc},
+				},
+			},
+			{
+				QueryID:   "suppressed-rule",
+				QueryName: "suppressed-rule",
+				Severity:  model.SeverityHigh,
+				Files: []model.VulnerableFile{
+					{
+						FileName:                 "suppressed.tf",
+						Line:                     20,
+						ResourceLocation:         loc,
+						IsSuppressed:             true,
+						SuppressionKind:          model.SuppressionKindInSource,
+						SuppressionJustification: model.SuppressionJustificationIgnoreComment,
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, GenerateReport(ctx, tmpDir, "result", summary, []string{"simple-json"}, &model.SCIInfo{}))
+
+	raw, err := os.ReadFile(filepath.Join(tmpDir, "result.simple.json"))
+	require.NoError(t, err)
+
+	var findings []map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &findings))
+
+	require.Len(t, findings, 1, "only the non-suppressed finding should appear")
+	require.Equal(t, "active-rule", findings[0]["queryID"])
+	require.Equal(t, "active.tf", findings[0]["fileName"])
+
+	// Caller's summary must not be mutated
+	require.Len(t, summary.Queries, 2)
+	require.True(t, summary.Queries[1].Files[0].IsSuppressed)
+}
+
+// TestHelpers_GenerateReport_SimpleJSON_Filenames verifies that PrintSimpleJSONReport
+// produces the correct output filename for a variety of input filename shapes.
+func TestHelpers_GenerateReport_SimpleJSON_Filenames(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		inputFilename    string
+		expectedFilename string
+	}{
+		// Plain stem: suffix appended normally.
+		{"result", "result.simple.json"},
+		// Stem containing a dot: suffix still appended (dot is not an extension separator here).
+		{"result.v2", "result.v2.simple.json"},
+		// Already carries the full suffix: must not double-append.
+		{"result.simple.json", "result.simple.json"},
+		// Foreign extension (e.g. default output-name): appended after, not replacing.
+		{"result.sarif", "result.sarif.simple.json"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.inputFilename, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, GenerateReport(ctx, dir, tc.inputFilename, test.SummaryMock, []string{"simple-json"}, &model.SCIInfo{}))
+			require.FileExists(t, filepath.Join(dir, tc.expectedFilename))
+		})
+	}
+}
+
+// TestHelpers_GenerateReport_SimpleJSON_MultiFormat verifies that requesting both sarif
+// and simple-json in a single GenerateReport call produces both output files.
+func TestHelpers_GenerateReport_SimpleJSON_MultiFormat(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	require.NoError(t, GenerateReport(ctx, dir, "result", test.SummaryMock, []string{"sarif", "simple-json"}, &model.SCIInfo{}))
+
+	require.FileExists(t, filepath.Join(dir, "result.sarif"))
+	require.FileExists(t, filepath.Join(dir, "result.simple.json"))
+
+	// Both files should be non-empty valid JSON.
+	sarifBytes, err := os.ReadFile(filepath.Join(dir, "result.sarif"))
+	require.NoError(t, err)
+	require.True(t, json.Valid(sarifBytes), "result.sarif is not valid JSON")
+
+	simpleBytes, err := os.ReadFile(filepath.Join(dir, "result.simple.json"))
+	require.NoError(t, err)
+	var findings []map[string]interface{}
+	require.NoError(t, json.Unmarshal(simpleBytes, &findings))
+	require.NotEmpty(t, findings)
+}
+
 // TestHelpers_GenerateReport_FiltersSuppressedForNonSarif ensures that
 // suppressed VulnerableFile entries do not leak into non-SARIF report formats
 // (json, csv, gitlab_sast, etc.), while SARIF still receives them so it can

--- a/pkg/report/simple_json.go
+++ b/pkg/report/simple_json.go
@@ -7,7 +7,6 @@ package report
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -15,18 +14,19 @@ import (
 
 // SimpleJSONFinding represents one finding in the simple-json report.
 type SimpleJSONFinding struct {
-	QueryName string `json:"queryName"`
-	Severity  string `json:"severity"`
-	Line      int    `json:"line"`
-	FileName  string `json:"fileName"`
+	QueryID     string `json:"queryID"`
+	QueryName   string `json:"queryName"`
+	Severity    string `json:"severity"`
+	Platform    string `json:"platform"`
+	Line        int    `json:"line"`
+	FileName    string `json:"fileName"`
+	FingerPrint string `json:"fingerPrint"`
 }
 
 // PrintSimpleJSONReport prints a flat JSON array of findings, one entry per (query × file) pair.
 func PrintSimpleJSONReport(ctx context.Context, path, filename string, body interface{}, sciInfo *model.SCIInfo) error {
-	// Strip existing extension so ExportJSONReport appends ".json" correctly
-	// (e.g. "result.sarif" → "result" → "result.json")
-	if ext := filepath.Ext(filename); ext != "" {
-		filename = strings.TrimSuffix(filename, ext)
+	if !strings.HasSuffix(filename, ".simple.json") {
+		filename += ".simple.json"
 	}
 
 	findings := []SimpleJSONFinding{}
@@ -39,10 +39,13 @@ func PrintSimpleJSONReport(ctx context.Context, path, filename string, body inte
 			q := &summary.Queries[i]
 			for j := range q.Files {
 				findings = append(findings, SimpleJSONFinding{
-					QueryName: q.QueryName,
-					Severity:  string(q.Severity),
-					Line:      q.Files[j].Line,
-					FileName:  q.Files[j].FileName,
+					QueryID:     q.QueryID,
+					QueryName:   q.QueryName,
+					Severity:    string(q.Severity),
+					Platform:    q.Platform,
+					Line:        q.Files[j].Line,
+					FileName:    q.Files[j].FileName,
+					FingerPrint: q.Files[j].Fingerprint,
 				})
 			}
 		}

--- a/pkg/report/simple_json.go
+++ b/pkg/report/simple_json.go
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package report
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+// SimpleJSONFinding represents one finding in the simple-json report.
+type SimpleJSONFinding struct {
+	QueryName string `json:"queryName"`
+	Severity  string `json:"severity"`
+	Line      int    `json:"line"`
+	FileName  string `json:"fileName"`
+}
+
+// PrintSimpleJSONReport prints a flat JSON array of findings, one entry per (query × file) pair.
+func PrintSimpleJSONReport(ctx context.Context, path, filename string, body interface{}, sciInfo *model.SCIInfo) error {
+	// Strip existing extension so ExportJSONReport appends ".json" correctly
+	// (e.g. "result.sarif" → "result" → "result.json")
+	if ext := filepath.Ext(filename); ext != "" {
+		filename = strings.TrimSuffix(filename, ext)
+	}
+
+	findings := []SimpleJSONFinding{}
+	if body != "" {
+		summary, err := getSummary(body)
+		if err != nil {
+			return err
+		}
+		for i := range summary.Queries {
+			q := &summary.Queries[i]
+			for j := range q.Files {
+				findings = append(findings, SimpleJSONFinding{
+					QueryName: q.QueryName,
+					Severity:  string(q.Severity),
+					Line:      q.Files[j].Line,
+					FileName:  q.Files[j].FileName,
+				})
+			}
+		}
+	}
+
+	return ExportJSONReport(ctx, path, filename, findings)
+}

--- a/pkg/report/simple_json_test.go
+++ b/pkg/report/simple_json_test.go
@@ -12,67 +12,99 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func readFindings(t *testing.T, dir, filename string) []SimpleJSONFinding {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, filename))
+	require.NoError(t, err)
+	var findings []SimpleJSONFinding
+	require.NoError(t, json.Unmarshal(raw, &findings))
+	return findings
+}
+
 func TestPrintSimpleJSONReport(t *testing.T) {
-	tests := []struct {
-		name            string
-		summary         model.Summary
-		filename        string
-		expectedLen     int
-		expectedOutFile string
-	}{
-		{
-			name:            "two findings from single query",
-			summary:         test.SummaryMock,
-			filename:        "output",
-			expectedLen:     2,
-			expectedOutFile: "output.json",
-		},
-		{
-			name:            "one finding critical",
-			summary:         test.SummaryMockCritical,
-			filename:        "output2",
-			expectedLen:     1,
-			expectedOutFile: "output2.json",
-		},
-		{
-			name:            "multi-query flattened",
-			summary:         test.ComplexSummaryMock,
-			filename:        "output3",
-			expectedLen:     6,
-			expectedOutFile: "output3.json",
-		},
-		{
-			name:            "strips existing extension from filename",
-			summary:         test.SummaryMockCritical,
-			filename:        "result.sarif",
-			expectedLen:     1,
-			expectedOutFile: "result.json",
-		},
-	}
-
 	ctx := context.Background()
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
 
-			err := PrintSimpleJSONReport(ctx, dir, tc.filename, tc.summary, &model.SCIInfo{})
-			require.NoError(t, err)
+	t.Run("single query two findings", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, PrintSimpleJSONReport(ctx, dir, "output", test.SummaryMock, &model.SCIInfo{}))
 
-			outPath := filepath.Join(dir, tc.expectedOutFile)
-			require.FileExists(t, outPath)
+		require.FileExists(t, filepath.Join(dir, "output.simple.json"))
+		findings := readFindings(t, dir, "output.simple.json")
+		require.Len(t, findings, 2)
 
-			raw, err := os.ReadFile(outPath)
-			require.NoError(t, err)
+		// queryHigh: QueryID "de7f5e83-da88-4046-871f-ea18504b1d43", severity HIGH, platform ""
+		require.Equal(t, "de7f5e83-da88-4046-871f-ea18504b1d43", findings[0].QueryID)
+		require.Equal(t, "ALB protocol is HTTP", findings[0].QueryName)
+		require.Equal(t, "HIGH", findings[0].Severity)
+		require.Equal(t, "positive.tf", filepath.Base(findings[0].FileName))
+		require.Equal(t, 25, findings[0].Line)
 
-			var findings []SimpleJSONFinding
-			require.NoError(t, json.Unmarshal(raw, &findings))
-			require.Len(t, findings, tc.expectedLen)
+		require.Equal(t, "de7f5e83-da88-4046-871f-ea18504b1d43", findings[1].QueryID)
+		require.Equal(t, 19, findings[1].Line)
+	})
 
-			for _, f := range findings {
-				require.NotEmpty(t, f.QueryName)
-				require.NotEmpty(t, f.Severity)
-				require.NotEmpty(t, f.FileName)
-			}
-		})
-	}
+	t.Run("single critical finding", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, PrintSimpleJSONReport(ctx, dir, "output", test.SummaryMockCritical, &model.SCIInfo{}))
+
+		require.FileExists(t, filepath.Join(dir, "output.simple.json"))
+		findings := readFindings(t, dir, "output.simple.json")
+		require.Len(t, findings, 1)
+
+		// queryCritical: QueryID "316278b3-87ac-444c-8f8f-a733a28da609", severity CRITICAL
+		require.Equal(t, "316278b3-87ac-444c-8f8f-a733a28da609", findings[0].QueryID)
+		require.Equal(t, "AmazonMQ Broker Encryption Disabled", findings[0].QueryName)
+		require.Equal(t, "CRITICAL", findings[0].Severity)
+		require.Equal(t, 6, findings[0].Line)
+	})
+
+	t.Run("multi-query flattened", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, PrintSimpleJSONReport(ctx, dir, "output", test.ComplexSummaryMock, &model.SCIInfo{}))
+
+		require.FileExists(t, filepath.Join(dir, "output.simple.json"))
+		findings := readFindings(t, dir, "output.simple.json")
+		// ComplexSummaryMock: queryHigh(2) + queryMedium(1) + queryHighCWE(2) + queryCriticalCLI(1) = 6
+		require.Len(t, findings, 6)
+
+		// All findings must have non-empty required fields
+		for i, f := range findings {
+			require.NotEmpty(t, f.QueryID, "finding %d: QueryID empty", i)
+			require.NotEmpty(t, f.QueryName, "finding %d: QueryName empty", i)
+			require.NotEmpty(t, f.Severity, "finding %d: Severity empty", i)
+			require.NotEmpty(t, f.FileName, "finding %d: FileName empty", i)
+		}
+	})
+
+	t.Run("fingerprint passed through from VulnerableFile", func(t *testing.T) {
+		summary := model.Summary{
+			Queries: []model.QueryResult{
+				{
+					QueryID:   "test-query-id",
+					QueryName: "Test Query",
+					Severity:  model.SeverityHigh,
+					Platform:  "Terraform",
+					Files: []model.VulnerableFile{
+						{FileName: "main.tf", Line: 1, Fingerprint: "abc123fingerprint"},
+					},
+				},
+			},
+		}
+		dir := t.TempDir()
+		require.NoError(t, PrintSimpleJSONReport(ctx, dir, "output", summary, &model.SCIInfo{}))
+
+		findings := readFindings(t, dir, "output.simple.json")
+		require.Len(t, findings, 1)
+		require.Equal(t, "abc123fingerprint", findings[0].FingerPrint)
+		require.Equal(t, "test-query-id", findings[0].QueryID)
+		require.Equal(t, "Terraform", findings[0].Platform)
+	})
+
+	t.Run("empty body produces empty array", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, PrintSimpleJSONReport(ctx, dir, "output", "", &model.SCIInfo{}))
+
+		findings := readFindings(t, dir, "output.simple.json")
+		require.Empty(t, findings)
+	})
 }

--- a/pkg/report/simple_json_test.go
+++ b/pkg/report/simple_json_test.go
@@ -1,0 +1,78 @@
+package report
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintSimpleJSONReport(t *testing.T) {
+	tests := []struct {
+		name            string
+		summary         model.Summary
+		filename        string
+		expectedLen     int
+		expectedOutFile string
+	}{
+		{
+			name:            "two findings from single query",
+			summary:         test.SummaryMock,
+			filename:        "output",
+			expectedLen:     2,
+			expectedOutFile: "output.json",
+		},
+		{
+			name:            "one finding critical",
+			summary:         test.SummaryMockCritical,
+			filename:        "output2",
+			expectedLen:     1,
+			expectedOutFile: "output2.json",
+		},
+		{
+			name:            "multi-query flattened",
+			summary:         test.ComplexSummaryMock,
+			filename:        "output3",
+			expectedLen:     6,
+			expectedOutFile: "output3.json",
+		},
+		{
+			name:            "strips existing extension from filename",
+			summary:         test.SummaryMockCritical,
+			filename:        "result.sarif",
+			expectedLen:     1,
+			expectedOutFile: "result.json",
+		},
+	}
+
+	ctx := context.Background()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			err := PrintSimpleJSONReport(ctx, dir, tc.filename, tc.summary, &model.SCIInfo{})
+			require.NoError(t, err)
+
+			outPath := filepath.Join(dir, tc.expectedOutFile)
+			require.FileExists(t, outPath)
+
+			raw, err := os.ReadFile(outPath)
+			require.NoError(t, err)
+
+			var findings []SimpleJSONFinding
+			require.NoError(t, json.Unmarshal(raw, &findings))
+			require.Len(t, findings, tc.expectedLen)
+
+			for _, f := range findings {
+				require.NotEmpty(t, f.QueryName)
+				require.NotEmpty(t, f.Severity)
+				require.NotEmpty(t, f.FileName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Testing the results is done with positive_expected_results.json files that encapsulate a few information about the findings. The scanner however only outputs sarif files, which makes it difficult to compare the results. The goal of this PR is therefore to create a new output format that mimics the positive_expected_result.json.

## Changes

- Created a flag that allows to choose the format of the results
- Added new `simple-json` format to the possible outputs
- Defined the `simple-json` creation logic

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## Testing

Ran the following command:
```
./bin/datadog-iac-scanner scan -o . -p rules-path/cosmosdb_account_ip_range_filter_not_set/ --report-format simple-json
```

Got the following output

```json
[
  {
    "queryName": "CosmosDB account IP range filter not set",
    "severity": "CRITICAL",
    "line": 1,
    "fileName": "assets/queries/terraform/azure/cosmosdb_account_ip_range_filter_not_set/test/positive.tf"
  },
  {
    "queryName": "Cosmos DB account without tags",
    "severity": "LOW",
    "line": 1,
    "fileName": "assets/queries/terraform/azure/cosmosdb_account_ip_range_filter_not_set/test/positive.tf"
  },
  {
    "queryName": "Cosmos DB account without tags",
    "severity": "LOW",
    "line": 1,
    "fileName": "assets/queries/terraform/azure/cosmosdb_account_ip_range_filter_not_set/test/negative.tf"
  },
  {
    "queryName": "Ensure that Azure cloud resource has a team tag",
    "severity": "LOW",
    "line": 1,
    "fileName": "assets/queries/terraform/azure/cosmosdb_account_ip_range_filter_not_set/test/positive.tf"
  },
  {
    "queryName": "Ensure that Azure cloud resource has a team tag",
    "severity": "LOW",
    "line": 1,
    "fileName": "assets/queries/terraform/azure/cosmosdb_account_ip_range_filter_not_set/test/negative.tf"
  }
]
```

Got the following output:

## Blast Radius

Won't affect scans unless the flag is passed

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
