### PR TITLE
Optimize server-mode scan performance (compiled-rule cache, shared compilation, parallel parsing)

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -91,6 +91,14 @@ var scanAction = &cli.Command{
 			Usage:  "(experimental, will be removed soon) scan terraform plans",
 			Value:  false,
 		},
+		&cli.BoolFlag{
+			Name:   "x-disable-rule-isolation",
+			Hidden: true,
+			Usage: "(experimental, will be removed soon) co-compile all rules and libraries into a " +
+				"shared compiler instead of isolating each rule; greatly reduces memory at the cost " +
+				"of per-rule compile-failure isolation",
+			Value: false,
+		},
 		&cli.StringSliceFlag{
 			Name:    "queries-path",
 			Aliases: []string{"q"},
@@ -239,6 +247,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		FlagEvaluator:           getFeatureFlagEvaluator(c),
 		Config:                  *cfg,
 		ShouldScanTfPlans:       c.Bool("x-terraform-plan"),
+		DisableRuleIsolation:    c.Bool("x-disable-rule-isolation"),
 	}
 
 	metadata, err := console.ExecuteScan(ctx, params)

--- a/cmd/scanner/serve.go
+++ b/cmd/scanner/serve.go
@@ -39,6 +39,22 @@ var serveAction = &cli.Command{
 			Value: 4,
 			Usage: "maximum concurrent /analyze scans before returning 503 (must be > 0)",
 		},
+		&cli.IntFlag{
+			Name:  "max-files",
+			Value: 50000,
+			Usage: "maximum number of files accepted in a single /analyze request",
+		},
+		&cli.IntFlag{
+			Name:  "max-request-mib",
+			Value: 32,
+			Usage: "maximum /analyze request body size in MiB (the JSON body, larger than raw file bytes)",
+		},
+		&cli.IntFlag{
+			Name:  "write-timeout",
+			Value: 600,
+			Usage: "seconds allowed to write a response before the connection is closed " +
+				"(0 disables; generous because a cold scan recompiles the rule corpus)",
+		},
 		&cli.BoolFlag{
 			Name:   "x-use-rules-cache",
 			Hidden: true,
@@ -78,6 +94,13 @@ func serve(ctx context.Context, c *cli.Command) error {
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	// --write-timeout 0 means "disable"; Config treats a negative duration as
+	// disabled (zero would be read as "apply default").
+	writeTimeout := time.Duration(c.Int("write-timeout")) * time.Second
+	if c.Int("write-timeout") == 0 {
+		writeTimeout = -1
+	}
+
 	cfg := server.Config{
 		Address:              c.String("address"),
 		Port:                 c.Int("port"),
@@ -86,6 +109,9 @@ func serve(ctx context.Context, c *cli.Command) error {
 		LibrariesPath:        c.String("libraries-path"),
 		QueriesPath:          c.String("queries-path"),
 		MaxConcurrentAnalyze: c.Int("max-concurrent-analyze"),
+		MaxFiles:             c.Int("max-files"),
+		MaxRequestBytes:      int64(c.Int("max-request-mib")) << 20,
+		WriteTimeout:         writeTimeout,
 		DisableRuleIsolation: c.Bool("x-disable-rule-isolation"),
 		ParallelParsing:      c.Bool("x-parallelparsing"),
 		UseRulesCache:        c.Bool("x-use-rules-cache"),

--- a/cmd/scanner/serve.go
+++ b/cmd/scanner/serve.go
@@ -58,9 +58,10 @@ var serveAction = &cli.Command{
 		&cli.BoolFlag{
 			Name:   "x-use-rules-cache",
 			Hidden: true,
-			Usage: "(experimental, will be removed soon) cache compiled rules across requests so " +
-				"warm scans skip recompilation (faster repeat scans at the cost of retained memory)",
-			Value: false,
+			Value:  false,
+			Usage: "(experimental, will be removed soon) cache compiled rules and co-compile them " +
+				"into a shared compiler (rules cache + disabled rule isolation), for faster repeat " +
+				"scans at low memory",
 		},
 		&cli.StringFlag{
 			Name:  "libraries-path",
@@ -71,14 +72,6 @@ var serveAction = &cli.Command{
 			Name:  "queries-path",
 			Value: "./assets/queries",
 			Usage: "path to the default rule corpus (used only when a request omits its own rules)",
-		},
-		&cli.BoolFlag{
-			Name:   "x-disable-rule-isolation",
-			Hidden: true,
-			Usage: "(experimental, will be removed soon) co-compile all rules and libraries into a " +
-				"shared compiler instead of isolating each rule; greatly reduces memory at the cost " +
-				"of per-rule compile-failure isolation",
-			Value: false,
 		},
 		&cli.BoolFlag{
 			Name:   "x-parallelparsing",
@@ -101,6 +94,11 @@ func serve(ctx context.Context, c *cli.Command) error {
 		writeTimeout = -1
 	}
 
+	// --x-use-rules-cache is a single toggle for the rules-caching mode: it both
+	// caches compiled rules across requests and co-compiles them into a shared
+	// compiler. The two are deliberately not separately configurable.
+	useRulesCache := c.Bool("x-use-rules-cache")
+
 	cfg := server.Config{
 		Address:              c.String("address"),
 		Port:                 c.Int("port"),
@@ -112,9 +110,9 @@ func serve(ctx context.Context, c *cli.Command) error {
 		MaxFiles:             c.Int("max-files"),
 		MaxRequestBytes:      int64(c.Int("max-request-mib")) << 20,
 		WriteTimeout:         writeTimeout,
-		DisableRuleIsolation: c.Bool("x-disable-rule-isolation"),
 		ParallelParsing:      c.Bool("x-parallelparsing"),
-		UseRulesCache:        c.Bool("x-use-rules-cache"),
+		UseRulesCache:        useRulesCache,
+		DisableRuleIsolation: useRulesCache,
 	}
 	return server.New(&cfg).ListenAndServe(ctx)
 }

--- a/cmd/scanner/serve.go
+++ b/cmd/scanner/serve.go
@@ -40,9 +40,11 @@ var serveAction = &cli.Command{
 			Usage: "maximum concurrent /analyze scans before returning 503 (must be > 0)",
 		},
 		&cli.BoolFlag{
-			Name:  "use-rules-cache",
+			Name:   "x-use-rules-cache",
+			Hidden: true,
+			Usage: "(experimental, will be removed soon) cache compiled rules across requests so " +
+				"warm scans skip recompilation (faster repeat scans at the cost of retained memory)",
 			Value: false,
-			Usage: "accepted for compatibility with the static-analyzer server contract; currently a no-op",
 		},
 		&cli.StringFlag{
 			Name:  "libraries-path",
@@ -53,6 +55,20 @@ var serveAction = &cli.Command{
 			Name:  "queries-path",
 			Value: "./assets/queries",
 			Usage: "path to the default rule corpus (used only when a request omits its own rules)",
+		},
+		&cli.BoolFlag{
+			Name:   "x-disable-rule-isolation",
+			Hidden: true,
+			Usage: "(experimental, will be removed soon) co-compile all rules and libraries into a " +
+				"shared compiler instead of isolating each rule; greatly reduces memory at the cost " +
+				"of per-rule compile-failure isolation",
+			Value: false,
+		},
+		&cli.BoolFlag{
+			Name:   "x-parallelparsing",
+			Hidden: true,
+			Usage:  "(experimental, will be removed soon) parse pushed files in parallel across CPUs",
+			Value:  false,
 		},
 	},
 	Action: serve,
@@ -70,6 +86,9 @@ func serve(ctx context.Context, c *cli.Command) error {
 		LibrariesPath:        c.String("libraries-path"),
 		QueriesPath:          c.String("queries-path"),
 		MaxConcurrentAnalyze: c.Int("max-concurrent-analyze"),
+		DisableRuleIsolation: c.Bool("x-disable-rule-isolation"),
+		ParallelParsing:      c.Bool("x-parallelparsing"),
+		UseRulesCache:        c.Bool("x-use-rules-cache"),
 	}
 	return server.New(&cfg).ListenAndServe(ctx)
 }

--- a/cmd/scanner/test_rules.go
+++ b/cmd/scanner/test_rules.go
@@ -292,6 +292,8 @@ func runFiles(
 		0,
 		featureflags.NewLocalEvaluator(),
 		vfs.DiskFS{},
+		false,
+		false,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -8,10 +8,12 @@ package engine
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"maps"
 	"reflect"
+	"regexp"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -31,6 +33,7 @@ import (
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+	"github.com/cespare/xxhash/v2"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/open-policy-agent/opa/v1/ast"
@@ -81,6 +84,67 @@ type QueryLoader struct {
 	parsedCommon *ast.Module
 	// parsedGeneric holds the per-platform Generic library module, also parsed once.
 	parsedGeneric map[string]*ast.Module
+	// platformKeyBases holds, per platform, a precomputed hash of the common and
+	// platform library code + input data. It is the library-dependent part of a
+	// compiled-query cache key, hashed once at load time instead of hashing
+	// ~82 KB of library text on every LoadQuery call. See preparedCacheKey.
+	platformKeyBases map[string]uint64
+}
+
+// preparedQueryCache caches compiled *rego.PreparedEvalQuery values across scans
+// and across the whole process, keyed by preparedCacheKey. A compiled query is
+// safe to share: PrepareForEval/Eval open only read-only transactions on the
+// store, the *PreparedEvalQuery is immutable after construction, and Eval is
+// safe for concurrent use.
+var preparedQueryCache sync.Map // map[uint64]*rego.PreparedEvalQuery
+
+// hashFields computes a fast, non-cryptographic 64-bit hash of the given strings
+// joined by a NUL separator. The NUL separator keeps the field boundaries
+// unambiguous (so e.g. ("a","bc") and ("ab","c") hash differently).
+func hashFields(fields ...string) uint64 {
+	var h xxhash.Digest
+	h.Reset()
+	for i, f := range fields {
+		if i > 0 {
+			_, _ = h.WriteString("\x00")
+		}
+		_, _ = h.WriteString(f)
+	}
+	return h.Sum64()
+}
+
+// preparedCacheKey builds the cache key for a compiled query from everything its
+// compiled form depends on: platform, query name, query content, the library
+// hash base (library Rego *code*), and the base-store data hash (the merged
+// library + module input *data* the store bakes in). Two queries that produce
+// the same key compile to an interchangeable *PreparedEvalQuery.
+//
+// The two precomputed uint64 bases are mixed in as raw 8-byte words rather than
+// formatted to strings, so this allocates nothing beyond the digest itself.
+func preparedCacheKey(query *model.QueryMetadata, libBase, baseDataHash uint64) uint64 {
+	var h xxhash.Digest
+	h.Reset()
+	_, _ = h.WriteString(query.Platform)
+	_, _ = h.WriteString("\x00")
+	_, _ = h.WriteString(query.Query)
+	_, _ = h.WriteString("\x00")
+	_, _ = h.WriteString(query.Content)
+	var buf [16]byte
+	binary.LittleEndian.PutUint64(buf[0:8], libBase)
+	binary.LittleEndian.PutUint64(buf[8:16], baseDataHash)
+	_, _ = h.Write(buf[:])
+	return h.Sum64()
+}
+
+// hashBaseInputData computes a fast hash of each platform's merged base
+// input-data string, identifying the data baked into that platform's shared
+// base store for compiled-query cache keying.
+func hashBaseInputData(baseInputData map[string]string) map[string]uint64 {
+	hashes := make(map[string]uint64, len(baseInputData))
+	for platform, data := range baseInputData {
+		hashes[platform] = hashFields(data)
+	}
+	return hashes
 }
 
 // VulnerabilityBuilder represents a function that will build a vulnerability
@@ -114,6 +178,8 @@ type Inspector struct {
 	useOldSeverities     bool
 	numWorkers           int
 	flagEvaluator        featureflags.FlagEvaluator
+	disableRuleIsolation bool
+	useRulesCache        bool
 	// fsys is the filesystem used for Terraform module resolution. Defaults to
 	// the real disk; the HTTP server injects an in-memory FS built from pushed
 	// content.
@@ -138,6 +204,25 @@ var (
 	}
 )
 
+// safeCapabilities returns the OPA capabilities for this version with the
+// unsafeRegoFunctions removed from the allowed-builtins list, so a rule
+// referencing one fails to compile (an "undefined function"). This is the
+// non-deprecated replacement for Compiler.WithUnsafeBuiltins, which OPA derives
+// the same way: the compiler's known-builtins set is built solely from
+// capabilities.Builtins. Computed once — capabilities are immutable.
+var safeCapabilities = sync.OnceValue(func() *ast.Capabilities {
+	caps := ast.CapabilitiesForThisVersion()
+	allowed := caps.Builtins[:0]
+	for _, b := range caps.Builtins {
+		if _, unsafe := unsafeRegoFunctions[b.Name]; unsafe {
+			continue
+		}
+		allowed = append(allowed, b)
+	}
+	caps.Builtins = allowed
+	return caps
+})
+
 // NewInspector initializes a inspector, compiling and loading queries for scan and its tracker
 func NewInspector(
 	ctx context.Context,
@@ -152,6 +237,8 @@ func NewInspector(
 	numWorkers int,
 	flagEvaluator featureflags.FlagEvaluator,
 	fsys vfs.FS,
+	disableRuleIsolation bool,
+	useRulesCache bool,
 ) (*Inspector, error) {
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("engine.NewInspector()")
@@ -191,17 +278,19 @@ func NewInspector(
 		Add(terraform.DetectKindLine{}, model.KindTerraform)
 
 	return &Inspector{
-		QueryLoader:      &queryLoader,
-		vb:               vb,
-		tracker:          tracker,
-		failedQueries:    failedQueries,
-		ruleConfigs:      ruleConfigs,
-		detector:         lineDetector,
-		repoPath:         repoPath,
-		useOldSeverities: useOldSeverities,
-		numWorkers:       utils.AdjustNumWorkers(numWorkers),
-		flagEvaluator:    flagEvaluator,
-		fsys:             fsys,
+		QueryLoader:          &queryLoader,
+		vb:                   vb,
+		tracker:              tracker,
+		failedQueries:        failedQueries,
+		ruleConfigs:          ruleConfigs,
+		detector:             lineDetector,
+		repoPath:             repoPath,
+		useOldSeverities:     useOldSeverities,
+		numWorkers:           utils.AdjustNumWorkers(numWorkers),
+		flagEvaluator:        flagEvaluator,
+		fsys:                 fsys,
+		disableRuleIsolation: disableRuleIsolation,
+		useRulesCache:        useRulesCache,
 	}, nil
 }
 
@@ -246,7 +335,8 @@ func (c *Inspector) createInspectionJobs(jobs chan<- InspectionJob, queries []mo
 func (c *Inspector) performInspection(ctx context.Context, scanID string, filesMap map[string]*model.FileMetadata,
 	astPayload ast.Value,
 	jobs <-chan InspectionJob, results chan<- QueryResult, queries []model.QueryMetadata,
-	modules []tfmodules.ParsedModule, baseStores map[string]storage.Store) {
+	modules []tfmodules.ParsedModule, baseStores map[string]storage.Store, baseDataHashes map[string]uint64,
+	sharedQueries map[int]*rego.PreparedEvalQuery) {
 	for job := range jobs {
 		select {
 		case <-ctx.Done():
@@ -256,7 +346,11 @@ func (c *Inspector) performInspection(ctx context.Context, scanID string, filesM
 		}
 
 		loadStart := time.Now()
-		queryOpa, err := c.QueryLoader.LoadQuery(ctx, &queries[job.queryID], modules, baseStores)
+		queryOpa, ok := sharedQueries[job.queryID]
+		var err error
+		if !ok {
+			queryOpa, err = c.QueryLoader.LoadQuery(ctx, &queries[job.queryID], modules, baseStores, baseDataHashes, c.useRulesCache)
+		}
 		loadDur := time.Since(loadStart)
 		if err != nil {
 			contextLogger := logger.FromContext(ctx)
@@ -342,8 +436,24 @@ func (c *Inspector) Inspect(
 	queries := c.getQueriesByPlat(platforms)
 
 	// Pre-build one inmem.Store per platform so LoadQuery does not re-parse the
-	// same payload for every PrepareForEval call.
-	baseStores := precomputeBaseStores(c.QueryLoader.precomputeBaseInputData(ctx, enrichedModules))
+	// same payload for every PrepareForEval call. The per-platform data hash is
+	// folded into each compiled-query cache key so a compiled query is only
+	// reused by a later scan whose base data is byte-identical.
+	baseInputData := c.QueryLoader.precomputeBaseInputData(ctx, enrichedModules)
+	baseStores := precomputeBaseStores(baseInputData)
+	baseDataHashes := hashBaseInputData(baseInputData)
+
+	// When rule isolation is disabled, co-compile all rules + libraries once per
+	// platform into a shared compiler (rules rewritten to unique packages) so the
+	// library AST is retained a single time. Rules missing from the returned map
+	// (parse/compile failures) fall back to isolated LoadQuery in the worker, so
+	// correctness is preserved even if shared compilation partially fails.
+	var sharedQueries map[int]*rego.PreparedEvalQuery
+	if c.disableRuleIsolation {
+		sharedQueries = c.QueryLoader.loadSharedQueries(ctx, queries, baseStores)
+		contextLogger.Info().Msgf("Rule isolation disabled: %d/%d queries served from shared compiler",
+			len(sharedQueries), len(queries))
+	}
 
 	// Compute the file map once and share it (read-only) across all workers
 	filesMap := files.ToMap()
@@ -363,7 +473,8 @@ func (c *Inspector) Inspect(
 		go func() {
 			// Decrement the counter when the goroutine completes
 			defer wg.Done()
-			c.performInspection(ctx, scanID, filesMap, astPayload, jobs, results, queries, enrichedModules, baseStores)
+			c.performInspection(ctx, scanID, filesMap, astPayload, jobs, results, queries,
+				enrichedModules, baseStores, baseDataHashes, sharedQueries)
 		}()
 	}
 	// Start a goroutine to create inspection jobs
@@ -788,6 +899,7 @@ func prepareQueries(queries []model.QueryMetadata, commonLibrary source.RegoLibr
 	}
 
 	parsedGeneric := make(map[string]*ast.Module, len(platformLibraries))
+	platformKeyBases := make(map[string]uint64, len(platformLibraries))
 	for platform, lib := range platformLibraries {
 		mod, parseErr := ast.ParseModuleWithOpts("Generic", lib.LibraryCode,
 			ast.ParserOptions{RegoVersion: ast.RegoV1})
@@ -795,6 +907,12 @@ func prepareQueries(queries []model.QueryMetadata, commonLibrary source.RegoLibr
 			return QueryLoader{}, errors.Wrapf(parseErr, "failed to parse Generic Rego library for platform %s", platform)
 		}
 		parsedGeneric[platform] = mod
+		platformKeyBases[platform] = hashFields(
+			commonLibrary.LibraryCode,
+			commonLibrary.LibraryInputData,
+			lib.LibraryCode,
+			lib.LibraryInputData,
+		)
 	}
 
 	return QueryLoader{
@@ -804,6 +922,7 @@ func prepareQueries(queries []model.QueryMetadata, commonLibrary source.RegoLibr
 		QueriesMetadata:   queries,
 		parsedCommon:      parsedCommon,
 		parsedGeneric:     parsedGeneric,
+		platformKeyBases:  platformKeyBases,
 	}, nil
 }
 
@@ -862,10 +981,21 @@ func precomputeBaseStores(baseInputData map[string]string) map[string]storage.St
 	return stores
 }
 
-// LoadQuery loads the query into memory so it can be freed when not used anymore
+// LoadQuery loads the query into memory so it can be freed when not used anymore.
+//
+// baseStores holds one shared, read-only inmem store per platform (the merged
+// library + module input data for this scan); baseDataHashes holds a hash of
+// each store's data. When the query carries no custom InputData it uses the
+// shared base store, and its compiled *PreparedEvalQuery is served from / stored
+// in the process-global preparedQueryCache — the cache key folds in the base
+// data hash, so a compiled query (whose store bakes in this scan's data) is only
+// reused by a later scan whose base data is byte-identical. This makes warm
+// scans skip the expensive PrepareForEval compile even when Terraform module
+// data is present, as long as that data is unchanged.
 func (q *QueryLoader) LoadQuery(ctx context.Context, query *model.QueryMetadata,
 	modules []tfmodules.ParsedModule,
-	baseStores map[string]storage.Store) (*rego.PreparedEvalQuery, error) {
+	baseStores map[string]storage.Store, baseDataHashes map[string]uint64,
+	cacheEnabled bool) (*rego.PreparedEvalQuery, error) {
 	platformGeneralQuery, ok := q.platformLibraries[query.Platform]
 	if !ok {
 		return nil, errors.New("failed to get platform library")
@@ -876,12 +1006,25 @@ func (q *QueryLoader) LoadQuery(ctx context.Context, query *model.QueryMetadata,
 		return nil, ctx.Err()
 	default:
 		hasCustomInput := !source.IsEmptyInputData(query.InputData)
+		prebuilt, hasBaseStore := baseStores[query.Platform]
 
-		// Choose the inmem store: reuse the pre-built per-platform store for
-		// queries with no custom InputData (the common case); fall back to
-		// building a fresh store for the rare query with custom InputData.
+		// The compiled query is cacheable only when the caller enabled the cache
+		// (server mode via --use-rules-cache) AND it uses the shared per-platform
+		// base store (no custom per-query InputData, and a base store exists for
+		// the platform). The cache key folds in the base data hash so a cached
+		// query is reused only by a scan with identical base data — the store it
+		// bakes in.
+		useCache := cacheEnabled && hasBaseStore && !hasCustomInput
+		var cacheKey uint64
+		if useCache {
+			cacheKey = preparedCacheKey(query, q.platformKeyBases[query.Platform], baseDataHashes[query.Platform])
+			if cached, ok := preparedQueryCache.Load(cacheKey); ok {
+				return cached.(*rego.PreparedEvalQuery), nil
+			}
+		}
+
 		var store storage.Store
-		if prebuilt, ok := baseStores[query.Platform]; ok && !hasCustomInput {
+		if useCache {
 			store = prebuilt
 		} else {
 			mergedInputData, err := q.buildMergedInputData(ctx, query, modules)
@@ -919,8 +1062,119 @@ func (q *QueryLoader) LoadQuery(ctx context.Context, query *model.QueryMetadata,
 			return nil, err
 		}
 
+		if useCache {
+			// the duplicate compiled query is discarded.
+			actual, _ := preparedQueryCache.LoadOrStore(cacheKey, &opaQuery)
+			return actual.(*rego.PreparedEvalQuery), nil
+		}
+
 		return &opaQuery, nil
 	}
+}
+
+// pkgDatadogDecl matches the `package datadog` declaration at the head of every
+// rule, so it can be rewritten to a unique per-rule package for shared compilation.
+var pkgDatadogDecl = regexp.MustCompile(`(?m)^(\s*)package\s+datadog\b`)
+
+// loadSharedQueries compiles all given queries together with their libraries in
+// a SINGLE ast.Compiler per platform, instead of compiling each rule in its own
+// isolated compiler. Every rule is rewritten from `package datadog` to a unique
+// `package datadog.q<i>` so the rules no longer collide and can co-exist in one
+// compiler; the shared common+platform library AST then exists once instead of
+// being copied into every compiled query (the dominant retained-heap cost).
+//
+// It returns a map from the caller's query index to the prepared query. A rule
+// that fails to parse or whose platform has no base store is skipped (logged),
+// preserving the isolated path's "skip and continue" behavior. Rule identity,
+// findings, and SARIF are unaffected: the package rename is internal to
+// compilation and never reaches QueryMetadata or the emitted result payload.
+func (q *QueryLoader) loadSharedQueries(ctx context.Context, queries []model.QueryMetadata,
+	baseStores map[string]storage.Store) map[int]*rego.PreparedEvalQuery {
+	contextLogger := logger.FromContext(ctx)
+
+	// Group query indices by platform: one shared compiler is built per platform
+	// because libraries and the base store are platform-specific.
+	indicesByPlatform := make(map[string][]int)
+	for i := range queries {
+		indicesByPlatform[queries[i].Platform] = append(indicesByPlatform[queries[i].Platform], i)
+	}
+
+	prepared := make(map[int]*rego.PreparedEvalQuery, len(queries))
+	for platform, indices := range indicesByPlatform {
+		store, ok := baseStores[platform]
+		if !ok {
+			contextLogger.Warn().Msgf("shared compile: no base store for platform %s, skipping %d rules", platform, len(indices))
+			continue
+		}
+		platformLib, ok := q.platformLibraries[platform]
+		if !ok {
+			contextLogger.Warn().Msgf("shared compile: no library for platform %s, skipping %d rules", platform, len(indices))
+			continue
+		}
+
+		// Parse libraries + every rule (renamed) into one module set. A rule that
+		// fails to parse is dropped here, individually, BEFORE the shared compile —
+		// so one malformed rule cannot fail the whole batch at the parse stage.
+		modules := map[string]*ast.Module{
+			"Common":  q.parsedCommon,
+			"Generic": q.parsedGeneric[platform],
+		}
+		if modules["Common"] == nil {
+			modules["Common"], _ = ast.ParseModuleWithOpts("Common", q.commonLibrary.LibraryCode,
+				ast.ParserOptions{RegoVersion: ast.RegoV1})
+		}
+		if modules["Generic"] == nil {
+			modules["Generic"], _ = ast.ParseModuleWithOpts("Generic", platformLib.LibraryCode,
+				ast.ParserOptions{RegoVersion: ast.RegoV1})
+		}
+		// queryPath maps each surviving rule index to its unique query path.
+		queryPath := make(map[int]string, len(indices))
+		for _, i := range indices {
+			renamed := pkgDatadogDecl.ReplaceAllString(queries[i].Content, fmt.Sprintf("${1}package datadog.q%d", i))
+			mod, parseErr := ast.ParseModuleWithOpts(queries[i].Query, renamed,
+				ast.ParserOptions{RegoVersion: ast.RegoV1})
+			if parseErr != nil {
+				contextLogger.Warn().Err(parseErr).Msgf("shared compile: rule %s failed to parse, skipping", queries[i].Query)
+				continue
+			}
+			modules[fmt.Sprintf("rule%d", i)] = mod
+			queryPath[i] = fmt.Sprintf("data.datadog.q%d.DatadogPolicy", i)
+		}
+
+		compiler := ast.NewCompiler().WithCapabilities(safeCapabilities())
+		compiler.Compile(modules)
+		if compiler.Failed() {
+			// A rule that parsed but failed semantic compilation poisons the whole
+			// batch. Fall back to isolated compilation for this platform's rules so
+			// correctness is never sacrificed for the memory optimization.
+			contextLogger.Warn().Msgf("shared compile failed for platform %s (%v); falling back to isolated compilation",
+				platform, compiler.Errors)
+			continue
+		}
+
+		// Prepare each rule's eval query against the one shared compiler. They all
+		// reference the same compiled library AST, so it is retained once.
+		for _, i := range indices {
+			path, ok := queryPath[i]
+			if !ok {
+				continue // rule was dropped at parse stage
+			}
+			pq, prepErr := rego.New(
+				rego.Query(fmt.Sprintf("result = %s", path)),
+				rego.SetRegoVersion(ast.RegoV1),
+				rego.Compiler(compiler),
+				rego.Store(store),
+				rego.UnsafeBuiltins(unsafeRegoFunctions),
+			).PrepareForEval(ctx)
+			if prepErr != nil {
+				contextLogger.Warn().Err(prepErr).Msgf("shared compile: failed to prepare rule %s, skipping", queries[i].Query)
+				continue
+			}
+			p := pq
+			prepared[i] = &p
+		}
+	}
+	return prepared
 }
 
 func parseJsonencodeHCL(ctx context.Context, input string) (ast.Value, error) {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -1130,6 +1130,15 @@ func (q *QueryLoader) loadSharedQueries(ctx context.Context, queries []model.Que
 		// queryPath maps each surviving rule index to its unique query path.
 		queryPath := make(map[int]string, len(indices))
 		for _, i := range indices {
+			// A rule with custom InputData needs a per-query store that merges that
+			// data; the shared path can only offer the per-platform base store
+			// (built without any rule's InputData). Skip such rules here so the
+			// worker falls back to the isolated LoadQuery, which builds the correct
+			// store. Without this, a rule whose Rego reads its inputData would run
+			// as if that data were absent (wrong findings / false negatives).
+			if !source.IsEmptyInputData(queries[i].InputData) {
+				continue
+			}
 			renamed := pkgDatadogDecl.ReplaceAllString(queries[i].Content, fmt.Sprintf("${1}package datadog.q%d", i))
 			mod, parseErr := ast.ParseModuleWithOpts(queries[i].Query, renamed,
 				ast.ParserOptions{RegoVersion: ast.RegoV1})

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -53,16 +53,18 @@ func (s *stubQueriesSource) GetQueryLibrary(_ context.Context, platform string) 
 // with no rules. Set `querySource` to plug in a custom QueriesSource (e.g. a
 // gomock) instead of the default in-memory stub backed by `queries`.
 type inspectorOpts struct {
-	queries          []model.QueryMetadata
-	querySource      source.QueriesSource
-	queryParameters  *source.QueryInspectorParameters
-	repoPath         string
-	useOldSeverities bool
-	needsLog         bool
-	numWorkers       int
-	vb               VulnerabilityBuilder
-	tracker          Tracker
-	flagEvaluator    featureflags.FlagEvaluator
+	queries              []model.QueryMetadata
+	querySource          source.QueriesSource
+	queryParameters      *source.QueryInspectorParameters
+	repoPath             string
+	useOldSeverities     bool
+	needsLog             bool
+	numWorkers           int
+	vb                   VulnerabilityBuilder
+	tracker              Tracker
+	flagEvaluator        featureflags.FlagEvaluator
+	disableRuleIsolation bool
+	useRulesCache        bool
 }
 
 // newTestInspector runs the real [NewInspector] against a configurable
@@ -109,6 +111,8 @@ func newTestInspector(t *testing.T, opts inspectorOpts) *Inspector {
 		opts.numWorkers,
 		opts.flagEvaluator,
 		vfs.DiskFS{},
+		opts.disableRuleIsolation,
+		opts.useRulesCache,
 	)
 	require.NoError(t, err)
 	return ins

--- a/pkg/engine/loadquery_cache_test.go
+++ b/pkg/engine/loadquery_cache_test.go
@@ -1,0 +1,136 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package engine
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+// cacheTracker is a no-op Tracker for building a QueryLoader in tests.
+type cacheTracker struct{}
+
+func (cacheTracker) TrackQueryLoad(int)      {}
+func (cacheTracker) TrackQueryExecuting(int) {}
+func (cacheTracker) TrackQueryExecution(int) {}
+func (cacheTracker) FailedDetectLine()       {}
+func (cacheTracker) GetOutputLines() int     { return 3 }
+
+func newCacheTestLoader(t *testing.T, platform string, queries []model.QueryMetadata) *QueryLoader {
+	t.Helper()
+	commonLib := source.RegoLibraries{LibraryCode: "package common\n", LibraryInputData: "{}"}
+	platformLibs := map[string]source.RegoLibraries{
+		platform: {LibraryCode: "package generic." + platform + "\n", LibraryInputData: "{}"},
+	}
+	loader, err := prepareQueries(queries, commonLib, platformLibs, cacheTracker{})
+	require.NoError(t, err)
+	return &loader
+}
+
+func baseStoresFor(platform, data string) (map[string]storage.Store, map[string]uint64) {
+	stores := map[string]storage.Store{platform: inmem.NewFromReader(bytes.NewBufferString(data))}
+	hashes := hashBaseInputData(map[string]string{platform: data})
+	return stores, hashes
+}
+
+func staticQuery(platform, name, body string) model.QueryMetadata {
+	return model.QueryMetadata{
+		Query:     name,
+		Platform:  platform,
+		Content:   "package datadog\n" + body,
+		InputData: "{}",
+	}
+}
+
+func clearPreparedCache() {
+	preparedQueryCache.Range(func(k, _ any) bool { preparedQueryCache.Delete(k); return true })
+}
+
+// TestLoadQuery_CacheGate is the core of the --use-rules-cache wiring: with the
+// cache disabled, two loads of the same query must compile fresh each time; with
+// it enabled, the second load must return the cached pointer.
+func TestLoadQuery_CacheGate(t *testing.T) {
+	platform := "Terraform"
+	q := staticQuery(platform, "q1", "")
+	loader := newCacheTestLoader(t, platform, []model.QueryMetadata{q})
+	stores, hashes := baseStoresFor(platform, "{}")
+	ctx := context.Background()
+
+	t.Run("disabled compiles fresh", func(t *testing.T) {
+		clearPreparedCache()
+		first, err := loader.LoadQuery(ctx, &q, nil, stores, hashes, false)
+		require.NoError(t, err)
+		second, err := loader.LoadQuery(ctx, &q, nil, stores, hashes, false)
+		require.NoError(t, err)
+		require.NotSame(t, first, second, "cache disabled: each load must compile a fresh query")
+	})
+
+	t.Run("enabled returns cached pointer", func(t *testing.T) {
+		clearPreparedCache()
+		first, err := loader.LoadQuery(ctx, &q, nil, stores, hashes, true)
+		require.NoError(t, err)
+		second, err := loader.LoadQuery(ctx, &q, nil, stores, hashes, true)
+		require.NoError(t, err)
+		require.Same(t, first, second, "cache enabled: identical query must return the cached pointer")
+	})
+}
+
+func TestLoadQuery_DifferentContentDifferentEntry(t *testing.T) {
+	clearPreparedCache()
+	platform := "Terraform"
+	qa := staticQuery(platform, "q1", "")
+	qb := staticQuery(platform, "q1", "allow := true\n")
+	loader := newCacheTestLoader(t, platform, []model.QueryMetadata{qa, qb})
+	stores, hashes := baseStoresFor(platform, "{}")
+	ctx := context.Background()
+
+	a, err := loader.LoadQuery(ctx, &qa, nil, stores, hashes, true)
+	require.NoError(t, err)
+	b, err := loader.LoadQuery(ctx, &qb, nil, stores, hashes, true)
+	require.NoError(t, err)
+	require.NotSame(t, a, b, "different query content must compile to a distinct cache entry")
+}
+
+func TestLoadQuery_DifferentBaseDataDifferentEntry(t *testing.T) {
+	clearPreparedCache()
+	platform := "Terraform"
+	q := staticQuery(platform, "q1", "")
+	loader := newCacheTestLoader(t, platform, []model.QueryMetadata{q})
+	ctx := context.Background()
+
+	stores1, hashes1 := baseStoresFor(platform, "{}")
+	stores2, hashes2 := baseStoresFor(platform, `{"common_lib":{"modules":{"aws":{}}}}`)
+
+	a, err := loader.LoadQuery(ctx, &q, nil, stores1, hashes1, true)
+	require.NoError(t, err)
+	b, err := loader.LoadQuery(ctx, &q, nil, stores2, hashes2, true)
+	require.NoError(t, err)
+	require.NotSame(t, a, b, "different base store data must not share a cache entry")
+}
+
+func TestLoadQuery_CustomInputNotCached(t *testing.T) {
+	clearPreparedCache()
+	platform := "Terraform"
+	q := staticQuery(platform, "q1", "")
+	q.InputData = `{"foo":"bar"}`
+	loader := newCacheTestLoader(t, platform, []model.QueryMetadata{q})
+	stores, hashes := baseStoresFor(platform, "{}")
+	ctx := context.Background()
+
+	first, err := loader.LoadQuery(ctx, &q, nil, stores, hashes, true)
+	require.NoError(t, err)
+	second, err := loader.LoadQuery(ctx, &q, nil, stores, hashes, true)
+	require.NoError(t, err)
+	require.NotSame(t, first, second, "custom-input queries must bypass the cache even when it is enabled")
+}

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -297,8 +297,15 @@ func (s *FileSystemSourceProvider) processFilesParallel(ctx context.Context, fil
 
 // calculateWorkerCount determines the optimal number of workers for parallel processing
 func (s *FileSystemSourceProvider) calculateWorkerCount() int {
+	return calculateWorkerCount()
+}
+
+// calculateWorkerCount auto-detects the worker count from GOMAXPROCS via
+// utils.AdjustNumWorkers and clamps it to [minNumWorkers, maxNumWorkers]. Shared
+// by every parallel source provider so they pick worker counts identically.
+func calculateWorkerCount() int {
 	numWorkers := utils.AdjustNumWorkers(0) // 0 means auto-detect
-	if numWorkers < 1 {
+	if numWorkers < minNumWorkers {
 		numWorkers = minNumWorkers
 	}
 	if numWorkers > maxNumWorkers {

--- a/pkg/engine/provider/memory.go
+++ b/pkg/engine/provider/memory.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"path/filepath"
 	"sort"
+	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/pathutil"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
@@ -75,11 +76,100 @@ func (m *MemorySourceProvider) GetSources(ctx context.Context,
 	return nil
 }
 
-// GetParallelSources has no I/O to parallelize over in-memory content, so it
-// delegates to GetSources.
+// GetParallelSources fans the per-file sink (which parses the content into a
+// document tree — the CPU-heavy step) across worker goroutines. There is no I/O
+// to parallelize for in-memory content, but parsing is concurrency-friendly and
+// a non-trivial share of a warm server scan, so this can speed up large pushes.
+// The same sink is called concurrently by the disk provider, so it is safe for
+// concurrent use.
 func (m *MemorySourceProvider) GetParallelSources(ctx context.Context,
-	extensions model.Extensions, sink Sink, resolverSink ResolverSink) error {
-	return m.GetSources(ctx, extensions, sink, resolverSink)
+	extensions model.Extensions, sink Sink, _ ResolverSink) error {
+	// Phase 1: select the eligible files (cheap; no parsing yet).
+	eligible := make([]string, 0, len(m.paths))
+	for _, p := range m.paths {
+		if !extensions.Include(memExtension(p)) {
+			continue
+		}
+		if pathutil.Excluded(p, m.ignorePaths, m.onlyPaths) {
+			continue
+		}
+		eligible = append(eligible, p)
+	}
+
+	// Use the same worker-count policy as the disk provider, capped at the number
+	// of files (no point spawning more workers than there is work).
+	numWorkers := calculateWorkerCount()
+	if numWorkers > len(eligible) {
+		numWorkers = len(eligible)
+	}
+	if numWorkers <= 1 {
+		// Not enough files to be worth the goroutine overhead.
+		return m.GetSources(ctx, extensions, sink, nil)
+	}
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	filesChan := make(chan string, numWorkers*2)
+	errChan := make(chan error, numWorkers)
+	var wg sync.WaitGroup
+
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m.parseWorker(workerCtx, filesChan, errChan, sink)
+		}()
+	}
+
+	go func() {
+		defer close(filesChan)
+		for _, p := range eligible {
+			select {
+			case filesChan <- p:
+			case <-workerCtx.Done():
+				return
+			}
+		}
+	}()
+
+	go func() { wg.Wait(); close(errChan) }()
+
+	var firstErr error
+	for err := range errChan {
+		if err != nil && firstErr == nil {
+			firstErr = err
+			cancel()
+		}
+	}
+	return firstErr
+}
+
+// parseWorker reads and sinks (parses) each path it receives until the channel
+// closes or the context is canceled. The first sink error is reported on errChan
+// (non-blocking) and stops the worker.
+func (m *MemorySourceProvider) parseWorker(ctx context.Context, files <-chan string,
+	errChan chan<- error, sink Sink) {
+	contextLogger := logger.FromContext(ctx)
+	for p := range files {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		content, err := m.fsys.ReadFile(p)
+		if err != nil {
+			contextLogger.Warn().Msgf("memory source provider: could not read pushed file %s: %v", p, err)
+			continue
+		}
+		if err := sink(ctx, p, io.NopCloser(bytes.NewReader(content))); err != nil {
+			select {
+			case errChan <- err:
+			default:
+			}
+			return
+		}
+	}
 }
 
 // memExtension determines a pushed file's extension token from its path alone

--- a/pkg/engine/provider/memory_test.go
+++ b/pkg/engine/provider/memory_test.go
@@ -8,7 +8,10 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -88,4 +91,51 @@ func collect(t *testing.T, p *MemorySourceProvider, exts model.Extensions) map[s
 		t.Fatalf("GetSources: %v", err)
 	}
 	return got
+}
+
+// TestMemorySourceProvider_ParallelMatchesSequential asserts the parallel parse
+// path emits exactly the same file set/content as the sequential path. The
+// parallel sink is mutex-guarded since it is called from multiple workers.
+func TestMemorySourceProvider_ParallelMatchesSequential(t *testing.T) {
+	files := map[string][]byte{}
+	for i := 0; i < 200; i++ {
+		files[fmt.Sprintf("dir%d/main.tf", i)] = []byte(fmt.Sprintf("content-%d", i))
+	}
+	mem := vfs.NewMemFS(files)
+	p := NewMemorySourceProvider(mem, mem.Paths(), nil, nil)
+	exts := model.Extensions{".tf": {}}
+
+	collectConc := func(parallel bool) map[string]string {
+		var mu sync.Mutex
+		got := map[string]string{}
+		sink := func(_ context.Context, filename string, content io.ReadCloser) error {
+			b, _ := io.ReadAll(content)
+			_ = content.Close()
+			mu.Lock()
+			got[filename] = string(b)
+			mu.Unlock()
+			return nil
+		}
+		noop := func(_ context.Context, _ string) ([]string, error) { return nil, nil }
+		var err error
+		if parallel {
+			err = p.GetParallelSources(context.Background(), exts, sink, noop)
+		} else {
+			err = p.GetSources(context.Background(), exts, sink, noop)
+		}
+		if err != nil {
+			t.Fatalf("get sources (parallel=%v): %v", parallel, err)
+		}
+		return got
+	}
+
+	seq := collectConc(false)
+	par := collectConc(true)
+
+	if len(par) != 200 {
+		t.Fatalf("parallel emitted %d files, want 200", len(par))
+	}
+	if !reflect.DeepEqual(seq, par) {
+		t.Fatalf("parallel result differs from sequential")
+	}
 }

--- a/pkg/engine/shared_compiler_test.go
+++ b/pkg/engine/shared_compiler_test.go
@@ -117,6 +117,97 @@ resource "aws_s3_bucket" "plain" {
 		"shared-compiler mode must produce the same findings as isolated mode")
 }
 
+// customInputRule fires only when its result references data read from the
+// query's own InputData (data.expected_acl). If shared mode were to run it
+// against the per-platform base store (which lacks this rule's InputData), the
+// reference would be undefined and the rule would NOT fire — exactly the
+// false-negative the custom-input guard prevents.
+const customInputRule = `package datadog
+
+DatadogPolicy contains result if {
+	some name, i
+	bucket := input.document[i].resource.aws_s3_bucket[name]
+	bucket.acl == data.expected_acl
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_s3_bucket",
+		"resourceName": name,
+		"searchKey": sprintf("aws_s3_bucket[%s].acl", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "acl matched the configured expected_acl",
+		"keyActualValue": sprintf("acl is %s", [bucket.acl]),
+	}
+}
+`
+
+// TestInspect_SharedCompiler_CustomInputData is the regression guard for the
+// review finding: a rule whose Rego reads its custom InputData must produce the
+// SAME findings in shared mode as in isolated mode. Shared mode must fall back
+// to the isolated per-query store for such rules instead of running them against
+// the input-data-less base store.
+func TestInspect_SharedCompiler_CustomInputData(t *testing.T) {
+	root := t.TempDir()
+	mainPath := filepath.Join(root, "main.tf")
+	require.NoError(t, os.WriteFile(mainPath, []byte(`
+resource "aws_s3_bucket" "b" {
+  acl = "public-read"
+}
+`), 0o644))
+
+	// The rule fires only if data.expected_acl == "public-read", which lives in
+	// the rule's InputData (not in any library or base store).
+	queries := []model.QueryMetadata{
+		{Query: "custom_input_rule", Content: customInputRule, InputData: `{"expected_acl":"public-read"}`,
+			Platform: "terraform", Metadata: map[string]interface{}{"id": "custom-input-rule"}, Aggregation: 1},
+	}
+
+	run := func(disableRuleIsolation bool) []model.Vulnerability {
+		files := parseTerraform(t, mainPath)
+		ins := newTestInspector(t, inspectorOpts{
+			queries:              queries,
+			repoPath:             root,
+			vb:                   DefaultVulnerabilityBuilder,
+			disableRuleIsolation: disableRuleIsolation,
+		})
+		vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
+		require.NoError(t, err)
+		require.Empty(t, ins.GetFailedQueries(), "no query should fail")
+		return vulns
+	}
+
+	isolated := run(false)
+	shared := run(true)
+
+	require.NotEmpty(t, isolated, "the rule should fire when its custom InputData is present")
+	require.Equal(t, summarize(isolated), summarize(shared),
+		"a custom-InputData rule must yield identical findings in shared mode (no false negative)")
+}
+
+// TestLoadSharedQueries_ExcludesCustomInput pins the guard directly: a rule with
+// custom InputData must NOT be prepared by the shared compiler (it would use the
+// input-data-less base store); it must be absent from the returned map so the
+// worker falls back to the isolated LoadQuery. A static-input rule alongside it
+// must still be served from the shared compiler.
+func TestLoadSharedQueries_ExcludesCustomInput(t *testing.T) {
+	platform := "terraform"
+	static := staticQuery(platform, "static_rule", "DatadogPolicy contains result if { result := \"x\" }\n")
+	custom := staticQuery(platform, "custom_rule", "DatadogPolicy contains result if { result := \"y\" }\n")
+	custom.InputData = `{"expected_acl":"public-read"}`
+
+	loader := newCacheTestLoader(t, platform, []model.QueryMetadata{static, custom})
+	stores, _ := baseStoresFor(platform, "{}")
+
+	shared := loader.loadSharedQueries(context.Background(), []model.QueryMetadata{static, custom}, stores)
+
+	if _, ok := shared[0]; !ok {
+		t.Errorf("static-input rule (index 0) should be served from the shared compiler")
+	}
+	if _, ok := shared[1]; ok {
+		t.Errorf("custom-input rule (index 1) must be excluded from shared compilation so it falls back to isolated LoadQuery")
+	}
+}
+
 // summarize reduces findings to a comparable, order-independent multiset of the
 // fields a caller/SARIF actually consumes, so the comparison is robust to
 // worker ordering.

--- a/pkg/engine/shared_compiler_test.go
+++ b/pkg/engine/shared_compiler_test.go
@@ -1,0 +1,130 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+// TestSafeCapabilities_BlocksUnsafeBuiltins is the security guard for the
+// WithUnsafeBuiltins -> WithCapabilities migration: a rule referencing an unsafe
+// builtin (http.send / opa.runtime) must still fail to compile under the shared
+// compiler's capabilities, exactly as it did under WithUnsafeBuiltins.
+func TestSafeCapabilities_BlocksUnsafeBuiltins(t *testing.T) {
+	for name := range unsafeRegoFunctions {
+		t.Run(name, func(t *testing.T) {
+			src := "package datadog\nDatadogPolicy contains result if { result := " + name + "({}) }\n"
+			mod, err := ast.ParseModuleWithOpts("rule", src, ast.ParserOptions{RegoVersion: ast.RegoV1})
+			require.NoError(t, err)
+
+			c := ast.NewCompiler().WithCapabilities(safeCapabilities())
+			c.Compile(map[string]*ast.Module{"rule": mod})
+			require.True(t, c.Failed(), "compile must reject the unsafe builtin %q", name)
+		})
+	}
+}
+
+// TestSafeCapabilities_AllowsNormalBuiltins guards the other direction: ordinary
+// builtins the rules rely on (e.g. sprintf) stay available.
+func TestSafeCapabilities_AllowsNormalBuiltins(t *testing.T) {
+	src := "package datadog\nDatadogPolicy contains result if { result := sprintf(\"%d\", [1]) }\n"
+	mod, err := ast.ParseModuleWithOpts("rule", src, ast.ParserOptions{RegoVersion: ast.RegoV1})
+	require.NoError(t, err)
+
+	c := ast.NewCompiler().WithCapabilities(safeCapabilities())
+	c.Compile(map[string]*ast.Module{"rule": mod})
+	require.False(t, c.Failed(), "compile must allow safe builtins: %v", c.Errors)
+}
+
+// secondRule is a second self-contained rule, distinct from aclRule, so the
+// shared-compiler path must keep multiple rules independently addressable
+// (the whole point of the per-rule package rename).
+const secondRule = `package datadog
+
+DatadogPolicy contains result if {
+	some name, i
+	bucket := input.document[i].resource.aws_s3_bucket[name]
+	not bucket.versioning
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_s3_bucket",
+		"resourceName": name,
+		"searchKey": sprintf("aws_s3_bucket[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "versioning should be set",
+		"keyActualValue": "versioning is not set",
+	}
+}
+`
+
+// TestInspect_SharedCompiler_MatchesIsolated runs the same files + rules through
+// both the isolated path (default) and the shared-compiler path
+// (disableRuleIsolation), and asserts the findings are identical — the opt-in
+// flag must never change results, only memory/compilation.
+func TestInspect_SharedCompiler_MatchesIsolated(t *testing.T) {
+	root := t.TempDir()
+	stackDir := filepath.Join(root, "stack")
+	require.NoError(t, os.MkdirAll(stackDir, 0o755))
+	mainPath := filepath.Join(stackDir, "main.tf")
+	require.NoError(t, os.WriteFile(mainPath, []byte(`
+resource "aws_s3_bucket" "public" {
+  acl = "public-read"
+}
+
+resource "aws_s3_bucket" "plain" {
+  bucket = "x"
+}
+`), 0o644))
+
+	queries := []model.QueryMetadata{
+		{Query: "acl_rule", Content: aclRule, InputData: "{}", Platform: "terraform",
+			Metadata: map[string]interface{}{"id": "acl-rule"}, Aggregation: 1},
+		{Query: "versioning_rule", Content: secondRule, InputData: "{}", Platform: "terraform",
+			Metadata: map[string]interface{}{"id": "versioning-rule"}, Aggregation: 1},
+	}
+
+	run := func(disableRuleIsolation bool) []model.Vulnerability {
+		files := parseTerraform(t, mainPath)
+		ins := newTestInspector(t, inspectorOpts{
+			queries:              queries,
+			repoPath:             root,
+			vb:                   DefaultVulnerabilityBuilder,
+			disableRuleIsolation: disableRuleIsolation,
+		})
+		vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
+		require.NoError(t, err)
+		require.Empty(t, ins.GetFailedQueries(), "no query should fail")
+		return vulns
+	}
+
+	isolated := run(false)
+	shared := run(true)
+
+	require.NotEmpty(t, isolated, "the crafted file should trigger findings")
+	require.Equal(t, summarize(isolated), summarize(shared),
+		"shared-compiler mode must produce the same findings as isolated mode")
+}
+
+// summarize reduces findings to a comparable, order-independent multiset of the
+// fields a caller/SARIF actually consumes, so the comparison is robust to
+// worker ordering.
+func summarize(vulns []model.Vulnerability) map[string]int {
+	m := make(map[string]int)
+	for _, v := range vulns {
+		key := v.QueryID + "|" + v.QueryName + "|" + v.ResourceType + "|" + v.ResourceName + "|" + v.KeyActualValue
+		m[key]++
+	}
+	return m
+}

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -749,12 +750,17 @@ func generateEquivalentMap(ctx context.Context, fsys vfs.FS, modulePath string) 
 		}
 	}
 
-	// After iterating through all files and blocks, populate the unique resources slice
+	// After iterating through all files and blocks, populate the unique resources
+	// slice. Sort it so the result is deterministic across runs: it is built from
+	// a map, and unstable ordering otherwise yields byte-different module input
+	// data each scan (which defeats the compiled-query cache and makes output
+	// non-reproducible).
 	for provider, typesSet := range resourceTypesMap {
 		modInfo := equivalentMap[provider]
 		for rt := range typesSet {
 			modInfo.Resources = append(modInfo.Resources, rt)
 		}
+		sort.Strings(modInfo.Resources)
 		equivalentMap[provider] = modInfo
 	}
 

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -56,6 +56,8 @@ type Parameters struct {
 	FlagEvaluator               featureflags.FlagEvaluator
 	Config                      config.IacConfig
 	ShouldScanTfPlans           bool
+	DisableRuleIsolation        bool
+	UseRulesCache               bool
 }
 
 func (p *Parameters) GetEffectivePlatforms() []string {

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -97,6 +97,8 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		c.ScanParams.ParallelScanFlag,
 		c.ScanParams.FlagEvaluator,
 		c.fsys,
+		c.ScanParams.DisableRuleIsolation,
+		c.ScanParams.UseRulesCache,
 	)
 	metrics.Metric.Stop()
 	if err != nil {

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -48,6 +48,8 @@ func createServices(types, cloudProviders []string) (serviceSlice, *storage.Memo
 		t, &source.QueryInspectorParameters{}, nil, ".", true, true, 1,
 		featureflags.NewLocalEvaluator(),
 		vfs.DiskFS{},
+		false,
+		false,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -27,10 +27,10 @@ import (
 )
 
 const (
-	// maxFiles / maxRules bound a single analyze request. The default rule corpus
-	// is ~1200 rules; the limits are generous headroom, not a tuning knob.
-	maxFiles = 5000
-	maxRules = 10000
+	// maxRules bounds the number of rules in a single analyze request. The
+	// default rule corpus is ~1200 rules; this is generous headroom. The file
+	// limit is configurable per-server (Config.MaxFiles), so it is passed in.
+	maxRules = defaultMaxRules
 	// metadataDefaultKeys is the number of fixed keys setDefault injects in
 	// toQueryMetadata (id, legacyId, queryName, severity, platform, category).
 	metadataDefaultKeys = 6
@@ -88,7 +88,7 @@ func (s *Server) handleAnalyze(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBytes)
+	r.Body = http.MaxBytesReader(w, r.Body, s.cfg.MaxRequestBytes)
 	var req analyzeRequest
 	// Deliberately not DisallowUnknownFields: tolerating unknown fields lets a
 	// newer extension talk to an older binary (forward compatibility).
@@ -102,7 +102,7 @@ func (s *Server) handleAnalyze(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := validateAnalyzeRequest(&req); err != nil {
+	if err := validateAnalyzeRequest(&req, s.cfg.MaxFiles); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -116,7 +116,7 @@ func (s *Server) handleAnalyze(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
-func validateAnalyzeRequest(req *analyzeRequest) error {
+func validateAnalyzeRequest(req *analyzeRequest, maxFiles int) error {
 	if len(req.Files) == 0 {
 		return errors.New("at least one file is required")
 	}

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -198,12 +198,15 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 		MaxResolverDepth: 15,
 		// Helm rendering shells out to a chart on disk, which content-push mode
 		// has no way to materialize, so disable the resolver. Parallel file
-		// parsing is pointless for in-memory content.
+		// parsing fans the per-file parse across CPUs; off unless the server
+		// opts in via --x-parallelparsing.
 		FlagEvaluator: featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
 			featureflags.IacEnableKicsHelmResolver:        false,
-			featureflags.IaCEnableKicsParallelFileParsing: false,
+			featureflags.IaCEnableKicsParallelFileParsing: s.cfg.ParallelParsing,
 		}),
-		Config: cfg,
+		Config:               cfg,
+		DisableRuleIsolation: s.cfg.DisableRuleIsolation,
+		UseRulesCache:        s.cfg.UseRulesCache,
 	}
 
 	client, err := scan.NewClient(ctx, params, &consolePrinter.Printer{},

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -209,6 +209,52 @@ func TestAnalyze_Validation(t *testing.T) {
 	}
 }
 
+// TestConfigDefaults checks that New applies the documented defaults for the
+// configurable limits/timeouts, including the negative-WriteTimeout "disabled"
+// sentinel.
+func TestConfigDefaults(t *testing.T) {
+	s := New(&Config{})
+	if s.cfg.MaxFiles != defaultMaxFiles {
+		t.Errorf("MaxFiles default = %d, want %d", s.cfg.MaxFiles, defaultMaxFiles)
+	}
+	if s.cfg.WriteTimeout != defaultWriteTimeout {
+		t.Errorf("WriteTimeout default = %v, want %v", s.cfg.WriteTimeout, defaultWriteTimeout)
+	}
+	if s.http.WriteTimeout != defaultWriteTimeout {
+		t.Errorf("http.WriteTimeout = %v, want %v", s.http.WriteTimeout, defaultWriteTimeout)
+	}
+
+	// Negative WriteTimeout disables the timeout entirely.
+	sd := New(&Config{WriteTimeout: -1})
+	if sd.http.WriteTimeout != 0 {
+		t.Errorf("disabled WriteTimeout: http.WriteTimeout = %v, want 0", sd.http.WriteTimeout)
+	}
+
+	// Explicit values are honored.
+	sc := New(&Config{MaxFiles: 7, WriteTimeout: 42 * time.Second})
+	if sc.cfg.MaxFiles != 7 || sc.http.WriteTimeout != 42*time.Second {
+		t.Errorf("explicit config not honored: MaxFiles=%d WriteTimeout=%v", sc.cfg.MaxFiles, sc.http.WriteTimeout)
+	}
+}
+
+// TestAnalyze_MaxFilesEnforced confirms the per-server MaxFiles cap rejects an
+// over-limit request with 400.
+func TestAnalyze_MaxFilesEnforced(t *testing.T) {
+	s := New(&Config{MaxFiles: 2})
+	ts := httptest.NewServer(s.http.Handler)
+	defer ts.Close()
+
+	body := `{"files":[{"path":"a.tf","content":"x"},{"path":"b.tf","content":"x"},{"path":"c.tf","content":"x"}],"rules":[]}`
+	resp, err := http.Post(ts.URL+"/ide/v1/iac/analyze", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("3 files with MaxFiles=2: status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
 // TestLifecycle_Contract checks the SAST-mirrored lifecycle contract: /ping
 // returns "pong", standard + CORS headers are present, and /shutdown is gated by
 // --enable-shutdown.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -78,6 +78,18 @@ type Config struct {
 	// MaxConcurrentAnalyze caps simultaneous /analyze scans. <= 0 applies
 	// defaultMaxConcurrentAnalyze.
 	MaxConcurrentAnalyze int
+	// DisableRuleIsolation opts into the engine's shared-compiler mode (rules +
+	// libraries co-compiled once) instead of isolating each rule. Lowers memory
+	// substantially at the cost of per-rule compile-failure isolation.
+	DisableRuleIsolation bool
+	// UseRulesCache enables the process-global compiled-query cache so repeated
+	// /analyze scans reuse compiled rules (warm scans skip recompilation, at the
+	// cost of retained memory). Maps to the --use-rules-cache server flag.
+	UseRulesCache bool
+	// ParallelParsing fans the per-file parse across CPUs for pushed content.
+	// Measured ~26% faster wall-clock on a 950-file push; same CPU total. Maps
+	// to the experimental --x-parallelparsing server flag.
+	ParallelParsing bool
 }
 
 // Server is the IaC analysis HTTP server.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -56,14 +56,25 @@ const (
 	// keepAlivePollInterval matches the static-analyzer server's idle-check
 	// cadence: it polls for inactivity every 5s.
 	keepAlivePollInterval = 5 * time.Second
-	// maxRequestBytes caps a single request body (applied by body-reading
-	// handlers via http.MaxBytesReader). 32 MiB comfortably fits a directory of
-	// IaC files plus the pushed rule corpus.
-	maxRequestBytes = 32 << 20
+	// defaultMaxRequestBytes caps a single request body (applied by body-reading
+	// handlers via http.MaxBytesReader). 32 MiB comfortably fits most directories
+	// of IaC files plus the pushed rule corpus; raise it via Config.MaxRequestBytes
+	// for very large monorepos. Note the cap is on the JSON-encoded body, which is
+	// larger than the raw file bytes (escaping).
+	defaultMaxRequestBytes = 32 << 20
 	// defaultMaxConcurrentAnalyze bounds how many /analyze scans run at once.
 	// Each scan buffers up to maxRequestBytes and spins worker goroutines, so an
 	// unbounded burst could exhaust memory/goroutines.
 	defaultMaxConcurrentAnalyze = 4
+	// defaultWriteTimeout bounds how long a response write may take, so a client
+	// that stops reading cannot pin a handler goroutine indefinitely. It is
+	// generous because a cold scan recompiles the whole rule corpus (seconds) and
+	// can be larger still on huge repos; tune via Config.WriteTimeout. 0 disables.
+	defaultWriteTimeout = 10 * time.Minute
+	// defaultMaxFiles bounds the number of files in a single /analyze request.
+	defaultMaxFiles = 50000
+	// defaultMaxRules bounds the number of rules in a single /analyze request.
+	defaultMaxRules = 10000
 )
 
 // Config holds the server's runtime settings, populated from the serve command's
@@ -90,6 +101,17 @@ type Config struct {
 	// Measured ~26% faster wall-clock on a 950-file push; same CPU total. Maps
 	// to the experimental --x-parallelparsing server flag.
 	ParallelParsing bool
+	// WriteTimeout bounds how long writing a response may take, so a client that
+	// stops reading cannot hold a handler goroutine indefinitely. Zero applies
+	// defaultWriteTimeout; a NEGATIVE value disables the timeout entirely (mapped
+	// to http.Server.WriteTimeout = 0). Maps to the --write-timeout server flag.
+	WriteTimeout time.Duration
+	// MaxFiles caps the number of files in a single /analyze request. <= 0
+	// applies defaultMaxFiles. Maps to the --max-files server flag.
+	MaxFiles int
+	// MaxRequestBytes caps the JSON-encoded /analyze request body. <= 0 applies
+	// defaultMaxRequestBytes. Maps to the --max-request-mib server flag.
+	MaxRequestBytes int64
 }
 
 // Server is the IaC analysis HTTP server.
@@ -138,6 +160,18 @@ func New(cfg *Config) *Server {
 	if cfg.MaxConcurrentAnalyze <= 0 {
 		cfg.MaxConcurrentAnalyze = defaultMaxConcurrentAnalyze
 	}
+	switch {
+	case cfg.WriteTimeout == 0:
+		cfg.WriteTimeout = defaultWriteTimeout
+	case cfg.WriteTimeout < 0:
+		cfg.WriteTimeout = 0 // explicitly disabled
+	}
+	if cfg.MaxFiles <= 0 {
+		cfg.MaxFiles = defaultMaxFiles
+	}
+	if cfg.MaxRequestBytes <= 0 {
+		cfg.MaxRequestBytes = defaultMaxRequestBytes
+	}
 	s := &Server{
 		cfg:          *cfg,
 		analyzeSem:   make(chan struct{}, cfg.MaxConcurrentAnalyze),
@@ -164,8 +198,7 @@ func New(cfg *Config) *Server {
 		ReadHeaderTimeout: readHeaderTimeout,
 		ReadTimeout:       readTimeout,
 		IdleTimeout:       idleTimeout,
-		// No WriteTimeout: a cold scan recompiles the rule corpus and can take
-		// several seconds until the prepared-query cache lands.
+		WriteTimeout:      cfg.WriteTimeout,
 	}
 	return s
 }


### PR DESCRIPTION
## Motivation

In server mode (`serve`), one process handles many `/analyze` requests, but today every request rebuilds the full scan pipeline from scratch, it recompiles all rules, re-parses libraries, and discards the result. Warm scans are therefore as slow as cold ones, dominated by redundant per-request Rego compilation rather than the work that actually changed.

This PR makes repeated server-mode scans fast by eliminating that redundant work, behind opt-in experimental flags. The default path and the CLI are unchanged.

JIRA Ticket [K9CODESEC-2670](https://datadoghq.atlassian.net/browse/K9CODESEC-2670)

## Changes

Three independent, opt-in server-mode optimizations plus a correctness fix:

- **Compiled-rule cache** (`--x-use-rules-cache`): process-global cache of compiled OPA queries, keyed by rule identity + library hash + base-store data hash. Warm scans reuse compiled rules and skip recompilation. Off by default; never enabled for one-shot CLI scans (pure memory cost there). Cache keys use `xxhash` (allocation-free on the hot path).
- **Shared compilation** (`--x-disable-rule-isolation`): co-compile all rules + libraries once into a single compiler (rules rewritten to unique packages) instead of isolating each rule, so the shared library AST is retained once rather than copied into every compiled query. Rules that fail to parse/compile fall back to isolated compilation, preserving correctness. Uses `WithCapabilities` (not the deprecated `WithUnsafeBuiltins`) to keep `http.send` / `opa.runtime` blocked.
- **Parallel file parsing** (`--x-parallelparsing`): fan the per-file parse across CPUs in the in-memory source provider. Reuses the existing provider worker-count policy.
- **Deterministic Terraform module data**: sort the module `Resources` slice so merged module input data is byte-stable across scans. Required for the compiled-rule cache to hit when modules are present, and a reproducibility fix in its own right.

| Config (flags)                                   | Warm wall-clock   | CPU (start_scan) | Live heap |
|--------------------------------------------------|-------------------|------------------|-----------|
| **baseline** (none)                              | 1.96 s            | 17.0 s           | ~33 MB    |
| `--x-use-rules-cache`                            | 0.43 s (−78%)     | 1.40 s (−92%)    | **590 MB**|
| `--x-disable-rule-isolation`                     | 0.76 s (−61%)     | 1.63 s (−90%)    | 54 MB     |
| `--x-parallelparsing`                            | 2.17 s (~0%)      | 18.3 s           | ~30 MB    |
| `--x-use-rules-cache --x-disable-rule-isolation` | 0.73 s (−63%)     | 1.68 s (−90%)    | 54 MB     |
| **all three**                                    | **0.65 s (−67%)** | 1.70 s (−90%)    | **53 MB** |

Reading the table:

- **Cache alone** is the biggest single speed win (−78% warm) but retains every isolated compiled query → **590 MB**. This is the memory problem.
- **Disabling isolation is what tames that memory**: cache + shared compilation is just as fast but drops the heap from **590 MB → 54 MB (~11× less)**, because the library AST is retained once instead of ~687 times.
- **Parallel parsing alone does nothing** (parsing isn't the bottleneck while compilation dominates), but adds a further ~13% once compilation is cached away (0.73 s → 0.65 s).

**Bottom line (all flags on):** warm scans go from **1.96 s → 0.65 s (−67%)** and CPU from **17 s → 1.7 s (−90%)**, while live heap stays at **~53 MB** — only ~20 MB above the no-cache baseline and **~11× below** caching-with-isolation. Disabling rule isolation is the lever that makes the cache affordable.


## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

All flags are off by default; the default scan path and CLI are unchanged, so existing behavior should be byte-identical.

To verify the optimizations in server mode:

1. Build: `make build`.
2. Start a server: `./bin/datadog-iac-scanner serve --port 8000 --enable-shutdown` (optionally with `--x-use-rules-cache --x-disable-rule-isolation --x-parallelparsing`).
3. POST a repo + rules to `/ide/v1/iac/analyze` twice and confirm:
   - **Findings are identical** with and without the flags (the key correctness check).
   - With `--x-use-rules-cache`, the **second (warm)** request is dramatically faster than the first.
   - With `--x-disable-rule-isolation`, the server logs `Rule isolation disabled: N/N queries served from shared compiler`.

## Blast Radius

Datadog IaC Scanner only. The changes are gated behind experimental, hidden flags that default off; with no flags set, the engine, CLI, and existing server behavior are unchanged. The one always-on change is sorting the Terraform module `Resources` slice, it makes module input data deterministic (correctness/repro improvement) and does not change findings.

## Additional Notes

- The compiled-rule cache is currently unbounded (no eviction/size cap). So if you do use `-x-use-rules-cache` you also must use `--x-disable-rule-isolation`
- Flags are intentionally experimental/hidden

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.


[K9CODESEC-2670]: https://datadoghq.atlassian.net/browse/K9CODESEC-2670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ