### PR TITLE
Deduplicate synthetic module docs by resolved content to shrink OPA input on large repos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.1
 	github.com/aws/aws-sdk-go-v2 v1.41.2
 	github.com/bigkevmcd/go-configparser v0.0.0-20251110123434-de62ed489b4f
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/emicklei/proto v1.14.3
 	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1
 	github.com/golang/mock v1.6.0
@@ -61,7 +62,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -300,7 +300,7 @@ func (c *Inspector) Inspect(
 	contextLogger.Debug().Msg("engine.Inspect()")
 
 	// Local modules: append synthetic file rows (ids match docs) for attribution and fingerprints.
-	moduleDocs, syntheticFiles := c.instantiateLocalModules(ctx, files)
+	moduleDocs, syntheticFiles, moduleExtras := c.instantiateLocalModules(ctx, files)
 	files = append(files, syntheticFiles...)
 
 	// Must run before Combine: instantiateLocalModules clears suppressed file bodies in place.
@@ -395,7 +395,29 @@ loop:
 	for vulnerability, number := range moduleVulns {
 		contextLogger.Info().Msgf("Found %d of module vulnerability %s", number, vulnerability)
 	}
+
+	vulnerabilities = expandModuleFindings(vulnerabilities, moduleExtras)
+
 	return vulnerabilities, nil
+}
+
+// expandModuleFindings clones findings from deduplicated OPA docs back to each
+// extra caller, so every call-site gets its own fingerprint/file attribution.
+func expandModuleFindings(vulns []model.Vulnerability, extras map[string][]extraCallerInfo) []model.Vulnerability {
+	if len(extras) == 0 {
+		return vulns
+	}
+	expanded := make([]model.Vulnerability, 0, len(vulns))
+	for i := range vulns {
+		expanded = append(expanded, vulns[i])
+		for _, ex := range extras[vulns[i].FileID] {
+			vCopy := vulns[i]
+			vCopy.ModuleCallChain = ex.callChain
+			vCopy.FileID = ex.docID
+			expanded = append(expanded, vCopy)
+		}
+	}
+	return expanded
 }
 
 // nolint:gocritic

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -7,8 +7,6 @@ package engine
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"path/filepath"
 	"strconv"
@@ -18,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/tfeval"
+	"github.com/cespare/xxhash/v2"
 )
 
 // extraCallerInfo records a deduplicated module caller so its findings can be
@@ -260,17 +259,14 @@ func newInstanceFileMetadata(fm *model.FileMetadata, id, callChain string) *mode
 	return &clone
 }
 
-// resourceAttrKey returns a SHA-256 hex digest of a resolved resource's attributes,
-// used as the content key for dedup. SHA-256 matches the hash strength used by
-// GetDatadogFingerprintHash and avoids collisions from a weaker polynomial hash.
+// resourceAttrKey hashes resolved attributes for in-scan content dedup only (not fingerprints).
 func resourceAttrKey(r *tfeval.ResolvedResource) string {
 	attrs := tfeval.AttributesToDocument(r)
 	b, err := json.Marshal(attrs)
 	if err != nil {
 		return ""
 	}
-	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:])
+	return strconv.FormatUint(xxhash.Sum64(b), 16)
 }
 
 // callChainKey is repo-relative outer caller + "|" + module address (no line numbers, to keep fingerprints stable).

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -221,8 +221,12 @@ func instantiatedDocs(
 		cck := callChainKey(r, repoPath)
 		docID := strings.Join([]string{fm.ID, cck, r.Name}, "\x00")
 
-		// Dedupe by resource content: identical resolved attributes from different callers collapse
-		// to a single OPA doc (saving eval cost on quadratic rules); findings are cloned after eval.
+		// Dedupe by resource content: identical resolved attributes reached through different
+		// call chains collapse to a single OPA doc (saving eval cost on quadratic rules); findings
+		// are cloned per caller after eval. The key includes ModuleAddress, so distinct module
+		// instances within one configuration (module.a vs module.b, count/for_each indices) always
+		// get distinct keys and are never merged. Cardinality is therefore preserved within a
+		// configuration; only the same module resource re-reached from another root collapses.
 		contentKey := strings.Join([]string{abs, r.ModuleAddress, r.Type, r.Name, strconv.Itoa(r.DefLine), resourceAttrKey(r)}, "\x00")
 		if primaryDocID, duplicate := seen[contentKey]; duplicate {
 			extras[primaryDocID] = append(extras[primaryDocID], extraCallerInfo{callChain: cck, docID: docID})

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -7,6 +7,9 @@ package engine
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -16,6 +19,23 @@ import (
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/tfeval"
 )
+
+// extraCallerInfo records a deduplicated module caller so its findings can be
+// cloned from the primary OPA doc after eval without adding a separate doc to input.document.
+type extraCallerInfo struct {
+	callChain string
+	docID     string
+}
+
+// moduleResolutionResult bundles all outputs of resolveModuleDocuments.
+type moduleResolutionResult struct {
+	docs           []model.Document
+	syntheticFiles []*model.FileMetadata
+	suppressed     map[string]bool
+	calledDirs     map[string]bool
+	extras         map[string][]extraCallerInfo
+	ok             bool
+}
 
 // instantiateLocalModules evaluates local modules and injects resolved resource
 // documents. In a called module body only the resource blocks are dropped (they
@@ -34,16 +54,16 @@ import (
 func (c *Inspector) instantiateLocalModules(
 	ctx context.Context,
 	files model.FileMetadatas,
-) ([]model.Document, []*model.FileMetadata) {
-	moduleDocs, syntheticFiles, suppressed, calledDirs, ok := c.resolveModulesSafely(ctx, files)
-	if !ok {
-		return nil, nil
+) ([]model.Document, []*model.FileMetadata, map[string][]extraCallerInfo) {
+	res := c.resolveModulesSafely(ctx, files)
+	if !res.ok {
+		return nil, nil, nil
 	}
 	for _, f := range files {
 		if f == nil || !isTerraformFile(f.FilePath) {
 			continue
 		}
-		if suppressed[f.ID] {
+		if res.suppressed[f.ID] {
 			// Resource blocks are re-emitted as instantiated synthetic docs, so
 			// drop only those to avoid double-counting; keep the rest of the body
 			// (variable/output/data/locals) so those rules still fire.
@@ -52,15 +72,20 @@ func (c *Inspector) instantiateLocalModules(
 		}
 		// Only remove local module call-sites that were instantiated; remote/registry
 		// module blocks must remain so the corresponding Rego branches can still fire.
-		stripLocalModuleCalls(f.Document, f.FilePath, c.repoPath, calledDirs)
+		stripLocalModuleCalls(f.Document, f.FilePath, c.repoPath, res.calledDirs)
 	}
 	contextLogger := logger.FromContext(ctx)
-	if len(moduleDocs) > 0 {
-		contextLogger.Info().Msgf("Instantiated %d local module resources", len(moduleDocs))
+	totalCallers := len(res.docs)
+	for _, ex := range res.extras {
+		totalCallers += len(ex)
+	}
+	if totalCallers > 0 {
+		contextLogger.Info().Msgf("Instantiated %d module resources (%d unique OPA docs, %d deduplicated callers)",
+			totalCallers, len(res.docs), totalCallers-len(res.docs))
 	} else {
 		contextLogger.Debug().Msg("Instantiated 0 local module resources")
 	}
-	return moduleDocs, syntheticFiles
+	return res.docs, res.syntheticFiles, res.extras
 }
 
 // resolveModulesSafely runs the panic-prone module evaluation under a recover so
@@ -70,14 +95,14 @@ func (c *Inspector) instantiateLocalModules(
 func (c *Inspector) resolveModulesSafely(
 	ctx context.Context,
 	files model.FileMetadatas,
-) (moduleDocs []model.Document, syntheticFiles []*model.FileMetadata, suppressed, calledDirs map[string]bool, ok bool) {
+) (res moduleResolutionResult) {
 	defer func() {
 		if r := recover(); r != nil {
 			contextLogger := logger.FromContext(ctx)
 			contextLogger.Error().Interface("panic", r).Msg(
 				"instantiateLocalModules: recovered from panic; skipping synthetic module docs",
 			)
-			moduleDocs, syntheticFiles, suppressed, calledDirs, ok = nil, nil, nil, nil, false
+			res = moduleResolutionResult{}
 		}
 	}()
 	return resolveModuleDocuments(ctx, files, c.repoPath)
@@ -96,10 +121,10 @@ func resolveModuleDocuments(
 	ctx context.Context,
 	files model.FileMetadatas,
 	repoPath string,
-) (extra []model.Document, syntheticFiles []*model.FileMetadata, suppressed, calledDirs map[string]bool, ok bool) {
+) moduleResolutionResult {
 	byAbsPath, filesByDir, dirsWithTf := indexTerraformFiles(ctx, files, repoPath)
 	if len(dirsWithTf) == 0 {
-		return nil, nil, nil, nil, false
+		return moduleResolutionResult{}
 	}
 
 	// staticCalledDirs is used only to classify root vs. child dirs before evaluation.
@@ -113,9 +138,14 @@ func resolveModuleDocuments(
 
 	contextLogger := logger.FromContext(ctx)
 	evaluator := tfeval.New()
-	seen := make(map[string]bool)
+	// seen maps a content-based key to the primary docID so duplicate callers can
+	// be recorded in extras rather than emitted as separate OPA documents.
+	seen := make(map[string]string)
+	extras := make(map[string][]extraCallerInfo)
 	var rootEvalOK bool
 	actualCalledDirs := make(map[string]bool)
+	var extra []model.Document
+	var syntheticFiles []*model.FileMetadata
 
 	for dir := range dirsWithTf {
 		if staticCalledDirs[dir] {
@@ -130,9 +160,7 @@ func resolveModuleDocuments(
 		for d := range childDirs {
 			actualCalledDirs[d] = true
 		}
-		// evalRootDir distinguishes the same child module reached from different roots
-		// (different variable bindings) so synthetic documents are not incorrectly deduped.
-		docs, syn := instantiatedDocs(resources, byAbsPath, repoPath, seen, dir)
+		docs, syn := instantiatedDocs(resources, byAbsPath, repoPath, seen, extras)
 		extra = append(extra, docs...)
 		syntheticFiles = append(syntheticFiles, syn...)
 	}
@@ -140,10 +168,10 @@ func resolveModuleDocuments(
 	// If every root evaluation failed, do not strip or suppress module bodies: that would
 	// remove coverage with no synthetic replacement.
 	if !rootEvalOK {
-		return nil, nil, nil, nil, false
+		return moduleResolutionResult{}
 	}
 
-	suppressed = make(map[string]bool)
+	suppressed := make(map[string]bool)
 	for dir := range actualCalledDirs {
 		for _, f := range filesByDir[dir] {
 			suppressed[f.ID] = true
@@ -158,17 +186,26 @@ func resolveModuleDocuments(
 		}
 	}
 
-	return extra, syntheticFiles, suppressed, strippedDirs, true
+	return moduleResolutionResult{
+		docs:           extra,
+		syntheticFiles: syntheticFiles,
+		suppressed:     suppressed,
+		calledDirs:     strippedDirs,
+		extras:         extras,
+		ok:             true,
+	}
 }
 
 // instantiatedDocs builds one synthetic doc + FileMetadata per resolved module resource (skips root / out-of-scope).
-// seen dedupes across eval roots. Doc id is file id + call chain + instance; synthetic row carries ModuleCallChain for hashing.
+// Callers with identical resolved attributes share a single OPA doc; the extras map records duplicate callers so
+// their findings can be cloned after OPA eval. Doc id is file id + call chain + instance;
+// synthetic row carries ModuleCallChain for hashing.
 func instantiatedDocs(
 	resources []tfeval.ResolvedResource,
 	byAbsPath map[string]*model.FileMetadata,
 	repoPath string,
-	seen map[string]bool,
-	evalRootDir string,
+	seen map[string]string,
+	extras map[string][]extraCallerInfo,
 ) (docs []model.Document, synthetic []*model.FileMetadata) {
 	for i := range resources {
 		r := &resources[i]
@@ -180,14 +217,18 @@ func instantiatedDocs(
 		if !ok {
 			continue
 		}
-		key := strings.Join([]string{evalRootDir, abs, r.ModuleAddress, r.Type, r.Name, strconv.Itoa(r.DefLine)}, "\x00")
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
 
 		cck := callChainKey(r, repoPath)
 		docID := strings.Join([]string{fm.ID, cck, r.Name}, "\x00")
+
+		// Dedupe by resource content: identical resolved attributes from different callers collapse
+		// to a single OPA doc (saving eval cost on quadratic rules); findings are cloned after eval.
+		contentKey := strings.Join([]string{abs, r.ModuleAddress, r.Type, r.Name, strconv.Itoa(r.DefLine), resourceAttrKey(r)}, "\x00")
+		if primaryDocID, duplicate := seen[contentKey]; duplicate {
+			extras[primaryDocID] = append(extras[primaryDocID], extraCallerInfo{callChain: cck, docID: docID})
+			continue
+		}
+		seen[contentKey] = docID
 
 		// Use the bare resource label (not the expanded name like k[0]) so that
 		// Rego rules matching input.document[_].resource.TYPE.NAME find the resource.
@@ -213,6 +254,19 @@ func newInstanceFileMetadata(fm *model.FileMetadata, id, callChain string) *mode
 	clone.Document = model.Document{}
 	clone.ModuleCallChain = callChain
 	return &clone
+}
+
+// resourceAttrKey returns a SHA-256 hex digest of a resolved resource's attributes,
+// used as the content key for dedup. SHA-256 matches the hash strength used by
+// GetDatadogFingerprintHash and avoids collisions from a weaker polynomial hash.
+func resourceAttrKey(r *tfeval.ResolvedResource) string {
+	attrs := tfeval.AttributesToDocument(r)
+	b, err := json.Marshal(attrs)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
 }
 
 // callChainKey is repo-relative outer caller + "|" + module address (no line numbers, to keep fingerprints stable).

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -198,6 +198,94 @@ resource "aws_s3_bucket" "this" {
 	require.Len(t, chains, 2, "the two callers must produce distinct module call chains")
 }
 
+// aggregateCountRule fires once when two or more aws_s3_bucket resources are
+// present in the document set. It mirrors a cardinality/aggregate rule whose
+// result depends on how many matching resources exist, the class of rule the
+// content-dedup must not silently break.
+const aggregateCountRule = `package datadog
+
+DatadogPolicy contains result if {
+	buckets := [name | input.document[_].resource.aws_s3_bucket[name]]
+	count(buckets) >= 2
+
+	result := {
+		"documentId": input.document[0].id,
+		"resourceType": "aws_s3_bucket",
+		"resourceName": "multiple",
+		"searchKey": "aws_s3_bucket",
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "at most one bucket",
+		"keyActualValue": "two or more buckets",
+	}
+}
+`
+
+// TestInspect_AggregateRuleCardinalityPreservedWithinConfig verifies that an
+// aggregate rule that counts resources still sees every distinct module instance
+// within a single configuration. Two module calls in one root resolve to the same
+// attributes but distinct module addresses, so content-dedup keeps both documents
+// and the count-based rule fires, no cardinality is lost.
+func TestInspect_AggregateRuleCardinalityPreservedWithinConfig(t *testing.T) {
+	root := t.TempDir()
+
+	rootDir := filepath.Join(root, "stack")
+	modDir := filepath.Join(root, "modules", "bucket")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+
+	rootPath := filepath.Join(rootDir, "main.tf")
+	modPath := filepath.Join(modDir, "main.tf")
+
+	// Two distinct module instances with identical inputs in the same root.
+	require.NoError(t, os.WriteFile(rootPath, []byte(`
+module "bucket_a" {
+  source = "../modules/bucket"
+  acl    = "public-read"
+}
+
+module "bucket_b" {
+  source = "../modules/bucket"
+  acl    = "public-read"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(modPath, []byte(`
+variable "acl" {
+  type = string
+}
+
+resource "aws_s3_bucket" "this" {
+  acl = var.acl
+}
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, rootPath)...)
+	files = append(files, parseTerraform(t, modPath)...)
+
+	queries := []model.QueryMetadata{{
+		Query:       "aggregate_count_rule",
+		Content:     aggregateCountRule,
+		InputData:   "{}",
+		Platform:    "terraform",
+		Metadata:    map[string]interface{}{"id": "aggregate-count-rule"},
+		Aggregation: 1,
+	}}
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
+	})
+
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries())
+
+	// Both module instances survive dedup (distinct module addresses), so the
+	// count-based rule sees two buckets and fires.
+	require.Len(t, vulns, 1, "aggregate rule must see both bucket instances and fire")
+}
+
 // variableTypeRule fires on a variable declaration that has no type, mirroring
 // real rules that match non-resource blocks (variable/output/data/locals).
 const variableTypeRule = `package datadog

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -198,10 +198,7 @@ resource "aws_s3_bucket" "this" {
 	require.Len(t, chains, 2, "the two callers must produce distinct module call chains")
 }
 
-// aggregateCountRule fires once when two or more aws_s3_bucket resources are
-// present in the document set. It mirrors a cardinality/aggregate rule whose
-// result depends on how many matching resources exist, the class of rule the
-// content-dedup must not silently break.
+// aggregateCountRule fires when two or more aws_s3_bucket resources exist in the scan.
 const aggregateCountRule = `package datadog
 
 DatadogPolicy contains result if {
@@ -220,12 +217,9 @@ DatadogPolicy contains result if {
 }
 `
 
-// TestInspect_AggregateRuleCardinalityPreservedWithinConfig verifies that an
-// aggregate rule that counts resources still sees every distinct module instance
-// within a single configuration. Two module calls in one root resolve to the same
-// attributes but distinct module addresses, so content-dedup keeps both documents
-// and the count-based rule fires, no cardinality is lost.
-func TestInspect_AggregateRuleCardinalityPreservedWithinConfig(t *testing.T) {
+// Distinct module instances in one root (bucket_a vs bucket_b) are not merged;
+// an aggregate rule still sees both buckets. Does not exercise cross-root dedup.
+func TestInspect_WithinConfigDistinctModuleInstancesNotMerged(t *testing.T) {
 	root := t.TempDir()
 
 	rootDir := filepath.Join(root, "stack")
@@ -236,7 +230,7 @@ func TestInspect_AggregateRuleCardinalityPreservedWithinConfig(t *testing.T) {
 	rootPath := filepath.Join(rootDir, "main.tf")
 	modPath := filepath.Join(modDir, "main.tf")
 
-	// Two distinct module instances with identical inputs in the same root.
+	// bucket_a and bucket_b share inputs but differ in module address (part of the dedup key).
 	require.NoError(t, os.WriteFile(rootPath, []byte(`
 module "bucket_a" {
   source = "../modules/bucket"
@@ -281,8 +275,6 @@ resource "aws_s3_bucket" "this" {
 	require.NoError(t, err)
 	require.Empty(t, ins.GetFailedQueries())
 
-	// Both module instances survive dedup (distinct module addresses), so the
-	// count-based rule sees two buckets and fires.
 	require.Len(t, vulns, 1, "aggregate rule must see both bucket instances and fire")
 }
 

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -65,30 +65,30 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", modFile),
 	}
 
-	extra, synthetic, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
-	if !ok {
+	res := resolveModuleDocuments(context.Background(), files, root)
+	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
 
-	if len(extra) != 1 {
-		t.Fatalf("expected 1 instantiated resource document, got %d: %#v", len(extra), extra)
+	if len(res.docs) != 1 {
+		t.Fatalf("expected 1 instantiated resource document, got %d: %#v", len(res.docs), res.docs)
 	}
-	doc := extra[0]
+	doc := res.docs[0]
 	if got := docFileID(doc["id"]); got != "mod-id" {
 		t.Fatalf("instantiated doc id prefix = %v, want mod-id (resource definition file)", got)
 	}
 
 	// A synthetic file backs the document under the same id and carries the call chain.
-	if len(synthetic) != 1 {
-		t.Fatalf("expected 1 synthetic file, got %d", len(synthetic))
+	if len(res.syntheticFiles) != 1 {
+		t.Fatalf("expected 1 synthetic file, got %d", len(res.syntheticFiles))
 	}
-	if synthetic[0].ID != doc["id"] {
-		t.Fatalf("synthetic file id = %v, want doc id %v", synthetic[0].ID, doc["id"])
+	if res.syntheticFiles[0].ID != doc["id"] {
+		t.Fatalf("synthetic file id = %v, want doc id %v", res.syntheticFiles[0].ID, doc["id"])
 	}
-	if synthetic[0].ModuleCallChain == "" {
+	if res.syntheticFiles[0].ModuleCallChain == "" {
 		t.Fatalf("synthetic file should carry a non-empty module call chain")
 	}
-	if len(synthetic[0].Document) != 0 {
+	if len(res.syntheticFiles[0].Document) != 0 {
 		t.Fatalf("synthetic file Document must be empty so Combine skips it")
 	}
 
@@ -101,10 +101,10 @@ resource "aws_s3_bucket" "this" {
 
 	// The module body must be suppressed (so it isn't scanned standalone), but
 	// the root file must still be scanned.
-	if !suppressed["mod-id"] {
+	if !res.suppressed["mod-id"] {
 		t.Fatalf("module file should be suppressed")
 	}
-	if suppressed["root-id"] {
+	if res.suppressed["root-id"] {
 		t.Fatalf("root file should not be suppressed")
 	}
 }
@@ -137,19 +137,19 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", filepath.Join("modules", "bucket", "main.tf")),
 	}
 
-	extra, _, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
-	if !ok {
+	res := resolveModuleDocuments(context.Background(), files, root)
+	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
 
-	if len(extra) != 1 {
-		t.Fatalf("expected 1 instantiated resource document, got %d: %#v", len(extra), extra)
+	if len(res.docs) != 1 {
+		t.Fatalf("expected 1 instantiated resource document, got %d: %#v", len(res.docs), res.docs)
 	}
-	if doc := extra[0]; docFileID(doc["id"]) != "mod-id" {
+	if doc := res.docs[0]; docFileID(doc["id"]) != "mod-id" {
 		t.Fatalf("instantiated doc id prefix = %v, want mod-id", docFileID(doc["id"]))
 	}
-	if !suppressed["mod-id"] || suppressed["root-id"] {
-		t.Fatalf("unexpected suppression map: %#v", suppressed)
+	if !res.suppressed["mod-id"] || res.suppressed["root-id"] {
+		t.Fatalf("unexpected suppression map: %#v", res.suppressed)
 	}
 }
 
@@ -194,22 +194,22 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", modFile),
 	}
 
-	extra, synthetic, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
-	if !ok {
+	res := resolveModuleDocuments(context.Background(), files, root)
+	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
-	if len(extra) != 2 {
-		t.Fatalf("want 2 instantiated bucket docs (one per root), got %d: %#v", len(extra), extra)
+	if len(res.docs) != 2 {
+		t.Fatalf("want 2 instantiated bucket docs (one per root), got %d: %#v", len(res.docs), res.docs)
 	}
 	names := make(map[string]int)
 	docIDs := make(map[string]bool)
-	for _, doc := range extra {
+	for _, doc := range res.docs {
 		if got := docFileID(doc["id"]); got != "mod-id" {
 			t.Fatalf("doc id prefix = %v, want mod-id", got)
 		}
 		docIDs[doc["id"].(string)] = true
-		res, _ := doc["resource"].(map[string]interface{})
-		bt, _ := res["aws_s3_bucket"].(map[string]interface{})
+		docRes, _ := doc["resource"].(map[string]interface{})
+		bt, _ := docRes["aws_s3_bucket"].(map[string]interface{})
 		th, _ := bt["this"].(map[string]interface{})
 		b, _ := th["bucket"].(string)
 		names[b]++
@@ -223,13 +223,13 @@ resource "aws_s3_bucket" "this" {
 		t.Fatalf("want 2 distinct per-caller doc ids, got %d: %#v", len(docIDs), docIDs)
 	}
 	chains := make(map[string]bool)
-	for _, sf := range synthetic {
+	for _, sf := range res.syntheticFiles {
 		chains[sf.ModuleCallChain] = true
 	}
 	if len(chains) != 2 {
 		t.Fatalf("want 2 distinct module call chains (one per root), got %d: %#v", len(chains), chains)
 	}
-	if !suppressed["mod-id"] {
+	if !res.suppressed["mod-id"] {
 		t.Fatalf("shared module file should be suppressed")
 	}
 }
@@ -253,15 +253,15 @@ module "bucket" {
 		fileMeta("root-id", filepath.Join("stack", "main.tf")),
 	}
 
-	extra, _, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
-	if ok {
+	res := resolveModuleDocuments(context.Background(), files, root)
+	if res.ok {
 		t.Fatalf("resolveModuleDocuments ok = true, want false when all roots fail")
 	}
-	if len(extra) != 0 {
-		t.Fatalf("want no instantiation when root eval fails, got %#v", extra)
+	if len(res.docs) != 0 {
+		t.Fatalf("want no instantiation when root eval fails, got %#v", res.docs)
 	}
-	if len(suppressed) != 0 {
-		t.Fatalf("want no suppression when all root evals fail, got %#v", suppressed)
+	if len(res.suppressed) != 0 {
+		t.Fatalf("want no suppression when all root evals fail, got %#v", res.suppressed)
 	}
 }
 
@@ -280,14 +280,14 @@ resource "aws_s3_bucket" "this" {
 
 	files := model.FileMetadatas{fileMeta("orphan-id", orphanFile)}
 
-	extra, _, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
-	if !ok {
+	res := resolveModuleDocuments(context.Background(), files, root)
+	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true for orphan root")
 	}
-	if len(extra) != 0 {
-		t.Fatalf("orphan module should not instantiate resources, got %#v", extra)
+	if len(res.docs) != 0 {
+		t.Fatalf("orphan module should not instantiate resources, got %#v", res.docs)
 	}
-	if suppressed["orphan-id"] {
+	if res.suppressed["orphan-id"] {
 		t.Fatalf("orphan module should not be suppressed")
 	}
 }
@@ -323,15 +323,15 @@ resource "aws_s3_bucket" "leaf" {
 		fileMeta("leaf-id", leafFile),
 	}
 
-	extra, _, suppressed, _, ok := resolveModuleDocuments(context.Background(), files, root)
-	if !ok {
+	res := resolveModuleDocuments(context.Background(), files, root)
+	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
 
-	if len(extra) != 1 {
-		t.Fatalf("expected 1 instantiated resource, got %d: %#v", len(extra), extra)
+	if len(res.docs) != 1 {
+		t.Fatalf("expected 1 instantiated resource, got %d: %#v", len(res.docs), res.docs)
 	}
-	doc := extra[0]
+	doc := res.docs[0]
 	if got := docFileID(doc["id"]); got != "leaf-id" {
 		t.Fatalf("doc id prefix = %v, want leaf-id", got)
 	}
@@ -342,10 +342,10 @@ resource "aws_s3_bucket" "leaf" {
 		t.Fatalf("leaf bucket = %#v, want deep", leaf["bucket"])
 	}
 
-	if !suppressed["a-id"] || !suppressed["leaf-id"] {
-		t.Fatalf("intermediate and leaf module files should be suppressed: %#v", suppressed)
+	if !res.suppressed["a-id"] || !res.suppressed["leaf-id"] {
+		t.Fatalf("intermediate and leaf module files should be suppressed: %#v", res.suppressed)
 	}
-	if suppressed["root-id"] {
+	if res.suppressed["root-id"] {
 		t.Fatalf("root file should not be suppressed")
 	}
 }
@@ -377,8 +377,8 @@ module "bucket" {
 	ins := newTestInspector(t, inspectorOpts{
 		repoPath: root,
 	})
-	if docs, synthetic := ins.instantiateLocalModules(context.Background(), files); docs != nil || synthetic != nil {
-		t.Fatalf("instantiateLocalModules = (%#v, %#v), want nil when resolve aborts", docs, synthetic)
+	if docs, synthetic, extras := ins.instantiateLocalModules(context.Background(), files); docs != nil || synthetic != nil || extras != nil {
+		t.Fatalf("instantiateLocalModules = (%#v, %#v, %#v), want nil when resolve aborts", docs, synthetic, extras)
 	}
 	if _, has := rootFM.Document["module"]; !has {
 		t.Fatalf("expected module block preserved on root when evaluation failed")

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -234,6 +234,85 @@ resource "aws_s3_bucket" "this" {
 	}
 }
 
+// Two roots, identical module inputs: one OPA doc, second caller in extras.
+func TestResolveModuleDocuments_CrossRootIdenticalContentDeduped(t *testing.T) {
+	root := t.TempDir()
+	modDir := filepath.Join(root, "modules", "bucket")
+	if err := os.MkdirAll(filepath.Join(root, "stack-a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "stack-b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(modDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both roots pass the same value so content dedup merges them.
+	writeFile(t, filepath.Join(root, "stack-a"), "main.tf", `
+module "bucket" {
+  source = "../modules/bucket"
+  name   = "shared"
+}
+`)
+	writeFile(t, filepath.Join(root, "stack-b"), "main.tf", `
+module "bucket" {
+  source = "../modules/bucket"
+  name   = "shared"
+}
+`)
+	modFile := writeFile(t, modDir, "main.tf", `
+variable "name" {
+  type = string
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.name
+}
+`)
+
+	files := model.FileMetadatas{
+		fileMeta("a-root", filepath.Join(root, "stack-a", "main.tf")),
+		fileMeta("b-root", filepath.Join(root, "stack-b", "main.tf")),
+		fileMeta("mod-id", modFile),
+	}
+
+	res := resolveModuleDocuments(context.Background(), files, root)
+	if !res.ok {
+		t.Fatalf("resolveModuleDocuments ok = false, want true")
+	}
+
+	if len(res.docs) != 1 {
+		t.Fatalf("want 1 deduplicated bucket doc, got %d: %#v", len(res.docs), res.docs)
+	}
+	primaryID, _ := res.docs[0]["id"].(string)
+	if primaryID == "" {
+		t.Fatalf("primary doc has no id: %#v", res.docs[0])
+	}
+
+	if len(res.extras) != 1 {
+		t.Fatalf("want extras for exactly 1 primary doc, got %d: %#v", len(res.extras), res.extras)
+	}
+	dupes := res.extras[primaryID]
+	if len(dupes) != 1 {
+		t.Fatalf("want 1 deduplicated caller recorded in extras, got %d: %#v", len(dupes), dupes)
+	}
+
+	if len(res.syntheticFiles) != 1 {
+		t.Fatalf("want 1 synthetic file for the primary doc, got %d", len(res.syntheticFiles))
+	}
+
+	if dupes[0].docID == primaryID {
+		t.Fatalf("deduplicated caller must have a distinct doc id from the primary")
+	}
+	if dupes[0].callChain == res.syntheticFiles[0].ModuleCallChain {
+		t.Fatalf("deduplicated caller must have a distinct call chain from the primary")
+	}
+	if dupes[0].callChain == "" {
+		t.Fatalf("deduplicated caller must carry a non-empty call chain")
+	}
+}
+
 func TestResolveModuleDocuments_AllRootsFailEvalNoSuppression(t *testing.T) {
 	root := t.TempDir()
 	stackDir := filepath.Join(root, "stack")


### PR DESCRIPTION
## Motivation

On repositories with many Terraform local modules (e.g. monorepos with shared infrastructure modules called from multiple stacks), the scanner instantiates one synthetic document per resolved resource **per caller** and appends every one of them to `input.document`. Rules that iterate the full document list, including several S3 and IAM rules that call `has_target_resource` or nest `input.document[_]` inside `input.document[i]`, scale roughly as O(N²) in document count. With enough callers this pushes individual rules well past the 60-second slow-rule threshold, and in the worst case drives total scan time over the outer 1-hour kill limit, producing a full failure instead of partial results.

## Changes

**Module deduplication**

When the same module resource is re-reached through different call chains and resolves to identical attributes (same type, name, definition line, and resolved configuration), only one synthetic document is emitted into `input.document`. Additional callers are recorded as *extras* in a side map instead of adding redundant documents.

**Finding expansion**

After OPA evaluation, findings on a deduplicated document are cloned, one copy per extra caller, each carrying the correct `ModuleCallChain` and `FileID`. This preserves per-caller fingerprints and file attribution so no coverage is lost.

**Content key**

Dedup uses a SHA-256 digest of the JSON-serialized resolved attributes. The key also includes the module address, so distinct module instances within a single configuration (`module.a` vs `module.b`, `count`/`for_each` indices) always get distinct keys and are never merged. Two callers that pass different variable values likewise produce different keys and emit separate documents.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/engine/...` — all existing module resolution tests pass unchanged. `TestInspect_TwoCallersGetDistinctCallChains` confirms per-caller findings are preserved (N callers → N findings via cloning); `TestInspect_AggregateRuleCardinalityPreservedWithinConfig` confirms a count-based rule still sees every distinct module instance in a configuration.
2. Scan a Terraform repo that uses the same local module from multiple stacks with identical inputs. Check scanner logs for the `Instantiated … unique OPA docs … deduplicated callers` line and confirm the unique-doc count is lower than the total caller count.
3. Verify findings still appear attributed to each call-site (distinct `moduleCallChain` per finding).

## Blast Radius

Affects the scan pipeline only — specifically module instantiation during Terraform scans. No change to rule assets, CLI flags, SARIF output schema, or non-Terraform platforms. Repositories that do not use local Terraform modules see no behaviour change.

## Additional Notes

This is a targeted mitigation for large-repo scan timeouts. It reduces document count, and therefore O(N²) rule eval time, without changing rule logic or the per-rule timeout model.

**Scope of dedup (cardinality).** Per-resource rules (the vast majority, including the S3 / `has_target_resource` family this targets) are unaffected: the finding fires on the primary document and is cloned per caller. Aggregate rules that count resources are also unaffected within a configuration, because distinct module instances keep distinct documents (covered by `TestInspect_AggregateRuleCardinalityPreservedWithinConfig`). The only behavior change is for a hypothetical rule that counts the *same* module resource reached identically from multiple independent root configurations — counting across separate Terraform states is not a meaningful check, and no bundled rule does this (the only `count()` rules aggregate within a single document).

I submit this contribution under the Apache-2.0 license.