### PR TITLE
Relax test-rules required field contract for presentation-only fields

### DIFF
--- a/cmd/scanner/test_rules.go
+++ b/cmd/scanner/test_rules.go
@@ -50,9 +50,6 @@ var resultShape = struct {
 	Required: []string{
 		"documentId",
 		"searchKey",
-		"issueType",
-		"keyExpectedValue",
-		"keyActualValue",
 	},
 	ResourceKeys: []string{"resourceType", "resourceName"},
 }


### PR DESCRIPTION
## Motivation

Rule results no longer emit `issueType`, `keyExpectedValue`, or `keyActualValue` as of a schema relaxation applied to the rule assets (equivalent of the contract change already shipped in the rule-assets repo). The `test-rules` validator still listed them as required fields, causing every `test-rules` CI run to fail for Ansible and other rules that dropped those optional presentation fields.

## Changes

**Rule test validator**

Removed `issueType`, `keyExpectedValue`, and `keyActualValue` from the `resultShape.Required` list in `cmd/scanner/test_rules.go`. The `allowedIssueTypes` guard on the `issueType` value is kept, so results that _do_ include the field are still validated; only the presence check is relaxed.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run `./bin/datadog-iac-scanner test-rules` (with a valid API key) and confirm that Ansible AWS rules no longer produce `Result missing required field` failures. Alternatively, let the `test-rules` CI job on this PR go green.

## Blast Radius

Only the `test-rules` command is affected. No change to scan output, findings, SARIF, or any runtime path.

## Additional Notes

N/A

I submit this contribution under the Apache-2.0 license.