### PR TITLE
Optimize S3 rules by pre-indexing bucket references in has_target_resource

### DIFF
--- a/assets/libraries/terraform.rego
+++ b/assets/libraries/terraform.rego
@@ -577,10 +577,18 @@ check_member(attribute, search) if {
 	startswith(attribute.member, search)
 }
 
-has_target_resource(bucketName, resourceName) if {
-	resource := input.document[i].resource[resourceName][_]
+# Set of [resourceType, bucketName] pairs referenced by any resource's `bucket`
+# attribute, built once per query (complete set rule, cached by OPA). Lets
+# has_target_resource do an O(1) membership check instead of re-scanning every
+# document for each bucket it is called with.
+target_resource_bucket_refs contains [resourceName, bucketName] if {
+	some resourceName
+	resource := input.document[_].resource[resourceName][_]
+	bucketName := split(resource.bucket, ".")[1]
+}
 
-	split(resource.bucket, ".")[1] == bucketName
+has_target_resource(bucketName, resourceName) if {
+	[resourceName, bucketName] in target_resource_bucket_refs
 }
 
 #Checks if an action is allowed for all principals


### PR DESCRIPTION
## Motivation

Several S3 rules (`s3_bucket_logging_disabled`, `s3_bucket_without_versioning`, `s3_bucket_without_enabled_mfa_delete`, `s3_static_website_host_enabled`, `cloudtrail_log_files_s3_bucket_with_logging_disabled`, and `aws_bom/s3_bucket`) call `tf_lib.has_target_resource(bucketName, resourceName)` to check whether a companion resource (versioning, logging, ACL, etc.) references a given bucket. The helper re-scanned every `input.document` for each bucket it was called with, making callers O(buckets × documents). With Terraform module instantiation inflating the document set, these rules were among the slowest in production (`service:iac-scanning @event:slow_rule`).

## Changes

**Rule library**

`has_target_resource` now consults `target_resource_bucket_refs`, a complete set rule that collects every `[resourceType, bucketName]` reference in a single pass and is cached by OPA for the duration of a query. The helper becomes an O(1) set-membership check. Its signature is unchanged, so all six callers are unaffected.

Benchmark on a synthetic module-inflated input (2,000 buckets, 500 companion resources across 50 documents), using `s3_bucket_logging_disabled` (where this helper is the sole cost):

| Rule | Before | After | Speedup |
|---|---|---|---|
| `s3_bucket_logging_disabled` | 1,276 ms | 44 ms | ~29x |

Findings are identical before and after (1,500 on the benchmark input). Rules that carry an additional per-rule quadratic (a bucket-to-versioning cross-join, e.g. `s3_bucket_without_versioning`) still improve here but have a separate residual cost to address in a follow-up.

## QA Instruction

1. `opa test assets/libraries/` — all 324 tests pass.
2. `go test ./pkg/engine/... -timeout 120s` — engine tests pass.
3. Optionally benchmark `s3_bucket_logging_disabled` against a module-heavy input with the patched vs unpatched `terraform.rego` and confirm identical findings.

## Blast Radius

DataDog IaC Scanner only. The change is limited to `has_target_resource` in `assets/libraries/terraform.rego`; the helper signature and results are unchanged, so the six S3-family rules that call it need no modification.

## Additional Notes

This is the shared-library counterpart to the per-rule pre-indexing applied to the privilege-escalation rules and the alb/shield rules — same technique (a once-per-query complete set rule replacing a per-resource document scan).

I submit this contribution under the Apache-2.0 license.
