### PR TITLE
Precompute ansible task index once per scan instead of per rule

### DIFF
--- a/assets/libraries/ansible.rego
+++ b/assets/libraries/ansible.rego
@@ -2,8 +2,16 @@ package generic.ansible
 
 import rego.v1
 
-# Global variable with all tasks in input
-tasks := TasksPerDocument
+# Global variable with all tasks in input.
+#
+# The engine precomputes this object once per scan and injects it as
+# data.precomputed_ansible_tasks, so the walk-heavy task flattening is not
+# rebuilt for every ansible rule. When the precomputed value is absent (rule
+# tooling, or a query carrying custom input data) the tasks are derived on
+# demand from the document set, yielding identical results.
+tasks := data.precomputed_ansible_tasks if {
+	data.precomputed_ansible_tasks
+} else := TasksPerDocument
 
 # Builds an object that stores all tasks for each document id
 TasksPerDocument[id] := result if {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -343,7 +343,23 @@ func (c *Inspector) Inspect(
 
 	// Pre-build one inmem.Store per platform so LoadQuery does not re-parse the
 	// same payload for every PrepareForEval call.
-	baseStores := precomputeBaseStores(c.QueryLoader.precomputeBaseInputData(ctx, enrichedModules))
+	baseInputData := c.QueryLoader.precomputeBaseInputData(ctx, enrichedModules)
+
+	// Compute the ansible task index once and inject it into the ansible store
+	// so the ~200 ansible rules read it instead of rebuilding it per query.
+	if _, ok := c.QueryLoader.parsedGeneric[ansiblePlatform]; ok {
+		if fragment, err := c.QueryLoader.precomputeAnsibleTasks(ctx, astPayload); err != nil {
+			contextLogger.Warn().Err(err).Msg("failed to precompute ansible tasks; rules will compute them per query")
+		} else if fragment != "" {
+			if merged, mErr := source.MergeInputData(baseInputData[ansiblePlatform], fragment); mErr == nil {
+				baseInputData[ansiblePlatform] = merged
+			} else {
+				contextLogger.Warn().Err(mErr).Msg("failed to merge precomputed ansible tasks into base input data")
+			}
+		}
+	}
+
+	baseStores := precomputeBaseStores(baseInputData)
 
 	// Compute the file map once and share it (read-only) across all workers
 	filesMap := files.ToMap()
@@ -848,6 +864,55 @@ func (q *QueryLoader) precomputeBaseInputData(ctx context.Context,
 		base[platform] = data
 	}
 	return base
+}
+
+// ansiblePlatform is the platform key used for ansible queries and libraries.
+const ansiblePlatform = "ansible"
+
+// precomputedAnsibleTasksKey is the input-data document key under which the
+// engine injects the once-per-scan ansible task index. The generic.ansible
+// library reads data.precomputed_ansible_tasks and falls back to computing the
+// tasks itself when the key is absent.
+const precomputedAnsibleTasksKey = "precomputed_ansible_tasks"
+
+// precomputeAnsibleTasks evaluates the generic.ansible task builder a single
+// time against the payload and returns the result as an input-data JSON
+// fragment. Each ansible rule is evaluated as an independent OPA query, so
+// without this every ansible rule rebuilds the same walk-heavy task structure;
+// injecting it once lets all rules read it from the store instead. An empty
+// string means there was nothing to inject (rules fall back to computing it).
+func (q *QueryLoader) precomputeAnsibleTasks(ctx context.Context, astPayload ast.Value) (string, error) {
+	lib, ok := q.parsedGeneric[ansiblePlatform]
+	if !ok || q.parsedCommon == nil {
+		return "", nil
+	}
+
+	prepared, err := rego.New(
+		rego.Query("data.generic.ansible.TasksPerDocument"),
+		rego.SetRegoVersion(ast.RegoV1),
+		rego.ParsedModule(q.parsedCommon),
+		rego.ParsedModule(lib),
+		rego.UnsafeBuiltins(unsafeRegoFunctions),
+	).PrepareForEval(ctx)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to prepare ansible task precompute")
+	}
+
+	results, err := prepared.Eval(ctx, rego.EvalParsedInput(astPayload))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to evaluate ansible task precompute")
+	}
+	if len(results) == 0 || len(results[0].Expressions) == 0 {
+		return "", nil
+	}
+
+	fragment, err := json.Marshal(map[string]interface{}{
+		precomputedAnsibleTasksKey: results[0].Expressions[0].Value,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal precomputed ansible tasks")
+	}
+	return string(fragment), nil
 }
 
 // precomputeBaseStores builds one inmem.Store per platform from the already-merged


### PR DESCRIPTION
## Motivation

Each IaC rule is evaluated as an independent OPA query that recompiles the shared libraries, so the `generic.ansible` task index (`TasksPerDocument`, a `walk`-based flattening of every playbook's tasks/blocks) is rebuilt from scratch for every one of the ~200 ansible rules. On ansible repositories with large playbooks this redundant rebuild is pure waste and shows up in the `slow_rule` logs.

JIRA Ticket: N/A (perf follow-up to the scan-timeout incident)

## Changes

- Engine: compute the ansible task index a single time per scan (one OPA eval of `data.generic.ansible.TasksPerDocument` against the payload) and merge it into the per-platform ansible input-data store as `data.precomputed_ansible_tasks`. Falls back silently to per-query computation on any error.
- Library (`assets/libraries/ansible.rego`): `tasks` now prefers the injected `data.precomputed_ansible_tasks` and falls back to `TasksPerDocument` when absent (rule tooling, custom-input-data queries), yielding identical results.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] All new and existing tests pass (`go test ./pkg/engine/...`).
- [ ] I have tested my changes on staging (if applicable).

## QA Instruction

Scan an ansible repo with large playbooks. Findings must be unchanged. I verified parity end-to-end by scanning an ansible corpus (250 fixture files) on this branch vs `main`: findings are identical grouped by (ruleId, file) — the only variance is pre-existing non-deterministic line attribution in `risky_file_permissions` (reproduces between two identical runs of the same binary).

Benchmarks:
- `opa bench` of one task-iterating rule on 8 docs x 1500 tasks: rebuild **119 ms/op** vs injected **60 ms/op**.
- End-to-end scan of 8 x 1500 diverse benign tasks: **~19.5s -> ~18.2s (~7%)**. The win is larger for block-heavy playbooks (which trigger the `walk`) and negligible for tiny playbooks. Note: real ansible scan time is dominated by per-rule compilation and individual rules' own task iteration, which this PR does not change.

## Blast Radius

DataDog IaC Scanner only, ansible platform. The library change keeps the on-demand path as a fallback, so behaviour is unchanged when the engine does not inject the precomputed value.

## Additional Notes

The in-repo `datadog-iac-scanner-default-rules` copy of `ansible.rego` should be synced with this change to avoid library drift (no behavioural impact there since its tooling does not inject the precomputed data).

I submit this contribution under the Apache-2.0 license.
