### PR TITLE
Evaluate each query against only its platform's documents

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/pkg/errors"
 	ignore "github.com/sabhiram/go-gitignore"
 
@@ -83,21 +84,21 @@ var (
 	listKeywordsGoogleDeployment = []string{"resources"}
 	armRegexTypes                = []string{"blueprint", "templateArtifact", "roleAssignmentArtifact", "policyAssignmentArtifact"}
 	possibleFileTypes            = map[string]bool{
-		".yml":        true,
-		".yaml":       true,
-		".json":       true,
-		".dockerfile": true,
-		"Dockerfile":  true,
-		".debian":     true,
-		".ubi8":       true,
-		".tf":         true,
-		"tfvars":      true,
-		".proto":      true,
-		".sh":         true,
-		".cfg":        true,
-		".conf":       true,
-		".ini":        true,
-		".bicep":      true,
+		yml:            true,
+		yaml:           true,
+		json:           true,
+		sh:             true,
+		extDockerfile:  true,
+		nameDockerfile: true,
+		extDebian:      true,
+		extUbi8:        true,
+		extTf:          true,
+		extTfvars:      true,
+		extProto:       true,
+		extCfg:         true,
+		extConf:        true,
+		extIni:         true,
+		extBicepFile:   true,
 	}
 	supportedRegexes = map[string][]string{
 		"azureresourcemanager": append(armRegexTypes, arm),
@@ -133,25 +134,37 @@ func PossibleFileTypes() []string {
 }
 
 const (
-	cdkTf        = "cdkTf"
-	yml          = ".yml"
-	yaml         = ".yaml"
-	json         = ".json"
-	sh           = ".sh"
-	arm          = "azureresourcemanager"
-	bicep        = "bicep"
-	kubernetes   = "kubernetes"
-	terraform    = "terraform"
-	gdm          = "googledeploymentmanager"
-	ansible      = "ansible"
-	grpc         = "grpc"
-	dockerfile   = "dockerfile"
-	crossplane   = "crossplane"
-	knative      = "knative"
-	cicd         = "cicd"
-	dependabot   = "dependabot"
-	githubAction = "githubAction"
-	sizeMb       = 1048576
+	cdkTf                 = "cdkTf"
+	yml                   = ".yml"
+	yaml                  = ".yaml"
+	json                  = ".json"
+	sh                    = ".sh"
+	arm                   = "azureresourcemanager"
+	bicep                 = "bicep"
+	kubernetes            = "kubernetes"
+	terraform             = "terraform"
+	gdm                   = "googledeploymentmanager"
+	ansible               = "ansible"
+	grpc                  = "grpc"
+	dockerfile            = "dockerfile"
+	crossplane            = "crossplane"
+	knative               = "knative"
+	cicd                  = "cicd"
+	dependabot            = "dependabot"
+	githubAction          = "githubAction"
+	sizeMb                = 1048576
+	extDockerfile         = ".dockerfile"
+	nameDockerfile        = "Dockerfile"
+	extPossibleDockerfile = "possibleDockerfile"
+	extUbi8               = ".ubi8"
+	extDebian             = ".debian"
+	extTf                 = ".tf"
+	extTfvars             = "tfvars"
+	extBicepFile          = ".bicep"
+	extProto              = ".proto"
+	extCfg                = ".cfg"
+	extConf               = ".conf"
+	extIni                = ".ini"
 )
 
 type Parameters struct {
@@ -440,56 +453,40 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 // worker determines the type of the file by ext (dockerfile and terraform)/content and
 // writes the answer to the results channel
 // if no types were found, the worker will write the path of the file in the unwanted channel
-func (a *analyzerInfo) worker(ctx context.Context, results, unwanted chan<- string, locCount chan<- int) { //nolint: gocyclo
+func (a *analyzerInfo) worker(ctx context.Context, results, unwanted chan<- string, locCount chan<- int) {
+	contextLogger := logger.FromContext(ctx)
 	ext, errExt := utils.GetExtension(ctx, a.filePath)
-	if errExt == nil {
-		linesCount, _ := utils.LineCounter(ctx, a.filePath)
+	if errExt != nil {
+		return
+	}
 
-		switch ext {
-		// Dockerfile (direct identification)
-		case ".dockerfile", "Dockerfile":
-			if a.isAvailableType(dockerfile) {
-				results <- dockerfile
-				locCount <- linesCount
-			}
-		// Dockerfile (indirect identification)
-		case "possibleDockerfile", ".ubi8", ".debian":
-			if a.isAvailableType(dockerfile) && isDockerfile(ctx, a.filePath) {
-				results <- dockerfile
-				locCount <- linesCount
-			} else {
-				unwanted <- a.filePath
-			}
-		// Terraform
-		case ".tf", "tfvars":
-			if a.isAvailableType(terraform) {
-				results <- terraform
-				locCount <- linesCount
-			}
-		// Bicep
-		case ".bicep":
-			if a.isAvailableType(bicep) {
-				results <- bicep
-				locCount <- linesCount
-			}
-		// GRPC
-		case ".proto":
-			if a.isAvailableType(grpc) {
-				results <- grpc
-				locCount <- linesCount
-			}
-		// It could be Ansible Config or Ansible Inventory
-		case ".cfg", ".conf", ".ini":
-			if a.isAvailableType(ansible) {
-				results <- ansible
-				locCount <- linesCount
-			}
-		/* It could be Ansible, Buildah, CICD, CloudFormation, Crossplane, OpenAPI, Azure Resource Manager
-		Docker Compose, Knative, Kubernetes, Pulumi, ServerlessFW or Google Deployment Manager*/
-		case yaml, yml, json, sh:
-			a.checkContent(ctx, results, unwanted, locCount, linesCount, ext)
+	linesCount, _ := utils.LineCounter(ctx, a.filePath)
+
+	var content []byte
+	if ext == yaml || ext == yml || ext == json || ext == sh {
+		var err error
+		content, err = os.ReadFile(a.filePath)
+		if err != nil {
+			contextLogger.Error().Msgf("failed to analyze file: %s", err)
+			return
 		}
 	}
+
+	platform := ClassifyFile(ctx, vfs.DiskFS{}, a.filePath, content, a.typesFlag)
+	if platform == "" {
+		unwanted <- a.filePath
+		return
+	}
+	if !a.isAvailableType(platform) {
+		// Content-detected files that do not match the requested platforms are
+		// excluded; extension-only types (e.g. .tf) are ignored silently.
+		if ext == yaml || ext == yml || ext == json || ext == sh {
+			unwanted <- a.filePath
+		}
+		return
+	}
+	results <- platform
+	locCount <- linesCount
 }
 
 func isDockerfile(ctx context.Context, path string) bool {
@@ -527,18 +524,12 @@ func needsOverride(check bool, returnType, key, ext string) bool {
 	return false
 }
 
-// checkContent will determine the file type by content when worker was unable to
-// determine by ext, if no type was determined checkContent adds it to unwanted channel
-func (a *analyzerInfo) checkContent(ctx context.Context, results, unwanted chan<- string, locCount chan<- int, linesCount int, ext string) {
-	contextLogger := logger.FromContext(ctx)
-	typesFlag := a.typesFlag
-	// get file content
-	content, err := os.ReadFile(a.filePath)
-	if err != nil {
-		contextLogger.Error().Msgf("failed to analyze file: %s", err)
-		return
-	}
-
+// classifyByContent determines the platform of a content-detected file (yaml,
+// yml, json, sh) using the type regexes and the post-processing in
+// checkReturnType. It returns the platform string (lowercased) or "" when none
+// matches or the file is a non-Terraform JSON (which the scanner does not scan).
+// typesFlag restricts the candidate platforms; pass nil or [""] to consider all.
+func classifyByContent(ctx context.Context, path string, content []byte, ext string, typesFlag []string) string {
 	returnType := ""
 
 	// Sort map so that CloudFormation (type that as less requireds) goes last
@@ -547,7 +538,7 @@ func (a *analyzerInfo) checkContent(ctx context.Context, results, unwanted chan<
 		keys = append(keys, k)
 	}
 
-	if typesFlag[0] != "" {
+	if len(typesFlag) > 0 && typesFlag[0] != "" {
 		keys = getKeysFromTypesFlag(typesFlag)
 	}
 
@@ -569,24 +560,84 @@ func (a *analyzerInfo) checkContent(ctx context.Context, results, unwanted chan<
 		}
 	}
 
-	endReturnType := checkReturnType(ctx, a.filePath, returnType, ext, content)
+	endReturnType := checkReturnType(ctx, path, returnType, ext, content)
 
 	// Only process JSON files if they are Terraform plans
 	// This will be the case until other platforms support json scanning
 	if ext == json && (endReturnType != "terraform" || returnType == cdkTf) {
-		unwanted <- a.filePath
-		return
+		return ""
 	}
 
-	if endReturnType != "" {
-		if a.isAvailableType(endReturnType) {
-			results <- endReturnType
-			locCount <- linesCount
-			return
-		}
+	return endReturnType
+}
+
+// ClassifyFile returns the platform a file would be classified as (lowercased,
+// e.g. "ansible", "kubernetes", "terraform", "bicep"), or "" when undetermined.
+// It mirrors the per-file detection used during analysis so callers (e.g. the
+// parsing sink) can attribute each parsed document to its platform without
+// re-running the full analyzer. content is the raw file bytes; typesFlag
+// restricts candidate platforms (case-insensitive; pass nil to consider all).
+// Passing the same platform set the analyzer used keeps the sink's
+// classification consistent with the analyzer's. fsys is the filesystem used
+// for extension detection; pass the in-memory FS for pushed content that never
+// touches disk, or nil to default to the real disk.
+func ClassifyFile(ctx context.Context, fsys vfs.FS, path string, content []byte, typesFlag []string) string {
+	if fsys == nil {
+		fsys = vfs.DiskFS{}
 	}
-	// No type was determined (ignore on parser)
-	unwanted <- a.filePath
+	typesFlag = typesLower(typesFlag)
+	ext, err := utils.GetExtensionWithFS(ctx, fsys, path)
+	if err != nil {
+		return ""
+	}
+	switch ext {
+	case extDockerfile, nameDockerfile:
+		return dockerfile
+	case extPossibleDockerfile, extUbi8, extDebian:
+		if isDockerfile(ctx, path) {
+			return dockerfile
+		}
+		return ""
+	case extTf, extTfvars:
+		return terraform
+	case extBicepFile:
+		return bicep
+	case extProto:
+		return grpc
+	case extCfg, extConf, extIni:
+		return ansible
+	case yaml, yml, json, sh:
+		return classifyByContent(ctx, path, content, ext, typesFlag)
+	}
+	return ""
+}
+
+// ClassifyParsedFile attributes a parsed file to its platform for payload
+// bucketing. FileKind overrides extension/content detection for unambiguous
+// types (Helm rendered manifests are Kubernetes, etc.). Returns "" when
+// undetermined. platforms is the scan's effective platform set, forwarded to
+// ClassifyFile so the sink classifies ambiguous files with the same candidate
+// set the analyzer used (e.g. a Crossplane file is "kubernetes" in a default
+// scan, "crossplane" only when Crossplane is enabled). fsys is forwarded for
+// extension detection so the server's in-memory pushed content (not on disk) is
+// classified correctly.
+func ClassifyParsedFile(ctx context.Context, fsys vfs.FS, platforms []string, kind model.FileKind, path string, content []byte) string {
+	switch kind {
+	case model.KindHELM:
+		return kubernetes
+	case model.KindTerraform, model.KindTerraformPlan:
+		return terraform
+	case model.KindDOCKER:
+		return dockerfile
+	case model.KindBICEP:
+		return arm
+	case model.KindPROTO:
+		return grpc
+	case model.KindINI, model.KindCFG:
+		return ansible
+	default:
+		return ClassifyFile(ctx, fsys, path, content, platforms)
+	}
 }
 
 func checkReturnType(ctx context.Context, path, returnType, ext string, content []byte) string {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -244,7 +244,7 @@ func (c *Inspector) createInspectionJobs(jobs chan<- InspectionJob, queries []mo
 
 // This function performs an inspection job and sends the result to the results channel
 func (c *Inspector) performInspection(ctx context.Context, scanID string, filesMap map[string]*model.FileMetadata,
-	astPayload ast.Value,
+	payloadByPlatform map[string]ast.Value, fullPayload ast.Value,
 	jobs <-chan InspectionJob, results chan<- QueryResult, queries []model.QueryMetadata,
 	modules []tfmodules.ParsedModule, baseStores map[string]storage.Store) {
 	for job := range jobs {
@@ -269,12 +269,16 @@ func (c *Inspector) performInspection(ctx context.Context, scanID string, filesM
 			Metadata: queries[job.queryID],
 		}
 
+		// Evaluate each query only against documents of its own platform. The
+		// payload is read-only, so sharing the per-platform ast.Value across jobs
+		// is safe.
+		payload := selectPlatformPayload(query.Metadata.Platform, payloadByPlatform, fullPayload)
 		queryContext := &QueryContext{
 			Ctx:           ctx,
 			scanID:        scanID,
 			Files:         filesMap,
 			Query:         query,
-			payload:       &astPayload,
+			payload:       &payload,
 			FlagEvaluator: c.flagEvaluator,
 		}
 
@@ -311,8 +315,6 @@ func (c *Inspector) Inspect(
 	// Must run after module mutations (which suppress module bodies in place).
 	combinedFiles := files.Combine(ctx, false)
 
-	vulnerabilities := make([]model.Vulnerability, 0)
-
 	// Step 1: Parse Terraform modules
 	parsedModules, err := tfmodules.ParseTerraformModules(ctx, c.fsys, files, c.numWorkers)
 	if err != nil {
@@ -324,86 +326,81 @@ func (c *Inspector) Inspect(
 	rootDir := c.repoPath
 	enrichedModules := tfmodules.ParseAllModuleVariables(ctx, c.fsys, parsedModules, rootDir)
 
-	// Convert combined documents directly to OPA AST, skipping the
-	// json.Marshal -> UnmarshalJSON round-trip to avoid intermediate copies.
-	docs := make([]interface{}, 0, len(combinedFiles.Documents))
-	for _, d := range combinedFiles.Documents {
-		docs = append(docs, map[string]interface{}(d))
-	}
-	for _, d := range moduleDocs {
-		docs = append(docs, map[string]interface{}(d))
-	}
-	astPayload, err := ast.InterfaceToValue(map[string]interface{}{
-		"document": docs,
-	})
-	if err != nil {
-		return vulnerabilities, err
-	}
-
-	// Transform jsonencode in payload once before running queries
-	// This avoids redundant transformations and prevents race conditions
-	astPayload = c.TransformJsonencodeInPayload(ctx, astPayload)
-
 	queries := c.getQueriesByPlat(platforms)
+
+	// Compute the file map once and share it (read-only) across all workers and
+	// payload partitioning.
+	filesMap := files.ToMap()
+
+	payloads, err := c.buildPlatformPayloads(ctx, filesMap, combinedFiles.Documents, moduleDocs, queries)
+	if err != nil {
+		return nil, err
+	}
 
 	// Pre-build one inmem.Store per platform so LoadQuery does not re-parse the
 	// same payload for every PrepareForEval call.
 	baseStores := precomputeBaseStores(c.QueryLoader.precomputeBaseInputData(ctx, enrichedModules))
 
-	// Compute the file map once and share it (read-only) across all workers
-	filesMap := files.ToMap()
+	vulnerabilities, err := c.executeQueries(ctx, scanID, filesMap, payloads, queries, enrichedModules, baseStores)
+	if err != nil {
+		return nil, err
+	}
+	return expandModuleFindings(vulnerabilities, moduleExtras), nil
+}
 
-	// Create a channel to collect the results
+// executeQueries runs all prepared queries concurrently and collects vulnerabilities.
+func (c *Inspector) executeQueries(
+	ctx context.Context,
+	scanID string,
+	filesMap map[string]*model.FileMetadata,
+	payloads platformPayloads,
+	queries []model.QueryMetadata,
+	enrichedModules []tfmodules.ParsedModule,
+	baseStores map[string]storage.Store,
+) ([]model.Vulnerability, error) {
 	results := make(chan QueryResult, len(queries))
-
-	// Create a channel for inspection jobs
 	jobs := make(chan InspectionJob, len(queries))
 
 	var wg sync.WaitGroup
-
-	// Start a goroutine for each worker
 	for w := 0; w < c.numWorkers; w++ {
 		wg.Add(1)
-
 		go func() {
-			// Decrement the counter when the goroutine completes
 			defer wg.Done()
-			c.performInspection(ctx, scanID, filesMap, astPayload, jobs, results, queries, enrichedModules, baseStores)
+			c.performInspection(ctx, scanID, filesMap, payloads.byPlatform, payloads.full, jobs, results, queries, enrichedModules, baseStores)
 		}()
 	}
-	// Start a goroutine to create inspection jobs
 	go c.createInspectionJobs(jobs, queries)
-
 	go func() {
-		// Wait for all jobs to finish
 		wg.Wait()
-		// Then close the results channel
 		close(results)
 	}()
 
-	// Collect all the results
+	return c.drainQueryResults(ctx, results, queries)
+}
+
+// drainQueryResults reads query results until the channel closes or the context is canceled.
+func (c *Inspector) drainQueryResults(
+	ctx context.Context,
+	results <-chan QueryResult,
+	queries []model.QueryMetadata,
+) ([]model.Vulnerability, error) {
+	contextLogger := logger.FromContext(ctx)
+	vulnerabilities := make([]model.Vulnerability, 0)
 	moduleVulns := make(map[string]int)
-loop:
 	for {
 		select {
 		case <-ctx.Done():
 			return vulnerabilities, ctx.Err()
 		case result, ok := <-results:
 			if !ok {
-				// Channel closed, we're done
-				break loop
+				for vulnerability, number := range moduleVulns {
+					contextLogger.Info().Msgf("Found %d of module vulnerability %s", number, vulnerability)
+				}
+				return vulnerabilities, nil
 			}
 			processResult(ctx, &result, &vulnerabilities, &moduleVulns, queries, c)
 		}
 	}
-
-	for vulnerability, number := range moduleVulns {
-		contextLogger.Info().Msgf("Found %d of module vulnerability %s", number, vulnerability)
-	}
-
-	vulnerabilities = expandModuleFindings(vulnerabilities, moduleExtras)
-
-	return vulnerabilities, nil
 }
 
 // expandModuleFindings clones findings from deduplicated OPA docs back to each
@@ -759,15 +756,176 @@ func checkComment(line int, ignoreLines []int) bool {
 	return false
 }
 
+// Platform keys used to bucket documents and route queries to per-platform payloads.
+const (
+	platformCommon         = "common"
+	platformK8s            = "k8s"
+	platformKubernetes     = "kubernetes"
+	platformBicep          = "bicep"
+	platformAzureRM        = "azureresourcemanager"
+	platformKnative        = "knative"
+	platformServerlessFW   = "serverlessfw"
+	platformCloudFormation = "cloudformation"
+)
+
+// platformPayloads holds per-platform OPA input payloads built once per scan.
+type platformPayloads struct {
+	byPlatform map[string]ast.Value
+	full       ast.Value
+}
+
+// partitionDocsByPlatform groups parsed documents by their file's platform
+// bucket(s); multi-platform files (Knative, Serverless Framework) land in both
+// their own and their parent platform's bucket via platformBucketKeys.
+// Documents with an undetermined platform are collected separately and later
+// merged into every platform's payload so no rule loses coverage.
+func partitionDocsByPlatform(
+	filesMap map[string]*model.FileMetadata,
+	combinedDocs, moduleDocs []model.Document,
+) (byPlatform map[string][]interface{}, unknown, all []interface{}) {
+	byPlatform = make(map[string][]interface{})
+	all = make([]interface{}, 0, len(combinedDocs)+len(moduleDocs))
+	addDoc := func(d model.Document) {
+		m := map[string]interface{}(d)
+		all = append(all, m)
+		id, _ := d["id"].(string)
+		var platform string
+		if fm := filesMap[id]; fm != nil {
+			platform = fm.Platform
+		}
+		keys := platformBucketKeys(platform)
+		if len(keys) == 0 {
+			unknown = append(unknown, m)
+			return
+		}
+		for _, key := range keys {
+			byPlatform[key] = append(byPlatform[key], m)
+		}
+	}
+	for _, d := range combinedDocs {
+		addDoc(d)
+	}
+	for _, d := range moduleDocs {
+		addDoc(d)
+	}
+	return byPlatform, unknown, all
+}
+
+// buildPlatformPayloads partitions documents by platform and builds one OPA
+// payload per queried platform. Common-platform queries receive the full
+// cross-platform payload.
+func (c *Inspector) buildPlatformPayloads(
+	ctx context.Context,
+	filesMap map[string]*model.FileMetadata,
+	combinedDocs, moduleDocs []model.Document,
+	queries []model.QueryMetadata,
+) (platformPayloads, error) {
+	docsByPlatform, unknownDocs, allDocs := partitionDocsByPlatform(filesMap, combinedDocs, moduleDocs)
+
+	makePayload := func(ds []interface{}) (ast.Value, error) {
+		v, err := ast.InterfaceToValue(map[string]interface{}{"document": ds})
+		if err != nil {
+			return nil, err
+		}
+		return c.TransformJsonencodeInPayload(ctx, v), nil
+	}
+
+	needFullPayload := false
+	neededPlatforms := make(map[string]bool)
+	for i := range queries {
+		key := canonicalPlatformKey(queries[i].Platform)
+		if key == platformCommon {
+			needFullPayload = true
+			continue
+		}
+		neededPlatforms[key] = true
+	}
+
+	out := platformPayloads{
+		byPlatform: make(map[string]ast.Value, len(neededPlatforms)),
+	}
+	for key := range neededPlatforms {
+		ds := docsByPlatform[key]
+		if len(unknownDocs) > 0 {
+			combined := make([]interface{}, 0, len(ds)+len(unknownDocs))
+			combined = append(combined, ds...)
+			combined = append(combined, unknownDocs...)
+			ds = combined
+		}
+		pv, err := makePayload(ds)
+		if err != nil {
+			return platformPayloads{}, err
+		}
+		out.byPlatform[key] = pv
+	}
+
+	if needFullPayload {
+		pv, err := makePayload(allDocs)
+		if err != nil {
+			return platformPayloads{}, err
+		}
+		out.full = pv
+	}
+
+	return out, nil
+}
+
+// canonicalPlatformKey maps a query- or file-level platform name to the single
+// lowercased key used to bucket documents and select per-platform payloads.
+// Kubernetes is keyed "kubernetes" (query metadata uses "k8s"), and Bicep is
+// scanned by the Azure Resource Manager rules (Bicep transpiles to ARM).
+func canonicalPlatformKey(p string) string {
+	p = strings.ToLower(p)
+	switch p {
+	case platformK8s:
+		return platformKubernetes
+	case platformBicep:
+		return platformAzureRM
+	}
+	return p
+}
+
+// platformBucketKeys returns every payload bucket a document of the given
+// platform must belong to. Knative manifests are also scanned by the Kubernetes
+// rules and Serverless Framework manifests by the CloudFormation rules; these
+// fan-outs mirror multiPlatformTypeCheck in the analyzer (which force-loads the
+// parent platform's queries), so those documents are placed in both their own
+// bucket and their parent platform's bucket. Every other platform (including
+// Crossplane, which is classified consistently by the sink and has its own
+// queries) maps to a single bucket. Returns nil for an undetermined platform so
+// the caller can treat it as unknown.
+func platformBucketKeys(platform string) []string {
+	key := canonicalPlatformKey(platform)
+	switch key {
+	case "":
+		return nil
+	case platformKnative:
+		return []string{platformKnative, platformKubernetes}
+	case platformServerlessFW:
+		return []string{platformServerlessFW, platformCloudFormation}
+	}
+	return []string{key}
+}
+
+// selectPlatformPayload returns the document payload a query should evaluate
+// against: its own platform's payload, or the full payload for common rules
+// (and as a defensive fallback when a platform payload was not built).
+func selectPlatformPayload(queryPlatform string, byPlatform map[string]ast.Value, full ast.Value) ast.Value {
+	if key := canonicalPlatformKey(queryPlatform); key != platformCommon {
+		if p, ok := byPlatform[key]; ok {
+			return p
+		}
+	}
+	return full
+}
+
 // contains is a simple method to check if a slice
 // contains an entry
 func contains(s []string, e string) bool {
-	if e == "common" {
+	if canonicalPlatformKey(e) == platformCommon {
 		return true
 	}
-	if e == "k8s" {
-		e = "kubernetes"
-	}
+	e = canonicalPlatformKey(e)
 	for _, a := range s {
 		if strings.EqualFold(a, e) {
 			return true

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/stretchr/testify/assert"
 
@@ -293,6 +294,103 @@ func TestEngine_contains(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestEngine_canonicalPlatformKey(t *testing.T) {
+	cases := map[string]string{
+		"k8s":                  "kubernetes",
+		"Kubernetes":           "kubernetes",
+		"K8S":                  "kubernetes",
+		"bicep":                "azureresourcemanager",
+		"Bicep":                "azureresourcemanager",
+		"azureResourceManager": "azureresourcemanager",
+		"cloudFormation":       "cloudformation",
+		"serverlessFW":         "serverlessfw",
+		"Ansible":              "ansible",
+		"terraform":            "terraform",
+		"common":               "common",
+	}
+	for in, want := range cases {
+		require.Equal(t, want, canonicalPlatformKey(in), "canonicalPlatformKey(%q)", in)
+	}
+}
+
+func TestEngine_platformBucketKeys(t *testing.T) {
+	cases := map[string][]string{
+		"":           nil,
+		"ansible":    {"ansible"},
+		"k8s":        {"kubernetes"},
+		"kubernetes": {"kubernetes"},
+		"bicep":      {"azureresourcemanager"},
+		"terraform":  {"terraform"},
+		"knative":    {"knative", "kubernetes"},
+		"Knative":    {"knative", "kubernetes"},
+		// Crossplane has its own queries and is classified consistently by the
+		// sink, so it maps to a single bucket (no kubernetes fan-out).
+		"crossplane":   {"crossplane"},
+		"serverlessfw": {"serverlessfw", "cloudformation"},
+		"serverlessFW": {"serverlessfw", "cloudformation"},
+	}
+	for in, want := range cases {
+		require.Equal(t, want, platformBucketKeys(in), "platformBucketKeys(%q)", in)
+	}
+}
+
+func Test_partitionDocsByPlatform(t *testing.T) {
+	filesMap := map[string]*model.FileMetadata{
+		"ansible-id":      {ID: "ansible-id", Platform: "ansible"},
+		"k8s-id":          {ID: "k8s-id", Platform: "kubernetes"},
+		"unknown-id":      {ID: "unknown-id", Platform: ""},
+		"query-k8s-id":    {ID: "query-k8s-id", Platform: "k8s"},
+		"knative-id":      {ID: "knative-id", Platform: "knative"},
+		"crossplane-id":   {ID: "crossplane-id", Platform: "crossplane"},
+		"serverlessfw-id": {ID: "serverlessfw-id", Platform: "serverlessfw"},
+	}
+	combined := []model.Document{
+		{"id": "ansible-id", "playbooks": []interface{}{}},
+		{"id": "k8s-id", "apiVersion": "v1", "kind": "Pod"},
+		{"id": "unknown-id", "foo": "bar"},
+		{"id": "query-k8s-id", "apiVersion": "v1", "kind": "Service"},
+		{"id": "knative-id", "apiVersion": "serving.knative.dev/v1", "kind": "Service"},
+		{"id": "crossplane-id", "apiVersion": "s3.aws.crossplane.io/v1beta1", "kind": "Bucket"},
+		{"id": "serverlessfw-id", "service": "my-svc", "provider": map[string]interface{}{}},
+	}
+
+	byPlatform, unknown, all := partitionDocsByPlatform(filesMap, combined, nil)
+
+	require.Len(t, all, 7)
+	require.Len(t, unknown, 1)
+	require.Equal(t, "unknown-id", unknown[0].(map[string]interface{})["id"])
+	require.Len(t, byPlatform["ansible"], 1)
+	require.Equal(t, "ansible-id", byPlatform["ansible"][0].(map[string]interface{})["id"])
+	// Knative docs are also scanned by Kubernetes rules; the kubernetes bucket
+	// holds the two k8s docs plus the knative one.
+	require.Len(t, byPlatform["knative"], 1)
+	require.Len(t, byPlatform["kubernetes"], 3)
+	// Crossplane is classified consistently and has its own queries, so it maps
+	// to a single bucket and is not mirrored into kubernetes.
+	require.Len(t, byPlatform["crossplane"], 1)
+	// Serverless Framework docs are scanned by both ServerlessFW and CloudFormation rules.
+	require.Len(t, byPlatform["serverlessfw"], 1)
+	require.Len(t, byPlatform["cloudformation"], 1)
+}
+
+func TestEngine_selectPlatformPayload(t *testing.T) {
+	full := ast.String("FULL")
+	byPlatform := map[string]ast.Value{
+		"ansible":    ast.String("ANSIBLE"),
+		"kubernetes": ast.String("K8S"),
+	}
+
+	// A query is routed to its own platform's payload.
+	require.Equal(t, ast.String("ANSIBLE"), selectPlatformPayload("ansible", byPlatform, full))
+	// "k8s" query metadata normalizes to the "kubernetes" bucket.
+	require.Equal(t, ast.String("K8S"), selectPlatformPayload("k8s", byPlatform, full))
+	// Common rules always see the full payload.
+	require.Equal(t, full, selectPlatformPayload("common", byPlatform, full))
+	require.Equal(t, full, selectPlatformPayload("Common", byPlatform, full))
+	// Defensive fallback: a platform with no built payload uses the full payload.
+	require.Equal(t, full, selectPlatformPayload("terraform", byPlatform, full))
 }
 
 func TestEngine_LenQueriesByPlat(t *testing.T) {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -168,6 +168,10 @@ type FileMetadata struct {
 	IsMinified        bool
 	// ModuleCallChain: synthetic rows for instantiated local modules; used in SARIF fingerprint (Terraform only).
 	ModuleCallChain string
+	// Platform is the lowercased platform the file was classified as (e.g.
+	// "ansible", "kubernetes", "terraform"); "" when undetermined. Used by the
+	// engine to evaluate each query only against documents of its own platform.
+	Platform string
 }
 
 // QueryMetadata is a representation of general information about a query

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -102,6 +102,16 @@ type Parser struct {
 	fsys       vfs.FS
 }
 
+// FS returns the filesystem used for extension detection. The HTTP server
+// injects an in-memory FS for pushed content; the CLI defaults to the real
+// disk. Never returns nil so callers can use it directly.
+func (c *Parser) FS() vfs.FS {
+	if c.fsys == nil {
+		return vfs.DiskFS{}
+	}
+	return c.fsys
+}
+
 // ParsedDocument is a struct containing data retrieved from parsing
 type ParsedDocument struct {
 	Docs          []model.Document

--- a/pkg/runner/resolver_sink.go
+++ b/pkg/runner/resolver_sink.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/analyzer"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/minified"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -102,6 +103,7 @@ func (s *Service) resolverSink(
 				ResolvedFiles:     documents.ResolvedFiles,
 				LinesOriginalData: utils.SplitLines(string(rfile.OriginalData)),
 				IsMinified:        documents.IsMinified,
+				Platform:          analyzer.ClassifyParsedFile(ctx, s.Parser.FS(), s.Platforms, kind, rfile.FileName, rfile.Content),
 			}
 			s.saveToFile(ctx, &file)
 		}

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -76,6 +76,10 @@ type Service struct {
 	files          model.FileMetadatas
 	filesMu        sync.Mutex
 	MaxFileSize    int
+	// Platforms is the scan's effective platform set, used to classify each
+	// parsed file's platform consistently with the analyzer so the engine can
+	// scope queries to their own platform's documents.
+	Platforms []string
 	// failedHelmChartDirsMu guards failedHelmChartDirs.
 	failedHelmChartDirsMu sync.RWMutex
 	// failedHelmChartDirs tracks chart directories that could not be rendered,

--- a/pkg/runner/sink.go
+++ b/pkg/runner/sink.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"sort"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/analyzer"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/jsonfilter/parser"
@@ -99,6 +100,7 @@ func (s *Service) sink(ctx context.Context, filename, scanID string,
 			ResolvedFiles:     documents.ResolvedFiles,
 			LinesOriginalData: utils.SplitLines(documents.Content),
 			IsMinified:        documents.IsMinified,
+			Platform:          analyzer.ClassifyParsedFile(ctx, s.Parser.FS(), s.Platforms, documents.Kind, filename, *content),
 		}
 
 		s.saveToFile(ctx, &file)

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -317,6 +317,7 @@ func (c *Client) createService(
 				Tracker:        t,
 				Resolver:       combinedResolver,
 				MaxFileSize:    c.ScanParams.MaxFileSizeFlag,
+				Platforms:      types,
 			},
 		)
 	}


### PR DESCRIPTION
## Motivation

On large polyglot repositories the scanner builds a single OPA payload containing every parsed document across all platforms, then evaluates each rule query against the full cross-platform payload. This means, for example, that every Ansible rule rebuilds its task index over thousands of Kubernetes, Helm-rendered, CloudFormation, and Terraform documents that are irrelevant to it. On a real-world Go monorepo (49 k YAML files, ~48 k parsed documents), a single Ansible rule takes ~27 s to evaluate due to this cross-platform document scanning; with ~221 Ansible rules the total Ansible eval time exceeds 100 minutes. The same mechanism inflates eval time for CloudFormation and Kubernetes rules on large mixed repos.

## Changes

**Platform classification**

A new `ClassifyFile` function in the analyzer package determines a file's platform from its extension and content, mirroring the per-file detection already done by the analyzer but making it available to the parsing layer. Kind is used as the authoritative signal for unambiguous types (Helm→kubernetes, Terraform→terraform, Bicep→azureresourcemanager, Dockerfile→dockerfile, GRPC→grpc, INI/CFG→ansible); ambiguous YAML/JSON files fall back to content-based regex classification.

**Scan pipeline**

Both the regular sink and the resolver sink now populate a `Platform` field on each `FileMetadata` at parse time. Synthetic Terraform module documents inherit the platform of their parent file via `FileMetadata` cloning.

**Rule engine**

`Inspect` partitions the combined document set by platform and builds one OPA payload per platform that is actually queried in that scan. Each rule query receives only its own platform's documents. Documents whose platform could not be determined are included in every platform's payload so no rule loses coverage. `common`-platform queries (force-enabled by the engine and not observed in production slow-rule telemetry) continue to receive the full cross-platform payload. Two small helpers, `normalizePlatformKey` and `selectPlatformPayload`, handle the query-metadata-to-platform-key mapping (e.g. `k8s`↔`kubernetes`, `Bicep`↔`azureresourcemanager`).

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/engine/... ./pkg/analyzer/... ./pkg/runner/... ./pkg/model/... ./pkg/scan/...` — all packages should pass.
2. Scan a fixture directory that contains multiple platform types (e.g. `test/fixtures/test_helm` alongside a Terraform or Ansible fixture) and confirm the SARIF output is identical to the output produced by `main`.
3. On a large mixed-platform repository, confirm per-rule eval times drop significantly for Ansible and CloudFormation rules by comparing scan durations.

## Blast Radius

This change affects all scans that parse more than one platform type. Scans of a single platform are unaffected (the per-platform payload equals the full payload). The findings set is unchanged, validated by a findings diff on a 1 048-file mixed repository (Kubernetes, Helm-rendered, Ansible, Terraform, CloudFormation) showing identical results (1 016 findings, zero lost, zero gained) against the `main` baseline.

## Additional Notes

Measured on a real-world monorepo (49 k YAML files):
- Single Ansible rule eval: 27.4 s → 3.1 ms (~8 800×)
- Full scan of 1 048-file mixed subset: ~16 min (baseline) → ~9 s (this PR)

I submit this contribution under the Apache-2.0 license.
