### PR TITLE
Fix report format validation rejecting all valid formats

### DIFF
--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -43,7 +43,7 @@ var reportGenerators = map[string]func(ctx context.Context, path, filename strin
 }
 
 func GetSupportedReportFormats() []string {
-	return []string{"sarif, simple-json"}
+	return []string{"sarif", "simple-json"}
 }
 
 // FileAnalyzer determines the type of extension in the passed config file by its content


### PR DESCRIPTION
## Motivation

Commit 1308b314 ("refactor: expose supported report formats") introduced helpers.GetSupportedReportFormats(), which is used to validate the --report-format flag. The function accidentally returned a single-element slice containing one comma-joined string ([]string{"sarif, simple-json"}) instead of two separate elements.

As a result, every report format was rejected by validation, including the valid ones. The error message joined the same slice and printed valid formats: sarif, simple-json, making the failure look self-contradictory:

Program failed: unknown report format "sarif"; valid formats: sarif, simple-json

## Changes

- Fixed GetSupportedReportFormats() in internal/console/helpers/helpers.go to return []string{"sarif", "simple-json"} (two separate elements) instead of a single comma-joined string.

## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Build the scanner and run a scan against a git repository with each supported format:

make build
./bin/datadog-iac-scanner scan -p <repo> -o /tmp/iac-out --report-format sarif
./bin/datadog-iac-scanner scan -p <repo> -o /tmp/iac-out --report-format simple-json

Both should complete and write a report. An unsupported value should still be rejected with the correct list:

./bin/datadog-iac-scanner scan -p <repo> -o /tmp/iac-out --report-format amogus
# -> unknown report format "amogus"; valid formats: sarif, simple-json

## Blast Radius

Datadog IaC Scanner only — specifically --report-format flag validation in the scan command. No impact on scanning logic or report content.

## Additional Notes

Regression introduced in 1308b314. The fix is a one-line correction to a slice literal.

I submit this contribution under the Apache-2.0 license.
