### PR TITLE
Gate Terraform local module instantiation behind a feature flag

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -87,6 +87,12 @@ var scanAction = &cli.Command{
 			Value:  false,
 		},
 		&cli.BoolFlag{
+			Name:   "x-local-module-eval",
+			Hidden: true,
+			Usage:  "(experimental) resolve Terraform local module variables before scanning",
+			Value:  false,
+		},
+		&cli.BoolFlag{
 			Name:   "x-terraform-plan",
 			Hidden: true,
 			Usage:  "(experimental, will be removed soon) scan terraform plans",
@@ -467,8 +473,10 @@ func selectPlatforms(platforms []string) []string {
 }
 
 func getFeatureFlagEvaluator(c *cli.Command) featureflags.FlagEvaluator {
-	overrides := map[string]bool{}
-	overrides[featureflags.IaCEnableKicsParallelFileParsing] = c.Bool("x-parallelparsing")
+	overrides := map[string]bool{
+		featureflags.IaCEnableKicsParallelFileParsing: c.Bool("x-parallelparsing"),
+		featureflags.IacEnableLocalModuleEval:         c.Bool("x-local-module-eval"),
+	}
 	return featureflags.NewLocalEvaluatorWithOverrides(overrides)
 }
 

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -299,11 +299,16 @@ func (c *Inspector) Inspect(
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("engine.Inspect()")
 
-	// Local modules: append synthetic file rows (ids match docs) for attribution and fingerprints.
-	moduleDocs, syntheticFiles, moduleExtras := c.instantiateLocalModules(ctx, files)
-	files = append(files, syntheticFiles...)
+	// Terraform local-module instantiation is gated so it can be disabled remotely.
+	var moduleDocs []model.Document
+	var moduleExtras map[string][]extraCallerInfo
+	if c.flagEvaluator != nil && c.flagEvaluator.EvaluateWithOrg(featureflags.IacEnableLocalModuleEval) {
+		var syntheticFiles []*model.FileMetadata
+		moduleDocs, syntheticFiles, moduleExtras = c.instantiateLocalModules(ctx, files)
+		files = append(files, syntheticFiles...)
+	}
 
-	// Must run before Combine: instantiateLocalModules clears suppressed file bodies in place.
+	// Must run after module mutations (which suppress module bodies in place).
 	combinedFiles := files.Combine(ctx, false)
 
 	vulnerabilities := make([]model.Vulnerability, 0)

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -12,12 +12,20 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	terraformParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform"
 	scanUtils "github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
+
+// moduleEvalEnabled returns a FlagEvaluator with local module evaluation turned on.
+func moduleEvalEnabled() featureflags.FlagEvaluator {
+	return featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
+		featureflags.IacEnableLocalModuleEval: true,
+	})
+}
 
 // aclRule fires when an aws_s3_bucket has acl == "public-read". It only matches
 // after a module is instantiated with that concrete value.
@@ -110,9 +118,10 @@ resource "aws_s3_bucket" "this" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:  queries,
-		repoPath: root,
-		vb:       DefaultVulnerabilityBuilder,
+		queries:       queries,
+		repoPath:      root,
+		vb:            DefaultVulnerabilityBuilder,
+		flagEvaluator: moduleEvalEnabled(),
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -177,9 +186,10 @@ resource "aws_s3_bucket" "this" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:  queries,
-		repoPath: root,
-		vb:       DefaultVulnerabilityBuilder,
+		queries:       queries,
+		repoPath:      root,
+		vb:            DefaultVulnerabilityBuilder,
+		flagEvaluator: moduleEvalEnabled(),
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -266,9 +276,10 @@ resource "aws_s3_bucket" "this" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:  queries,
-		repoPath: root,
-		vb:       DefaultVulnerabilityBuilder,
+		queries:       queries,
+		repoPath:      root,
+		vb:            DefaultVulnerabilityBuilder,
+		flagEvaluator: moduleEvalEnabled(),
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -343,9 +354,10 @@ resource "aws_s3_bucket" "this" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:  queries,
-		repoPath: root,
-		vb:       DefaultVulnerabilityBuilder,
+		queries:       queries,
+		repoPath:      root,
+		vb:            DefaultVulnerabilityBuilder,
+		flagEvaluator: moduleEvalEnabled(),
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -443,9 +455,10 @@ resource "aws_s3_bucket" "this" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:  queries,
-		repoPath: root,
-		vb:       DefaultVulnerabilityBuilder,
+		queries:       queries,
+		repoPath:      root,
+		vb:            DefaultVulnerabilityBuilder,
+		flagEvaluator: moduleEvalEnabled(),
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -495,4 +508,49 @@ resource "aws_s3_bucket" "this" {
 	require.NoError(t, err)
 	require.Empty(t, ins.GetFailedQueries())
 	require.Len(t, vulns, numQueries)
+}
+
+// TestInspect_LocalModuleEvalDisabled_FlagOff confirms that when the flag is off
+// (default) the module body is scanned as-is with no synthetic docs injected.
+func TestInspect_LocalModuleEvalDisabled_FlagOff(t *testing.T) {
+	root := t.TempDir()
+	rootPath := filepath.Join(root, "main.tf")
+	modDir := filepath.Join(root, "modules", "s3")
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+	modPath := filepath.Join(modDir, "main.tf")
+
+	require.NoError(t, os.WriteFile(rootPath, []byte(`
+module "s3" {
+  source = "./modules/s3"
+  acl    = "public-read"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(modPath, []byte(`
+variable "acl" {}
+resource "aws_s3_bucket" "this" { acl = var.acl }
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, rootPath)...)
+	files = append(files, parseTerraform(t, modPath)...)
+
+	queries := []model.QueryMetadata{{
+		Query:       "acl_rule",
+		Content:     aclRule,
+		InputData:   "{}",
+		Platform:    "terraform",
+		Metadata:    map[string]interface{}{"id": "acl-rule"},
+		Aggregation: 1,
+	}}
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
+	})
+
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries())
+	require.Empty(t, vulns, "module eval disabled: rule must not fire on unresolved module reference")
 }

--- a/pkg/featureflags/evaluator.go
+++ b/pkg/featureflags/evaluator.go
@@ -7,6 +7,8 @@ const (
 	IacEnableKicsPlatform            = "k9-iac-enable-kics-platform"
 	IacEnableKicsHelmResolver        = "k9-iac-enable-kics-helm-resolver"
 	IaCEnableKicsParallelFileParsing = "k9-iac-enable-kics-parallel-file-parsing"
+	// IacEnableLocalModuleEval gates Terraform local-module instantiation.
+	IacEnableLocalModuleEval = "k9-iac-enable-local-module-eval"
 )
 
 type FlagEvaluator interface {

--- a/pkg/featureflags/local_evaluator.go
+++ b/pkg/featureflags/local_evaluator.go
@@ -12,6 +12,7 @@ func NewLocalEvaluatorWithOverrides(overrides map[string]bool) *LocalEvaluator {
 		IacEnableKicsPlatform:            true,
 		IacEnableKicsHelmResolver:        true,
 		IaCEnableKicsParallelFileParsing: false,
+		IacEnableLocalModuleEval:         false,
 	}
 
 	for k, v := range overrides {


### PR DESCRIPTION
## Motivation

Local Terraform module instantiation changes scan behavior and adds runtime cost on large repositories. To unblock the v1.6.0 release while slow-rule performance work continues, module resolution should be opt-in rather than always on.

## Changes

**Feature flags**

Add `k9-iac-enable-local-module-eval`, defaulting to `false` in the local evaluator.

**Scan pipeline**

When the flag is off, skip `instantiateLocalModules` and `expandModuleFindings`. Module files are scanned as parsed HCL with unresolved `var.*` references, matching the pre-module-instantiation behavior.

**Tests**

Enable the flag explicitly in existing module integration tests. Add a regression test confirming the default-off path does not inject synthetic module documents.

## QA Instruction

1. `go test ./pkg/engine/ -run TestInspect -count=1`
2. Build the scanner and run a Terraform repo with local modules; confirm no synthetic module documents are added by default.
3. Enable `k9-iac-enable-local-module-eval` and confirm module instantiation findings are restored.

## Impact

CLI and server scans default to the prior module scanning behavior until the flag is enabled remotely.