### PR TITLE
Speed up IAM privilege-escalation rules on large Terraform repos

### DIFF
--- a/assets/libraries/common.rego
+++ b/assets/libraries/common.rego
@@ -738,6 +738,18 @@ _policy_wildcard_actions(policyObj) := {lower(a) |
 	a := _to_action_array(statement.Action)[_]
 }
 
+_managed_policy_types := {"aws_iam_role_policy", "aws_iam_user_policy", "aws_iam_group_policy", "aws_iam_policy"}
+
+# [policyResourceName, wildcardAction] pairs across every managed policy type,
+# built in one document pass. Only policies granting an Allow on "*" contribute,
+# so this set stays small. The attachment branches below resolve a policy_arn
+# reference via membership here instead of rescanning every document per
+# attachment (previously O(attachments × docs)).
+_policy_name_wildcard_perms := {[name, permission] |
+	policyObj := input.document[_].resource[_managed_policy_types[_]][name]
+	permission := _policy_wildcard_actions(policyObj)[_]
+}
+
 # Pre-computed sets of [principalName, permission] pairs, one per principal type.
 #
 # Using complete set rules (not incremental/partial rules) guarantees that OPA
@@ -755,9 +767,9 @@ _role_dangerous_pairs := {[roleName, permission] |
 	attachment := input.document[_].resource[attachments[_]][_]
 	roleName := get_role_from_policy_attachment(attachment)
 	policyName := split(attachment.policy_arn, ".")[1]
-	policies := {"aws_iam_role_policy", "aws_iam_user_policy", "aws_iam_group_policy", "aws_iam_policy"}
-	resourcePolicy := input.document[_].resource[policies[_]][policyName]
-	permission := _policy_wildcard_actions(resourcePolicy)[_]
+	some pair in _policy_name_wildcard_perms
+	pair[0] == policyName
+	permission := pair[1]
 }
 
 _user_dangerous_pairs := {[userName, permission] |
@@ -769,9 +781,9 @@ _user_dangerous_pairs := {[userName, permission] |
 	attachment := input.document[_].resource[attachments[_]][_]
 	userName := get_user_from_policy_attachment(attachment)
 	policyName := split(attachment.policy_arn, ".")[1]
-	policies := {"aws_iam_role_policy", "aws_iam_user_policy", "aws_iam_group_policy", "aws_iam_policy"}
-	resourcePolicy := input.document[_].resource[policies[_]][policyName]
-	permission := _policy_wildcard_actions(resourcePolicy)[_]
+	some pair in _policy_name_wildcard_perms
+	pair[0] == policyName
+	permission := pair[1]
 }
 
 _group_dangerous_pairs := {[groupName, permission] |
@@ -783,9 +795,9 @@ _group_dangerous_pairs := {[groupName, permission] |
 	attachment := input.document[_].resource[attachments[_]][_]
 	groupName := get_group_from_policy_attachment(attachment)
 	policyName := split(attachment.policy_arn, ".")[1]
-	policies := {"aws_iam_role_policy", "aws_iam_user_policy", "aws_iam_group_policy", "aws_iam_policy"}
-	resourcePolicy := input.document[_].resource[policies[_]][policyName]
-	permission := _policy_wildcard_actions(resourcePolicy)[_]
+	some pair in _policy_name_wildcard_perms
+	pair[0] == policyName
+	permission := pair[1]
 }
 
 group_unrecommended_permission_policy_scenarios(targetGroup, permission) if {

--- a/assets/libraries/test/common_test.rego
+++ b/assets/libraries/test/common_test.rego
@@ -742,3 +742,54 @@ test_is_iam_policy_principal_scoped_specific_cidr if {
 	}
 	is_iam_policy_principal_scoped_by_condition(statement)
 }
+
+_wildcard_policy_json := `{"Statement":[{"Action":["iam:PassRole","sts:AssumeRole"],"Effect":"Allow","Resource":"*"}]}`
+
+test_role_dangerous_pairs_inline_policy if {
+	doc := {"document": [{"resource": {"aws_iam_role_policy": {"p": {
+		"role": "aws_iam_role.r1.name",
+		"policy": _wildcard_policy_json,
+	}}}}]}
+	role_unrecommended_permission_policy_scenarios("r1", "iam:PassRole") with input as doc
+	role_unrecommended_permission_policy_scenarios("r1", "sts:AssumeRole") with input as doc
+}
+
+# Attachment references a managed policy declared in a DIFFERENT document; the
+# precomputed name index must still resolve it.
+test_role_dangerous_pairs_attachment_cross_document if {
+	doc := {"document": [
+		{"resource": {"aws_iam_role_policy_attachment": {"a": {
+			"role": "aws_iam_role.r1.name",
+			"policy_arn": "aws_iam_policy.shared.arn",
+		}}}},
+		{"resource": {"aws_iam_policy": {"shared": {
+			"name": "shared",
+			"policy": _wildcard_policy_json,
+		}}}},
+	]}
+	role_unrecommended_permission_policy_scenarios("r1", "iam:PassRole") with input as doc
+	role_unrecommended_permission_policy_scenarios("r1", "sts:AssumeRole") with input as doc
+}
+
+test_user_dangerous_pairs_attachment_cross_document if {
+	doc := {"document": [
+		{"resource": {"aws_iam_policy_attachment": {"a": {
+			"users": ["aws_iam_user.u1.name"],
+			"policy_arn": "aws_iam_policy.shared.arn",
+		}}}},
+		{"resource": {"aws_iam_policy": {"shared": {
+			"name": "shared",
+			"policy": _wildcard_policy_json,
+		}}}},
+	]}
+	user_unrecommended_permission_policy_scenarios("u1", "iam:PassRole") with input as doc
+}
+
+# A policy scoped to a specific resource (not "*") must not produce any pair.
+test_role_dangerous_pairs_non_wildcard_resource_excluded if {
+	doc := {"document": [{"resource": {"aws_iam_role_policy": {"p": {
+		"role": "aws_iam_role.r1.name",
+		"policy": `{"Statement":[{"Action":["iam:PassRole"],"Effect":"Allow","Resource":"arn:aws:iam::123:role/x"}]}`,
+	}}}}]}
+	not role_unrecommended_permission_policy_scenarios("r1", "iam:PassRole") with input as doc
+}

--- a/assets/libraries/test/common_test.rego
+++ b/assets/libraries/test/common_test.rego
@@ -793,3 +793,47 @@ test_role_dangerous_pairs_non_wildcard_resource_excluded if {
 	}}}}]}
 	not role_unrecommended_permission_policy_scenarios("r1", "iam:PassRole") with input as doc
 }
+
+test_user_dangerous_pairs_inline_policy if {
+	doc := {"document": [{"resource": {"aws_iam_user_policy": {"p": {
+		"user": "aws_iam_user.u1.name",
+		"policy": _wildcard_policy_json,
+	}}}}]}
+	user_unrecommended_permission_policy_scenarios("u1", "iam:PassRole") with input as doc
+	user_unrecommended_permission_policy_scenarios("u1", "sts:AssumeRole") with input as doc
+}
+
+test_group_dangerous_pairs_inline_policy if {
+	doc := {"document": [{"resource": {"aws_iam_group_policy": {"p": {
+		"group": "aws_iam_group.g1.name",
+		"policy": _wildcard_policy_json,
+	}}}}]}
+	group_unrecommended_permission_policy_scenarios("g1", "iam:PassRole") with input as doc
+	group_unrecommended_permission_policy_scenarios("g1", "sts:AssumeRole") with input as doc
+}
+
+# Group attachment references a managed policy in a DIFFERENT document; the
+# precomputed name index must still resolve it.
+test_group_dangerous_pairs_attachment_cross_document if {
+	doc := {"document": [
+		{"resource": {"aws_iam_group_policy_attachment": {"a": {
+			"group": "aws_iam_group.g1.name",
+			"policy_arn": "aws_iam_policy.shared.arn",
+		}}}},
+		{"resource": {"aws_iam_policy": {"shared": {
+			"name": "shared",
+			"policy": _wildcard_policy_json,
+		}}}},
+	]}
+	group_unrecommended_permission_policy_scenarios("g1", "iam:PassRole") with input as doc
+	group_unrecommended_permission_policy_scenarios("g1", "sts:AssumeRole") with input as doc
+}
+
+# A group with a policy scoped to a specific resource (not "*") must not fire.
+test_group_dangerous_pairs_non_wildcard_resource_excluded if {
+	doc := {"document": [{"resource": {"aws_iam_group_policy": {"p": {
+		"group": "aws_iam_group.g1.name",
+		"policy": `{"Statement":[{"Action":["iam:PassRole"],"Effect":"Allow","Resource":"arn:aws:iam::123:role/x"}]}`,
+	}}}}]}
+	not group_unrecommended_permission_policy_scenarios("g1", "iam:PassRole") with input as doc
+}


### PR DESCRIPTION
## Motivation

On large Terraform repositories, the IAM privilege-escalation rule family was a major scan bottleneck. Each rule rebuilt dangerous-permission sets by resolving `policy_arn` attachments with an O(attachments × documents) document rescan. This is a followup of https://github.com/DataDog/datadog-iac-scanner/pull/221, which improved these queries, but there was a bigger improvement possible.

## Changes

**IAM helpers (`common.rego`)**

Build `_policy_name_wildcard_perms` once per query in a single pass over managed policy resources. Attachment branches for roles, users, and groups now resolve `policy_arn` references via membership in that set instead of rescanning every document for each attachment.

**Tests**

Add regression coverage for inline policies, cross-document attachment resolution, and non-wildcard policy exclusion.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `opa test assets/libraries/ --v1-compatible`
2. Build the scanner and scan a large Terraform repo with many IAM roles and policy attachments.
3. Confirm privilege-escalation rules no longer appear in slow-rule logs and total scan time drops materially.

On `cloud-inventory` (29,788 files, full rule corpus): scan time dropped from ~8m to ~1m53s, with 0 slow IAM privilege-escalation rules (previously 19 rules at ~3 min each).

## Blast Radius

Affects Terraform IAM privilege-escalation rules that use `*_unrecommended_permission_policy_scenarios` in `common.rego`. No CLI or engine behavior changes.

## Additional Notes

N/A

I submit this contribution under the Apache-2.0 license.