### PR TITLE
Cache Terraform HCL parses during line detection

### DIFF
--- a/pkg/detector/terraform/terraform_detect.go
+++ b/pkg/detector/terraform/terraform_detect.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/detector"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
@@ -25,12 +26,37 @@ const strNestedEnd = "nested-end"
 const strNestedStart = "nested-start"
 const strNestedBody = "nested-body"
 
-type DetectKindLine struct{}
+// DetectKindLine holds a per-scan HCL parse cache. Multiple findings in the
+// same file reuse the parsed body instead of re-running hclsyntax.ParseConfig
+// for each one, which is the dominant cost when a single rule fires thousands
+// of times across a large repo.
+type DetectKindLine struct {
+	// hclCache maps file path → *hclsyntax.Body, populated on first parse.
+	hclCache sync.Map
+}
+
+// cachedParseBody parses src as HCL and returns the body, reusing a previously
+// parsed result for the same filePath within this scan.
+func (d *DetectKindLine) cachedParseBody(src []byte, filePath string) (*hclsyntax.Body, error) {
+	if cached, ok := d.hclCache.Load(filePath); ok {
+		return cached.(*hclsyntax.Body), nil
+	}
+	hclFile, diagnostics := hclsyntax.ParseConfig(src, filePath, hcl.InitialPos)
+	if diagnostics.HasErrors() {
+		return nil, fmt.Errorf("failed to parse HCL: %v", diagnostics.Errs())
+	}
+	body, ok := hclFile.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil, fmt.Errorf("unexpected HCL body type")
+	}
+	d.hclCache.Store(filePath, body)
+	return body, nil
+}
 
 const undetectedVulnerabilityLine = -1
 
 // DetectLine searches vulnerability line in terraform files
-func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata,
+func (d *DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata,
 	searchKey string, outputLines int) model.VulnerabilityLines {
 	contextLogger := logger.FromContext(ctx)
 	searchKey = sanitizeSearchKey(searchKey)
@@ -80,9 +106,14 @@ func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata
 
 	if detection.FoundAtLeastOne {
 		line := detection.CurrentLine + 1
-		vulnLines, err := locateTerraformBlock(ctx, []byte(file.OriginalData), line, lines)
+		body, parseErr := d.cachedParseBody([]byte(file.OriginalData), file.FilePath)
+		if parseErr != nil {
+			contextLogger.Error().Err(parseErr).Msgf("Failed to parse block at line %d in file %s", line, file.FilePath)
+			return buildEmptyVulnerabilityLines(file)
+		}
+		vulnLines, err := locateTerraformBlock(ctx, body, line, lines)
 		if err != nil {
-			contextLogger.Error().Err(err).Msgf("Failed to parse block at line %d in file %s", line, file.FilePath)
+			contextLogger.Error().Err(err).Msgf("Failed to locate block at line %d in file %s", line, file.FilePath)
 			return buildEmptyVulnerabilityLines(file)
 		}
 		vulnLines.Line = line
@@ -111,26 +142,19 @@ func sanitizeSearchKey(key string) string {
 	return re.ReplaceAllString(key, "[$1]")
 }
 
-func locateTerraformBlock(ctx context.Context, src []byte, identifyingLine int, strLines []string) (model.VulnerabilityLines, error) {
+// locateTerraformBlock finds the block containing identifyingLine in a pre-parsed
+// HCL body and returns its location metadata. The caller is responsible for
+// parsing (and optionally caching) the body via cachedParseBody.
+func locateTerraformBlock(
+	ctx context.Context,
+	body *hclsyntax.Body,
+	identifyingLine int,
+	strLines []string,
+) (model.VulnerabilityLines, error) {
 	contextLogger := logger.FromContext(ctx)
-	filePath := "temp.tf"
 
 	if identifyingLine <= 0 || identifyingLine > len(strLines) {
 		err := fmt.Errorf("line %d is out of range", identifyingLine)
-		contextLogger.Error().Msg(err.Error())
-		return model.VulnerabilityLines{}, err
-	}
-
-	hclFile, diagnostics := hclsyntax.ParseConfig(src, filePath, hcl.InitialPos)
-	if diagnostics.HasErrors() {
-		err := fmt.Errorf("failed to parse HCL: %v", diagnostics.Errs())
-		contextLogger.Error().Msg(err.Error())
-		return model.VulnerabilityLines{}, err
-	}
-
-	body, ok := hclFile.Body.(*hclsyntax.Body)
-	if !ok {
-		err := fmt.Errorf("unexpected HCL body type")
 		contextLogger.Error().Msg(err.Error())
 		return model.VulnerabilityLines{}, err
 	}

--- a/pkg/detector/terraform/terraform_detect_test.go
+++ b/pkg/detector/terraform/terraform_detect_test.go
@@ -530,7 +530,7 @@ func TestDetectTerraformLine(t *testing.T) { //nolint
 
 	ctx := context.Background()
 	for i, testCase := range testCases {
-		detector := DetectKindLine{}
+		detector := &DetectKindLine{}
 		t.Run(fmt.Sprintf("detectTerraformLine-%d", i), func(t *testing.T) {
 			v := detector.DetectLine(ctx, testCase.file, testCase.searchKey, 3)
 			require.Equal(t, testCase.expected, v)
@@ -820,7 +820,7 @@ func TestDetectTerraformLineRemediations(t *testing.T) {
 
 	ctx := context.Background()
 	for i, testCase := range testCases {
-		detector := DetectKindLine{}
+		detector := &DetectKindLine{}
 		t.Run(fmt.Sprintf("detectTerraformLine-%d", i), func(t *testing.T) {
 			v := detector.DetectLine(ctx, testCase.file, testCase.searchKey, 3)
 			require.Equal(t, testCase.expected, v)
@@ -985,7 +985,7 @@ func TestDetectLinePolicyStatementPrincipalJsonencode(t *testing.T) {
 		OriginalData:      policyStatementPrincipalJSONEncode,
 		LinesOriginalData: utils.SplitLines(policyStatementPrincipalJSONEncode),
 	}
-	got := DetectKindLine{}.DetectLine(ctx, file, `aws_s3_bucket_policy[x].policy.Statement[0].Principal`, 3)
+	got := (&DetectKindLine{}).DetectLine(ctx, file, `aws_s3_bucket_policy[x].policy.Statement[0].Principal`, 3)
 	require.Equal(t, 8, got.Line)
 	// The remediation/region anchor must stay on the identifying line inside the
 	// jsonencode(...) body rather than being pushed past the wrapping `})`,
@@ -1003,6 +1003,6 @@ func TestDetectLinePolicyStatementPrincipalHeredocJSON(t *testing.T) {
 		OriginalData:      policyStatementPrincipalHeredocJSON,
 		LinesOriginalData: utils.SplitLines(policyStatementPrincipalHeredocJSON),
 	}
-	got := DetectKindLine{}.DetectLine(ctx, file, `aws_ecr_repository_policy[x].policy.Statement[0].Principal`, 3)
+	got := (&DetectKindLine{}).DetectLine(ctx, file, `aws_ecr_repository_policy[x].policy.Statement[0].Principal`, 3)
 	require.Equal(t, 9, got.Line)
 }

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -188,7 +188,7 @@ func NewInspector(
 	lineDetector := detector.NewDetectLine(tracker.GetOutputLines()).
 		Add(helm.DetectKindLine{}, model.KindHELM).
 		Add(docker.DetectKindLine{}, model.KindDOCKER).
-		Add(terraform.DetectKindLine{}, model.KindTerraform)
+		Add(&terraform.DetectKindLine{}, model.KindTerraform)
 
 	return &Inspector{
 		QueryLoader:      &queryLoader,

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -435,6 +435,61 @@ func TestAnalyze_ConcurrencyLimit(t *testing.T) {
 	}
 }
 
+// TestAnalyze_HCLCacheIsolatedBetweenRequests verifies that the per-scan HCL
+// parse cache does not bleed between server analyze calls. If the cache were
+// reused across requests, the second request's line-detection would use stale
+// block ranges from the first parse and report an incorrect finding line.
+func TestAnalyze_HCLCacheIsolatedBetweenRequests(t *testing.T) {
+	s := newTestServer(t)
+	rule := teamTagRule(t)
+
+	// Request 1: resource is at line 1.
+	req1 := analyzeRequest{
+		Files:    []analyzeFile{{Path: "infra/main.tf", Content: "resource \"aws_s3_bucket\" \"b\" {\n  bucket = \"x\"\n}\n"}},
+		Rules:    []analyzeRule{rule},
+		Platform: []string{"terraform"},
+	}
+	out1, _ := postAnalyze(t, s, req1)
+	if len(out1.Findings) == 0 {
+		t.Fatalf("request 1: expected at least one finding, got none")
+	}
+	var line1 int
+	for _, f := range out1.Findings {
+		if f.QueryID == rule.ID {
+			line1 = f.Line
+		}
+	}
+	if line1 == 0 {
+		t.Fatalf("request 1: rule did not fire")
+	}
+
+	// Request 2: same path, resource pushed down by 3 blank lines. A stale
+	// cached body from request 1 would return the old block range (line 1),
+	// not the updated one.
+	req2 := analyzeRequest{
+		Files:    []analyzeFile{{Path: "infra/main.tf", Content: "\n\n\nresource \"aws_s3_bucket\" \"b\" {\n  bucket = \"x\"\n}\n"}},
+		Rules:    []analyzeRule{rule},
+		Platform: []string{"terraform"},
+	}
+	out2, _ := postAnalyze(t, s, req2)
+	if len(out2.Findings) == 0 {
+		t.Fatalf("request 2: expected at least one finding, got none")
+	}
+	var line2 int
+	for _, f := range out2.Findings {
+		if f.QueryID == rule.ID {
+			line2 = f.Line
+		}
+	}
+	if line2 == 0 {
+		t.Fatalf("request 2: rule did not fire")
+	}
+
+	if line2 <= line1 {
+		t.Errorf("request 2 finding line = %d, want > %d (resource was pushed down by 3 lines; stale HCL cache would return the old position)", line2, line1)
+	}
+}
+
 func readAll(resp *http.Response) ([]byte, error) {
 	defer resp.Body.Close()
 	var buf bytes.Buffer


### PR DESCRIPTION
## Motivation

Terraform line detection calls `hclsyntax.ParseConfig` once per finding to locate resource blocks. Rules that fire thousands of times on the same files (for example team-tag checks) spend most of their decode time re-parsing identical `.tf` sources.

## Changes

**Terraform detector**

Add a per-scan `sync.Map` on `DetectKindLine` that caches parsed `*hclsyntax.Body` by file path. `locateTerraformBlock` now receives a pre-parsed body instead of parsing on every call.

**Inspector**

Register the Terraform detector as a pointer so the cache is not copied across calls.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/detector/terraform/...`
2. Build the scanner and run a large Terraform repo.
3. Compare scan duration and slow-rule logs before/after; findings count should be unchanged.

## Blast Radius

CLI scan decode path for Terraform findings only. No change to Rego evaluation, fingerprints, or non-Terraform platforms.

## Additional Notes

I submit this contribution under the Apache-2.0 license.