### PR TITLE
Add a shared CPU budget to fix negative scaling at high core counts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -222,7 +222,7 @@ require (
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -393,11 +393,12 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 
 	// Detect each file's type with a bounded worker pool. File-type detection
 	// reads file content (I/O-bound), so it does not consume the shared CPU
-	// budget. Workers write into the results/unwanted/locCount channels, which
-	// computeValues drains concurrently below; the channels are closed once all
-	// files are processed.
+	// budget and fans out wider than the core count (same [min,max] bounds as the
+	// filesystem reader). Workers write into the results/unwanted/locCount
+	// channels, which computeValues drains concurrently below; the channels are
+	// closed once all files are processed.
 	go func() {
-		_ = utils.ForEach(ctx, files, utils.PoolOptions{Workers: a.NumWorkers},
+		_ = utils.ForEach(ctx, files, utils.PoolOptions{MinWorkers: utils.IOMinWorkers, MaxWorkers: utils.IOMaxWorkers},
 			func(ctx context.Context, filePath string, _ int) error {
 				analyzerInfo := &analyzerInfo{
 					typesFlag: typesFlag,

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -397,8 +397,14 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 	// filesystem reader). Workers write into the results/unwanted/locCount
 	// channels, which computeValues drains concurrently below; the channels are
 	// closed once all files are processed.
+	//
+	// forEachErr is written by the goroutine before it closes the channels and
+	// read only after computeValues has drained them to completion; the channel
+	// close/receive ordering guarantees the write is visible here without a race.
+	var forEachErr error
 	go func() {
-		_ = utils.ForEach(ctx, files, utils.PoolOptions{MinWorkers: utils.IOMinWorkers, MaxWorkers: utils.IOMaxWorkers},
+		forEachErr = utils.ForEach(ctx, files,
+			utils.PoolOptions{Workers: a.NumWorkers, MinWorkers: utils.IOMinWorkers, MaxWorkers: utils.IOMaxWorkers},
 			func(ctx context.Context, filePath string, _ int) error {
 				analyzerInfo := &analyzerInfo{
 					typesFlag: typesFlag,
@@ -413,6 +419,11 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 	}()
 
 	availableTypes, unwantedPaths, loc := computeValues(results, unwanted, locCount)
+	// A canceled scan must surface the cancellation rather than be reported as a
+	// successful analysis with partial results.
+	if forEachErr != nil {
+		return returnAnalyzedPaths, forEachErr
+	}
 	multiPlatformTypeCheck(&availableTypes)
 	unwantedPaths = append(unwantedPaths, ignoreFiles...)
 	unwantedPaths = append(unwantedPaths, projectConfigFiles...)

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -13,7 +13,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"sync"
 	"unicode"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/metrics"
@@ -338,7 +337,6 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 
 	var err error
 	var files []string
-	var wg sync.WaitGroup
 	// results is the channel shared by the workers that contains the types found
 	results := make(chan string)
 	locCount := make(chan int)
@@ -393,48 +391,21 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 
 	typesFlag := typesLower(a.Types)
 
-	// Use a worker pool to limit concurrent file analysis
-	numWorkers := utils.AdjustNumWorkers(a.NumWorkers)
-
-	// Create a job channel for files to analyze
-	jobs := make(chan string, len(files))
-
-	// Start worker pool
-	for i := 0; i < numWorkers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for filePath := range jobs {
-				select {
-				case <-ctx.Done():
-					return
-				default:
-				}
-
+	// Detect each file's type with a bounded worker pool. File-type detection
+	// reads file content (I/O-bound), so it does not consume the shared CPU
+	// budget. Workers write into the results/unwanted/locCount channels, which
+	// computeValues drains concurrently below; the channels are closed once all
+	// files are processed.
+	go func() {
+		_ = utils.ForEach(ctx, files, utils.PoolOptions{Workers: a.NumWorkers},
+			func(ctx context.Context, filePath string, _ int) error {
 				analyzerInfo := &analyzerInfo{
 					typesFlag: typesFlag,
 					filePath:  filePath,
 				}
 				analyzerInfo.worker(ctx, results, unwanted, locCount)
-			}
-		}()
-	}
-
-	// Feed jobs to workers
-	go func() {
-		defer close(jobs)
-		for _, file := range files {
-			select {
-			case <-ctx.Done():
-				return
-			case jobs <- file:
-			}
-		}
-	}()
-
-	go func() {
-		wg.Wait()
-		// close channel results when the worker has finished writing into it
+				return nil
+			})
 		close(unwanted)
 		close(results)
 		close(locCount)

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -296,9 +296,14 @@ func (c *Inspector) Inspect(
 	// Must run after module mutations (which suppress module bodies in place).
 	combinedFiles := files.Combine(ctx, false)
 
-	// Step 1: Parse Terraform modules
+	// Step 1: Parse Terraform modules. A genuine per-file HCL parse failure is
+	// non-fatal (logged, scan continues), but a context cancellation must abort
+	// the scan rather than proceed with partial module data.
 	parsedModules, err := tfmodules.ParseTerraformModules(ctx, c.fsys, files, c.numWorkers)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		contextLogger.Warn().Err(err).Msg("Failed to parse Terraform modules")
 	}
 	contextLogger.Info().Msgf("Found %d modules", len(parsedModules))

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -308,9 +308,14 @@ func (c *Inspector) Inspect(
 	}
 	contextLogger.Info().Msgf("Found %d modules", len(parsedModules))
 
-	// Step 2: Enrich modules with parsed variables
+	// Step 2: Enrich modules with parsed variables. As with Step 1, a context
+	// cancellation must abort the scan rather than proceed with partial module
+	// data; per-module parse failures are non-fatal and handled internally.
 	rootDir := c.repoPath
-	enrichedModules := tfmodules.ParseAllModuleVariables(ctx, c.fsys, parsedModules, rootDir)
+	enrichedModules, err := tfmodules.ParseAllModuleVariables(ctx, c.fsys, parsedModules, rootDir)
+	if err != nil {
+		return nil, err
+	}
 
 	queries := c.getQueriesByPlat(platforms)
 
@@ -359,13 +364,10 @@ func (c *Inspector) executeQueries(
 			results[i] = c.evalQuery(ctx, scanID, filesMap, payloads, queries, i, enrichedModules, baseStores)
 			return nil
 		})
+	// The closure never returns a non-nil error itself, so ForEach only reports
+	// context cancellation here; surfacing it keeps a canceled scan from being
+	// reported as a successful scan with partial/empty results.
 	if err != nil {
-		return vulnerabilities, err
-	}
-
-	// A canceled scan must surface the cancellation rather than be reported as a
-	// successful scan with partial/empty results.
-	if err := ctx.Err(); err != nil {
 		return vulnerabilities, err
 	}
 

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -224,75 +224,56 @@ func getPlatformLibraries(ctx context.Context, queriesSource source.QueriesSourc
 	return platformLibraries
 }
 
-type InspectionJob struct {
-	queryID int
-}
-
 type QueryResult struct {
 	vulnerabilities []model.Vulnerability
 	err             error
 	queryID         int
 }
 
-// This function creates an inspection task and sends it to the jobs channel
-func (c *Inspector) createInspectionJobs(jobs chan<- InspectionJob, queries []model.QueryMetadata) {
-	defer close(jobs)
-	for i := range queries {
-		jobs <- InspectionJob{queryID: i}
+// evalQuery loads and evaluates a single query, returning its result. A load
+// failure yields an empty result (the query is skipped, matching the previous
+// behavior); an eval failure yields a result carrying the error so the serial
+// aggregation can record it.
+func (c *Inspector) evalQuery(ctx context.Context, scanID string, filesMap map[string]*model.FileMetadata,
+	payloads platformPayloads, queries []model.QueryMetadata, queryID int,
+	modules []tfmodules.ParsedModule, baseStores map[string]storage.Store) QueryResult {
+	contextLogger := logger.FromContext(ctx)
+
+	loadStart := time.Now()
+	queryOpa, err := c.QueryLoader.LoadQuery(ctx, &queries[queryID], modules, baseStores)
+	loadDur := time.Since(loadStart)
+	if err != nil {
+		contextLogger.Warn().Err(err).Msgf("failed to load query %s", queries[queryID].Query)
+		return QueryResult{queryID: queryID}
 	}
-}
 
-// This function performs an inspection job and sends the result to the results channel
-func (c *Inspector) performInspection(ctx context.Context, scanID string, filesMap map[string]*model.FileMetadata,
-	payloadByPlatform map[string]ast.Value, fullPayload ast.Value,
-	jobs <-chan InspectionJob, results chan<- QueryResult, queries []model.QueryMetadata,
-	modules []tfmodules.ParsedModule, baseStores map[string]storage.Store) {
-	for job := range jobs {
-		select {
-		case <-ctx.Done():
-			// Stop accepting job and return on context cancellation
-			return
-		default:
-		}
-
-		loadStart := time.Now()
-		queryOpa, err := c.QueryLoader.LoadQuery(ctx, &queries[job.queryID], modules, baseStores)
-		loadDur := time.Since(loadStart)
-		if err != nil {
-			contextLogger := logger.FromContext(ctx)
-			contextLogger.Warn().Err(err).Msgf("failed to load query %s", queries[job.queryID].Query)
-			continue
-		}
-
-		query := &PreparedQuery{
-			OpaQuery: *queryOpa,
-			Metadata: queries[job.queryID],
-		}
-
-		// Evaluate each query only against documents of its own platform. The
-		// payload is read-only, so sharing the per-platform ast.Value across jobs
-		// is safe.
-		payload := selectPlatformPayload(query.Metadata.Platform, payloadByPlatform, fullPayload)
-		queryContext := &QueryContext{
-			Ctx:           ctx,
-			scanID:        scanID,
-			Files:         filesMap,
-			Query:         query,
-			payload:       &payload,
-			FlagEvaluator: c.flagEvaluator,
-		}
-
-		evalStart := time.Now()
-		vuls, err := c.doRun(ctx, queryContext)
-		evalDur := time.Since(evalStart)
-		contextLogger := logger.FromContext(ctx)
-		contextLogger.Debug().Msgf("query timing: load=%s eval=%s query=%s",
-			loadDur.Round(time.Millisecond), evalDur.Round(time.Millisecond), queries[job.queryID].Query)
-		if err == nil {
-			c.tracker.TrackQueryExecution(query.Metadata.Aggregation)
-		}
-		results <- QueryResult{vulnerabilities: vuls, err: err, queryID: job.queryID}
+	query := &PreparedQuery{
+		OpaQuery: *queryOpa,
+		Metadata: queries[queryID],
 	}
+
+	// Evaluate each query only against documents of its own platform. The
+	// payload is read-only, so sharing the per-platform ast.Value across workers
+	// is safe.
+	payload := selectPlatformPayload(query.Metadata.Platform, payloads.byPlatform, payloads.full)
+	queryContext := &QueryContext{
+		Ctx:           ctx,
+		scanID:        scanID,
+		Files:         filesMap,
+		Query:         query,
+		payload:       &payload,
+		FlagEvaluator: c.flagEvaluator,
+	}
+
+	evalStart := time.Now()
+	vuls, err := c.doRun(ctx, queryContext)
+	evalDur := time.Since(evalStart)
+	contextLogger.Debug().Msgf("query timing: load=%s eval=%s query=%s",
+		loadDur.Round(time.Millisecond), evalDur.Round(time.Millisecond), queries[queryID].Query)
+	if err == nil {
+		c.tracker.TrackQueryExecution(query.Metadata.Aggregation)
+	}
+	return QueryResult{vulnerabilities: vuls, err: err, queryID: queryID}
 }
 
 func (c *Inspector) Inspect(
@@ -358,49 +339,34 @@ func (c *Inspector) executeQueries(
 	enrichedModules []tfmodules.ParsedModule,
 	baseStores map[string]storage.Store,
 ) ([]model.Vulnerability, error) {
-	results := make(chan QueryResult, len(queries))
-	jobs := make(chan InspectionJob, len(queries))
-
-	var wg sync.WaitGroup
-	for w := 0; w < c.numWorkers; w++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			c.performInspection(ctx, scanID, filesMap, payloads.byPlatform, payloads.full, jobs, results, queries, enrichedModules, baseStores)
-		}()
-	}
-	go c.createInspectionJobs(jobs, queries)
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	return c.drainQueryResults(ctx, results, queries)
-}
-
-// drainQueryResults reads query results until the channel closes or the context is canceled.
-func (c *Inspector) drainQueryResults(
-	ctx context.Context,
-	results <-chan QueryResult,
-	queries []model.QueryMetadata,
-) ([]model.Vulnerability, error) {
 	contextLogger := logger.FromContext(ctx)
 	vulnerabilities := make([]model.Vulnerability, 0)
-	moduleVulns := make(map[string]int)
-	for {
-		select {
-		case <-ctx.Done():
-			return vulnerabilities, ctx.Err()
-		case result, ok := <-results:
-			if !ok {
-				for vulnerability, number := range moduleVulns {
-					contextLogger.Info().Msgf("Found %d of module vulnerability %s", number, vulnerability)
-				}
-				return vulnerabilities, nil
-			}
-			processResult(ctx, &result, &vulnerabilities, &moduleVulns, queries, c)
-		}
+
+	// Evaluate each query in parallel. Eval is CPU-bound (Rego), so the pool
+	// draws from the process-wide CPU budget: when this scan runs as one of N
+	// concurrent per-platform services, all their query pools share the same
+	// budget and cannot oversubscribe the machine. Results land in an
+	// index-aligned slice (no shared mutable state between workers); the actual
+	// aggregation happens serially below.
+	results := make([]QueryResult, len(queries))
+	err := utils.ForEach(ctx, queries, utils.PoolOptions{Workers: c.numWorkers, CPUBound: true},
+		func(ctx context.Context, _ model.QueryMetadata, i int) error {
+			results[i] = c.evalQuery(ctx, scanID, filesMap, payloads, queries, i, enrichedModules, baseStores)
+			return nil
+		})
+	if err != nil {
+		return vulnerabilities, err
 	}
+
+	// Aggregate serially: processResult mutates shared state.
+	moduleVulns := make(map[string]int)
+	for i := range results {
+		processResult(ctx, &results[i], &vulnerabilities, &moduleVulns, queries, c)
+	}
+	for vulnerability, number := range moduleVulns {
+		contextLogger.Info().Msgf("Found %d of module vulnerability %s", number, vulnerability)
+	}
+	return vulnerabilities, nil
 }
 
 // expandModuleFindings clones findings from deduplicated OPA docs back to each

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -358,6 +358,12 @@ func (c *Inspector) executeQueries(
 		return vulnerabilities, err
 	}
 
+	// A canceled scan must surface the cancellation rather than be reported as a
+	// successful scan with partial/empty results.
+	if err := ctx.Err(); err != nil {
+		return vulnerabilities, err
+	}
+
 	// Aggregate serially: processResult mutates shared state.
 	moduleVulns := make(map[string]int)
 	for i := range results {

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/open-policy-agent/opa/v1/storage"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
@@ -1216,4 +1217,33 @@ func TestInspector_FailedQueriesConcurrentWrites(t *testing.T) {
 
 	// Sanity: the failures were actually recorded
 	require.NotEmpty(t, ins.GetFailedQueries())
+}
+
+// TestExecuteQueries_CanceledContextReturnsError guards the cancellation
+// contract: a scan whose context is canceled must surface ctx.Err() rather than
+// be reported as a successful scan with partial/empty results.
+func TestExecuteQueries_CanceledContextReturnsError(t *testing.T) {
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: io.Discard})
+
+	queries := []model.QueryMetadata{
+		{Query: "query-0", Platform: "terraform"},
+		{Query: "query-1", Platform: "terraform"},
+	}
+	inspector := newTestInspector(t, inspectorOpts{numWorkers: len(queries), queries: queries})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled scan
+
+	vulns, err := inspector.executeQueries(
+		ctx,
+		"scan-id",
+		map[string]*model.FileMetadata{},
+		platformPayloads{},
+		queries,
+		nil,
+		map[string]storage.Store{},
+	)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, vulns)
 }

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -257,77 +257,16 @@ func (s *FileSystemSourceProvider) processFilesParallel(ctx context.Context, fil
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	contextLogger := logger.FromContext(ctx)
 
-	numWorkers := s.calculateWorkerCount()
-	contextLogger.Info().Msgf("Processing files with %d workers", numWorkers)
-
-	workerCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// Create channels for work distribution
-	filesChan := make(chan string, numWorkers*2)
-	errChan := make(chan error, numWorkers)
-	var wg sync.WaitGroup
-
-	// Start worker goroutines
-	for i := 0; i < numWorkers; i++ {
-		wg.Add(1)
-		go s.processFileWorker(workerCtx, &wg, filesChan, errChan, sink)
-	}
-
-	// Feed files to workers
-	go s.feedFilesToWorkers(workerCtx, files, filesChan)
-
-	go func() {
-		wg.Wait()
-		close(errChan)
-	}()
-
-	var firstErr error
-	for err := range errChan {
-		if err != nil && firstErr == nil {
-			firstErr = err
-			cancel()
-		}
-	}
-
-	return firstErr
-}
-
-// calculateWorkerCount determines the optimal number of workers for parallel processing
-func (s *FileSystemSourceProvider) calculateWorkerCount() int {
-	numWorkers := utils.AdjustNumWorkers(0) // 0 means auto-detect
-	if numWorkers < 1 {
-		numWorkers = minNumWorkers
-	}
-	if numWorkers > maxNumWorkers {
-		numWorkers = maxNumWorkers
-	}
-	return numWorkers
-}
-
-// processFileWorker is a worker goroutine that processes files from the channel
-func (s *FileSystemSourceProvider) processFileWorker(ctx context.Context, wg *sync.WaitGroup,
-	filesChan <-chan string, errChan chan<- error, sink Sink) {
-	defer wg.Done()
-	for filePath := range filesChan {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
-		if err := s.processFile(ctx, filePath, sink); err != nil {
-			select {
-			case errChan <- err:
-			case <-ctx.Done():
-				return
-			}
-			// Stop processing more files after encountering an error
-			return
-		}
-	}
+	// File reading is I/O-bound, so this pool does NOT draw from the shared CPU
+	// budget (it would only waste CPU slots while blocked on disk). It keeps its
+	// own wider [min,max] bound so disk parallelism is not throttled by core
+	// count. The first error cancels the rest.
+	return utils.ForEach(ctx, files,
+		utils.PoolOptions{MinWorkers: minNumWorkers, MaxWorkers: maxNumWorkers},
+		func(ctx context.Context, filePath string, _ int) error {
+			return s.processFile(ctx, filePath, sink)
+		})
 }
 
 // processFile opens and processes a single file
@@ -342,18 +281,6 @@ func (s *FileSystemSourceProvider) processFile(ctx context.Context, filePath str
 	defer c.Close() //nolint:all
 
 	return sink(ctx, filePath, c)
-}
-
-// feedFilesToWorkers sends files to the worker pool through the channel
-func (s *FileSystemSourceProvider) feedFilesToWorkers(ctx context.Context, files []string, filesChan chan<- string) {
-	defer close(filesChan)
-	for _, file := range files {
-		select {
-		case <-ctx.Done():
-			return
-		case filesChan <- file:
-		}
-	}
 }
 
 func (s *FileSystemSourceProvider) walkDir(ctx context.Context, scanPath string,

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -32,11 +32,6 @@ type FileSystemSourceProvider struct {
 	mu        sync.RWMutex
 }
 
-const (
-	minNumWorkers = 4
-	maxNumWorkers = 64
-)
-
 var (
 	queryRegexExcludeTerraCache = regexp.MustCompile(fmt.Sprintf(`^(.*?%s)?\.terra.*`, regexp.QuoteMeta(string(os.PathSeparator))))
 	// ErrNotSupportedFile - error representing when a file format is not supported by the scanner
@@ -263,7 +258,7 @@ func (s *FileSystemSourceProvider) processFilesParallel(ctx context.Context, fil
 	// own wider [min,max] bound so disk parallelism is not throttled by core
 	// count. The first error cancels the rest.
 	return utils.ForEach(ctx, files,
-		utils.PoolOptions{MinWorkers: minNumWorkers, MaxWorkers: maxNumWorkers},
+		utils.PoolOptions{MinWorkers: utils.IOMinWorkers, MaxWorkers: utils.IOMaxWorkers},
 		func(ctx context.Context, filePath string, _ int) error {
 			return s.processFile(ctx, filePath, sink)
 		})

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -582,7 +582,7 @@ func DetectModuleSourceType(source string) (string, string) {
 	return stringUnknown, ""
 }
 
-func ParseAllModuleVariables(ctx context.Context, fsys vfs.FS, modules map[string]ParsedModule, rootDir string) []ParsedModule {
+func ParseAllModuleVariables(ctx context.Context, fsys vfs.FS, modules map[string]ParsedModule, rootDir string) ([]ParsedModule, error) {
 	contextLogger := logger.FromContext(ctx)
 
 	// Iterate in a stable key order so the result slice is deterministic across
@@ -598,7 +598,12 @@ func ParseAllModuleVariables(ctx context.Context, fsys vfs.FS, modules map[strin
 	// Each module's equivalent-map generation reads files and parses HCL
 	// (CPU-bound), so the pool draws from the shared CPU budget. Results are
 	// written index-aligned, no shared mutable state between workers.
-	_ = utils.ForEach(ctx, keys, utils.PoolOptions{CPUBound: true},
+	//
+	// A per-module equivalent-map failure is non-fatal (logged, the module is
+	// kept without attributes data). ForEach only returns an error on context
+	// cancellation; we surface it so the caller aborts rather than proceeding
+	// with a partially-filled slice (unwritten slots would be zero-value holes).
+	err := utils.ForEach(ctx, keys, utils.PoolOptions{CPUBound: true},
 		func(ctx context.Context, key string, i int) error {
 			mod := modules[key]
 			if !mod.IsLocal {
@@ -615,7 +620,10 @@ func ParseAllModuleVariables(ctx context.Context, fsys vfs.FS, modules map[strin
 			finalModules[i] = mod
 			return nil
 		})
-	return finalModules
+	if err != nil {
+		return nil, err
+	}
+	return finalModules, nil
 }
 
 func generateEquivalentMap(ctx context.Context, fsys vfs.FS, modulePath string) (map[string]ModuleAttributesInfo, error) {

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -31,11 +32,6 @@ type ParsedModule struct {
 	SourceType     string // local, git, registry, etc.
 	RegistryScope  string // public, private, or "" (non-registry)
 	AttributesData map[string]ModuleAttributesInfo
-}
-
-type ModuleParseResult struct {
-	Module ParsedModule
-	Error  error
 }
 
 type ModuleAttributesInfo struct {
@@ -117,38 +113,22 @@ func parseHCLBodies(ctx context.Context, files model.FileMetadatas, numWorkers i
 	bodyCache := &sync.Map{}
 
 	bodies := make([]*hclsyntax.Body, len(tfFiles))
-	numWorkers = utils.AdjustNumWorkers(numWorkers)
-	if numWorkers > len(tfFiles) {
-		numWorkers = len(tfFiles)
-	}
-
-	indices := make(chan int)
-	var wg sync.WaitGroup
-	for w := 0; w < numWorkers; w++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for i := range indices {
-				file := tfFiles[i]
-				content := getFileContent(file)
-				body, diags := parseHCLBodyCached(bodyCache, content, file.FilePath)
-				if diags.HasErrors() {
-					contextLogger.Warn().Msgf("Skipping file %s due to HCL parse errors: %s", file.FilePath, diags.Error())
-					continue
-				}
-				if body == nil {
-					contextLogger.Error().Msgf("Unexpected body type in %s", file.FilePath)
-					continue
-				}
-				bodies[i] = body
+	// HCL parsing is CPU-bound, so the pool draws from the shared CPU budget.
+	_ = utils.ForEach(ctx, tfFiles, utils.PoolOptions{Workers: numWorkers, CPUBound: true},
+		func(_ context.Context, file *model.FileMetadata, i int) error {
+			content := getFileContent(file)
+			body, diags := parseHCLBodyCached(bodyCache, content, file.FilePath)
+			if diags.HasErrors() {
+				contextLogger.Warn().Msgf("Skipping file %s due to HCL parse errors: %s", file.FilePath, diags.Error())
+				return nil
 			}
-		}()
-	}
-	for i := range tfFiles {
-		indices <- i
-	}
-	close(indices)
-	wg.Wait()
+			if body == nil {
+				contextLogger.Error().Msgf("Unexpected body type in %s", file.FilePath)
+				return nil
+			}
+			bodies[i] = body
+			return nil
+		})
 
 	for i, file := range tfFiles {
 		if bodies[i] != nil {
@@ -596,80 +576,38 @@ func DetectModuleSourceType(source string) (string, string) {
 
 func ParseAllModuleVariables(ctx context.Context, fsys vfs.FS, modules map[string]ParsedModule, rootDir string) []ParsedModule {
 	contextLogger := logger.FromContext(ctx)
-	numWorkers := 4
 
-	input := make(chan ParsedModule)
-	output := make(chan ModuleParseResult)
-
-	var wg sync.WaitGroup
-
-	// Fan-out: Start workers
-	for i := 0; i < numWorkers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case mod, ok := <-input:
-					if !ok {
-						// Channel closed, we’re done
-						return
-					}
-					if !mod.IsLocal {
-						output <- ModuleParseResult{Module: mod}
-						continue
-					}
-					modulePath := resolveModulePath(mod.AbsSource, rootDir)
-
-					attributesData, err := generateEquivalentMap(ctx, fsys, modulePath)
-					if err != nil {
-						contextLogger.Warn().Msg("Failed to generate equivalent map")
-					} else {
-						mod.AttributesData = attributesData
-					}
-					output <- ModuleParseResult{Module: mod, Error: err}
-				}
-			}
-		}()
+	// Iterate in a stable key order so the result slice is deterministic across
+	// scans (map ranging is randomized, which previously made the output order
+	// vary and could defeat the downstream compiled-query cache).
+	keys := make([]string, 0, len(modules))
+	for k := range modules {
+		keys = append(keys, k)
 	}
+	sort.Strings(keys)
 
-	// Fan-in: Close output when all workers are done
-	go func() {
-		wg.Wait()
-		close(output)
-	}()
-
-	// Feed input channel
-	go func() {
-		defer close(input)
-		for _, mod := range modules {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				input <- mod
+	finalModules := make([]ParsedModule, len(keys))
+	// Each module's equivalent-map generation reads files and parses HCL
+	// (CPU-bound), so the pool draws from the shared CPU budget. Results are
+	// written index-aligned, no shared mutable state between workers.
+	_ = utils.ForEach(ctx, keys, utils.PoolOptions{CPUBound: true},
+		func(ctx context.Context, key string, i int) error {
+			mod := modules[key]
+			if !mod.IsLocal {
+				finalModules[i] = mod
+				return nil
 			}
-		}
-	}()
-
-	// Collect results
-	finalModules := make([]ParsedModule, 0, len(modules))
-	for {
-		select {
-		case <-ctx.Done():
-			return finalModules
-		case res, ok := <-output:
-			if !ok {
-				return finalModules
+			modulePath := resolveModulePath(mod.AbsSource, rootDir)
+			attributesData, err := generateEquivalentMap(ctx, fsys, modulePath)
+			if err != nil {
+				contextLogger.Warn().Msgf("Failed to parse module %s: %v", mod.Name, err)
+			} else {
+				mod.AttributesData = attributesData
 			}
-			if res.Error != nil {
-				contextLogger.Warn().Msgf("Failed to parse module %s: %v", res.Module.Name, res.Error)
-			}
-			finalModules = append(finalModules, res.Module)
-		}
-	}
+			finalModules[i] = mod
+			return nil
+		})
+	return finalModules
 }
 
 func generateEquivalentMap(ctx context.Context, fsys vfs.FS, modulePath string) (map[string]ModuleAttributesInfo, error) {

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -96,7 +96,7 @@ func parseHCLBodyCached(cache *sync.Map, content, filePath string) (*hclsyntax.B
 	return body, diags
 }
 
-func parseHCLBodies(ctx context.Context, files model.FileMetadatas, numWorkers int) map[string]*hclsyntax.Body {
+func parseHCLBodies(ctx context.Context, files model.FileMetadatas, numWorkers int) (map[string]*hclsyntax.Body, error) {
 	contextLogger := logger.FromContext(ctx)
 	parsedBodies := make(map[string]*hclsyntax.Body)
 
@@ -107,14 +107,16 @@ func parseHCLBodies(ctx context.Context, files model.FileMetadatas, numWorkers i
 		}
 	}
 	if len(tfFiles) == 0 {
-		return parsedBodies
+		return parsedBodies, nil
 	}
 
 	bodyCache := &sync.Map{}
 
 	bodies := make([]*hclsyntax.Body, len(tfFiles))
 	// HCL parsing is CPU-bound, so the pool draws from the shared CPU budget.
-	_ = utils.ForEach(ctx, tfFiles, utils.PoolOptions{Workers: numWorkers, CPUBound: true},
+	// Individual HCL parse errors are logged and skipped (not fatal); ForEach
+	// only returns an error on context cancellation, which the caller surfaces.
+	err := utils.ForEach(ctx, tfFiles, utils.PoolOptions{Workers: numWorkers, CPUBound: true},
 		func(_ context.Context, file *model.FileMetadata, i int) error {
 			content := getFileContent(file)
 			body, diags := parseHCLBodyCached(bodyCache, content, file.FilePath)
@@ -129,13 +131,16 @@ func parseHCLBodies(ctx context.Context, files model.FileMetadatas, numWorkers i
 			bodies[i] = body
 			return nil
 		})
+	if err != nil {
+		return parsedBodies, err
+	}
 
 	for i, file := range tfFiles {
 		if bodies[i] != nil {
 			parsedBodies[file.FilePath] = bodies[i]
 		}
 	}
-	return parsedBodies
+	return parsedBodies, nil
 }
 
 func collectLocalsAndVars(body *hclsyntax.Body, localsMap, varsMap map[string]string) {
@@ -225,7 +230,10 @@ func extractModuleBlocks(
 // ParseTerraformModules parses HCL content and extracts module source/version.
 // numWorkers: 0 means auto-detect (GOMAXPROCS).
 func ParseTerraformModules(ctx context.Context, fsys vfs.FS, files model.FileMetadatas, numWorkers int) (map[string]ParsedModule, error) {
-	parsedBodies := parseHCLBodies(ctx, files, numWorkers)
+	parsedBodies, err := parseHCLBodies(ctx, files, numWorkers)
+	if err != nil {
+		return nil, err
+	}
 	modules := make(map[string]ParsedModule)
 
 	// Group files by directory so locals/vars are scoped per Terraform module root,

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -104,6 +104,24 @@ func TestParseTerraformModules_CanceledContext(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+// TestParseAllModuleVariables_CanceledContext guards the cancellation contract:
+// results are written into an index-aligned slice, so a canceled scan must
+// surface ctx.Err() rather than return a slice padded with zero-value holes for
+// the modules whose workers never ran.
+func TestParseAllModuleVariables_CanceledContext(t *testing.T) {
+	modules := map[string]ParsedModule{
+		"a": {Name: "a", IsLocal: true, AbsSource: t.TempDir()},
+		"b": {Name: "b", IsLocal: true, AbsSource: t.TempDir()},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled scan
+
+	got, err := ParseAllModuleVariables(ctx, vfs.DiskFS{}, modules, t.TempDir())
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, got)
+}
+
 func TestParseTerraformModules(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -85,6 +85,25 @@ module "local_bucket" {
 	}
 }
 
+// TestParseTerraformModules_CanceledContext guards the cancellation contract:
+// a canceled scan must surface ctx.Err() rather than silently return partial
+// module data. HCL parse workers skip individual failures, so without an
+// explicit propagation a canceled parse would return (partial, nil).
+func TestParseTerraformModules_CanceledContext(t *testing.T) {
+	files := model.FileMetadatas{
+		&model.FileMetadata{
+			FilePath:     filepath.Join(t.TempDir(), "main.tf"),
+			OriginalData: `module "m" { source = "./x" }`,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled scan
+
+	_, err := ParseTerraformModules(ctx, vfs.DiskFS{}, files, 0)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestParseTerraformModules(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/scan/utils_test.go
+++ b/pkg/scan/utils_test.go
@@ -128,7 +128,7 @@ func Test_GetTotalFiles(t *testing.T) {
 		{
 			name:           "count utils folder files",
 			paths:          []string{filepath.Join("..", "..", "pkg", "utils")},
-			expectedOutput: 20,
+			expectedOutput: 21,
 		},
 		{
 			name:           "count analyzer folder files",
@@ -138,7 +138,7 @@ func Test_GetTotalFiles(t *testing.T) {
 		{
 			name:           "count analyzer and utils folder files",
 			paths:          []string{filepath.Join("..", "..", "pkg", "analyzer"), filepath.Join("..", "..", "pkg", "utils")},
-			expectedOutput: 22,
+			expectedOutput: 23,
 		},
 		{
 			name:           "count invalid folder",

--- a/pkg/utils/workers.go
+++ b/pkg/utils/workers.go
@@ -29,14 +29,7 @@ func AdjustNumWorkers(workers int) int {
 // it updated), so in a container it already reflects the CPU quota rather than
 // the host core count.
 func AvailableCPUs() int {
-	return atLeastOne(runtime.GOMAXPROCS(-1))
-}
-
-func atLeastOne(n int) int {
-	if n < 1 {
-		return 1
-	}
-	return n
+	return max(runtime.GOMAXPROCS(-1), 1)
 }
 
 // cpuBudget is the process-wide pool of CPU-bound work slots, sized to
@@ -50,6 +43,14 @@ func atLeastOne(n int) int {
 // oversubscription factors showed >1.0 never helped and slightly hurt, because
 // the CPU-bound phase is compute-saturated and extra workers only add scheduler
 // and GC contention.
+//
+// Sizing is lazy and one-shot (sync.Once): the semaphore is created on the first
+// CPU-bound scan, by which point GOMAXPROCS has stabilized to the cgroup quota
+// (init happens long before any scan). We intentionally do NOT resize if
+// GOMAXPROCS later grows — semaphore.Weighted has no resize API, and the only
+// case this matters is a long-lived server (serve mode) that captured a
+// transient low quota straddling its very first scan. That is a known, accepted
+// limitation; a resizable gate was judged not worth the hand-rolled concurrency.
 var (
 	cpuBudgetOnce sync.Once
 	cpuBudget     *semaphore.Weighted
@@ -86,9 +87,12 @@ const (
 type PoolOptions struct {
 	// Workers is the desired fan-out width. 0 means auto-detect (AvailableCPUs).
 	Workers int
-	// MinWorkers, when > 0, raises Workers up to this floor.
+	// MinWorkers, when > 0, raises an AUTO-DETECTED worker count up to this floor.
+	// It does not apply when Workers is set explicitly: an explicit low count is
+	// a deliberate concurrency limit and must be honored, not floored.
 	MinWorkers int
-	// MaxWorkers, when > 0, caps Workers at this ceiling.
+	// MaxWorkers, when > 0, caps Workers at this ceiling (applies to both
+	// auto-detected and explicit counts; e.g. an open-file-descriptor cap).
 	MaxWorkers int
 	// CPUBound, when true, makes each item acquire one slot of the shared CPU
 	// budget before running. Leave false for I/O-bound work (file reads, network)
@@ -98,7 +102,9 @@ type PoolOptions struct {
 
 func (o PoolOptions) resolveWorkers(items int) int {
 	w := AdjustNumWorkers(o.Workers)
-	if o.MinWorkers > 0 && w < o.MinWorkers {
+	// The floor lifts a small auto-detected count on tiny machines, but an
+	// explicit Workers value is a caller-imposed limit we must not raise.
+	if o.Workers == 0 && o.MinWorkers > 0 && w < o.MinWorkers {
 		w = o.MinWorkers
 	}
 	if o.MaxWorkers > 0 && w > o.MaxWorkers {
@@ -107,7 +113,7 @@ func (o PoolOptions) resolveWorkers(items int) int {
 	if items > 0 && w > items {
 		w = items
 	}
-	return atLeastOne(w)
+	return max(w, 1)
 }
 
 // ForEach runs fn over every item using a bounded worker pool. It replaces the
@@ -143,7 +149,16 @@ func ForEach[T any](ctx context.Context, items []T, opts PoolOptions, fn func(ct
 	g.SetLimit(numWorkers)
 
 	for i := range items {
+		// Stop scheduling once the group is canceled (first error or parent
+		// cancellation). g.SetLimit throttles launches but does not halt this
+		// producer, so without this check a canceled run over a large slice would
+		// still queue O(len(items)) no-op goroutines before g.Wait returns.
+		if gctx.Err() != nil {
+			break
+		}
 		g.Go(func() error {
+			// A goroutine may have been queued behind the SetLimit gate before the
+			// group was canceled; skip its work rather than run it needlessly.
 			if gctx.Err() != nil {
 				return gctx.Err()
 			}
@@ -155,5 +170,15 @@ func ForEach[T any](ctx context.Context, items []T, opts PoolOptions, fn func(ct
 		})
 	}
 
-	return g.Wait()
+	err := g.Wait()
+	if err == nil {
+		// Breaking out of the loop above (or launching zero error-returning
+		// goroutines) can leave g.Wait with nothing to report even though the run
+		// was canceled. Surface the cancellation so callers do not mistake a
+		// canceled run for a complete one.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+	}
+	return err
 }

--- a/pkg/utils/workers.go
+++ b/pkg/utils/workers.go
@@ -5,13 +5,129 @@
  */
 package utils
 
-import "runtime"
+import (
+	"context"
+	"runtime"
+	"sync"
 
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
+)
+
+// AdjustNumWorkers normalizes a requested worker count. A value of 0 means
+// "auto-detect": use the number of CPUs the process may actually use.
 func AdjustNumWorkers(workers int) int {
-	// for the case in which the end user decides to use num workers as "auto-detected"
-	// we will set the number of workers to the number of CPUs available based on GOMAXPROCS value
 	if workers == 0 {
-		return runtime.GOMAXPROCS(-1)
+		return AvailableCPUs()
 	}
 	return workers
+}
+
+// AvailableCPUs returns the number of CPUs this process can realistically use,
+// as a whole number >= 1. We trust GOMAXPROCS: as of Go 1.25 the runtime
+// initializes GOMAXPROCS from the cgroup CPU bandwidth limit on Linux (and keeps
+// it updated), so in a container it already reflects the CPU quota rather than
+// the host core count.
+func AvailableCPUs() int {
+	return atLeastOne(runtime.GOMAXPROCS(-1))
+}
+
+func atLeastOne(n int) int {
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// cpuBudget is the process-wide pool of CPU-bound work slots. Every nested
+// worker pool that does CPU-heavy work (Rego eval, HCL parsing, file-type
+// detection) acquires a slot before working and releases it after. Because the
+// budget is shared, deeply nested fan-out (e.g. N services each running its own
+// query pool) can no longer oversubscribe the machine: at most AvailableCPUs()
+// CPU-bound goroutines run at once, regardless of how the pools nest.
+var (
+	cpuBudgetOnce sync.Once
+	cpuBudget     *semaphore.Weighted
+)
+
+func cpuBudgetSem() *semaphore.Weighted {
+	cpuBudgetOnce.Do(func() {
+		cpuBudget = semaphore.NewWeighted(int64(AvailableCPUs()))
+	})
+	return cpuBudget
+}
+
+// CPUBound runs fn while holding one slot of the process-wide CPU budget. It
+// blocks until a slot is free or ctx is canceled (returning ctx.Err()).
+func CPUBound(ctx context.Context, fn func() error) error {
+	sem := cpuBudgetSem()
+	if err := sem.Acquire(ctx, 1); err != nil {
+		return err
+	}
+	defer sem.Release(1)
+	return fn()
+}
+
+// PoolOptions configures ForEach.
+type PoolOptions struct {
+	// Workers is the desired fan-out width. 0 means auto-detect (AvailableCPUs).
+	Workers int
+	// MinWorkers, when > 0, raises Workers up to this floor.
+	MinWorkers int
+	// MaxWorkers, when > 0, caps Workers at this ceiling.
+	MaxWorkers int
+	// CPUBound, when true, makes each item acquire one slot of the shared CPU
+	// budget before running. Leave false for I/O-bound work (file reads, network)
+	// so it does not occupy a CPU slot while blocked.
+	CPUBound bool
+}
+
+func (o PoolOptions) resolveWorkers(items int) int {
+	w := AdjustNumWorkers(o.Workers)
+	if o.MinWorkers > 0 && w < o.MinWorkers {
+		w = o.MinWorkers
+	}
+	if o.MaxWorkers > 0 && w > o.MaxWorkers {
+		w = o.MaxWorkers
+	}
+	if items > 0 && w > items {
+		w = items
+	}
+	return atLeastOne(w)
+}
+
+// ForEach runs fn over every item using a bounded worker pool. It replaces the
+// hand-rolled "jobs channel + N goroutines + WaitGroup + closer" pattern that
+// was duplicated across the engine, analyzer and Terraform-module parsers.
+//
+// fn receives the original slice index so callers can write results into a
+// preallocated, index-aligned output slice without sharing mutable state.
+//
+// If opts.CPUBound is set, each invocation of fn is wrapped in CPUBound so the
+// work draws from the shared process-wide CPU budget. The first non-nil error
+// cancels the remaining work and is returned.
+func ForEach[T any](ctx context.Context, items []T, opts PoolOptions, fn func(ctx context.Context, item T, index int) error) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	numWorkers := opts.resolveWorkers(len(items))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(numWorkers)
+
+	for i := range items {
+		g.Go(func() error {
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
+			run := func() error { return fn(gctx, items[i], i) }
+			if opts.CPUBound {
+				return CPUBound(gctx, run)
+			}
+			return run()
+		})
+	}
+
+	return g.Wait()
 }

--- a/pkg/utils/workers.go
+++ b/pkg/utils/workers.go
@@ -39,12 +39,17 @@ func atLeastOne(n int) int {
 	return n
 }
 
-// cpuBudget is the process-wide pool of CPU-bound work slots. Every nested
-// worker pool that does CPU-heavy work (Rego eval, HCL parsing, file-type
-// detection) acquires a slot before working and releases it after. Because the
+// cpuBudget is the process-wide pool of CPU-bound work slots, sized to
+// AvailableCPUs(). Every nested worker pool that does CPU-heavy work (Rego eval,
+// HCL parsing) acquires a slot before working and releases it after. Because the
 // budget is shared, deeply nested fan-out (e.g. N services each running its own
 // query pool) can no longer oversubscribe the machine: at most AvailableCPUs()
 // CPU-bound goroutines run at once, regardless of how the pools nest.
+//
+// The budget equals the core count (no oversubscription): a benchmark sweep over
+// oversubscription factors showed >1.0 never helped and slightly hurt, because
+// the CPU-bound phase is compute-saturated and extra workers only add scheduler
+// and GC contention.
 var (
 	cpuBudgetOnce sync.Once
 	cpuBudget     *semaphore.Weighted
@@ -67,6 +72,15 @@ func CPUBound(ctx context.Context, fn func() error) error {
 	defer sem.Release(1)
 	return fn()
 }
+
+// IO worker bounds. I/O-bound pools (file open/read) fan out wider than the
+// core count because workers spend most of their time blocked on the kernel, so
+// more goroutines than cores keeps the disk/FS queue full. The floor guarantees
+// useful parallelism on tiny machines; the ceiling caps open file descriptors.
+const (
+	IOMinWorkers = 4
+	IOMaxWorkers = 64
+)
 
 // PoolOptions configures ForEach.
 type PoolOptions struct {

--- a/pkg/utils/workers.go
+++ b/pkg/utils/workers.go
@@ -120,6 +120,16 @@ func (o PoolOptions) resolveWorkers(items int) int {
 // If opts.CPUBound is set, each invocation of fn is wrapped in CPUBound so the
 // work draws from the shared process-wide CPU budget. The first non-nil error
 // cancels the remaining work and is returned.
+//
+// SetLimit and CPUBound are two distinct limits and both are needed:
+//   - g.SetLimit caps goroutines for THIS pool. It bounds fan-out width and
+//     memory per pool, and applies to I/O-bound pools too (where it can exceed
+//     the core count, e.g. [4,64], so blocked file reads keep the disk busy).
+//   - CPUBound draws from a single semaphore shared by ALL pools process-wide.
+//     It bounds how much CPU-heavy work runs at once regardless of how pools
+//     nest — N per-platform scans each running their own query pool cannot
+//     collectively oversubscribe the cores. SetLimit alone can't do this: each
+//     pool's limit is independent, so nesting would multiply (N x limit).
 func ForEach[T any](ctx context.Context, items []T, opts PoolOptions, fn func(ctx context.Context, item T, index int) error) error {
 	if len(items) == 0 {
 		return nil
@@ -128,6 +138,8 @@ func ForEach[T any](ctx context.Context, items []T, opts PoolOptions, fn func(ct
 	numWorkers := opts.resolveWorkers(len(items))
 
 	g, gctx := errgroup.WithContext(ctx)
+	// Per-pool goroutine cap (fan-out width / memory). The cross-pool CPU cap is
+	// the shared semaphore applied via CPUBound below, not this limit.
 	g.SetLimit(numWorkers)
 
 	for i := range items {

--- a/pkg/utils/workers_test.go
+++ b/pkg/utils/workers_test.go
@@ -87,6 +87,44 @@ func TestForEach_FirstErrorReturnedAndCancels(t *testing.T) {
 	}
 }
 
+func TestResolveWorkers_ExplicitCountNotFlooredByMinWorkers(t *testing.T) {
+	// An explicit low Workers count is a deliberate concurrency limit and must
+	// be honored rather than raised to MinWorkers.
+	if got := (PoolOptions{Workers: 2, MinWorkers: IOMinWorkers, MaxWorkers: IOMaxWorkers}).resolveWorkers(100); got != 2 {
+		t.Fatalf("explicit low count should be honored, got %d, want 2", got)
+	}
+	// The floor still lifts an auto-detected count on tiny machines.
+	if got := (PoolOptions{Workers: 0, MinWorkers: IOMinWorkers}).resolveWorkers(100); got < IOMinWorkers {
+		t.Fatalf("auto-detected count should be floored to %d, got %d", IOMinWorkers, got)
+	}
+	// The ceiling still caps an explicit count that exceeds it.
+	if got := (PoolOptions{Workers: 1000, MaxWorkers: IOMaxWorkers}).resolveWorkers(10000); got != IOMaxWorkers {
+		t.Fatalf("explicit count above ceiling should be capped to %d, got %d", IOMaxWorkers, got)
+	}
+}
+
+func TestForEach_CanceledContextStopsSchedulingAndSurfacesErr(t *testing.T) {
+	// A pre-canceled context must surface ctx.Err() and run few (ideally zero)
+	// items rather than scheduling a no-op goroutine per element.
+	items := make([]int, 10000)
+	var ran atomic.Int64
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := ForEach(ctx, items, PoolOptions{Workers: 4},
+		func(context.Context, int, int) error {
+			ran.Add(1)
+			return nil
+		})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if n := ran.Load(); n > int64(len(items)/2) {
+		t.Fatalf("canceled run scheduled too many items: %d of %d", n, len(items))
+	}
+}
+
 func TestForEach_WorkerCapBound(t *testing.T) {
 	// CPUBound work must never exceed the shared budget concurrently.
 	budget := AvailableCPUs()

--- a/pkg/utils/workers_test.go
+++ b/pkg/utils/workers_test.go
@@ -27,6 +27,12 @@ func TestAvailableCPUs(t *testing.T) {
 	}
 }
 
+func TestIOWorkerBounds(t *testing.T) {
+	if IOMinWorkers < 1 || IOMaxWorkers < IOMinWorkers {
+		t.Fatalf("invalid IO bounds [%d,%d]", IOMinWorkers, IOMaxWorkers)
+	}
+}
+
 func TestForEach_AllItemsProcessedIndexAligned(t *testing.T) {
 	const n = 100
 	items := make([]int, n)

--- a/pkg/utils/workers_test.go
+++ b/pkg/utils/workers_test.go
@@ -1,0 +1,108 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package utils
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAdjustNumWorkers(t *testing.T) {
+	if got := AdjustNumWorkers(7); got != 7 {
+		t.Fatalf("explicit count: got %d, want 7", got)
+	}
+	if got := AdjustNumWorkers(0); got < 1 {
+		t.Fatalf("auto-detect must be >= 1, got %d", got)
+	}
+}
+
+func TestAvailableCPUs(t *testing.T) {
+	if got := AvailableCPUs(); got < 1 {
+		t.Fatalf("AvailableCPUs must be >= 1, got %d", got)
+	}
+}
+
+func TestForEach_AllItemsProcessedIndexAligned(t *testing.T) {
+	const n = 100
+	items := make([]int, n)
+	for i := range items {
+		items[i] = i * 2
+	}
+	out := make([]int, n)
+
+	err := ForEach(context.Background(), items, PoolOptions{Workers: 8, CPUBound: true},
+		func(_ context.Context, item, i int) error {
+			out[i] = item + 1 // index-aligned write, no shared mutable state
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := range out {
+		if want := i*2 + 1; out[i] != want {
+			t.Fatalf("out[%d] = %d, want %d", i, out[i], want)
+		}
+	}
+}
+
+func TestForEach_Empty(t *testing.T) {
+	called := false
+	err := ForEach(context.Background(), []int{}, PoolOptions{}, func(context.Context, int, int) error {
+		called = true
+		return nil
+	})
+	if err != nil || called {
+		t.Fatalf("empty slice should not call fn or error; err=%v called=%v", err, called)
+	}
+}
+
+func TestForEach_FirstErrorReturnedAndCancels(t *testing.T) {
+	sentinel := errors.New("boom")
+	items := make([]int, 50)
+	var ran atomic.Int64
+
+	err := ForEach(context.Background(), items, PoolOptions{Workers: 4},
+		func(ctx context.Context, _, i int) error {
+			ran.Add(1)
+			if i == 0 {
+				return sentinel
+			}
+			// Later items should observe cancellation rather than all running.
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+}
+
+func TestForEach_WorkerCapBound(t *testing.T) {
+	// CPUBound work must never exceed the shared budget concurrently.
+	budget := AvailableCPUs()
+	var inFlight, maxInFlight atomic.Int64
+	items := make([]int, 200)
+
+	err := ForEach(context.Background(), items, PoolOptions{Workers: 64, CPUBound: true},
+		func(context.Context, int, int) error {
+			cur := inFlight.Add(1)
+			for {
+				old := maxInFlight.Load()
+				if cur <= old || maxInFlight.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			inFlight.Add(-1)
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if int(maxInFlight.Load()) > budget {
+		t.Fatalf("CPU-bound concurrency %d exceeded budget %d", maxInFlight.Load(), budget)
+	}
+}


### PR DESCRIPTION
## Motivation

A scan runs several worker pools, and they **nest**. The scanner fans out one goroutine *per service*, and inside each service the query-evaluation pool spins up its own `GOMAXPROCS` workers. There were five such pools in total (query eval, file reading, HCL body parsing, module-variable parsing, file-type detection), each independently sizing itself to roughly the core count, with no shared notion of how much CPU work was allowed to run at once.

The result: in-flight CPU-bound goroutines scaled as `Nservices × GOMAXPROCS`, well over 100 goroutines competing for 16 cores (on my laptop). Past a point, **adding cores made scans slower, not faster** (negative scaling): the pools oversubscribed the machine and the extra goroutines added scheduler churn, cache thrashing, and lock contention. A `GOMAXPROCS` sweep confirmed it, latency got worse going from 8 to 16 cores, and concurrent scans showed almost no throughput gain.

On top of that, the five pools were inconsistent: only the file reader clamped its worker count to `[4, 64]`; the module-variable pool ignored the auto-sizing helper and hardcoded `4`; the file-type analyzer is I/O-bound (it reads file content) but was capped at `GOMAXPROCS` while the otherwise-identical file reader fanned out to 64; and all five were hand-rolled copies of the same channel + `WaitGroup` + closer boilerplate.

JIRA Ticket: [K9CODESEC-2731](https://datadoghq.atlassian.net/browse/K9CODESEC-2731)

- Introduced a **process-wide shared CPU budget** (weighted semaphore sized to the available CPU count). Every CPU-bound pool (Rego eval, HCL parsing, module-variable parsing) acquires one slot per unit of work, so nesting no longer multiplies, at most `AvailableCPUs()` CPU-bound goroutines run at once regardless of how deep the pools stack.
- **Unified the five worker pools** behind one generic helper (`utils.ForEach`, errgroup-backed), replacing the duplicated fan-out/`WaitGroup`/closer boilerplate.
- **Separated CPU-bound from I/O-bound work**: I/O-bound pools (file reading, file-type detection) do *not* consume the CPU budget (blocking on disk shouldn't hold a CPU slot) and fan out wider than the core count via shared `IOMinWorkers`/`IOMaxWorkers` (`[4, 64]`) constants in `workers.go`. Fixes the analyzer being throttled to `GOMAXPROCS`.
- Removed the hardcoded `4` in module-variable parsing and made that pass **deterministic** (sorted iteration order).
- Single source of truth for core count (`utils.AvailableCPUs()`) used everywhere instead of ad-hoc `GOMAXPROCS` reads.
- Added unit tests for the new worker helper and CPU budget; added a benchmark harness for the `GOMAXPROCS` sweep.

## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

The change is internal (concurrency), so the observable behavior must be **identical** while scaling improves:

- **Correctness:** scan a repo before and after this PR; the findings count and SARIF output must be unchanged.
- **Scaling:** run the same scan at `GOMAXPROCS=4`, `8`, `16` (e.g. `GOMAXPROCS=16 datadog-iac-scanner scan -p <repo> -o <out>`). Higher core counts should be the same or faster — in particular 16 cores should no longer be slower than 8 (the previous negative-scaling regression).
- **Race safety:** `go test -race ./pkg/engine/... ./pkg/utils/ ./pkg/analyzer/ ./pkg/parser/terraform/modules/` passes clean.

## Blast Radius

Datadog IaC Scanner only. The change is confined to the scanner's internal worker/concurrency layer (`pkg/utils`, `pkg/engine`, `pkg/analyzer`, `pkg/parser/terraform/modules`, `pkg/engine/provider`). No public API, CLI flag, rule, or output-format change. No impact on other services or documentation.


I submit this contribution under the Apache-2.0 license.


[K9CODESEC-2731]: https://datadoghq.atlassian.net/browse/K9CODESEC-2731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ