### PR TITLE
TFPlans: searchLines as searchKeys

### DIFF
--- a/pkg/detector/default_detect.go
+++ b/pkg/detector/default_detect.go
@@ -17,8 +17,10 @@ import (
 
 const (
 	undetectedVulnerabilityLine = -1
-	// resource, type, name, and at least one attribute segment.
-	tfPlanMinAttributePathLen = 4
+	// resource, type, and name; the resource block's own header line is now
+	// injected into the remapped plan document (see pkg/parser/json/tfplan.go),
+	// so a bare resource-level searchKey can resolve structurally too.
+	tfPlanMinAttributePathLen = 3
 )
 
 type defaultDetectLine struct {
@@ -156,15 +158,22 @@ func detectTerraformPlanLine(
 
 // terraformPlanPath turns a plan searchKey into structural path components for
 // GetLineBySearchLine. It expands bracket groups ("type[name]" -> type, name;
-// "list[0]" -> list, 0), drops value anchors (key=value -> key), and ensures the
-// path is rooted at the plan's top-level "resource" key.
+// "list[0]" -> list, 0), drops value anchors (key=value -> key), strips the
+// "{{ }}" templating some Rego rules wrap the name in, and ensures the path
+// is rooted at the plan's top-level "resource" key.
+//
+// Bracket contents can contain dots (module-prefixed keys, e.g.
+// "type[module.foo.name]") and/or a count/for_each suffix bracket (e.g.
+// "type[this[0]]"), so the top-level dot-split ignores dots inside an
+// unclosed "[...]" (see splitTopLevelDots), and a group's closing bracket is
+// its LAST "]", not the first one found after "[".
 func terraformPlanPath(searchKey string) ([]string, bool) {
 	// Drop the value anchor (key=value) up front; the value may contain dots.
 	if eq := strings.Index(searchKey, "="); eq >= 0 {
 		searchKey = searchKey[:eq]
 	}
 	var comps []string
-	for _, seg := range strings.Split(searchKey, ".") {
+	for _, seg := range splitTopLevelDots(searchKey) {
 		seg = strings.TrimSpace(seg)
 		if seg == "" {
 			continue
@@ -180,11 +189,14 @@ func terraformPlanPath(searchKey string) ([]string, bool) {
 			if head := seg[:open]; head != "" {
 				comps = append(comps, head)
 			}
-			closeIdx := strings.Index(seg, "]")
+			closeIdx := strings.LastIndex(seg, "]")
 			if closeIdx < 0 || closeIdx < open {
 				break
 			}
-			if inner := seg[open+1 : closeIdx]; inner != "" {
+			inner := seg[open+1 : closeIdx]
+			inner = strings.TrimPrefix(inner, "{{")
+			inner = strings.TrimSuffix(inner, "}}")
+			if inner != "" {
 				comps = append(comps, inner)
 			}
 			seg = seg[closeIdx+1:]
@@ -195,6 +207,30 @@ func terraformPlanPath(searchKey string) ([]string, bool) {
 		comps = comps[1:]
 	}
 	return append([]string{"resource"}, comps...), explicitResourcePath
+}
+
+// splitTopLevelDots splits s on "." like strings.Split, except dots inside an
+// unclosed "[...]" group aren't treated as separators, e.g.
+// "type[module.foo.name].attr" splits into ["type[module.foo.name]", "attr"].
+func splitTopLevelDots(s string) []string {
+	var segs []string
+	depth, start := 0, 0
+	for i, c := range s {
+		switch c {
+		case '[':
+			depth++
+		case ']':
+			if depth > 0 {
+				depth--
+			}
+		case '.':
+			if depth == 0 {
+				segs = append(segs, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	return append(segs, s[start:])
 }
 
 // handleArrayIndex handles paths that contain numeric segments. It first attempts a

--- a/pkg/detector/default_detect_test.go
+++ b/pkg/detector/default_detect_test.go
@@ -382,6 +382,37 @@ func Test_terraformPlanPath(t *testing.T) {
 			searchKey: "azurerm_sql_firewall_rule[positive1]",
 			want:      []string{"resource", "azurerm_sql_firewall_rule", "positive1"},
 		},
+		{
+			// Module resources are keyed "name[N]" (count/for_each index), so the
+			// resource-name bracket itself can contain a nested "[0]" suffix.
+			name:      "module_resource_with_count_index",
+			searchKey: "aws_dynamodb_table[this[0]].server_side_encryption",
+			want:      []string{"resource", "aws_dynamodb_table", "this[0]", "server_side_encryption"},
+		},
+		{
+			// Module-prefixed keys contain dots inside the bracket.
+			name:      "module_prefixed_resource",
+			searchKey: "aws_s3_bucket[module.app1.data].bucket",
+			want:      []string{"resource", "aws_s3_bucket", "module.app1.data", "bucket"},
+		},
+		{
+			// Module-prefixed key combined with a for_each index suffix.
+			name:      "module_prefixed_resource_with_for_each_index",
+			searchKey: `aws_s3_bucket[module.app1.data["prod"]].bucket`,
+			want:      []string{"resource", "aws_s3_bucket", `module.app1.data["prod"]`, "bucket"},
+		},
+		{
+			// Some Rego rules wrap the resource name in "{{ }}" templating.
+			name:      "curly_brace_wrapped_name",
+			searchKey: "aws_s3_bucket_object[{{this[0]}}]",
+			want:      []string{"resource", "aws_s3_bucket_object", "this[0]"},
+		},
+		{
+			// Curly-brace templating combined with a module-prefixed name.
+			name:      "curly_brace_wrapped_module_prefixed_name",
+			searchKey: "aws_s3_bucket_object[{{module.s3_object.this[0]}}]",
+			want:      []string{"resource", "aws_s3_bucket_object", "module.s3_object.this[0]"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -436,6 +467,7 @@ func Test_detectLineTerraformPlan(t *testing.T) {
 
 func Test_detectLineTerraformPlanResourceLevel(t *testing.T) {
 	plan := `{
+  "format_version": "1.0",
   "planned_values": {
     "root_module": {
       "resources": [{
@@ -460,7 +492,106 @@ func Test_detectLineTerraformPlanResourceLevel(t *testing.T) {
 		LinesOriginalData: utils.SplitLines(plan),
 	}
 	got := defaultDetectLine{}.DetectLine(context.Background(), file, "resource.aws_api_gateway_deployment[positive1]", 0)
-	require.Equal(t, 5, got.Line)
+	// The resource's "values" attribute line is injected structurally now,
+	// instead of falling back to a text match on the resource address.
+	require.Equal(t, 9, got.Line)
+}
+
+func Test_detectLineTerraformPlanModuleResourceWithCountIndex(t *testing.T) {
+	plan := `{
+  "format_version": "1.0",
+  "planned_values": {
+    "root_module": {
+      "resources": [],
+      "child_modules": [{
+        "address": "module.dynamodb_table",
+        "resources": [{
+          "address": "module.dynamodb_table.aws_dynamodb_table.this[0]",
+          "type": "aws_dynamodb_table",
+          "name": "this",
+          "index": 0,
+          "values": {
+            "name": "my-table",
+            "server_side_encryption": {
+              "enabled": true
+            }
+          }
+        }]
+      }]
+    }
+  }
+}`
+	p := &jsonParser.Parser{}
+	_, docs, _, _, err := p.Parse(context.Background(), []byte(plan), "plan.json", false, 1)
+	require.NoError(t, err)
+
+	file := &model.FileMetadata{
+		Kind:              model.KindTerraformPlan,
+		LineInfoDocument:  docs[0],
+		LinesOriginalData: utils.SplitLines(plan),
+	}
+	// Child-module keys are module-prefixed plus the index suffix, so the
+	// searchKey bracket contents contain dots and a nested "[0]".
+	got := defaultDetectLine{}.DetectLine(
+		context.Background(), file, "aws_dynamodb_table[module.dynamodb_table.this[0]].server_side_encryption", 0,
+	)
+	require.Equal(t, 15, got.Line)
+}
+
+func Test_detectLineTerraformPlanSiblingModulesSameTypeAndName(t *testing.T) {
+	// Two resources sharing type+name in sibling modules must both stay
+	// resolvable via distinct module-prefixed keys, not collide.
+	plan := `{
+  "format_version": "1.0",
+  "planned_values": {
+    "root_module": {
+      "resources": [],
+      "child_modules": [
+        {
+          "address": "module.app1",
+          "resources": [{
+            "address": "module.app1.aws_s3_bucket.data",
+            "type": "aws_s3_bucket",
+            "name": "data",
+            "values": {
+              "bucket": "app1-data",
+              "acl": "private"
+            }
+          }]
+        },
+        {
+          "address": "module.app2",
+          "resources": [{
+            "address": "module.app2.aws_s3_bucket.data",
+            "type": "aws_s3_bucket",
+            "name": "data",
+            "values": {
+              "bucket": "app2-data",
+              "acl": "public-read"
+            }
+          }]
+        }
+      ]
+    }
+  }
+}`
+	p := &jsonParser.Parser{}
+	_, docs, _, _, err := p.Parse(context.Background(), []byte(plan), "plan.json", false, 1)
+	require.NoError(t, err)
+
+	file := &model.FileMetadata{
+		Kind:              model.KindTerraformPlan,
+		LineInfoDocument:  docs[0],
+		LinesOriginalData: utils.SplitLines(plan),
+	}
+
+	d := defaultDetectLine{}
+	app1 := d.DetectLine(context.Background(), file, "aws_s3_bucket[module.app1.data].acl", 0)
+	app2 := d.DetectLine(context.Background(), file, "aws_s3_bucket[module.app2.data].acl", 0)
+
+	require.Greater(t, app1.Line, 1)
+	require.Greater(t, app2.Line, 1)
+	require.NotEqual(t, app1.Line, app2.Line)
 }
 
 func Test_detectLineTerraformPlanMinified(t *testing.T) {

--- a/pkg/detector/search_line_detector.go
+++ b/pkg/detector/search_line_detector.go
@@ -98,11 +98,14 @@ func (d *searchLineDetector) preparePath(pathItems []string) int {
 
 // getResult creates the paths to be used by gjson pkg to find the line in the content
 func (d *searchLineDetector) getResult() int {
+	// Escape '.' like preparePath does for every other path segment, so a dotted
+	// targetObj isn't misread by gjson as nested path segments.
+	targetObj := strings.ReplaceAll(d.targetObj, ".", "\\.")
 	pathObjects := []string{
-		d.resolvedPath + "._dd_lines._dd_" + d.targetObj + "._dd_line",
-		d.resolvedPath + "." + d.targetObj + "._dd_lines._dd__default._dd_line",
-		d.resolvedArrayPath + "." + d.targetObj + "._dd__default._dd_line",
-		d.resolvedArrayPath + "._dd_" + d.targetObj + "._dd_line",
+		d.resolvedPath + "._dd_lines._dd_" + targetObj + "._dd_line",
+		d.resolvedPath + "." + targetObj + "._dd_lines._dd__default._dd_line",
+		d.resolvedArrayPath + "." + targetObj + "._dd__default._dd_line",
+		d.resolvedArrayPath + "._dd_" + targetObj + "._dd_line",
 	}
 
 	result := -1

--- a/pkg/detector/search_line_detector_test.go
+++ b/pkg/detector/search_line_detector_test.go
@@ -201,6 +201,41 @@ func TestGetLineBySearchLine(t *testing.T) { //nolint
 			want:    4,
 			wantErr: false,
 		},
+		{ //nolint
+			// The final path component (targetObj) must be dot-escaped too, or
+			// gjson misreads a dotted key as nested paths.
+			name: "test with dots on final path component",
+			args: args{
+				pathComponents: []string{"father", "module.staging.web"},
+				file: &model.FileMetadata{
+					LineInfoDocument: map[string]any{
+						"_dd_lines": map[string]any{
+							"_dd__default": map[string]any{
+								"_dd_line": 0,
+							},
+							"_dd_father": map[string]any{
+								"_dd_line": 2,
+							},
+						},
+						"father": map[string]any{
+							"_dd_lines": map[string]any{
+								"_dd__default": map[string]any{
+									"_dd_line": 2,
+								},
+								"_dd_module.staging.web": map[string]any{
+									"_dd_line": 3,
+								},
+							},
+							"module.staging.web": map[string]any{
+								"instance_type": "t2.micro",
+							},
+						},
+					},
+				},
+			},
+			want:    3,
+			wantErr: false,
+		},
 		{
 			name: "test number issue with array",
 			args: args{

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	hcl_plan "github.com/hashicorp/terraform-json"
+	"github.com/tidwall/gjson"
 )
 
 // TFPlan is an auxiliary structure for parsing tfplans as a scanner Document
@@ -18,11 +19,14 @@ type TFPlan struct {
 	Resource map[string]TFPlanResource `json:"resource"`
 }
 
-// TFPlanResource is an auxiliary structure for parsing tfplans as a scanner Document
-type TFPlanResource map[string]TFPlanNamedResource
+// TFPlanResource is an auxiliary structure for parsing tfplans as a scanner Document.
+// Values are either a TFPlanNamedResource (keyed by resource name) or, under the
+// reserved "_dd_lines" key, a map[string]*model.LineObject holding each sibling
+// resource's header line (see readModule).
+type TFPlanResource map[string]any
 
 // TFPlanNamedResource is an auxiliary structure for parsing tfplans as a scanner Document
-type TFPlanNamedResource map[string]interface{}
+type TFPlanNamedResource map[string]any
 
 // parseTFPlan unmarshals Document as a plan so it can be rebuilt with only
 // the required information
@@ -40,17 +44,54 @@ func parseTFPlan(doc model.Document) (model.Document, error) {
 		return model.Document{}, err
 	}
 
-	parsedPlan := readPlan(plan)
+	// hcl_plan.Plan is a typed struct so unmarshaling drops the injected
+	// _dd_lines keys along with each resource's "values" attribute line. Read
+	// those lines back out of the raw bytes (via gjson, keyed by resource
+	// address) before that information is lost.
+	resourceLines := extractResourceHeaderLines(b)
+
+	parsedPlan := readPlan(plan, resourceLines)
 	return parsedPlan, nil
 }
 
+// extractResourceHeaderLines walks the raw plan JSON and returns, for every
+// planned resource, the _dd_line of its "values" attribute (i.e. where the
+// resource's own attribute block starts), keyed by resource address. Array
+// elements don't carry their own _dd_lines sibling (see setSeqLines in
+// json_line.go) — that information lives positionally in the parent module's
+// "_dd_lines._dd_resources._dd_arr" instead.
+func extractResourceHeaderLines(rawPlan []byte) map[string]int {
+	lines := make(map[string]int)
+	root_module := gjson.GetBytes(rawPlan, "planned_values.root_module")
+	walkModule(&root_module, lines)
+	return lines
+}
+
+func walkModule(module *gjson.Result, lines map[string]int) {
+	resources := module.Get("resources").Array()
+	arr := module.Get("_dd_lines._dd_resources._dd_arr").Array()
+	for i, resource := range resources {
+		if i >= len(arr) {
+			break
+		}
+		address := resource.Get("address").String()
+		if line := arr[i].Get("_dd_values._dd_line").Int(); line > 0 {
+			lines[address] = int(line)
+		}
+	}
+	module.Get("child_modules").ForEach(func(_, child gjson.Result) bool {
+		walkModule(&child, lines)
+		return true
+	})
+}
+
 // readPlan extracts the information needed from a Terraform plan and converts it to a scanner Document
-func readPlan(plan *hcl_plan.Plan) model.Document {
+func readPlan(plan *hcl_plan.Plan, resourceLines map[string]int) model.Document {
 	kp := TFPlan{
 		Resource: make(map[string]TFPlanResource),
 	}
 
-	kp.readModule(plan.PlannedValues.RootModule)
+	kp.readModule(plan.PlannedValues.RootModule, "", resourceLines)
 
 	doc := model.Document{}
 
@@ -66,25 +107,23 @@ func readPlan(plan *hcl_plan.Plan) model.Document {
 	return doc
 }
 
-// readModule will iterate over all planned_value getting the information required
-// It recursively processes all modules and accumulates resources without losing data
-func (kp *TFPlan) readModule(module *hcl_plan.StateModule) {
-	kp.readModuleWithAddress(module, "")
-}
-
-// readModuleWithAddress recursively processes a module and its children with full address path
-// to ensure unique resource identification across the module tree
-func (kp *TFPlan) readModuleWithAddress(module *hcl_plan.StateModule, moduleAddress string) {
+// readModule recursively processes a module and its children, accumulating
+// resources from every module into the same flat resource.<type>.<name> map
+// without losing data across modules. moduleAddress is the full address of
+// module (e.g. "module.staging"), or "" for the root module.
+func (kp *TFPlan) readModule(module *hcl_plan.StateModule, moduleAddress string, resourceLines map[string]int) {
 	// Process all resources in this module
 	for _, resource := range module.Resources {
 		// Ensure the resource type map exists - accumulate, don't reinitialize!
 		if kp.Resource[resource.Type] == nil {
-			kp.Resource[resource.Type] = make(map[string]TFPlanNamedResource)
+			kp.Resource[resource.Type] = make(TFPlanResource)
 		}
+		typeRes := kp.Resource[resource.Type]
 
-		// Build resource key with module path for child modules
-		// Root module resources keep simple names for backward compatibility
-		// Child module resources are prefixed with their module path
+		// Root-module resources keep their plain name. Child-module resources
+		// get their module address prefixed, so same-type-same-name resources
+		// in different modules don't collide into one map entry (which would
+		// silently drop a resource from evaluation).
 		resourceKey := resource.Name
 		if moduleAddress != "" {
 			resourceKey = moduleAddress + "." + resource.Name
@@ -97,15 +136,24 @@ func (kp *TFPlan) readModuleWithAddress(module *hcl_plan.StateModule, moduleAddr
 		}
 
 		// Accumulate the resource into the existing type map
-		kp.Resource[resource.Type][resourceKey] = resource.AttributeValues
+		typeRes[resourceKey] = TFPlanNamedResource(resource.AttributeValues)
+
+		// Inject the resource's "values" attribute line as a sibling _dd_lines
+		// entry at resource.<type>._dd_lines._dd_<name>._dd_line, matching the
+		// gjson path GetLineBySearchLine builds for a bare resource searchKey.
+		if line, ok := resourceLines[resource.Address]; ok {
+			ddLines, isMap := typeRes["_dd_lines"].(map[string]*model.LineObject)
+			if !isMap {
+				ddLines = make(map[string]*model.LineObject)
+				typeRes["_dd_lines"] = ddLines
+			}
+			ddLines["_dd_"+resourceKey] = &model.LineObject{Line: line}
+		}
 	}
 
-	// Recursively process child modules with their full address path
+	// Recursively process child modules, accumulating into the same map
 	for _, childModule := range module.ChildModules {
-		// The childModule.Address already contains the full path from root
-		// (e.g., "module.networking" or "module.networking.module.security")
-		// So we pass it directly without combining with parent
-		kp.readModuleWithAddress(childModule, childModule.Address)
+		kp.readModule(childModule, childModule.Address, resourceLines)
 	}
 }
 

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -149,7 +149,7 @@ func TestJson_parseTFPlan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "test - same resource name in different modules",
+			name: "test - same resource name in different modules is preserved with module-prefixed keys",
 			args: args{
 				doc: model.Document{
 					"format_version":    "1.2",
@@ -193,6 +193,8 @@ func TestJson_parseTFPlan(t *testing.T) {
 					},
 				},
 			},
+			// Child-module resources are module-prefixed, so they no longer
+			// collide with the root-module resource of the same type+name.
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_instance": map[string]interface{}{
@@ -290,7 +292,7 @@ func TestJson_parseTFPlan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "test - multiple sibling modules with same resource types",
+			name: "test - multiple sibling modules with same resource types is preserved with module-prefixed keys",
 			args: args{
 				doc: model.Document{
 					"format_version":    "1.2",
@@ -332,6 +334,7 @@ func TestJson_parseTFPlan(t *testing.T) {
 					},
 				},
 			},
+			// Distinct module-prefixed keys, so both remain visible.
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
@@ -492,6 +495,61 @@ func TestJson_parseTFPlan(t *testing.T) {
 						"data[\"dev\"]": map[string]interface{}{
 							"bucket": "dev-data-bucket",
 							"acl":    "private",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// Mirrors what initializeJSONLine/setLineInfo injects: the resources
+			// array element's own line lives in the parent's
+			// "_dd_lines._dd_resources._dd_arr", not on the element itself.
+			name: "test - injects resource values line from _dd_lines",
+			args: args{
+				doc: model.Document{
+					"format_version":    "0.2",
+					"terraform_version": "1.0.5",
+					"variables":         map[string]any{},
+					"planned_values": map[string]any{
+						"root_module": map[string]any{
+							"_dd_lines": map[string]any{
+								"_dd_resources": map[string]any{
+									"_dd_arr": []map[string]any{
+										{
+											"_dd__default": map[string]any{"_dd_line": 5},
+											"_dd_values":   map[string]any{"_dd_line": 7},
+										},
+									},
+								},
+							},
+							"resources": []map[string]any{
+								{
+									"address": "fakewebservices_database.prod_db",
+									"mode":    "managed",
+									"type":    "fakewebservices_database",
+									"name":    "prod_db",
+									"values": map[string]any{
+										"name": "Production DB",
+										"size": 256,
+									},
+								},
+							},
+						},
+					},
+					"resource_changes": []map[string]any{},
+					"configuration":    map[string]any{},
+				},
+			},
+			want: model.Document{
+				"resource": map[string]any{
+					"fakewebservices_database": map[string]any{
+						"_dd_lines": map[string]any{
+							"_dd_prod_db": map[string]any{"_dd_line": (float64)(7)},
+						},
+						"prod_db": map[string]any{
+							"name": "Production DB",
+							"size": (float64)(256),
 						},
 					},
 				},


### PR DESCRIPTION
## Motivation

The terraform plans need to use a logic more subtle than the `searchKey`, the logic of the `searchLine` fits the use case better because of the complexity of the file.

A previous PR has introduced usage of the `searchLine` logic with `searchKey`, however, in some cases, this logic is not used:

- The `searchLine` logic usage is gated by the a minimum number of information within the `searchKey` ("resource" + 3 other location marks).
- The `searchLine` logic uses the `_dd_line` attribute under a resource mark. This attribute needs to be populated in order for the scanner to retrieve the line.

## Changes

- Each resource's line number is now injected into the document, so a bare `resource.type.name` searchKey (no attribute) can resolve its line directly, without text matching.
- `terraformPlanPath` now handles dots inside brackets (module-prefixed names) and strips `{{ }}` wrapping some rules put around the resource name.
- `search_line_detector.go` now escapes dots in the last path segment, so dotted resource keys resolve correctly.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA

- Tests are broken in this PR because of the behavioural changes of the scanner, the new lines found by the scanner are indeed the expected ones.

## Testing

Tested against the latest batch of rules in [this PR](https://github.com/DataDog/datadog-iac-scanner-default-rules/pull/66). Also ran the full `./tool.sh test` suite (1397 rules) against this branch: it caught 4 rules whose expected test line moved (now more precise, pointing at the resource's `values` block instead of a coincidental text match) — fixed in the default-rules repo.

## Blast Radius

Terraform plan (JSON) scanning only. Resources inside non-root modules will report different (and, for the collision bug, newly-appearing) findings and line numbers. Rules using `{{ }}`-wrapped searchKeys on terraform plans may report a different, more accurate line.

## Rolling out

Immediately after merging this PR, this next [PR](https://github.com/DataDog/datadog-iac-scanner-default-rules/pull/73) has to be merged in the rules to update the expectations.

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
