### PR TITLE
Fix synthetic module doc model for local module evaluation

### DIFF
--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -1250,3 +1250,31 @@ func TestExecuteQueries_CanceledContextReturnsError(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.Empty(t, vulns)
 }
+
+func TestExpandModuleFindings_NoExtrasUnchanged(t *testing.T) {
+	vulns := []model.Vulnerability{{FileID: "primary", QueryName: "rule-a"}}
+	got := expandModuleFindings(vulns, nil)
+	require.Equal(t, vulns, got)
+}
+
+func TestExpandModuleFindings_ClonesPerExtraCaller(t *testing.T) {
+	primaryID := "primary\x00stack-a|module.app\x00this"
+	extraID := "extra\x00stack-b|module.app\x00this"
+	extras := map[string][]extraCallerInfo{
+		primaryID: {{callChain: "stack-b|module.app", docID: extraID}},
+	}
+	vulns := []model.Vulnerability{{
+		FileID:    primaryID,
+		FileName:  "modules/app/main.tf",
+		Line:      5,
+		QueryName: "rule-a",
+	}}
+	got := expandModuleFindings(vulns, extras)
+	require.Len(t, got, 2)
+	require.Equal(t, primaryID, got[0].FileID)
+	require.Equal(t, extraID, got[1].FileID)
+	require.Equal(t, "stack-b|module.app", got[1].ModuleCallChain)
+	require.Equal(t, got[0].Line, got[1].Line)
+	require.Equal(t, got[0].FileName, got[1].FileName)
+	require.Equal(t, got[0].QueryName, got[1].QueryName)
+}

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -8,7 +8,9 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -195,10 +197,14 @@ func resolveModuleDocuments(
 	}
 }
 
-// instantiatedDocs builds one synthetic doc + FileMetadata per resolved module resource (skips root / out-of-scope).
-// Callers with identical resolved attributes share a single OPA doc; the extras map records duplicate callers so
-// their findings can be cloned after OPA eval. Doc id is file id + call chain + instance;
-// synthetic row carries ModuleCallChain for hashing.
+// moduleRefEntry holds resolved resource data for _refs injection and dedup.
+type moduleRefEntry struct {
+	typ, name, definedIn, defLine string
+	attrs                         interface{}
+}
+
+// instantiatedDocs emits one synthetic OPA doc per resolved module resource instance.
+// Identical callers are recorded in extras for post-eval finding cloning.
 func instantiatedDocs(
 	resources []tfeval.ResolvedResource,
 	byAbsPath map[string]*model.FileMetadata,
@@ -206,6 +212,24 @@ func instantiatedDocs(
 	seen map[string]string,
 	extras map[string][]extraCallerInfo,
 ) (docs []model.Document, synthetic []*model.FileMetadata) {
+	// Pass 1: index resources per call chain.
+	cckRefs := make(map[string][]moduleRefEntry)
+	for i := range resources {
+		r := &resources[i]
+		if r.ModuleAddress == "" {
+			continue
+		}
+		cck := callChainKey(r, repoPath)
+		cckRefs[cck] = append(cckRefs[cck], moduleRefEntry{
+			typ:       r.Type,
+			name:      r.Name,
+			definedIn: absPath(r.DefinedIn, repoPath),
+			defLine:   strconv.Itoa(r.DefLine),
+			attrs:     tfeval.AttributesToDocument(r),
+		})
+	}
+
+	// Pass 2: emit one doc per instance.
 	for i := range resources {
 		r := &resources[i]
 		if r.ModuleAddress == "" {
@@ -218,24 +242,18 @@ func instantiatedDocs(
 		}
 
 		cck := callChainKey(r, repoPath)
-		docID := strings.Join([]string{fm.ID, cck, r.Name}, "\x00")
+		docID := fm.ID + "\x00" + cck + "\x00" + r.Name
 
-		// Dedupe by resource content: identical resolved attributes reached through different
-		// call chains collapse to a single OPA doc (saving eval cost on quadratic rules); findings
-		// are cloned per caller after eval. The key includes ModuleAddress, so distinct module
-		// instances within one configuration (module.a vs module.b, count/for_each indices) always
-		// get distinct keys and are never merged. Cardinality is therefore preserved within a
-		// configuration; only the same module resource re-reached from another root collapses.
-		contentKey := strings.Join([]string{abs, r.ModuleAddress, r.Type, r.Name, strconv.Itoa(r.DefLine), resourceAttrKey(r)}, "\x00")
-		if primaryDocID, duplicate := seen[contentKey]; duplicate {
+		contentKey := moduleCallContentKey(r, cckRefs[cck], repoPath)
+		if primaryDocID, dup := seen[contentKey]; dup {
 			extras[primaryDocID] = append(extras[primaryDocID], extraCallerInfo{callChain: cck, docID: docID})
 			continue
 		}
 		seen[contentKey] = docID
 
-		// Use the bare resource label (not the expanded name like k[0]) so that
-		// Rego rules matching input.document[_].resource.TYPE.NAME find the resource.
-		docs = append(docs, model.Document{
+		refsMap := buildRefsMap(r, cckRefs[cck])
+
+		doc := model.Document{
 			"id":   docID,
 			"file": fm.FilePath,
 			"resource": map[string]interface{}{
@@ -243,30 +261,75 @@ func instantiatedDocs(
 					tfeval.ResourceBaseName(r.Name): tfeval.AttributesToDocument(r),
 				},
 			},
-		})
+		}
+		if len(refsMap) > 0 {
+			doc["_refs"] = map[string]interface{}{"resource": refsMap}
+		}
+		docs = append(docs, doc)
 		synthetic = append(synthetic, newInstanceFileMetadata(fm, docID, cck))
 	}
 	return docs, synthetic
 }
 
-// newInstanceFileMetadata is a clone with empty Document (Combine skips it); same path/source/
-// LineInfoDocument as fm for line detection; id and ModuleCallChain match the synthetic doc.
+// moduleCallContentKey hashes the resource and every resolved resource in its module call.
+func moduleCallContentKey(self *tfeval.ResolvedResource, allInCall []moduleRefEntry, repoPath string) string {
+	type row struct{ typ, name, definedIn, defLine, attrKey string }
+	rows := make([]row, 0, len(allInCall))
+	for _, e := range allInCall {
+		b, _ := json.Marshal(e.attrs)
+		rows = append(rows, row{e.typ, e.name, e.definedIn, e.defLine, strconv.FormatUint(xxhash.Sum64(b), 16)})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		for _, pair := range [][2]string{
+			{rows[i].typ, rows[j].typ},
+			{rows[i].name, rows[j].name},
+			{rows[i].definedIn, rows[j].definedIn},
+			{rows[i].defLine, rows[j].defLine},
+			{rows[i].attrKey, rows[j].attrKey},
+		} {
+			if pair[0] != pair[1] {
+				return pair[0] < pair[1]
+			}
+		}
+		return false
+	})
+	parts := []string{
+		self.ModuleAddress, self.Type, self.Name,
+		absPath(self.DefinedIn, repoPath), strconv.Itoa(self.DefLine),
+	}
+	for _, r := range rows {
+		parts = append(parts, r.typ, r.name, r.definedIn, r.defLine, r.attrKey)
+	}
+	return strings.Join(parts, "\x00")
+}
+
+// buildRefsMap returns sibling resources in the same module call (for walk-based rules).
+func buildRefsMap(self *tfeval.ResolvedResource, allInCall []moduleRefEntry) map[string]interface{} {
+	refs := make(map[string]interface{})
+	for _, e := range allInCall {
+		if e.typ == self.Type && e.name == self.Name {
+			continue
+		}
+		inner, _ := refs[e.typ].(map[string]interface{})
+		if inner == nil {
+			inner = make(map[string]interface{})
+			refs[e.typ] = inner
+		}
+		inner[e.name] = e.attrs
+	}
+	return refs
+}
+
+// newInstanceFileMetadata clones fm for a synthetic doc (empty Document so Combine skips it).
 func newInstanceFileMetadata(fm *model.FileMetadata, id, callChain string) *model.FileMetadata {
 	clone := *fm
 	clone.ID = id
 	clone.Document = model.Document{}
 	clone.ModuleCallChain = callChain
-	return &clone
-}
-
-// resourceAttrKey hashes resolved attributes for in-scan content dedup only (not fingerprints).
-func resourceAttrKey(r *tfeval.ResolvedResource) string {
-	attrs := tfeval.AttributesToDocument(r)
-	b, err := json.Marshal(attrs)
-	if err != nil {
-		return ""
+	if fm.LineInfoDocument != nil {
+		clone.LineInfoDocument = maps.Clone(fm.LineInfoDocument)
 	}
-	return strconv.FormatUint(xxhash.Sum64(b), 16)
+	return &clone
 }
 
 // callChainKey is repo-relative outer caller + "|" + module address (no line numbers, to keep fingerprints stable).

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -456,6 +456,275 @@ resource "aws_s3_bucket" "this" {
 	require.Equal(t, "aws_s3_bucket", vulns[0].ResourceType, "finding must come from the resource branch, not the module branch")
 }
 
+// sgNotUsedRule fires when an aws_security_group is not referenced anywhere in the document.
+const sgNotUsedRule = `package datadog
+
+DatadogPolicy contains result if {
+	some i, doc in input.document
+	some sgName, _ in doc.resource.aws_security_group
+
+	not sg_is_used(sgName, doc)
+
+	result := {
+		"documentId":   input.document[i].id,
+		"resourceType": "aws_security_group",
+		"resourceName": sgName,
+		"searchKey":    sprintf("aws_security_group[%s]", [sgName]),
+	}
+}
+
+sg_is_used(sgName, doc) if {
+	[_, value] := walk(doc)
+	value.security_group_id == sprintf("aws_security_group.%s.id", [sgName])
+}
+
+sg_is_used(sgName, doc) if {
+	[_, value] := walk(doc)
+	some v in value.vpc_security_group_ids
+	v == sprintf("aws_security_group.%s.id", [sgName])
+}
+`
+
+// Cross-file SG reference in a module must suppress sg_not_used.
+func TestInspect_CrossFileModuleRefsResolvedBySiblings(t *testing.T) {
+	root := t.TempDir()
+
+	rootDir := filepath.Join(root, "stack")
+	modDir := filepath.Join(root, "modules", "app")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+
+	rootPath := filepath.Join(rootDir, "main.tf")
+	sgPath := filepath.Join(modDir, "sg.tf")
+	instancePath := filepath.Join(modDir, "instance.tf")
+
+	require.NoError(t, os.WriteFile(rootPath, []byte(`
+module "app" {
+  source = "../modules/app"
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(sgPath, []byte(`
+resource "aws_security_group" "web" {
+  name = "web-sg"
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(instancePath, []byte(`
+resource "aws_instance" "app" {
+  ami           = "ami-12345678"
+  instance_type = "t3.micro"
+  vpc_security_group_ids = ["aws_security_group.web.id"]
+}
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, rootPath)...)
+	files = append(files, parseTerraform(t, sgPath)...)
+	files = append(files, parseTerraform(t, instancePath)...)
+
+	queries := []model.QueryMetadata{{
+		Query:       "sg_not_used_rule",
+		Content:     sgNotUsedRule,
+		InputData:   "{}",
+		Platform:    "terraform",
+		Metadata:    map[string]interface{}{"id": "sg-not-used"},
+		Aggregation: 1,
+	}}
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries:       queries,
+		repoPath:      root,
+		vb:            DefaultVulnerabilityBuilder,
+		flagEvaluator: moduleEvalEnabled(),
+	})
+
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries())
+
+	require.Empty(t, vulns, "sg_not_used must not fire when the SG is referenced in a sibling module file")
+}
+
+func TestInspect_CrossFileUnusedSGStillFires(t *testing.T) {
+	root := t.TempDir()
+
+	rootDir := filepath.Join(root, "stack")
+	modDir := filepath.Join(root, "modules", "app")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+
+	rootPath := filepath.Join(rootDir, "main.tf")
+	sgPath := filepath.Join(modDir, "sg.tf")
+	instancePath := filepath.Join(modDir, "instance.tf")
+
+	require.NoError(t, os.WriteFile(rootPath, []byte(`
+module "app" {
+  source = "../modules/app"
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(sgPath, []byte(`
+resource "aws_security_group" "web" {
+  name = "web-sg"
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(instancePath, []byte(`
+resource "aws_instance" "app" {
+  ami           = "ami-12345678"
+  instance_type = "t3.micro"
+}
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, rootPath)...)
+	files = append(files, parseTerraform(t, sgPath)...)
+	files = append(files, parseTerraform(t, instancePath)...)
+
+	queries := []model.QueryMetadata{{
+		Query:       "sg_not_used_rule",
+		Content:     sgNotUsedRule,
+		InputData:   "{}",
+		Platform:    "terraform",
+		Metadata:    map[string]interface{}{"id": "sg-not-used"},
+		Aggregation: 1,
+	}}
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries:       queries,
+		repoPath:      root,
+		vb:            DefaultVulnerabilityBuilder,
+		flagEvaluator: moduleEvalEnabled(),
+	})
+
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries())
+
+	require.Len(t, vulns, 1, "genuinely unused SG must still be reported")
+	require.Equal(t, "aws_security_group", vulns[0].ResourceType)
+}
+
+func TestInspect_CrossRootDivergentSiblingNotDeduped(t *testing.T) {
+	root := t.TempDir()
+
+	modDir := filepath.Join(root, "modules", "net")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "stack-a"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "stack-b"), 0o755))
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+
+	aPath := filepath.Join(root, "stack-a", "main.tf")
+	bPath := filepath.Join(root, "stack-b", "main.tf")
+	sgPath := filepath.Join(modDir, "sg.tf")
+	instancePath := filepath.Join(modDir, "instance.tf")
+
+	require.NoError(t, os.WriteFile(aPath, []byte(`
+module "net" { source = "../modules/net" }
+`), 0o644))
+	require.NoError(t, os.WriteFile(bPath, []byte(`
+module "net" { source = "../modules/net" }
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(sgPath, []byte(`
+resource "aws_security_group" "firewall" {
+  name = "firewall-sg"
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(instancePath, []byte(`
+resource "aws_instance" "server" {
+  ami           = "ami-12345678"
+  instance_type = "t3.micro"
+  vpc_security_group_ids = ["aws_security_group.firewall.id"]
+}
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, aPath)...)
+	files = append(files, parseTerraform(t, bPath)...)
+	files = append(files, parseTerraform(t, sgPath)...)
+	files = append(files, parseTerraform(t, instancePath)...)
+
+	queries := []model.QueryMetadata{{
+		Query:       "sg_not_used_rule",
+		Content:     sgNotUsedRule,
+		InputData:   "{}",
+		Platform:    "terraform",
+		Metadata:    map[string]interface{}{"id": "sg-not-used"},
+		Aggregation: 1,
+	}}
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries:       queries,
+		repoPath:      root,
+		vb:            DefaultVulnerabilityBuilder,
+		flagEvaluator: moduleEvalEnabled(),
+	})
+
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries())
+
+	require.Empty(t, vulns, "sg_not_used must not fire when the SG is referenced in a sibling module file")
+}
+
+func TestInspect_CountExpansionBothInstancesScanned(t *testing.T) {
+	root := t.TempDir()
+
+	rootDir := filepath.Join(root, "stack")
+	modDir := filepath.Join(root, "modules", "buckets")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+
+	rootPath := filepath.Join(rootDir, "main.tf")
+	modPath := filepath.Join(modDir, "main.tf")
+
+	require.NoError(t, os.WriteFile(rootPath, []byte(`
+module "buckets" {
+  source = "../modules/buckets"
+  acl    = "public-read"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(modPath, []byte(`
+variable "acl" {
+  type = string
+}
+
+resource "aws_s3_bucket" "replica" {
+  count  = 2
+  bucket = "bucket-${count.index}"
+  acl    = var.acl
+}
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, rootPath)...)
+	files = append(files, parseTerraform(t, modPath)...)
+
+	queries := []model.QueryMetadata{{
+		Query:       "acl_rule",
+		Content:     aclRule,
+		InputData:   "{}",
+		Platform:    "terraform",
+		Metadata:    map[string]interface{}{"id": "acl-rule"},
+		Aggregation: 1,
+	}}
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries:       queries,
+		repoPath:      root,
+		vb:            DefaultVulnerabilityBuilder,
+		flagEvaluator: moduleEvalEnabled(),
+	})
+
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries())
+
+	require.Len(t, vulns, 2, "both count-expanded instances must produce a finding")
+}
+
 // TestInspect_SharedBaseStoresConcurrentReads runs multiple queries on one platform
 // with several workers so shared baseStores are read concurrently (-race).
 func TestInspect_SharedBaseStoresConcurrentReads(t *testing.T) {

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 )
 
-// docFileID is the prefix of synthetic doc ids: fileID\x00callChain\x00name.
+// docFileID is the prefix of synthetic doc ids: fileID\x00callChain.
 func docFileID(id interface{}) string {
 	s, _ := id.(string)
 	return strings.SplitN(s, "\x00", 2)[0]
@@ -310,6 +310,86 @@ resource "aws_s3_bucket" "this" {
 	}
 	if dupes[0].callChain == "" {
 		t.Fatalf("deduplicated caller must carry a non-empty call chain")
+	}
+}
+
+func TestNewInstanceFileMetadata_LineInfoDocumentNotAliased(t *testing.T) {
+	fm := &model.FileMetadata{
+		ID: "mod-id",
+		LineInfoDocument: map[string]interface{}{
+			"resource": map[string]interface{}{
+				"aws_s3_bucket": map[string]interface{}{"this": map[string]interface{}{}},
+			},
+		},
+	}
+	synth := newInstanceFileMetadata(fm, "synth-id", "stack|module.x")
+	delete(fm.LineInfoDocument, "resource")
+	if _, ok := synth.LineInfoDocument["resource"]; !ok {
+		t.Fatal("synthetic LineInfoDocument must keep resource after suppression on parent")
+	}
+}
+
+func TestResolveModuleDocuments_DifferentSourcesSameAttrsNotDeduped(t *testing.T) {
+	root := t.TempDir()
+	modA := filepath.Join(root, "modules", "bucket-a")
+	modB := filepath.Join(root, "modules", "bucket-b")
+	if err := os.MkdirAll(filepath.Join(root, "stack-a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "stack-b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(modA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(modB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(root, "stack-a"), "main.tf", `
+module "bucket" {
+  source = "../modules/bucket-a"
+  name   = "shared"
+}
+`)
+	writeFile(t, filepath.Join(root, "stack-b"), "main.tf", `
+module "bucket" {
+  source = "../modules/bucket-b"
+  name   = "shared"
+}
+`)
+	modAFile := writeFile(t, modA, "main.tf", `
+variable "name" { type = string }
+resource "aws_s3_bucket" "this" { bucket = var.name }
+`)
+	modBFile := writeFile(t, modB, "main.tf", `
+variable "name" { type = string }
+resource "aws_s3_bucket" "this" { bucket = var.name }
+`)
+
+	files := model.FileMetadatas{
+		fileMeta("a-root", filepath.Join(root, "stack-a", "main.tf")),
+		fileMeta("b-root", filepath.Join(root, "stack-b", "main.tf")),
+		fileMeta("mod-a", modAFile),
+		fileMeta("mod-b", modBFile),
+	}
+
+	res := resolveModuleDocuments(context.Background(), files, root)
+	if !res.ok {
+		t.Fatalf("resolveModuleDocuments ok = false, want true")
+	}
+	if len(res.docs) != 2 {
+		t.Fatalf("want 2 docs (different module sources), got %d: %#v", len(res.docs), res.docs)
+	}
+	if len(res.extras) != 0 {
+		t.Fatalf("want no dedup extras for distinct module sources, got %#v", res.extras)
+	}
+	docIDs := make(map[string]bool)
+	for _, doc := range res.docs {
+		docIDs[doc["id"].(string)] = true
+	}
+	if len(docIDs) != 2 {
+		t.Fatalf("want 2 distinct doc ids, got %d: %#v", len(docIDs), docIDs)
 	}
 }
 


### PR DESCRIPTION
## Motivation

When `--x-local-module-eval` is enabled, the scanner instantiates Terraform module resources and emits synthetic OPA documents for them. The previous implementation had two correctness bugs identified when I re-reviewed:

1. **Cross-root dedup used per-file content only.** Two callers from different root stacks could be incorrectly merged if their shared resource file had identical content but sibling files differed (e.g. one caller's `instance.tf` references a security group; the other's does not). This caused one caller's findings to be silently dropped.

2. **count/for_each instances collapsed to base name.** When a resource expanded to multiple instances (e.g. `replica[0]`, `replica[1]`), all instances were written into a single map under the bare label `replica`. Each subsequent instance silently overwrote the previous one, so only one finding was produced instead of one per instance.

## Changes

**Per-instance findings**

Each expanded module resource instance (from `count` or `for_each`) is now scanned independently. A module that creates two bucket replicas with the same misconfiguration will report two findings instead of one.

**Cross-file references inside a module**

When a module splits resources across multiple `.tf` files, references between them are now visible to cross-resource rules. A security group defined in `sg.tf` and used by an instance in `instance.tf` is correctly treated as in use, so rules like "Security group not used" no longer fire false positives in that case.

**Deduplication across callers**

When the same module is called from multiple root stacks, callers are only treated as identical when the entire module call resolves to the same content, not just when one file matches. Two stacks that share an identical security group definition but differ elsewhere (e.g. one references the SG, the other does not) are no longer merged, so each stack keeps its own findings. Identical callers from different roots are still deduplicated as before.

## QA Instruction

1. `go test ./pkg/engine/...` — all existing and new tests pass.
2. `golangci-lint run ./pkg/engine/...` — no issues.
3. Build: `go build -o /tmp/iac-scanner ./cmd/scanner/`
4. Scan a Terraform repository with local modules: `./iac-scanner scan --x-local-module-eval --type terraform --path <repo>` and confirm no unexpected changes in finding counts for cross-resource rules like "Security group not used".

## Impact

Affects only the `--x-local-module-eval` experimental code path. The baseline scan pipeline (flag off) is unchanged. Modules without `count`/`for_each` and without cross-file references are unaffected in behaviour; only the two buggy edge cases now produce correct results.