### PR TITLE
POC: Pulumi multi-language IaC parsing support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,9 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/tree-sitter/tree-sitter-bash v0.25.1
+	github.com/tree-sitter/tree-sitter-javascript v0.23.1
+	github.com/tree-sitter/tree-sitter-python v0.25.0
+	github.com/tree-sitter/tree-sitter-typescript v0.23.2
 	github.com/urfave/cli/v3 v3.6.2
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/yargevad/filepathx v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -519,12 +519,14 @@ github.com/tree-sitter/tree-sitter-json v0.24.8 h1:tV5rMkihgtiOe14a9LHfDY5kzTl5G
 github.com/tree-sitter/tree-sitter-json v0.24.8/go.mod h1:F351KK0KGvCaYbZ5zxwx/gWWvZhIDl0eMtn+1r+gQbo=
 github.com/tree-sitter/tree-sitter-php v0.23.11 h1:iHewsLNDmznh8kgGyfWfujsZxIz1YGbSd2ZTEM0ZiP8=
 github.com/tree-sitter/tree-sitter-php v0.23.11/go.mod h1:T/kbfi+UcCywQfUNAJnGTN/fMSUjnwPXA8k4yoIks74=
-github.com/tree-sitter/tree-sitter-python v0.23.6 h1:qHnWFR5WhtMQpxBZRwiaU5Hk/29vGju6CVtmvu5Haas=
-github.com/tree-sitter/tree-sitter-python v0.23.6/go.mod h1:cpdthSy/Yoa28aJFBscFHlGiU+cnSiSh1kuDVtI8YeM=
+github.com/tree-sitter/tree-sitter-python v0.25.0 h1:O6XD9v8U1LOcRc3cNj9nM7XufrtEBezE6VrpRrHZDf0=
+github.com/tree-sitter/tree-sitter-python v0.25.0/go.mod h1:cpdthSy/Yoa28aJFBscFHlGiU+cnSiSh1kuDVtI8YeM=
 github.com/tree-sitter/tree-sitter-ruby v0.23.1 h1:T/NKHUA+iVbHM440hFx+lzVOzS4dV6z8Qw8ai+72bYo=
 github.com/tree-sitter/tree-sitter-ruby v0.23.1/go.mod h1:kUS4kCCQloFcdX6sdpr8p6r2rogbM6ZjTox5ZOQy8cA=
 github.com/tree-sitter/tree-sitter-rust v0.23.2 h1:6AtoooCW5GqNrRpfnvl0iUhxTAZEovEmLKDbyHlfw90=
 github.com/tree-sitter/tree-sitter-rust v0.23.2/go.mod h1:hfeGWic9BAfgTrc7Xf6FaOAguCFJRo3RBbs7QJ6D7MI=
+github.com/tree-sitter/tree-sitter-typescript v0.23.2 h1:/Odvphn18PniVixb9e97X0DbNVsU6Qocv9mfkyzdXwU=
+github.com/tree-sitter/tree-sitter-typescript v0.23.2/go.mod h1:zjzMXT/Ulffel2xfOcAkQQkiAkmgnbtPGlFQw/5X4xA=
 github.com/urfave/cli/v3 v3.6.2 h1:lQuqiPrZ1cIz8hz+HcrG0TNZFxU70dPZ3Yl+pSrH9A8=
 github.com/urfave/cli/v3 v3.6.2/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/valyala/fastjson v1.6.10 h1:/yjJg8jaVQdYR3arGxPE2X5z89xrlhS0eGXdv+ADTh4=

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -70,6 +70,14 @@ var (
 	pulumiNameRegex                                 = regexp.MustCompile(`name\s*:`)
 	pulumiRuntimeRegex                              = regexp.MustCompile(`runtime\s*:`)
 	pulumiResourcesRegex                            = regexp.MustCompile(`resources\s*:`)
+	// Anchored to start-of-line so comments like "# import pulumi_aws" are
+	// not matched.
+	pulumiSrcPythonRegex = regexp.MustCompile(`(?m)^(?:import|from)\s+pulumi`)
+	// Leading quote ensures we match only actual Go import path strings, not
+	// comments that mention the URL.
+	pulumiSrcGoRegex = regexp.MustCompile(`"github\.com/pulumi/pulumi-`)
+	// Anchored import statement; avoids matching "// uses @pulumi/aws" comments.
+	pulumiSrcTSRegex = regexp.MustCompile(`(?m)^import\s[^@\n]*@pulumi/`)
 	serverlessServiceRegex                          = regexp.MustCompile(`service\s*:`)
 	serverlessProviderRegex                         = regexp.MustCompile(`(^|\n)provider\s*:`)
 	cicdOnRegex                                     = regexp.MustCompile(`\s*on:\s*`)
@@ -100,6 +108,10 @@ var (
 		extConf:        true,
 		extIni:         true,
 		extBicepFile:   true,
+		extPy:          true,
+		extTs:          true,
+		extJs:          true,
+		extGo:          true,
 	}
 	supportedRegexes = map[string][]string{
 		"azureresourcemanager": append(armRegexTypes, arm),
@@ -166,6 +178,10 @@ const (
 	extCfg                = ".cfg"
 	extConf               = ".conf"
 	extIni                = ".ini"
+	extPy                 = ".py"
+	extTs                 = ".ts"
+	extJs                 = ".js"
+	extGo                 = ".go"
 )
 
 type Parameters struct {
@@ -738,6 +754,18 @@ func classifyFile(ctx context.Context, fsys vfs.FS, path string, content []byte,
 		return ansible
 	case yaml, yml, json, sh:
 		return classifyByContent(ctx, path, content, ext, typesFlag, hc)
+	case extPy:
+		if pulumiSrcPythonRegex.Match(content) {
+			return "pulumi"
+		}
+	case extTs, extJs:
+		if pulumiSrcTSRegex.Match(content) {
+			return "pulumi"
+		}
+	case extGo:
+		if pulumiSrcGoRegex.Match(content) {
+			return "pulumi"
+		}
 	}
 	return ""
 }
@@ -773,6 +801,10 @@ func PlatformForKind(kind model.FileKind) (string, bool) {
 		return grpc, true
 	case model.KindINI, model.KindCFG:
 		return ansible, true
+	case model.KindPulumiPython, model.KindPulumiTypeScript, model.KindPulumiJS, model.KindPulumiGo:
+		// All Pulumi source-language parsers produce the same document schema and
+		// are evaluated by the same Rego rules as Pulumi YAML.
+		return "pulumi", true
 	default:
 		return "", false
 	}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -27,9 +27,13 @@ const (
 	KindPROTO         FileKind = "PROTO"
 	KindCOMMON        FileKind = "*"
 	KindHELM          FileKind = "HELM"
-	KindBUILDAH       FileKind = "SH"
-	KindCFG           FileKind = "CFG"
-	KindINI           FileKind = "INI"
+	KindBUILDAH          FileKind = "SH"
+	KindCFG              FileKind = "CFG"
+	KindINI              FileKind = "INI"
+	KindPulumiPython     FileKind = "PULUMI_PY"
+	KindPulumiTypeScript FileKind = "PULUMI_TS"
+	KindPulumiJS         FileKind = "PULUMI_JS"
+	KindPulumiGo         FileKind = "PULUMI_GO"
 )
 
 // Constants to describe commands given from comments

--- a/pkg/parser/pulumi/context.go
+++ b/pkg/parser/pulumi/context.go
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package pulumi
+
+import "context"
+
+type contextKey struct{}
+
+// FileSymbols holds statically extracted exported symbols from a single source file.
+// Only literal-valued exports (strings, numbers, bools, plain maps, plain slices)
+// are stored; dynamic or computed values are omitted.
+type FileSymbols struct {
+	Values map[string]interface{}
+}
+
+// ProjectIndex maps absolute (slash-separated) file paths to their exported symbols.
+// It is built once from the full file inventory before individual files are parsed,
+// allowing parsers to resolve cross-file constants without a second repo walk.
+type ProjectIndex struct {
+	ByFile map[string]*FileSymbols
+}
+
+// Lookup returns the FileSymbols for absPath, or nil if not indexed.
+func (idx *ProjectIndex) Lookup(absPath string) *FileSymbols {
+	if idx == nil {
+		return nil
+	}
+	return idx.ByFile[absPath]
+}
+
+// WithProjectIndex attaches idx to ctx so all language parsers can resolve
+// cross-file constants without changing the kindParser interface.
+func WithProjectIndex(ctx context.Context, idx *ProjectIndex) context.Context {
+	return context.WithValue(ctx, contextKey{}, idx)
+}
+
+// ProjectIndexFromContext returns the *ProjectIndex attached to ctx, or nil.
+func ProjectIndexFromContext(ctx context.Context) *ProjectIndex {
+	v, _ := ctx.Value(contextKey{}).(*ProjectIndex)
+	return v
+}

--- a/pkg/parser/pulumi/golang/parser.go
+++ b/pkg/parser/pulumi/golang/parser.go
@@ -1,0 +1,450 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+// Package golang implements a static Pulumi-Go parser using the standard
+// go/ast library.
+//
+// It extracts resource constructor calls of the form:
+//
+//	bucket, _ := s3.NewBucketV2(ctx, "my-bucket", &s3.BucketV2Args{
+//	    Acl: pulumi.String("public-read"),
+//	})
+//
+// and produces a model.Document matching the Pulumi YAML schema.
+package golang
+
+import (
+	"context"
+	"fmt"
+	goast "go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	pulumi "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi"
+)
+
+// Parser implements parser.kindParser for Pulumi Go programs.
+type Parser struct{}
+
+func (p *Parser) GetKind() model.FileKind        { return model.KindPulumiGo }
+func (p *Parser) GetCommentToken() string         { return "//" }
+func (p *Parser) SupportedExtensions() []string   { return []string{".go"} }
+func (p *Parser) SupportedTypes() map[string]bool { return map[string]bool{"pulumi": true} }
+
+func (p *Parser) StringifyContent(content []byte) (string, error) {
+	return string(content), nil
+}
+
+func (p *Parser) Parse(
+	ctx context.Context,
+	fileContent []byte,
+	filename string,
+	_ bool, _ int,
+) ([]byte, []model.Document, []int, map[string]model.ResolvedFile, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filename, fileContent, 0)
+	if err != nil {
+		// Tolerate partial parse errors; go/parser still returns what it could.
+		if f == nil {
+			return fileContent, nil, nil, nil, nil
+		}
+	}
+
+	pkgInfos := buildImportMap(f)
+	if len(pkgInfos) == 0 {
+		return fileContent, nil, nil, nil, nil
+	}
+
+	// Load package-level symbols from sibling files via the project index.
+	var pkgSyms map[string]interface{}
+	if idx := pulumi.ProjectIndexFromContext(ctx); idx != nil {
+		if syms := idx.Lookup(filepath.ToSlash(filename)); syms != nil {
+			pkgSyms = syms.Values
+		}
+	}
+
+	resources := extractResources(f, fset, pkgInfos, pkgSyms)
+	if len(resources) == 0 {
+		return fileContent, nil, nil, nil, nil
+	}
+
+	resourcesMap := map[string]interface{}{}
+	resourcesDDLines := map[string]int{}
+	for name, r := range resources {
+		resourcesMap[name] = r.toMap()
+		resourcesDDLines[name] = r.line
+	}
+	resourcesMap["_dd_lines"] = pulumi.BuildDDLines(0, resourcesDDLines)
+
+	doc := model.Document{
+		"runtime":   "go",
+		"resources": resourcesMap,
+		"_dd_lines": pulumi.BuildDDLines(0, map[string]int{"resources": 0}),
+	}
+
+	return fileContent, []model.Document{doc}, nil, nil, nil
+}
+
+// ── import resolution ────────────────────────────────────────────────────────
+
+// pkgInfo holds the resolved provider and module for a Go import.
+type pkgInfo struct {
+	provider string // e.g. "aws"
+	module   string // e.g. "s3"
+	localPkg string // local package alias used in the file
+}
+
+// buildImportMap scans import declarations and returns a map from local package
+// name → pkgInfo for Pulumi provider imports.
+func buildImportMap(f *goast.File) map[string]*pkgInfo {
+	out := map[string]*pkgInfo{}
+	for _, imp := range f.Imports {
+		if imp.Path == nil {
+			continue
+		}
+		importPath := strings.Trim(imp.Path.Value, `"`)
+
+		provider, module := pulumi.GoImportToProviderModule(importPath)
+		if provider == "" {
+			continue
+		}
+
+		// Determine the local package name used in the file.
+		localName := module
+		if imp.Name != nil && imp.Name.Name != "_" && imp.Name.Name != "." {
+			localName = imp.Name.Name
+		}
+
+		out[localName] = &pkgInfo{
+			provider: provider,
+			module:   module,
+			localPkg: localName,
+		}
+	}
+	return out
+}
+
+// ── resource extraction ──────────────────────────────────────────────────────
+
+type resource struct {
+	typeToken  string
+	line       int
+	properties map[string]propValue
+}
+
+type propValue struct {
+	value interface{}
+	line  int
+}
+
+func (r *resource) toMap() map[string]interface{} {
+	props := map[string]interface{}{}
+	propsLines := map[string]int{}
+	for k, pv := range r.properties {
+		props[k] = pv.value
+		propsLines[k] = pv.line
+	}
+	props["_dd_lines"] = pulumi.BuildDDLines(r.line, propsLines)
+
+	return map[string]interface{}{
+		"type":       r.typeToken,
+		"properties": props,
+		"_dd_lines": pulumi.BuildDDLines(r.line, map[string]int{
+			"type":       r.line,
+			"properties": r.line,
+		}),
+	}
+}
+
+func extractResources(f *goast.File, fset *token.FileSet, pkgInfos map[string]*pkgInfo, pkgSyms map[string]interface{}) map[string]*resource {
+	resources := map[string]*resource{}
+
+	goast.Inspect(f, func(n goast.Node) bool {
+		callExpr, ok := n.(*goast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		// Looking for pkg.NewTypeName(ctx, "name", &pkg.TypeNameArgs{...})
+		sel, ok := callExpr.Fun.(*goast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := sel.X.(*goast.Ident)
+		if !ok {
+			return true
+		}
+
+		localPkg := ident.Name
+		constructorName := sel.Sel.Name
+
+		// Constructor must start with "New".
+		if !strings.HasPrefix(constructorName, "New") {
+			return true
+		}
+
+		info, ok := pkgInfos[localPkg]
+		if !ok {
+			return true
+		}
+
+		resourceType := constructorName[len("New"):] // strip "New"
+		typeToken := info.provider + ":" + info.module + ":" + resourceType
+
+		line := fset.Position(callExpr.Pos()).Line
+
+		// args: (ctx, "logical-name", &pkg.TypeArgs{...}, opts...)
+		logicalName, props := extractCallArgs(callExpr, fset, pkgSyms)
+		if logicalName == "" {
+			return true
+		}
+
+		resources[logicalName] = &resource{
+			typeToken:  typeToken,
+			line:       line,
+			properties: props,
+		}
+		return true
+	})
+	return resources
+}
+
+// extractCallArgs extracts the logical name and properties from a Pulumi Go
+// constructor call.  Pulumi Go constructors follow the signature:
+//
+//	New<Type>(ctx, name string, args *TypeArgs, opts ...ResourceOption) (*Type, error)
+func extractCallArgs(call *goast.CallExpr, fset *token.FileSet, pkgSyms map[string]interface{}) (string, map[string]propValue) {
+	props := map[string]propValue{}
+	var logicalName string
+
+	if len(call.Args) < 2 {
+		return "", props
+	}
+
+	// arg[1] is the logical name — string literal or a named constant.
+	switch a := call.Args[1].(type) {
+	case *goast.BasicLit:
+		if a.Kind == token.STRING {
+			logicalName = strings.Trim(a.Value, `"`)
+		}
+	case *goast.Ident:
+		if pkgSyms != nil {
+			if v, ok := pkgSyms[a.Name]; ok {
+				logicalName, _ = v.(string)
+			}
+		}
+	}
+	if logicalName == "" {
+		return "", props
+	}
+
+	// arg[2] is &pkg.TypeArgs{...} — extract the composite literal.
+	if len(call.Args) < 3 {
+		return logicalName, props
+	}
+	argsArg := call.Args[2]
+
+	// Unwrap & if present.
+	if unary, ok := argsArg.(*goast.UnaryExpr); ok {
+		argsArg = unary.X
+	}
+
+	// Resolve identifier (variable) or zero-arg call from pkgSyms.
+	if pkgSyms != nil {
+		var symName string
+		if ident, ok := argsArg.(*goast.Ident); ok {
+			symName = ident.Name
+		} else if callExpr, ok := argsArg.(*goast.CallExpr); ok && len(callExpr.Args) == 0 {
+			if ident, ok := callExpr.Fun.(*goast.Ident); ok {
+				symName = ident.Name
+			}
+		}
+		if symName != "" {
+			if v, ok := pkgSyms[symName]; ok {
+				if m, ok := v.(map[string]interface{}); ok {
+					for k, val := range m {
+						if k == "_dd_lines" {
+							continue
+						}
+						key := lowerFirst(k)
+						props[key] = propValue{value: val, line: 0}
+					}
+				}
+			}
+			return logicalName, props
+		}
+	}
+
+	compLit, ok := argsArg.(*goast.CompositeLit)
+	if !ok {
+		return logicalName, props
+	}
+
+	for _, elt := range compLit.Elts {
+		kv, ok := elt.(*goast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		keyIdent, ok := kv.Key.(*goast.Ident)
+		if !ok {
+			continue
+		}
+		key := lowerFirst(keyIdent.Name)
+		propLine := fset.Position(kv.Pos()).Line
+
+		val := extractValue(kv.Value, fset, pkgSyms)
+		if val != nil {
+			props[key] = propValue{value: val, line: propLine}
+		}
+	}
+	return logicalName, props
+}
+
+// extractValue resolves a Go AST expression to a Go value.
+// Handles pulumi.String("x"), pulumi.Bool(true), pulumi.Int(n), literals,
+// composite literals, and slice literals.
+func extractValue(expr goast.Expr, fset *token.FileSet, pkgSyms map[string]interface{}) interface{} {
+	switch e := expr.(type) {
+	case *goast.BasicLit:
+		switch e.Kind {
+		case token.STRING:
+			return strings.Trim(e.Value, `"`)
+		case token.INT:
+			var n int
+			fmt.Sscanf(e.Value, "%d", &n)
+			return n
+		case token.FLOAT:
+			var f float64
+			fmt.Sscanf(e.Value, "%f", &f)
+			return f
+		}
+	case *goast.Ident:
+		switch e.Name {
+		case "true":
+			return true
+		case "false":
+			return false
+		case "nil":
+			return nil
+		}
+		// Resolve package-level constants and variables from sibling files.
+		if pkgSyms != nil {
+			if v, ok := pkgSyms[e.Name]; ok {
+				return v
+			}
+		}
+	case *goast.BinaryExpr:
+		// String concatenation: "prefix-" + region or "a" + "b"
+		if e.Op == token.ADD {
+			left := extractValue(e.X, fset, pkgSyms)
+			right := extractValue(e.Y, fset, pkgSyms)
+			if ls, ok := left.(string); ok {
+				if rs, ok := right.(string); ok {
+					return ls + rs
+				}
+			}
+		}
+	case *goast.CallExpr:
+		// pulumi.String("x"), pulumi.Bool(true), pulumi.Int(42), pulumi.Float64(3.14)
+		if isPulumiWrap(e) && len(e.Args) == 1 {
+			return extractValue(e.Args[0], fset, pkgSyms)
+		}
+		// cfg.GetBool("key"), cfg.GetString("key"), cfg.Require("key"), etc.
+		if v, ok := extractConfigGetterValue(e); ok {
+			return v
+		}
+		// Zero-arg function call whose return value is indexed in pkgSyms
+		// (e.g. opts := getDefaultArgs()).
+		if len(e.Args) == 0 && pkgSyms != nil {
+			if ident, ok := e.Fun.(*goast.Ident); ok {
+				if v, ok := pkgSyms[ident.Name]; ok {
+					return v
+				}
+			}
+		}
+	case *goast.CompositeLit:
+		return extractCompositeLit(e, fset, pkgSyms)
+	case *goast.UnaryExpr:
+		// &pkg.TypeArgs{...}
+		return extractValue(e.X, fset, pkgSyms)
+	}
+	return nil
+}
+
+// isPulumiWrap reports whether a call is a pulumi.String / pulumi.Bool / … wrapper.
+func isPulumiWrap(call *goast.CallExpr) bool {
+	sel, ok := call.Fun.(*goast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*goast.Ident)
+	if !ok {
+		return false
+	}
+	return pkg.Name == "pulumi"
+}
+
+func extractCompositeLit(lit *goast.CompositeLit, fset *token.FileSet, pkgSyms map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{}
+	ddLines := map[string]int{}
+	defLine := fset.Position(lit.Pos()).Line
+
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*goast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		keyIdent, ok := kv.Key.(*goast.Ident)
+		if !ok {
+			continue
+		}
+		key := lowerFirst(keyIdent.Name)
+		propLine := fset.Position(kv.Pos()).Line
+		val := extractValue(kv.Value, fset, pkgSyms)
+		if val != nil {
+			out[key] = val
+			ddLines[key] = propLine
+		}
+	}
+	out["_dd_lines"] = pulumi.BuildDDLines(defLine, ddLines)
+	return out
+}
+
+// extractConfigGetterValue recognises Pulumi config getter calls such as
+// cfg.GetBool("key") and returns the zero value for that type, allowing the
+// scanner to evaluate security rules conservatively when config values are used
+// directly as resource properties.
+func extractConfigGetterValue(call *goast.CallExpr) (interface{}, bool) {
+	sel, ok := call.Fun.(*goast.SelectorExpr)
+	if !ok {
+		return nil, false
+	}
+	method := sel.Sel.Name
+	switch method {
+	case "GetBool", "RequireBool":
+		return false, true
+	case "GetInt", "RequireInt":
+		return 0, true
+	case "GetFloat64", "RequireFloat64":
+		return 0.0, true
+	case "Get", "Require", "GetSecret", "RequireSecret",
+		"GetObject", "RequireObject":
+		return "", true
+	}
+	return nil, false
+}
+
+// lowerFirst lowercases the first rune of s (Go struct fields are PascalCase
+// but Pulumi property names are camelCase).
+func lowerFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToLower(s[:1]) + s[1:]
+}

--- a/pkg/parser/pulumi/golang/parser_test.go
+++ b/pkg/parser/pulumi/golang/parser_test.go
@@ -1,0 +1,124 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package golang
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParser_GetKind(t *testing.T) {
+	require.Equal(t, model.KindPulumiGo, (&Parser{}).GetKind())
+}
+
+func TestParser_SupportedExtensions(t *testing.T) {
+	require.Equal(t, []string{".go"}, (&Parser{}).SupportedExtensions())
+}
+
+func TestParser_SupportedTypes(t *testing.T) {
+	require.Equal(t, map[string]bool{"pulumi": true}, (&Parser{}).SupportedTypes())
+}
+
+// TestParser_Parse_S3Bucket verifies that an aws.s3.NewBucketV2 call is
+// extracted and represented with the correct type token and properties.
+func TestParser_Parse_S3Bucket(t *testing.T) {
+	src := []byte(`package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := s3.NewBucketV2(ctx, "my-bucket", &s3.BucketV2Args{
+			Acl: pulumi.String("public-read"),
+		})
+		return err
+	})
+}
+`)
+	p := &Parser{}
+	_, docs, _, _, err := p.Parse(context.Background(), src, "main.go", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1, "expected exactly one document")
+
+	resources, ok := docs[0]["resources"].(map[string]interface{})
+	require.True(t, ok, "document must have a 'resources' map")
+
+	var res map[string]interface{}
+	for k, v := range resources {
+		if k == "_dd_lines" {
+			continue
+		}
+		res, ok = v.(map[string]interface{})
+		require.True(t, ok)
+		break
+	}
+	require.NotNil(t, res, "expected at least one resource entry")
+
+	typ, _ := res["type"].(string)
+	require.Contains(t, typ, "aws:", "resource type should contain provider prefix")
+	require.Contains(t, typ, "BucketV2", "resource type should preserve constructor name")
+}
+
+// TestParser_Parse_NoImport verifies that a Go file without Pulumi SDK imports
+// produces no documents.
+func TestParser_Parse_NoImport(t *testing.T) {
+	src := []byte(`package main
+
+import "fmt"
+
+func main() { fmt.Println("hello") }
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "main.go", false, 0)
+	require.NoError(t, err)
+	require.Empty(t, docs, "non-Pulumi file must produce no documents")
+}
+
+// TestParser_Parse_MultiResource verifies that multiple resource constructor
+// calls in a single file all appear in the extracted document.
+func TestParser_Parse_MultiResource(t *testing.T) {
+	src := []byte(`package main
+
+import (
+	ec2 "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		vpc, err := ec2.NewVpc(ctx, "main-vpc", &ec2.VpcArgs{
+			CidrBlock: pulumi.String("10.0.0.0/16"),
+		})
+		if err != nil {
+			return err
+		}
+		_, err = ec2.NewSecurityGroup(ctx, "web-sg", &ec2.SecurityGroupArgs{
+			VpcId: vpc.ID(),
+		})
+		return err
+	})
+}
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "infra.go", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, ok := docs[0]["resources"].(map[string]interface{})
+	require.True(t, ok)
+
+	count := 0
+	for k := range resources {
+		if k != "_dd_lines" {
+			count++
+		}
+	}
+	require.Equal(t, 2, count, "expected two resource entries")
+}

--- a/pkg/parser/pulumi/javascript/parser.go
+++ b/pkg/parser/pulumi/javascript/parser.go
@@ -1,0 +1,45 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+// Package javascript implements a static Pulumi-JavaScript parser.
+//
+// It delegates to the TypeScript parser's shared AST walking logic using the
+// tree-sitter JavaScript grammar, so all import forms (require() and ESM) and
+// resource extraction patterns supported for TypeScript are also supported here.
+package javascript
+
+import (
+	"context"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_javascript "github.com/tree-sitter/tree-sitter-javascript/bindings/go"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/typescript"
+)
+
+var lang = sitter.NewLanguage(tree_sitter_javascript.Language())
+
+// Parser implements parser.kindParser for Pulumi JavaScript programs.
+type Parser struct{}
+
+func (p *Parser) GetKind() model.FileKind        { return model.KindPulumiJS }
+func (p *Parser) GetCommentToken() string         { return "//" }
+func (p *Parser) SupportedExtensions() []string   { return []string{".js"} }
+func (p *Parser) SupportedTypes() map[string]bool { return map[string]bool{"pulumi": true} }
+
+func (p *Parser) StringifyContent(content []byte) (string, error) {
+	return string(content), nil
+}
+
+func (p *Parser) Parse(
+	ctx context.Context,
+	fileContent []byte,
+	filename string,
+	_ bool, _ int,
+) ([]byte, []model.Document, []int, map[string]model.ResolvedFile, error) {
+	return typescript.ParseWithLanguage(ctx, lang, "pulumi javascript parser", fileContent, filename)
+}

--- a/pkg/parser/pulumi/javascript/parser_test.go
+++ b/pkg/parser/pulumi/javascript/parser_test.go
@@ -1,0 +1,69 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package javascript_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/javascript"
+)
+
+func TestJavaScriptParser_RequireImport(t *testing.T) {
+	src := []byte(`
+const aws = require("@pulumi/aws");
+const bucket = new aws.s3.BucketV2("my-bucket", {
+    acl: "public-read",
+});
+`)
+	p := &javascript.Parser{}
+	_, docs, _, _, err := p.Parse(context.Background(), src, "index.js", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+
+	resources, ok := docs[0]["resources"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected resources map")
+	}
+	res, ok := resources["my-bucket"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected my-bucket resource, got keys: %v", resourceKeys(resources))
+	}
+	typ, _ := res["type"].(string)
+	if typ != "aws:s3:BucketV2" {
+		t.Errorf("unexpected type: %v", typ)
+	}
+}
+
+func TestJavaScriptParser_ESMImport(t *testing.T) {
+	src := []byte(`
+import * as aws from "@pulumi/aws";
+const bucket = new aws.s3.BucketV2("esm-bucket", {
+    acl: "private",
+});
+`)
+	p := &javascript.Parser{}
+	_, docs, _, _, err := p.Parse(context.Background(), src, "index.js", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+}
+
+func resourceKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/pkg/parser/pulumi/multifile_test.go
+++ b/pkg/parser/pulumi/multifile_test.go
@@ -1,0 +1,528 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package pulumi_test
+
+import (
+	"context"
+	"testing"
+
+	pulumi "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi"
+	pulumiGo "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/golang"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/javascript"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/projectindex"
+	pulumiPy "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/python"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/typescript"
+)
+
+// ── TypeScript ────────────────────────────────────────────────────────────────
+
+// TestMultiFile_TS_NamedImport verifies that a named export from a sibling .ts
+// file is resolved and injected as a resource property.
+func TestMultiFile_TS_NamedImport(t *testing.T) {
+	configSrc := []byte(`
+export const defaultAcl = "public-read";
+export const skipFinalSnapshot = false;
+`)
+
+	mainSrc := []byte(`
+import * as aws from "@pulumi/aws";
+import { defaultAcl, skipFinalSnapshot } from "./config";
+
+const bucket = new aws.s3.BucketV2("my-bucket", {
+    acl: defaultAcl,
+});
+`)
+
+	cache := map[string][]byte{
+		"/repo/config.ts": configSrc,
+		"/repo/index.ts":  mainSrc,
+	}
+	idx := projectindex.Build([]string{"/repo/config.ts", "/repo/index.ts"}, cache)
+	ctx := pulumi.WithProjectIndex(context.Background(), idx)
+
+	_, docs, _, _, err := (&typescript.Parser{}).Parse(ctx, mainSrc, "/repo/index.ts", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least one document")
+	}
+
+	resources := resourcesMap(t, docs[0])
+	res := resourceEntry(t, resources, "my-bucket")
+	props := propsMap(t, res)
+	assertProp(t, props, "acl", "public-read")
+}
+
+// TestMultiFile_TS_NamespaceImport verifies that a namespace import resolves
+// member expressions like cfg.defaultAcl.
+func TestMultiFile_TS_NamespaceImport(t *testing.T) {
+	configSrc := []byte(`
+export const defaultAcl = "private";
+`)
+	mainSrc := []byte(`
+import * as aws from "@pulumi/aws";
+import * as cfg from "./config";
+
+const bucket = new aws.s3.BucketV2("ns-bucket", {
+    acl: cfg.defaultAcl,
+});
+`)
+
+	cache := map[string][]byte{
+		"/repo/config.ts":  configSrc,
+		"/repo/index2.ts":  mainSrc,
+	}
+	idx := projectindex.Build([]string{"/repo/config.ts", "/repo/index2.ts"}, cache)
+	ctx := pulumi.WithProjectIndex(context.Background(), idx)
+
+	_, docs, _, _, err := (&typescript.Parser{}).Parse(ctx, mainSrc, "/repo/index2.ts", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least one document")
+	}
+	resources := resourcesMap(t, docs[0])
+	res := resourceEntry(t, resources, "ns-bucket")
+	props := propsMap(t, res)
+	assertProp(t, props, "acl", "private")
+}
+
+// TestMultiFile_TS_Spread verifies that spreading a namespace import merges all
+// exported values into the resource properties.
+func TestMultiFile_TS_Spread(t *testing.T) {
+	configSrc := []byte(`
+export const defaults = { acl: "public-read", region: "us-east-1" };
+`)
+	mainSrc := []byte(`
+import * as aws from "@pulumi/aws";
+import { defaults } from "./config";
+
+const bucket = new aws.s3.BucketV2("spread-bucket", { ...defaults });
+`)
+
+	cache := map[string][]byte{
+		"/repo/config.ts":  configSrc,
+		"/repo/spread.ts":  mainSrc,
+	}
+	idx := projectindex.Build([]string{"/repo/config.ts", "/repo/spread.ts"}, cache)
+	ctx := pulumi.WithProjectIndex(context.Background(), idx)
+
+	_, docs, _, _, err := (&typescript.Parser{}).Parse(ctx, mainSrc, "/repo/spread.ts", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least one document")
+	}
+	resources := resourcesMap(t, docs[0])
+	res := resourceEntry(t, resources, "spread-bucket")
+	props := propsMap(t, res)
+	assertProp(t, props, "acl", "public-read")
+}
+
+// TestMultiFile_JS_Require verifies CommonJS require of a local module.
+func TestMultiFile_JS_Require(t *testing.T) {
+	configSrc := []byte(`
+module.exports = {
+    acl: "private",
+};
+`)
+	mainSrc := []byte(`
+const aws = require("@pulumi/aws");
+const cfg = require("./config");
+
+const bucket = new aws.s3.BucketV2("js-bucket", {
+    acl: cfg.acl,
+});
+`)
+
+	cache := map[string][]byte{
+		"/repo/config.js": configSrc,
+		"/repo/index.js":  mainSrc,
+	}
+	idx := projectindex.Build([]string{"/repo/config.js", "/repo/index.js"}, cache)
+	ctx := pulumi.WithProjectIndex(context.Background(), idx)
+
+	_, docs, _, _, err := (&javascript.Parser{}).Parse(ctx, mainSrc, "/repo/index.js", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least one document")
+	}
+	resources := resourcesMap(t, docs[0])
+	res := resourceEntry(t, resources, "js-bucket")
+	props := propsMap(t, res)
+	assertProp(t, props, "acl", "private")
+}
+
+// ── Python ────────────────────────────────────────────────────────────────────
+
+func TestMultiFile_Python_FromImport(t *testing.T) {
+	configSrc := []byte(`
+DEFAULT_ACL = "public-read"
+SKIP_FINAL = True
+`)
+	mainSrc := []byte(`
+import pulumi_aws as aws
+from config import DEFAULT_ACL, SKIP_FINAL
+
+bucket = aws.s3.BucketV2("py-bucket",
+    acl=DEFAULT_ACL,
+    skip_final_snapshot=SKIP_FINAL,
+)
+`)
+
+	cache := map[string][]byte{
+		"/repo/config.py": configSrc,
+		"/repo/main.py":   mainSrc,
+	}
+	idx := projectindex.Build([]string{"/repo/config.py", "/repo/main.py"}, cache)
+	ctx := pulumi.WithProjectIndex(context.Background(), idx)
+
+	_, docs, _, _, err := (&pulumiPy.Parser{}).Parse(ctx, mainSrc, "/repo/main.py", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least one document")
+	}
+	resources := resourcesMap(t, docs[0])
+	res := resourceEntry(t, resources, "py-bucket")
+	props := propsMap(t, res)
+	assertProp(t, props, "acl", "public-read")
+	assertProp(t, props, "skipFinalSnapshot", true)
+}
+
+// ── Go ────────────────────────────────────────────────────────────────────────
+
+func TestMultiFile_Go_SiblingConst(t *testing.T) {
+	configSrc := []byte(`package main
+
+const defaultACL = "public-read"
+`)
+	mainSrc := []byte(`package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := s3.NewBucketV2(ctx, "go-bucket", &s3.BucketV2Args{
+			Acl: pulumi.String(defaultACL),
+		})
+		return err
+	})
+}
+`)
+
+	cache := map[string][]byte{
+		"/repo/config.go": configSrc,
+		"/repo/main.go":   mainSrc,
+	}
+	idx := projectindex.Build([]string{"/repo/config.go", "/repo/main.go"}, cache)
+	ctx := pulumi.WithProjectIndex(context.Background(), idx)
+
+	_, docs, _, _, err := (&pulumiGo.Parser{}).Parse(ctx, mainSrc, "/repo/main.go", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least one document")
+	}
+	resources := resourcesMap(t, docs[0])
+	res := resourceEntry(t, resources, "go-bucket")
+	props := propsMap(t, res)
+	assertProp(t, props, "acl", "public-read")
+}
+
+// TestMultiFile_Go_IdentifierLogicalName verifies that logical names that are
+// identifiers resolved via pkgSyms (cross-file constants) work correctly.
+func TestMultiFile_Go_IdentifierLogicalName(t *testing.T) {
+	configSrc := []byte(`package main
+
+const bucketName = "named-bucket"
+`)
+	mainSrc := []byte(`package main
+
+import (
+	s3 "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := s3.NewBucketV2(ctx, bucketName, &s3.BucketV2Args{
+			Acl: pulumi.String("private"),
+		})
+		return err
+	})
+}
+`)
+
+	cache := map[string][]byte{
+		"/repo/config.go": configSrc,
+		"/repo/main.go":   mainSrc,
+	}
+	idx := projectindex.Build([]string{"/repo/config.go", "/repo/main.go"}, cache)
+	ctx := pulumi.WithProjectIndex(context.Background(), idx)
+
+	_, docs, _, _, err := (&pulumiGo.Parser{}).Parse(ctx, mainSrc, "/repo/main.go", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least one document")
+	}
+	resources := resourcesMap(t, docs[0])
+	res := resourceEntry(t, resources, "named-bucket")
+	props := propsMap(t, res)
+	assertProp(t, props, "acl", "private")
+}
+
+// TestMultiFile_Go_Arg2Identifier verifies that when arg[2] of a constructor is
+// a package-level variable identifier, its properties are resolved via pkgSyms.
+func TestMultiFile_Go_Arg2Identifier(t *testing.T) {
+	configSrc := []byte(`package main
+
+import (
+	s3 "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+var defaultBucketArgs = s3.BucketV2Args{
+	Acl: pulumi.String("public-read"),
+}
+`)
+	mainSrc := []byte(`package main
+
+import (
+	s3 "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := s3.NewBucketV2(ctx, "arg2-bucket", &defaultBucketArgs)
+		return err
+	})
+}
+`)
+	cache := map[string][]byte{
+		"/repo/config.go": configSrc,
+		"/repo/main.go":   mainSrc,
+	}
+	idx := projectindex.Build([]string{"/repo/config.go", "/repo/main.go"}, cache)
+	ctx := pulumi.WithProjectIndex(context.Background(), idx)
+
+	_, docs, _, _, err := (&pulumiGo.Parser{}).Parse(ctx, mainSrc, "/repo/main.go", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least one document")
+	}
+	resources := resourcesMap(t, docs[0])
+	res := resourceEntry(t, resources, "arg2-bucket")
+	props := propsMap(t, res)
+	assertProp(t, props, "acl", "public-read")
+}
+
+// TestMultiFile_Go_StringConcat verifies that "a" + "b" property values are resolved.
+func TestMultiFile_Go_StringConcat(t *testing.T) {
+	src := []byte(`package main
+
+import (
+	s3 "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := s3.NewBucketV2(ctx, "concat-bucket", &s3.BucketV2Args{
+			Acl: pulumi.String("public" + "-read"),
+		})
+		return err
+	})
+}
+`)
+	_, docs, _, _, err := (&pulumiGo.Parser{}).Parse(context.Background(), src, "/repo/main.go", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least one document")
+	}
+	resources := resourcesMap(t, docs[0])
+	res := resourceEntry(t, resources, "concat-bucket")
+	props := propsMap(t, res)
+	assertProp(t, props, "acl", "public-read")
+}
+
+// TestMultiFile_Go_MultiResultHelper verifies that a package-level var holding
+// a composite literal is indexed and resolved as arg[2] via pkgSyms.
+func TestMultiFile_Go_MultiResultHelper(t *testing.T) {
+	helperSrc := []byte(`package main
+
+import (
+	s3 "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+var defaultBucketArgs = &s3.BucketV2Args{Acl: pulumi.String("public-read")}
+`)
+	mainSrc := []byte(`package main
+
+import (
+	s3 "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := s3.NewBucketV2(ctx, "helper-bucket", defaultBucketArgs)
+		return err
+	})
+}
+`)
+	cache := map[string][]byte{
+		"/repo/helpers.go": helperSrc,
+		"/repo/main.go":    mainSrc,
+	}
+	idx := projectindex.Build([]string{"/repo/helpers.go", "/repo/main.go"}, cache)
+	ctx := pulumi.WithProjectIndex(context.Background(), idx)
+
+	_, docs, _, _, err := (&pulumiGo.Parser{}).Parse(ctx, mainSrc, "/repo/main.go", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least one document")
+	}
+	resources := resourcesMap(t, docs[0])
+	res := resourceEntry(t, resources, "helper-bucket")
+	props := propsMap(t, res)
+	assertProp(t, props, "acl", "public-read")
+}
+
+// TestMultiFile_Go_ZeroArgFunctionCall verifies that a zero-arg helper function
+// exported from a sibling file is resolved when called as a property value.
+func TestMultiFile_Go_ZeroArgFunctionCall(t *testing.T) {
+	helperSrc := []byte(`package main
+
+func getDefaultRegion() string {
+	return "us-east-1"
+}
+`)
+	mainSrc := []byte(`package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := s3.NewBucketV2(ctx, "fn-bucket", &s3.BucketV2Args{
+			Region: pulumi.String(getDefaultRegion()),
+		})
+		return err
+	})
+}
+`)
+
+	cache := map[string][]byte{
+		"/repo/helper.go": helperSrc,
+		"/repo/main.go":   mainSrc,
+	}
+	idx := projectindex.Build([]string{"/repo/helper.go", "/repo/main.go"}, cache)
+	ctx := pulumi.WithProjectIndex(context.Background(), idx)
+
+	_, docs, _, _, err := (&pulumiGo.Parser{}).Parse(ctx, mainSrc, "/repo/main.go", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least one document")
+	}
+	resources := resourcesMap(t, docs[0])
+	res := resourceEntry(t, resources, "fn-bucket")
+	props := propsMap(t, res)
+	assertProp(t, props, "region", "us-east-1")
+}
+
+// TestMultiFile_NoContext verifies that parsers still work when no ProjectIndex
+// is attached to the context (backward compatibility).
+func TestMultiFile_NoContext(t *testing.T) {
+	src := []byte(`
+import * as aws from "@pulumi/aws";
+const bucket = new aws.s3.BucketV2("no-ctx-bucket", { acl: "private" });
+`)
+	_, docs, _, _, err := (&typescript.Parser{}).Parse(context.Background(), src, "/repo/index.ts", false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected document even without context")
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func resourcesMap(t *testing.T, doc map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	m, ok := doc["resources"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("document has no resources map; doc keys: %v", mapKeys(doc))
+	}
+	return m
+}
+
+func resourceEntry(t *testing.T, resources map[string]interface{}, name string) map[string]interface{} {
+	t.Helper()
+	v, ok := resources[name]
+	if !ok {
+		t.Fatalf("resource %q not found; available: %v", name, mapKeys(resources))
+	}
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		t.Fatalf("resource %q is not a map", name)
+	}
+	return m
+}
+
+func propsMap(t *testing.T, res map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	m, ok := res["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("resource has no properties map")
+	}
+	return m
+}
+
+func assertProp(t *testing.T, props map[string]interface{}, key string, want interface{}) {
+	t.Helper()
+	got, ok := props[key]
+	if !ok {
+		t.Errorf("property %q not found; available: %v", key, mapKeys(props))
+		return
+	}
+	if got != want {
+		t.Errorf("property %q: got %v (%T), want %v (%T)", key, got, got, want, want)
+	}
+}
+
+func mapKeys(m map[string]interface{}) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/pkg/parser/pulumi/projectindex/index.go
+++ b/pkg/parser/pulumi/projectindex/index.go
@@ -1,0 +1,760 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+// Package projectindex builds a conservative cross-file symbol index for Pulumi
+// projects. It performs a lightweight AST scan of each source file looking only
+// for top-level exported constants, variables, and simple zero-arg functions
+// that return a literal value.  Dynamic, computed, or non-literal exports are
+// silently skipped — parsers fall back to their existing single-file behaviour.
+package projectindex
+
+import (
+	"fmt"
+	goast "go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_javascript "github.com/tree-sitter/tree-sitter-javascript/bindings/go"
+	tree_sitter_python "github.com/tree-sitter/tree-sitter-python/bindings/go"
+	tree_sitter_typescript "github.com/tree-sitter/tree-sitter-typescript/bindings/go"
+
+	pulumi "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi"
+)
+
+var (
+	tsLang = sitter.NewLanguage(tree_sitter_typescript.LanguageTypescript())
+	jsLang = sitter.NewLanguage(tree_sitter_javascript.Language())
+	pyLang = sitter.NewLanguage(tree_sitter_python.Language())
+)
+
+// Build creates a ProjectIndex from the given file list and content cache.
+// Files not present in contentCache are read from disk.  Files with
+// unrecognised extensions are silently skipped.
+func Build(paths []string, contentCache map[string][]byte) *pulumi.ProjectIndex {
+	idx := &pulumi.ProjectIndex{
+		ByFile: make(map[string]*pulumi.FileSymbols, len(paths)),
+	}
+
+	// Collect Go files by directory so we can do same-package analysis.
+	goDirs := map[string][]string{} // dir → []absPath
+
+	for _, p := range paths {
+		norm := filepath.ToSlash(p)
+		ext := strings.ToLower(filepath.Ext(norm))
+		src := content(norm, contentCache)
+		if src == nil {
+			continue
+		}
+
+		switch ext {
+		case ".ts":
+			if syms := extractTSSymbols(src, tsLang); len(syms) > 0 {
+				idx.ByFile[norm] = &pulumi.FileSymbols{Values: syms}
+			}
+		case ".js":
+			if syms := extractTSSymbols(src, jsLang); len(syms) > 0 {
+				idx.ByFile[norm] = &pulumi.FileSymbols{Values: syms}
+			}
+		case ".py":
+			if syms := extractPySymbols(src); len(syms) > 0 {
+				idx.ByFile[norm] = &pulumi.FileSymbols{Values: syms}
+			}
+		case ".go":
+			dir := filepath.ToSlash(filepath.Dir(norm))
+			goDirs[dir] = append(goDirs[dir], norm)
+		}
+	}
+
+	// For Go, build per-package symbol tables by parsing all files in each dir.
+	for dir, goPaths := range goDirs {
+		syms := extractGoPackageSymbols(dir, goPaths, contentCache)
+		for _, p := range goPaths {
+			norm := filepath.ToSlash(p)
+			if idx.ByFile[norm] == nil {
+				idx.ByFile[norm] = &pulumi.FileSymbols{Values: make(map[string]interface{})}
+			}
+			// Each Go file in the package shares the whole package's symbol table —
+			// the parser only has one file's AST so it needs access to sibling consts.
+			for k, v := range syms {
+				idx.ByFile[norm].Values[k] = v
+			}
+		}
+		_ = dir
+	}
+
+	return idx
+}
+
+// content returns the byte content for path from the cache or disk.
+func content(path string, cache map[string][]byte) []byte {
+	if cache != nil {
+		if b, ok := cache[path]; ok {
+			return b
+		}
+	}
+	b, err := os.ReadFile(filepath.FromSlash(path))
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// ── TypeScript / JavaScript ───────────────────────────────────────────────────
+
+// extractTSSymbols extracts top-level exported symbols using the given
+// tree-sitter grammar (TypeScript or JavaScript).
+func extractTSSymbols(src []byte, lang *sitter.Language) map[string]interface{} {
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(lang); err != nil {
+		return nil
+	}
+	tree := p.Parse(src, nil)
+	if tree == nil {
+		return nil
+	}
+	defer tree.Close()
+
+	out := map[string]interface{}{}
+	root := tree.RootNode()
+
+	cursor := root.Walk()
+	defer cursor.Close()
+
+	var walk func()
+	walk = func() {
+		node := cursor.Node()
+		switch node.Kind() {
+		case "export_statement":
+			extractTSExport(node, src, out)
+		case "expression_statement":
+			extractModuleExports(node, src, out)
+		}
+		if cursor.GotoFirstChild() {
+			for {
+				walk()
+				if !cursor.GotoNextSibling() {
+					break
+				}
+			}
+			cursor.GotoParent()
+		}
+	}
+	walk()
+	return out
+}
+
+// extractTSExport handles:
+//
+//	export const NAME = <literal>
+//	export const NAME = () => <literal>
+//	export function NAME() { return <literal>; }
+//	export default <literal>
+func extractTSExport(node *sitter.Node, src []byte, out map[string]interface{}) {
+	decl := node.ChildByFieldName("declaration")
+	if decl == nil {
+		// `export { NAME }` re-export, OR `export default expr` where the
+		// field binding is unreliable. Look for a non-clause named child.
+		for i := uint(0); i < node.NamedChildCount(); i++ {
+			child := node.NamedChild(i)
+			if child == nil {
+				continue
+			}
+			switch child.Kind() {
+			case "export_clause", "namespace_export", "from_clause":
+				return // re-export — no value to extract
+			default:
+				if v, ok := tsValueOrArrow(child, src); ok {
+					out["default"] = v
+				}
+				return
+			}
+		}
+		return
+	}
+	switch decl.Kind() {
+	case "lexical_declaration", "variable_declaration":
+		for i := uint(0); i < decl.NamedChildCount(); i++ {
+			vd := decl.NamedChild(i)
+			if vd == nil || vd.Kind() != "variable_declarator" {
+				continue
+			}
+			name := vd.ChildByFieldName("name")
+			value := vd.ChildByFieldName("value")
+			if name == nil || value == nil {
+				continue
+			}
+			if v, ok := tsValueOrArrow(value, src); ok {
+				out[name.Utf8Text(src)] = v
+			}
+		}
+	case "function_declaration":
+		name := decl.ChildByFieldName("name")
+		body := decl.ChildByFieldName("body")
+		if name == nil || body == nil {
+			return
+		}
+		if v, ok := tsSingleReturnValue(body, src); ok {
+			out[name.Utf8Text(src)] = v
+		}
+	default:
+		// export default <expr> — store under the "default" key so that
+		// `import x from "./mod"` can resolve it.
+		if v, ok := tsLiteralValue(decl, src); ok {
+			out["default"] = v
+		}
+	}
+}
+
+// tsValueOrArrow extracts a literal value from a node that is either a direct
+// literal/object or a zero-arg arrow function returning one.
+func tsValueOrArrow(node *sitter.Node, src []byte) (interface{}, bool) {
+	if node.Kind() != "arrow_function" {
+		return tsLiteralValue(node, src)
+	}
+	body := node.ChildByFieldName("body")
+	if body == nil {
+		return nil, false
+	}
+	// Expression body: () => "value"
+	if body.Kind() != "statement_block" {
+		return tsLiteralValue(body, src)
+	}
+	// Block body: () => { return "value"; }
+	return tsSingleReturnValue(body, src)
+}
+
+// extractModuleExports handles:
+//
+//	module.exports = { key: value, ... }
+//	module.exports.NAME = <literal>
+func extractModuleExports(node *sitter.Node, src []byte, out map[string]interface{}) {
+	if node.NamedChildCount() == 0 {
+		return
+	}
+	expr := node.NamedChild(0)
+	if expr == nil || expr.Kind() != "assignment_expression" {
+		return
+	}
+	left := expr.ChildByFieldName("left")
+	right := expr.ChildByFieldName("right")
+	if left == nil || right == nil {
+		return
+	}
+	leftText := left.Utf8Text(src)
+
+	if leftText == "module.exports" {
+		// module.exports = { k: v, ... }
+		if right.Kind() == "object" {
+			mergeTSObject(right, src, out)
+		}
+		return
+	}
+	// module.exports.NAME = <literal>
+	if strings.HasPrefix(leftText, "module.exports.") {
+		name := leftText[len("module.exports."):]
+		if name != "" {
+			if v, ok := tsLiteralValue(right, src); ok {
+				out[name] = v
+			}
+		}
+	}
+}
+
+func mergeTSObject(node *sitter.Node, src []byte, out map[string]interface{}) {
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil || child.Kind() != "pair" {
+			continue
+		}
+		k := child.ChildByFieldName("key")
+		v := child.ChildByFieldName("value")
+		if k == nil || v == nil {
+			continue
+		}
+		key := strings.Trim(k.Utf8Text(src), `"'`)
+		if val, ok := tsLiteralValue(v, src); ok {
+			out[key] = val
+		}
+	}
+}
+
+// tsSingleReturnValue extracts the literal value from the last return statement
+// in a function body. Any number of preceding statements is tolerated so that
+// functions with logging or early setup are not excluded, as long as the final
+// statement is an unconditional return of a literal expression.
+func tsSingleReturnValue(body *sitter.Node, src []byte) (interface{}, bool) {
+	if body.NamedChildCount() == 0 {
+		return nil, false
+	}
+	last := body.NamedChild(body.NamedChildCount() - 1)
+	if last == nil || last.Kind() != "return_statement" {
+		return nil, false
+	}
+	if last.NamedChildCount() == 0 {
+		return nil, false
+	}
+	return tsLiteralValue(last.NamedChild(0), src)
+}
+
+// tsLiteralValue resolves a tree-sitter node to a Go primitive/map/slice.
+func tsLiteralValue(node *sitter.Node, src []byte) (interface{}, bool) {
+	if node == nil {
+		return nil, false
+	}
+	switch node.Kind() {
+	case "string":
+		text := node.Utf8Text(src)
+		text = strings.TrimPrefix(text, "`")
+		text = strings.TrimSuffix(text, "`")
+		text = strings.Trim(text, `"'`)
+		return text, true
+	case "number":
+		var n float64
+		fmt.Sscanf(node.Utf8Text(src), "%f", &n)
+		return n, true
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	case "null", "undefined":
+		return nil, true
+	case "template_string":
+		// Extract only the static string_fragment parts; interpolations are skipped.
+		var parts []string
+		for i := uint(0); i < node.ChildCount(); i++ {
+			child := node.Child(i)
+			if child != nil && child.Kind() == "string_fragment" {
+				parts = append(parts, child.Utf8Text(src))
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, ""), true
+		}
+		return nil, false
+	case "object":
+		m := map[string]interface{}{}
+		for i := uint(0); i < node.NamedChildCount(); i++ {
+			child := node.NamedChild(i)
+			if child == nil || child.Kind() != "pair" {
+				continue
+			}
+			k := child.ChildByFieldName("key")
+			v := child.ChildByFieldName("value")
+			if k == nil || v == nil {
+				continue
+			}
+			key := strings.Trim(k.Utf8Text(src), `"'`)
+			if val, ok := tsLiteralValue(v, src); ok {
+				m[key] = val
+			}
+		}
+		return m, true
+	case "array":
+		var arr []interface{}
+		for i := uint(0); i < node.NamedChildCount(); i++ {
+			child := node.NamedChild(i)
+			if child == nil {
+				continue
+			}
+			if v, ok := tsLiteralValue(child, src); ok {
+				arr = append(arr, v)
+			}
+		}
+		return arr, true
+	}
+	return nil, false
+}
+
+// ── Python ────────────────────────────────────────────────────────────────────
+
+// extractPySymbols extracts module-level assignments and simple def-return functions.
+func extractPySymbols(src []byte) map[string]interface{} {
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(pyLang); err != nil {
+		return nil
+	}
+	tree := p.Parse(src, nil)
+	if tree == nil {
+		return nil
+	}
+	defer tree.Close()
+
+	out := map[string]interface{}{}
+	root := tree.RootNode()
+
+	// Only top-level nodes (direct children of module root).
+	// In tree-sitter-python, plain assignments are wrapped in expression_statement.
+	for i := uint(0); i < root.NamedChildCount(); i++ {
+		node := root.NamedChild(i)
+		if node == nil {
+			continue
+		}
+		// Unwrap expression_statement → assignment.
+		target := node
+		if node.Kind() == "expression_statement" && node.NamedChildCount() == 1 {
+			target = node.NamedChild(0)
+		}
+		if target == nil {
+			continue
+		}
+		switch target.Kind() {
+		case "assignment":
+			left := target.ChildByFieldName("left")
+			right := target.ChildByFieldName("right")
+			if left == nil || right == nil || left.Kind() != "identifier" {
+				continue
+			}
+			if v, ok := pyLiteralValue(right, src); ok {
+				out[left.Utf8Text(src)] = v
+			}
+		case "function_definition":
+			name := target.ChildByFieldName("name")
+			body := target.ChildByFieldName("body")
+			if name == nil || body == nil {
+				continue
+			}
+			if v, ok := pySingleReturnValue(body, src); ok {
+				out[name.Utf8Text(src)] = v
+			}
+		}
+		// function_definition at the top level (not wrapped in expression_statement).
+		if node.Kind() == "function_definition" {
+			name := node.ChildByFieldName("name")
+			body := node.ChildByFieldName("body")
+			if name != nil && body != nil {
+				if v, ok := pySingleReturnValue(body, src); ok {
+					out[name.Utf8Text(src)] = v
+				}
+			}
+		}
+	}
+	return out
+}
+
+// pySingleReturnValue extracts the literal value from the last return statement
+// in a Python function body, tolerating any number of preceding statements.
+func pySingleReturnValue(body *sitter.Node, src []byte) (interface{}, bool) {
+	if body.NamedChildCount() == 0 {
+		return nil, false
+	}
+	last := body.NamedChild(body.NamedChildCount() - 1)
+	if last == nil || last.Kind() != "return_statement" {
+		return nil, false
+	}
+	if last.NamedChildCount() == 0 {
+		return nil, false
+	}
+	return pyLiteralValue(last.NamedChild(0), src)
+}
+
+func pyLiteralValue(node *sitter.Node, src []byte) (interface{}, bool) {
+	if node == nil {
+		return nil, false
+	}
+	switch node.Kind() {
+	case "string":
+		return pyIndexExtractString(node, src)
+	case "binary_operator":
+		// String concatenation: "a" + "b"
+		op := node.ChildByFieldName("operator")
+		if op != nil && op.Utf8Text(src) == "+" {
+			left := node.ChildByFieldName("left")
+			right := node.ChildByFieldName("right")
+			lv, lok := pyLiteralValue(left, src)
+			rv, rok := pyLiteralValue(right, src)
+			if lok && rok {
+				if ls, ok := lv.(string); ok {
+					if rs, ok := rv.(string); ok {
+						return ls + rs, true
+					}
+				}
+			}
+		}
+		return nil, false
+	case "integer":
+		var n int
+		fmt.Sscanf(node.Utf8Text(src), "%d", &n)
+		return n, true
+	case "float":
+		var f float64
+		fmt.Sscanf(node.Utf8Text(src), "%f", &f)
+		return f, true
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	case "none":
+		return nil, true
+	case "dictionary":
+		m := map[string]interface{}{}
+		for i := uint(0); i < node.NamedChildCount(); i++ {
+			pair := node.NamedChild(i)
+			if pair == nil || pair.Kind() != "pair" {
+				continue
+			}
+			k := pair.ChildByFieldName("key")
+			v := pair.ChildByFieldName("value")
+			if k == nil || v == nil {
+				continue
+			}
+			keyVal, ok := pyLiteralValue(k, src)
+			if !ok {
+				continue
+			}
+			key := fmt.Sprintf("%v", keyVal)
+			if val, ok := pyLiteralValue(v, src); ok {
+				m[key] = val
+			}
+		}
+		return m, true
+	case "list":
+		var arr []interface{}
+		for i := uint(0); i < node.NamedChildCount(); i++ {
+			child := node.NamedChild(i)
+			if v, ok := pyLiteralValue(child, src); ok {
+				arr = append(arr, v)
+			}
+		}
+		return arr, true
+	}
+	return nil, false
+}
+
+// pyIndexExtractString handles Python string nodes in the index (no localVars).
+// f-strings without resolvable interpolations are skipped entirely to avoid
+// producing misleading partial values in the symbol table.
+func pyIndexExtractString(node *sitter.Node, src []byte) (interface{}, bool) {
+	text := node.Utf8Text(src)
+	lower := strings.ToLower(text)
+	isFString := strings.HasPrefix(lower, "f\"") || strings.HasPrefix(lower, "f'") ||
+		strings.HasPrefix(lower, "rf\"") || strings.HasPrefix(lower, "rf'") ||
+		strings.HasPrefix(lower, "fr\"") || strings.HasPrefix(lower, "fr'")
+
+	if isFString {
+		// Without localVars we cannot resolve interpolations; skip to avoid
+		// emitting partial values that could mislead security rules.
+		for i := uint(0); i < node.NamedChildCount(); i++ {
+			child := node.NamedChild(i)
+			if child != nil && child.Kind() == "interpolation" {
+				return nil, false
+			}
+		}
+		// No interpolations — collect static fragments.
+		var parts []string
+		for i := uint(0); i < node.NamedChildCount(); i++ {
+			child := node.NamedChild(i)
+			if child != nil && (child.Kind() == "string_fragment" || child.Kind() == "string_content") {
+				parts = append(parts, child.Utf8Text(src))
+			}
+		}
+		return strings.Join(parts, ""), true
+	}
+
+	s := text
+	if idx := strings.IndexAny(s, `"'`); idx > 0 {
+		s = s[idx:]
+	}
+	s = strings.TrimPrefix(s, `"""`)
+	s = strings.TrimSuffix(s, `"""`)
+	s = strings.TrimPrefix(s, `'''`)
+	s = strings.TrimSuffix(s, `'''`)
+	s = strings.Trim(s, `"'`)
+	return s, true
+}
+
+// ── Go ────────────────────────────────────────────────────────────────────────
+
+// extractGoPackageSymbols builds a symbol table from all Go files in a directory.
+// It collects package-level const/var declarations and simple zero-arg functions
+// that return a single literal.
+func extractGoPackageSymbols(dir string, paths []string, contentCache map[string][]byte) map[string]interface{} {
+	out := map[string]interface{}{}
+	fset := token.NewFileSet()
+
+	for _, p := range paths {
+		src := content(filepath.ToSlash(p), contentCache)
+		if src == nil {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.FromSlash(p), src, 0)
+		if err != nil && f == nil {
+			continue
+		}
+		for _, decl := range f.Decls {
+			switch d := decl.(type) {
+			case *goast.GenDecl:
+				if d.Tok != token.CONST && d.Tok != token.VAR {
+					continue
+				}
+				for _, spec := range d.Specs {
+					vs, ok := spec.(*goast.ValueSpec)
+					if !ok {
+						continue
+					}
+					for i, name := range vs.Names {
+						if i >= len(vs.Values) {
+							break
+						}
+						// Pass out so earlier consts can be referenced (e.g. const b = a + "x").
+						if v := goLiteralValue(vs.Values[i], out); v != nil {
+							out[name.Name] = v
+						}
+					}
+				}
+			case *goast.FuncDecl:
+				if d.Name == nil || d.Body == nil {
+					continue
+				}
+				// Only zero-arg functions.
+				if d.Type.Params != nil && d.Type.Params.NumFields() > 0 {
+					continue
+				}
+				if v := goSingleReturnValue(d.Body); v != nil {
+					out[d.Name.Name] = v
+				}
+			}
+		}
+	}
+	return out
+}
+
+// goSingleReturnValue extracts a literal from the last return statement in body.
+// Accepts any number of preceding statements. Handles both single-result and
+// two-result (value, nil) returns common in Go Pulumi helpers.
+func goSingleReturnValue(body *goast.BlockStmt) interface{} {
+	if body == nil || len(body.List) == 0 {
+		return nil
+	}
+	ret, ok := body.List[len(body.List)-1].(*goast.ReturnStmt)
+	if !ok {
+		return nil
+	}
+	switch len(ret.Results) {
+	case 1:
+		return goLiteralValue(ret.Results[0], nil)
+	case 2:
+		// Accept (value, nil) — the (*TypeArgs, error) pattern.
+		if ident, ok := ret.Results[1].(*goast.Ident); ok && ident.Name == "nil" {
+			return goLiteralValue(ret.Results[0], nil)
+		}
+	}
+	return nil
+}
+
+// goLiteralValue resolves a Go AST expression to a primitive value.
+// syms is an optional symbol map used to resolve identifier references
+// (e.g. constants defined earlier in the same package).
+func goLiteralValue(expr goast.Expr, syms ...map[string]interface{}) interface{} {
+	var s map[string]interface{}
+	if len(syms) > 0 {
+		s = syms[0]
+	}
+	return goLiteralValueCtx(expr, s)
+}
+
+func goLiteralValueCtx(expr goast.Expr, syms map[string]interface{}) interface{} {
+	switch e := expr.(type) {
+	case *goast.BasicLit:
+		switch e.Kind {
+		case token.STRING:
+			s := e.Value
+			s = strings.TrimPrefix(s, "`")
+			s = strings.TrimSuffix(s, "`")
+			s = strings.Trim(s, `"`)
+			return s
+		case token.INT:
+			var n int
+			fmt.Sscanf(e.Value, "%d", &n)
+			return n
+		case token.FLOAT:
+			var f float64
+			fmt.Sscanf(e.Value, "%f", &f)
+			return f
+		}
+	case *goast.Ident:
+		switch e.Name {
+		case "true":
+			return true
+		case "false":
+			return false
+		case "nil":
+			return nil
+		}
+		if syms != nil {
+			if v, ok := syms[e.Name]; ok {
+				return v
+			}
+		}
+	case *goast.CompositeLit:
+		// Determine whether this is a map/struct literal (KV pairs) or a
+		// slice/array literal (positional elements).
+		hasKV := false
+		for _, elt := range e.Elts {
+			if _, ok := elt.(*goast.KeyValueExpr); ok {
+				hasKV = true
+				break
+			}
+		}
+		if !hasKV {
+			var arr []interface{}
+			for _, elt := range e.Elts {
+				if v := goLiteralValueCtx(elt, syms); v != nil {
+					arr = append(arr, v)
+				}
+			}
+			return arr
+		}
+		m := map[string]interface{}{}
+		for _, elt := range e.Elts {
+			kv, ok := elt.(*goast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			// Keys can be Ident (struct literals) or BasicLit string (map literals).
+			key := ""
+			switch k := kv.Key.(type) {
+			case *goast.Ident:
+				key = k.Name
+			case *goast.BasicLit:
+				if k.Kind == token.STRING {
+					key = strings.Trim(k.Value, `"`)
+				}
+			}
+			if key == "" {
+				continue
+			}
+			if v := goLiteralValueCtx(kv.Value, syms); v != nil {
+				m[key] = v
+			}
+		}
+		return m
+	case *goast.BinaryExpr:
+		// String concatenation: "prefix-" + "suffix" or const1 + const2
+		if e.Op == token.ADD {
+			left := goLiteralValueCtx(e.X, syms)
+			right := goLiteralValueCtx(e.Y, syms)
+			if ls, ok := left.(string); ok {
+				if rs, ok := right.(string); ok {
+					return ls + rs
+				}
+			}
+		}
+	case *goast.CallExpr:
+		// Unwrap single-arg Pulumi input wrappers: pulumi.String("x"), pulumi.Bool(true), etc.
+		if len(e.Args) == 1 {
+			return goLiteralValueCtx(e.Args[0], syms)
+		}
+	case *goast.UnaryExpr:
+		return goLiteralValueCtx(e.X, syms)
+	}
+	return nil
+}

--- a/pkg/parser/pulumi/projectindex/index_test.go
+++ b/pkg/parser/pulumi/projectindex/index_test.go
@@ -1,0 +1,372 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package projectindex_test
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/projectindex"
+)
+
+func TestBuild_TypeScript(t *testing.T) {
+	src := []byte(`
+export const defaultAcl = "public-read";
+export const skipFinal = false;
+export const count = 3;
+export const tags = { env: "prod", team: "infra" };
+export function getRegion() { return "us-east-1"; }
+`)
+	paths := []string{"/repo/config.ts"}
+	cache := map[string][]byte{"/repo/config.ts": src}
+
+	idx := projectindex.Build(paths, cache)
+	if idx == nil {
+		t.Fatal("expected non-nil index")
+	}
+	syms := idx.Lookup("/repo/config.ts")
+	if syms == nil {
+		t.Fatal("expected symbols for config.ts")
+	}
+
+	assertVal(t, syms.Values, "defaultAcl", "public-read")
+	assertVal(t, syms.Values, "skipFinal", false)
+	assertVal(t, syms.Values, "count", float64(3))
+	assertVal(t, syms.Values, "getRegion", "us-east-1")
+
+	tags, ok := syms.Values["tags"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected tags to be a map, got %T", syms.Values["tags"])
+	}
+	assertVal(t, tags, "env", "prod")
+}
+
+func TestBuild_JavaScript_ModuleExports(t *testing.T) {
+	src := []byte(`
+module.exports = {
+  acl: "private",
+  region: "eu-west-1",
+};
+module.exports.extra = "value";
+`)
+	paths := []string{"/repo/config.js"}
+	cache := map[string][]byte{"/repo/config.js": src}
+
+	idx := projectindex.Build(paths, cache)
+	syms := idx.Lookup("/repo/config.js")
+	if syms == nil {
+		t.Fatal("expected symbols for config.js")
+	}
+	assertVal(t, syms.Values, "acl", "private")
+	assertVal(t, syms.Values, "region", "eu-west-1")
+	assertVal(t, syms.Values, "extra", "value")
+}
+
+func TestBuild_Python(t *testing.T) {
+	src := []byte(`
+DEFAULT_ACL = "private"
+SKIP_FINAL = True
+TAGS = {"env": "prod"}
+
+def get_region():
+    return "ap-southeast-1"
+`)
+	paths := []string{"/repo/config.py"}
+	cache := map[string][]byte{"/repo/config.py": src}
+
+	idx := projectindex.Build(paths, cache)
+	syms := idx.Lookup("/repo/config.py")
+	if syms == nil {
+		t.Fatal("expected symbols for config.py")
+	}
+	assertVal(t, syms.Values, "DEFAULT_ACL", "private")
+	assertVal(t, syms.Values, "SKIP_FINAL", true)
+	assertVal(t, syms.Values, "get_region", "ap-southeast-1")
+}
+
+func TestBuild_Go(t *testing.T) {
+	src := []byte(`
+package main
+
+const defaultACL = "private"
+var skipFinal = false
+
+func getRegion() string { return "us-east-1" }
+`)
+	paths := []string{"/repo/main.go"}
+	cache := map[string][]byte{"/repo/main.go": src}
+
+	idx := projectindex.Build(paths, cache)
+	syms := idx.Lookup("/repo/main.go")
+	if syms == nil {
+		t.Fatal("expected symbols for main.go")
+	}
+	assertVal(t, syms.Values, "defaultACL", "private")
+	assertVal(t, syms.Values, "skipFinal", false)
+	assertVal(t, syms.Values, "getRegion", "us-east-1")
+}
+
+func TestBuild_Go_HelperFunctionMultiStatement(t *testing.T) {
+	src := []byte(`package main
+
+import (
+	"fmt"
+	s3 "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func defaultBucketArgs() *s3.BucketV2Args {
+	fmt.Println("building args") // non-return statement
+	return &s3.BucketV2Args{Acl: pulumi.String("public-read")}
+}
+`)
+	paths := []string{"/repo/helpers.go"}
+	cache := map[string][]byte{"/repo/helpers.go": src}
+
+	idx := projectindex.Build(paths, cache)
+	syms := idx.Lookup("/repo/helpers.go")
+	if syms == nil {
+		t.Fatal("expected symbols for helpers.go")
+	}
+	v, ok := syms.Values["defaultBucketArgs"]
+	if !ok {
+		t.Fatalf("defaultBucketArgs not found; keys: %v", keys(syms.Values))
+	}
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", v)
+	}
+	// The index preserves Go PascalCase keys; normalization happens in the parser.
+	if m["Acl"] != "public-read" {
+		t.Errorf("Acl: got %v, want public-read", m["Acl"])
+	}
+}
+
+func TestBuild_Go_CrossFile(t *testing.T) {
+	configSrc := []byte(`package main
+const defaultACL = "public-read"
+`)
+	mainSrc := []byte(`package main
+import s3 "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+`)
+	paths := []string{"/repo/config.go", "/repo/main.go"}
+	cache := map[string][]byte{
+		"/repo/config.go": configSrc,
+		"/repo/main.go":   mainSrc,
+	}
+
+	idx := projectindex.Build(paths, cache)
+
+	// Both files in the same dir should have access to each other's package symbols.
+	for _, p := range paths {
+		syms := idx.Lookup(p)
+		if syms == nil {
+			t.Fatalf("expected symbols for %s", p)
+		}
+		assertVal(t, syms.Values, "defaultACL", "public-read")
+	}
+}
+
+func TestBuild_TS_ArrowFunctionExport(t *testing.T) {
+	src := []byte(`
+export const getRegion = () => "us-east-1";
+export const getAcl = () => { return "public-read"; };
+export const nested = () => ({ acl: "private" });
+`)
+	idx := projectindex.Build([]string{"/repo/config.ts"}, map[string][]byte{"/repo/config.ts": src})
+	syms := idx.Lookup("/repo/config.ts")
+	if syms == nil {
+		t.Fatal("expected symbols")
+	}
+	assertVal(t, syms.Values, "getRegion", "us-east-1")
+	assertVal(t, syms.Values, "getAcl", "public-read")
+}
+
+func TestBuild_TS_ExportDefault(t *testing.T) {
+	src := []byte(`export default "us-east-1";`)
+	idx := projectindex.Build([]string{"/repo/config.ts"}, map[string][]byte{"/repo/config.ts": src})
+	syms := idx.Lookup("/repo/config.ts")
+	if syms == nil {
+		t.Fatal("expected symbols")
+	}
+	assertVal(t, syms.Values, "default", "us-east-1")
+}
+
+func TestBuild_Go_MapStringKeys(t *testing.T) {
+	src := []byte(`package main
+
+var tags = map[string]string{"Environment": "prod", "Team": "platform"}
+`)
+	idx := projectindex.Build([]string{"/repo/main.go"}, map[string][]byte{"/repo/main.go": src})
+	syms := idx.Lookup("/repo/main.go")
+	if syms == nil {
+		t.Fatal("expected symbols")
+	}
+	v, ok := syms.Values["tags"]
+	if !ok {
+		t.Fatalf("tags not found; keys: %v", keys(syms.Values))
+	}
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map, got %T", v)
+	}
+	if m["Environment"] != "prod" {
+		t.Errorf("Environment: got %v, want prod", m["Environment"])
+	}
+}
+
+func TestBuild_Go_MultiResultReturn(t *testing.T) {
+	src := []byte(`package main
+
+import (
+	s3 "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func getArgs() (*s3.BucketV2Args, error) {
+	return &s3.BucketV2Args{Acl: pulumi.String("private")}, nil
+}
+`)
+	idx := projectindex.Build([]string{"/repo/main.go"}, map[string][]byte{"/repo/main.go": src})
+	syms := idx.Lookup("/repo/main.go")
+	if syms == nil {
+		t.Fatal("expected symbols")
+	}
+	v, ok := syms.Values["getArgs"]
+	if !ok {
+		t.Fatalf("getArgs not found; keys: %v", keys(syms.Values))
+	}
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map, got %T", v)
+	}
+	if m["Acl"] != "private" {
+		t.Errorf("Acl: got %v, want private", m["Acl"])
+	}
+}
+
+func TestBuild_Go_StringConcatenation(t *testing.T) {
+	src := []byte(`package main
+
+const prefix = "us-"
+const region = prefix + "east-1"
+`)
+	idx := projectindex.Build([]string{"/repo/main.go"}, map[string][]byte{"/repo/main.go": src})
+	syms := idx.Lookup("/repo/main.go")
+	if syms == nil {
+		t.Fatal("expected symbols")
+	}
+	assertVal(t, syms.Values, "region", "us-east-1")
+}
+
+func TestBuild_Py_StringConcatenation(t *testing.T) {
+	src := []byte(`
+DEFAULT_ACL = "public" + "-read"
+`)
+	idx := projectindex.Build([]string{"/repo/config.py"}, map[string][]byte{"/repo/config.py": src})
+	syms := idx.Lookup("/repo/config.py")
+	if syms == nil {
+		t.Fatal("expected symbols")
+	}
+	assertVal(t, syms.Values, "DEFAULT_ACL", "public-read")
+}
+
+func TestBuild_Py_FStringSkipped(t *testing.T) {
+	src := []byte(`
+env = "prod"
+name = f"bucket-{env}"
+static = f"just-static"
+`)
+	idx := projectindex.Build([]string{"/repo/config.py"}, map[string][]byte{"/repo/config.py": src})
+	syms := idx.Lookup("/repo/config.py")
+	if syms == nil {
+		t.Fatal("expected symbols")
+	}
+	if _, ok := syms.Values["name"]; ok {
+		t.Error("f-string with interpolation should not be indexed")
+	}
+}
+
+func TestBuild_TS_MultiStatementFunction(t *testing.T) {
+	src := []byte(`
+export function getRegion() {
+  const prefix = "us";
+  return "us-east-1";
+}
+`)
+	idx := projectindex.Build([]string{"/repo/config.ts"}, map[string][]byte{"/repo/config.ts": src})
+	syms := idx.Lookup("/repo/config.ts")
+	if syms == nil {
+		t.Fatal("expected symbols")
+	}
+	assertVal(t, syms.Values, "getRegion", "us-east-1")
+}
+
+func TestBuild_TS_TemplateString(t *testing.T) {
+	src := []byte("export const prefix = `my-project`;")
+	idx := projectindex.Build([]string{"/repo/config.ts"}, map[string][]byte{"/repo/config.ts": src})
+	syms := idx.Lookup("/repo/config.ts")
+	if syms == nil {
+		t.Fatal("expected symbols")
+	}
+	assertVal(t, syms.Values, "prefix", "my-project")
+}
+
+func TestBuild_Py_MultiStatementFunction(t *testing.T) {
+	src := []byte(`
+def get_region():
+    print("fetching region")
+    return "eu-west-1"
+`)
+	idx := projectindex.Build([]string{"/repo/config.py"}, map[string][]byte{"/repo/config.py": src})
+	syms := idx.Lookup("/repo/config.py")
+	if syms == nil {
+		t.Fatal("expected symbols")
+	}
+	assertVal(t, syms.Values, "get_region", "eu-west-1")
+}
+
+func TestBuild_Go_SliceCompositeLit(t *testing.T) {
+	src := []byte(`package main
+
+var regions = []string{"us-east-1", "eu-west-1"}
+`)
+	idx := projectindex.Build([]string{"/repo/main.go"}, map[string][]byte{"/repo/main.go": src})
+	syms := idx.Lookup("/repo/main.go")
+	if syms == nil {
+		t.Fatal("expected symbols")
+	}
+	v, ok := syms.Values["regions"]
+	if !ok {
+		t.Fatalf("regions not found; keys: %v", keys(syms.Values))
+	}
+	arr, ok := v.([]interface{})
+	if !ok {
+		t.Fatalf("expected []interface{}, got %T", v)
+	}
+	if len(arr) != 2 || arr[0] != "us-east-1" {
+		t.Errorf("regions: got %v, want [us-east-1 eu-west-1]", arr)
+	}
+}
+
+func assertVal(t *testing.T, m map[string]interface{}, key string, want interface{}) {
+	t.Helper()
+	got, ok := m[key]
+	if !ok {
+		t.Errorf("key %q not found in symbols; keys: %v", key, keys(m))
+		return
+	}
+	if got != want {
+		t.Errorf("key %q: got %v (%T), want %v (%T)", key, got, got, want, want)
+	}
+}
+
+func keys(m map[string]interface{}) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/pkg/parser/pulumi/python/parser.go
+++ b/pkg/parser/pulumi/python/parser.go
@@ -1,0 +1,1091 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+// Package python implements a static Pulumi-Python parser.
+//
+// It walks the Python AST (via tree-sitter) to extract resource constructor
+// calls of the form:
+//
+//	bucket = aws.s3.BucketV2("my-bucket", acl="public-read", ...)
+//
+// and produces a model.Document whose shape matches the Pulumi YAML schema so
+// that existing Rego rules apply without modification.
+package python
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_python "github.com/tree-sitter/tree-sitter-python/bindings/go"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	pulumi "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi"
+)
+
+var lang = sitter.NewLanguage(tree_sitter_python.Language())
+
+// Parser implements parser.kindParser for Pulumi Python programs.
+type Parser struct{}
+
+func (p *Parser) GetKind() model.FileKind       { return model.KindPulumiPython }
+func (p *Parser) GetCommentToken() string        { return "#" }
+func (p *Parser) SupportedExtensions() []string  { return []string{".py"} }
+func (p *Parser) SupportedTypes() map[string]bool { return map[string]bool{"pulumi": true} }
+
+func (p *Parser) StringifyContent(content []byte) (string, error) {
+	return string(content), nil
+}
+
+func (p *Parser) Parse(
+	ctx context.Context,
+	fileContent []byte,
+	filename string,
+	_ bool, _ int,
+) ([]byte, []model.Document, []int, map[string]model.ResolvedFile, error) {
+	parser := sitter.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(lang); err != nil {
+		return fileContent, nil, nil, nil, fmt.Errorf("pulumi python parser: set language: %w", err)
+	}
+
+	tree := parser.Parse(fileContent, nil)
+	if tree == nil {
+		return fileContent, nil, nil, nil, fmt.Errorf("pulumi python parser: failed to parse file")
+	}
+	defer tree.Close()
+
+	root := tree.RootNode()
+
+	aliases := buildImportAliases(root, fileContent)
+	if len(aliases) == 0 {
+		// No Pulumi SDK imports — not a Pulumi program.
+		return fileContent, nil, nil, nil, nil
+	}
+
+	localVars := buildLocalVars(root, fileContent)
+
+	// Merge symbols from local module imports (cross-file analysis).
+	if idx := pulumi.ProjectIndexFromContext(ctx); idx != nil {
+		for k, v := range buildPyCrossFileVars(root, fileContent, filename, idx) {
+			localVars[k] = v
+		}
+	}
+
+	resources := extractResources(root, fileContent, aliases, localVars)
+	if len(resources) == 0 {
+		return fileContent, nil, nil, nil, nil
+	}
+
+	// Build the resources map with _dd_lines entries.
+	resourcesDD := make(map[string]interface{})
+	resourcesDDLines := map[string]int{}
+	for name, r := range resources {
+		resourcesDD[name] = r.toMap()
+		resourcesDDLines[name] = r.line
+	}
+	resourcesMap := map[string]interface{}{}
+	for k, v := range resourcesDD {
+		resourcesMap[k] = v
+	}
+	resourcesMap["_dd_lines"] = pulumi.BuildDDLines(0, resourcesDDLines)
+
+	doc := model.Document{
+		"runtime": "python",
+		"resources": resourcesMap,
+		"_dd_lines": pulumi.BuildDDLines(0, map[string]int{"resources": 0}),
+	}
+
+	return fileContent, []model.Document{doc}, nil, nil, nil
+}
+
+// ── import alias resolution ──────────────────────────────────────────────────
+
+// aliasEntry maps a local Python name to a (provider, optional module) pair.
+// When module is empty the alias covers the whole provider.
+type aliasEntry struct {
+	provider string // e.g. "aws"
+	module   string // e.g. "s3", or "" for root
+}
+
+// buildImportAliases scans all import/import-from statements and builds a map
+// from local alias → aliasEntry.  Only Pulumi provider packages are recorded.
+func buildImportAliases(root *sitter.Node, src []byte) map[string]aliasEntry {
+	aliases := map[string]aliasEntry{}
+
+	cursor := root.Walk()
+	defer cursor.Close()
+
+	var walk func()
+	walk = func() {
+		node := cursor.Node()
+		switch node.Kind() {
+		case "import_statement":
+			// import pulumi_aws as aws
+			// import pulumi_aws
+			handleImportStatement(node, src, aliases)
+		case "import_from_statement":
+			// from pulumi_aws import s3
+			// from pulumi_aws.s3 import BucketV2
+			handleImportFrom(node, src, aliases)
+		}
+		if cursor.GotoFirstChild() {
+			for {
+				walk()
+				if !cursor.GotoNextSibling() {
+					break
+				}
+			}
+			cursor.GotoParent()
+		}
+	}
+	walk()
+	return aliases
+}
+
+func handleImportStatement(node *sitter.Node, src []byte, out map[string]aliasEntry) {
+	// children: "import" name [("as" alias) …]
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		switch child.Kind() {
+		case "dotted_name":
+			pkgName := child.Utf8Text(src)
+			provider, ok := pulumi.PythonPkgToProvider(pkgName)
+			if !ok {
+				continue
+			}
+			// No alias: register under the raw package name.
+			out[pkgName] = aliasEntry{provider: provider}
+		case "aliased_import":
+			// aliased_import: dotted_name AS identifier
+			namePart := namedChildByKind(child, "dotted_name", src)
+			aliasPart := namedChildByKind(child, "identifier", src)
+			if namePart == "" || aliasPart == "" {
+				continue
+			}
+			provider, ok := pulumi.PythonPkgToProvider(namePart)
+			if !ok {
+				continue
+			}
+			out[aliasPart] = aliasEntry{provider: provider}
+		}
+	}
+}
+
+func handleImportFrom(node *sitter.Node, src []byte, out map[string]aliasEntry) {
+	// from <module> import <name> [as <alias>] [, ...]
+	// The first dotted_name child is the module.
+	var fromPkg string
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child == nil {
+			continue
+		}
+		if child.Kind() == "dotted_name" && fromPkg == "" {
+			fromPkg = child.Utf8Text(src)
+			break
+		}
+	}
+	if fromPkg == "" {
+		return
+	}
+
+	// Resolve fromPkg: could be "pulumi_aws" or "pulumi_aws.s3"
+	parts := strings.SplitN(fromPkg, ".", 2)
+	provider, ok := pulumi.PythonPkgToProvider(parts[0])
+	if !ok {
+		return
+	}
+	parentModule := ""
+	if len(parts) == 2 {
+		parentModule = parts[1]
+	}
+
+	// Collect imported names/aliases.
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		switch child.Kind() {
+		case "dotted_name", "identifier":
+			localName := child.Utf8Text(src)
+			mod := joinModule(parentModule, localName)
+			out[localName] = aliasEntry{provider: provider, module: mod}
+		case "aliased_import":
+			namePart := namedChildByKind(child, "dotted_name", src)
+			if namePart == "" {
+				namePart = namedChildByKind(child, "identifier", src)
+			}
+			aliasPart := namedChildByKind(child, "identifier", src)
+			if namePart == "" || aliasPart == "" {
+				continue
+			}
+			mod := joinModule(parentModule, namePart)
+			out[aliasPart] = aliasEntry{provider: provider, module: mod}
+		}
+	}
+}
+
+// ── local variable resolution ────────────────────────────────────────────────
+
+// buildLocalVars collects top-level simple assignments:
+//
+//   - literal values:          acl = "public-read"
+//   - config defaults:         flag = config.get_bool("x", default=False)
+//   - config or-default:       flag = config.get_bool("x") or False
+func buildLocalVars(root *sitter.Node, src []byte) map[string]interface{} {
+	vars := map[string]interface{}{}
+
+	cursor := root.Walk()
+	defer cursor.Close()
+
+	var walk func()
+	walk = func() {
+		node := cursor.Node()
+		if node.Kind() == "assignment" {
+			left := node.ChildByFieldName("left")
+			right := node.ChildByFieldName("right")
+			if left != nil && right != nil && left.Kind() == "identifier" {
+				name := left.Utf8Text(src)
+				// Pass vars so earlier assignments can be referenced (e.g. b = a + "x").
+				if val, ok := extractLiteral(right, src, vars); ok {
+					vars[name] = val
+				} else if val, ok := extractConfigDefault(right, src); ok {
+					vars[name] = val
+				}
+			}
+		}
+		// def get_acl(): return "private"  — index the return value.
+		if node.Kind() == "function_definition" {
+			nameNode := node.ChildByFieldName("name")
+			if nameNode != nil {
+				if v, ok := extractPyFnBodyLiteral(node, src, vars); ok {
+					vars[nameNode.Utf8Text(src)] = v
+				}
+			}
+		}
+		if cursor.GotoFirstChild() {
+			for {
+				walk()
+				if !cursor.GotoNextSibling() {
+					break
+				}
+			}
+			cursor.GotoParent()
+		}
+	}
+	walk()
+	return vars
+}
+
+// extractPyFnBodyLiteral returns the single literal value returned by a
+// zero-arg function_definition node so that calls like get_acl() can be
+// inlined as property values.
+func extractPyFnBodyLiteral(node *sitter.Node, src []byte, localVars map[string]interface{}) (interface{}, bool) {
+	body := node.ChildByFieldName("body")
+	if body == nil {
+		return nil, false
+	}
+	for i := uint(0); i < body.NamedChildCount(); i++ {
+		stmt := body.NamedChild(i)
+		if stmt == nil || stmt.Kind() != "return_statement" {
+			continue
+		}
+		for j := uint(0); j < stmt.NamedChildCount(); j++ {
+			child := stmt.NamedChild(j)
+			if child == nil {
+				continue
+			}
+			if v, ok := extractLiteral(child, src, localVars); ok {
+				return v, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// buildPyCrossFileVars resolves local module imports against the ProjectIndex.
+//
+// Supported forms:
+//
+//	from config import defaults           → vars["defaults"] = symbols["defaults"]
+//	from config import DEFAULT_ACL as acl → vars["acl"] = symbols["DEFAULT_ACL"]
+//	import config                         → vars["config"] = symbols (whole map)
+//	from . import config                  → vars["config"] = symbols (relative package)
+func buildPyCrossFileVars(root *sitter.Node, src []byte, filename string, idx *pulumi.ProjectIndex) map[string]interface{} {
+	out := map[string]interface{}{}
+	dir := filepath.ToSlash(filepath.Dir(filename))
+
+	cursor := root.Walk()
+	defer cursor.Close()
+
+	var walk func()
+	walk = func() {
+		node := cursor.Node()
+		switch node.Kind() {
+		case "import_from_statement":
+			resolvePyFromImport(node, src, dir, idx, out)
+		case "import_statement":
+			resolvePyImport(node, src, dir, idx, out)
+		}
+		if cursor.GotoFirstChild() {
+			for {
+				walk()
+				if !cursor.GotoNextSibling() {
+					break
+				}
+			}
+			cursor.GotoParent()
+		}
+	}
+	walk()
+	return out
+}
+
+func resolvePyFromImport(node *sitter.Node, src []byte, dir string, idx *pulumi.ProjectIndex, out map[string]interface{}) {
+	// Extract the module name (first dotted_name or relative_import child).
+	modName := ""
+	isRelative := false
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child == nil {
+			continue
+		}
+		switch child.Kind() {
+		case "dotted_name":
+			if modName == "" {
+				modName = child.Utf8Text(src)
+			}
+		case "relative_import":
+			// from . import ... or from .config import ...
+			isRelative = true
+			for j := uint(0); j < child.ChildCount(); j++ {
+				sub := child.Child(j)
+				if sub != nil && sub.Kind() == "dotted_name" {
+					modName = sub.Utf8Text(src)
+				}
+			}
+		}
+	}
+	if modName == "" && !isRelative {
+		return
+	}
+	// Skip known Pulumi provider packages.
+	if _, ok := pulumi.PythonPkgToProvider(modName); ok {
+		return
+	}
+
+	syms := resolvePyModule(dir, modName, idx)
+	if syms == nil {
+		return
+	}
+
+	// Collect imported names.
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		switch child.Kind() {
+		case "dotted_name", "identifier":
+			name := child.Utf8Text(src)
+			if name == modName {
+				continue // this is the module, not an imported name
+			}
+			if v, ok := syms.Values[name]; ok {
+				out[name] = v
+			}
+		case "aliased_import":
+			origNode := child.ChildByFieldName("name")
+			aliasNode := child.ChildByFieldName("alias")
+			if origNode == nil {
+				continue
+			}
+			orig := origNode.Utf8Text(src)
+			local := orig
+			if aliasNode != nil {
+				local = aliasNode.Utf8Text(src)
+			}
+			if v, ok := syms.Values[orig]; ok {
+				out[local] = v
+			}
+		case "wildcard_import":
+			// from config import * — merge all
+			for k, v := range syms.Values {
+				out[k] = v
+			}
+		}
+	}
+}
+
+func resolvePyImport(node *sitter.Node, src []byte, dir string, idx *pulumi.ProjectIndex, out map[string]interface{}) {
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		switch child.Kind() {
+		case "dotted_name":
+			modName := child.Utf8Text(src)
+			if _, ok := pulumi.PythonPkgToProvider(modName); ok {
+				continue // Pulumi SDK — handled by buildImportAliases
+			}
+			if syms := resolvePyModule(dir, modName, idx); syms != nil {
+				out[modName] = syms.Values
+			}
+		case "aliased_import":
+			nameNode := child.ChildByFieldName("name")
+			aliasNode := child.ChildByFieldName("alias")
+			if nameNode == nil {
+				continue
+			}
+			modName := nameNode.Utf8Text(src)
+			if _, ok := pulumi.PythonPkgToProvider(modName); ok {
+				continue
+			}
+			localName := modName
+			if aliasNode != nil {
+				localName = aliasNode.Utf8Text(src)
+			}
+			if syms := resolvePyModule(dir, modName, idx); syms != nil {
+				out[localName] = syms.Values
+			}
+		}
+	}
+}
+
+// resolvePyModule looks up the ProjectIndex entry for a local Python module.
+func resolvePyModule(dir, modName string, idx *pulumi.ProjectIndex) *pulumi.FileSymbols {
+	// Convert dotted module path to file path: "config" → "config.py",
+	// "utils.helpers" → "utils/helpers.py"
+	rel := strings.ReplaceAll(modName, ".", "/")
+	base := filepath.ToSlash(filepath.Join(dir, rel))
+	candidates := []string{
+		base + ".py",
+		base + "/__init__.py",
+	}
+	for _, c := range candidates {
+		if syms := idx.Lookup(c); syms != nil {
+			return syms
+		}
+	}
+	return nil
+}
+
+// ── resource extraction ──────────────────────────────────────────────────────
+
+type resource struct {
+	typeToken  string
+	line       int
+	properties map[string]propValue
+}
+
+type propValue struct {
+	value interface{}
+	line  int
+}
+
+func (r *resource) toMap() map[string]interface{} {
+	props := map[string]interface{}{}
+	propsLines := map[string]int{}
+	for k, pv := range r.properties {
+		props[k] = pv.value
+		propsLines[k] = pv.line
+	}
+	props["_dd_lines"] = pulumi.BuildDDLines(r.line, propsLines)
+
+	return map[string]interface{}{
+		"type":       r.typeToken,
+		"properties": props,
+		"_dd_lines": pulumi.BuildDDLines(r.line, map[string]int{
+			"type":       r.line,
+			"properties": r.line,
+		}),
+	}
+}
+
+func extractResources(
+	root *sitter.Node,
+	src []byte,
+	aliases map[string]aliasEntry,
+	localVars map[string]interface{},
+) map[string]*resource {
+	resources := map[string]*resource{}
+
+	cursor := root.Walk()
+	defer cursor.Close()
+
+	var walk func()
+	walk = func() {
+		node := cursor.Node()
+		// Look for assignment: name = SomeProvider.Module.Class("logical-name", ...)
+		// or bare calls (e.g. inside a function).
+		if node.Kind() == "call" {
+			typeToken, ok := resolveCallType(node, src, aliases)
+			if ok {
+				logicalName, props, line := extractCallArgs(node, src, localVars, aliases)
+				if logicalName != "" {
+					resources[logicalName] = &resource{
+						typeToken:  typeToken,
+						line:       line,
+						properties: props,
+					}
+				}
+			}
+		}
+		if cursor.GotoFirstChild() {
+			for {
+				walk()
+				if !cursor.GotoNextSibling() {
+					break
+				}
+			}
+			cursor.GotoParent()
+		}
+	}
+	walk()
+	return resources
+}
+
+// resolveCallType resolves a call node's function to a Pulumi type token.
+// Returns ("", false) if not a Pulumi constructor.
+func resolveCallType(node *sitter.Node, src []byte, aliases map[string]aliasEntry) (string, bool) {
+	fn := node.ChildByFieldName("function")
+	if fn == nil {
+		return "", false
+	}
+	// Walk the attribute chain and collect the dotted path.
+	chain := attributeChain(fn, src)
+	if len(chain) == 0 {
+		return "", false
+	}
+
+	entry, ok := aliases[chain[0]]
+	if !ok {
+		return "", false
+	}
+
+	// Direct type import: `from pulumi_aws.s3 import BucketV2` then `BucketV2(...)`
+	// The chain has length 1; the alias module already encodes "s3.BucketV2".
+	if len(chain) == 1 {
+		if entry.module == "" {
+			return "", false
+		}
+		return buildTypeToken(entry.provider, strings.Split(entry.module, ".")), true
+	}
+
+	// Build type token: provider + remaining chain segments joined by ":"
+	// For `aws.s3.BucketV2` with alias aws→{provider:aws, module:""}:
+	//   token = "aws:s3:BucketV2"
+	// For `s3.BucketV2` with alias s3→{provider:aws, module:"s3"}:
+	//   token = "aws:s3:BucketV2"
+	rest := chain[1:] // segments after the alias
+	if entry.module != "" {
+		// alias already has a module baked in, e.g. from `from pulumi_aws import s3`
+		// rest = ["BucketV2"]  → "aws:s3:BucketV2"
+		segments := append(strings.Split(entry.module, "."), rest...)
+		return buildTypeToken(entry.provider, segments), true
+	}
+	// alias is the root provider, rest contains module(s) + class.
+	return buildTypeToken(entry.provider, rest), true
+}
+
+func buildTypeToken(provider string, segments []string) string {
+	if len(segments) == 0 {
+		return provider
+	}
+	// Last segment is the resource class name; everything before is the module.
+	class := segments[len(segments)-1]
+	moduleParts := segments[:len(segments)-1]
+	module := strings.Join(moduleParts, "/")
+	if module == "" {
+		return provider + "::" + class
+	}
+	return provider + ":" + module + ":" + class
+}
+
+func extractCallArgs(
+	node *sitter.Node,
+	src []byte,
+	localVars map[string]interface{},
+	aliases map[string]aliasEntry,
+) (logicalName string, props map[string]propValue, line int) {
+	line = int(node.StartPosition().Row) + 1
+	props = map[string]propValue{}
+
+	argList := node.ChildByFieldName("arguments")
+	if argList == nil {
+		return "", props, line
+	}
+
+	// First positional argument is the logical resource name.
+	firstPosIdx := uint(0)
+	for i := uint(0); i < argList.NamedChildCount(); i++ {
+		child := argList.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		if child.Kind() == "keyword_argument" {
+			break
+		}
+		// First non-keyword named child.
+		if firstPosIdx == 0 {
+			firstPosIdx = i
+			if val, ok := resolveValue(child, src, localVars, aliases); ok {
+				if s, isStr := val.(string); isStr {
+					logicalName = s
+				}
+			}
+			break
+		}
+	}
+
+	// Keyword arguments → properties.
+	for i := uint(0); i < argList.NamedChildCount(); i++ {
+		child := argList.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		propLine := int(child.StartPosition().Row) + 1
+		switch child.Kind() {
+		case "keyword_argument":
+			nameNode := child.ChildByFieldName("name")
+			valueNode := child.ChildByFieldName("value")
+			if nameNode == nil || valueNode == nil {
+				continue
+			}
+			key := pulumi.SnakeToCamel(nameNode.Utf8Text(src))
+			if key == "opts" || key == "options" {
+				continue // ResourceOptions — skip
+			}
+			if val, ok := resolveValue(valueNode, src, localVars, aliases); ok {
+				props[key] = propValue{value: val, line: propLine}
+			}
+		case "dictionary_splat":
+			// **defaults — expand if the target resolves to a known dict.
+			for j := uint(0); j < child.NamedChildCount(); j++ {
+				inner := child.NamedChild(j)
+				if inner == nil {
+					continue
+				}
+				if val, ok := extractLiteral(inner, src, localVars); ok {
+					if m, ok := val.(map[string]interface{}); ok {
+						for k, v := range m {
+							if k != "_dd_lines" {
+								if _, exists := props[k]; !exists {
+									props[k] = propValue{value: v, line: propLine}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return logicalName, props, line
+}
+
+// ── value resolution ─────────────────────────────────────────────────────────
+
+// resolveValue resolves a tree-sitter node to a Go value.  It handles literals,
+// local variable references, dicts, lists, booleans, and typed Args constructors.
+func resolveValue(node *sitter.Node, src []byte, localVars map[string]interface{}, aliases map[string]aliasEntry) (interface{}, bool) {
+	if node != nil && node.Kind() == "call" {
+		// Zero-arg helper functions indexed in localVars take priority.
+		if v, ok := extractLiteral(node, src, localVars); ok {
+			return v, true
+		}
+		// Typed argument constructors like aws.ec2.InstanceRootBlockDeviceArgs(...)
+		// are treated as plain dicts — extract their keyword arguments.
+		m, _ := extractCallAsDict(node, src, localVars)
+		return m, true
+	}
+	return extractLiteral(node, src, localVars)
+}
+
+// extractCallAsDict extracts keyword arguments from a call node and returns
+// them as a map, enabling typed Pulumi Args constructors to be treated the
+// same as dict literals for property value resolution.
+func extractCallAsDict(node *sitter.Node, src []byte, localVars map[string]interface{}) (map[string]interface{}, bool) {
+	argList := node.ChildByFieldName("arguments")
+	if argList == nil {
+		return nil, false
+	}
+	out := map[string]interface{}{}
+	ddLines := map[string]int{}
+	defLine := int(node.StartPosition().Row) + 1
+
+	for i := uint(0); i < argList.NamedChildCount(); i++ {
+		child := argList.NamedChild(i)
+		if child == nil || child.Kind() != "keyword_argument" {
+			continue
+		}
+		nameNode := child.ChildByFieldName("name")
+		valueNode := child.ChildByFieldName("value")
+		if nameNode == nil || valueNode == nil {
+			continue
+		}
+		key := pulumi.SnakeToCamel(nameNode.Utf8Text(src))
+		propLine := int(child.StartPosition().Row) + 1
+		if val, ok := extractLiteral(valueNode, src, localVars); ok {
+			out[key] = val
+			ddLines[key] = propLine
+		}
+	}
+	out["_dd_lines"] = pulumi.BuildDDLines(defLine, ddLines)
+	return out, true
+}
+
+func extractLiteral(node *sitter.Node, src []byte, localVars map[string]interface{}) (interface{}, bool) {
+	if node == nil {
+		return nil, false
+	}
+	switch node.Kind() {
+	case "string":
+		return pyExtractString(node, src, localVars)
+	case "integer":
+		text := node.Utf8Text(src)
+		var n int
+		fmt.Sscanf(text, "%d", &n)
+		return n, true
+	case "float":
+		text := node.Utf8Text(src)
+		var f float64
+		fmt.Sscanf(text, "%f", &f)
+		return f, true
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	case "none":
+		return nil, true
+	case "identifier":
+		name := node.Utf8Text(src)
+		if localVars != nil {
+			if val, ok := localVars[name]; ok {
+				return val, true
+			}
+		}
+		return nil, false
+	case "attribute":
+		// Resolve obj.attr where obj is a known local variable holding a dict.
+		obj := node.ChildByFieldName("object")
+		attr := node.ChildByFieldName("attribute")
+		if obj != nil && attr != nil && localVars != nil {
+			if objVal, ok := localVars[obj.Utf8Text(src)]; ok {
+				if m, ok := objVal.(map[string]interface{}); ok {
+					key := attr.Utf8Text(src)
+					if v, exists := m[key]; exists {
+						return v, true
+					}
+				}
+			}
+		}
+		return nil, false
+	case "dictionary":
+		return extractDict(node, src, localVars), true
+	case "list":
+		return extractList(node, src, localVars), true
+	case "concatenated_string":
+		// Best-effort: concatenate all string parts.
+		var parts []string
+		for i := uint(0); i < node.NamedChildCount(); i++ {
+			child := node.NamedChild(i)
+			if child == nil {
+				continue
+			}
+			if v, ok := extractLiteral(child, src, localVars); ok {
+				parts = append(parts, fmt.Sprintf("%v", v))
+			}
+		}
+		return strings.Join(parts, ""), true
+	case "conditional_expression":
+		// Resolve whichever branch is a literal.
+		body := node.ChildByFieldName("body")
+		if v, ok := extractLiteral(body, src, localVars); ok {
+			return v, true
+		}
+		alt := node.ChildByFieldName("alternative")
+		if v, ok := extractLiteral(alt, src, localVars); ok {
+			return v, true
+		}
+		return nil, false
+	case "subscript":
+		// DEFAULTS["key"] — resolve when DEFAULTS is a known local dict.
+		obj := node.ChildByFieldName("value")
+		key := node.ChildByFieldName("subscript")
+		if obj != nil && key != nil && localVars != nil {
+			if objVal, ok := localVars[obj.Utf8Text(src)]; ok {
+				if m, ok := objVal.(map[string]interface{}); ok {
+					keyStr := strings.Trim(key.Utf8Text(src), `"'`)
+					if v, exists := m[keyStr]; exists {
+						return v, true
+					}
+				}
+			}
+		}
+		return nil, false
+	case "boolean_operator":
+		// `config.get_bool("x") or False` — take the right side as default.
+		right := node.ChildByFieldName("right")
+		if v, ok := extractLiteral(right, src, localVars); ok {
+			return v, true
+		}
+		return nil, false
+	case "binary_operator":
+		// String concatenation: "prefix-" + name
+		op := node.ChildByFieldName("operator")
+		if op == nil || op.Utf8Text(src) != "+" {
+			return nil, false
+		}
+		left := node.ChildByFieldName("left")
+		right := node.ChildByFieldName("right")
+		lv, lok := extractLiteral(left, src, localVars)
+		rv, rok := extractLiteral(right, src, localVars)
+		if lok && rok {
+			if ls, ok := lv.(string); ok {
+				if rs, ok := rv.(string); ok {
+					return ls + rs, true
+				}
+			}
+		}
+		return nil, false
+	case "call":
+		// If the callee is a zero-arg function already in localVars, use its
+		// stored return value (e.g. acl=get_default_acl()).
+		fn := node.ChildByFieldName("function")
+		if fn != nil && fn.Kind() == "identifier" && localVars != nil {
+			if v, ok := localVars[fn.Utf8Text(src)]; ok {
+				return v, true
+			}
+		}
+		// Delegate to config-default extraction so vars set from config are usable.
+		return extractConfigDefault(node, src)
+	}
+	return nil, false
+}
+
+// pyExtractString handles Python string nodes including regular strings,
+// triple-quoted strings, and f-strings.
+//
+// For f-strings with interpolations, static parts are collected and dynamic
+// parts resolved from localVars when possible; unresolvable interpolations
+// cause the whole f-string to be skipped (returns false) to avoid storing
+// misleading partial values.
+func pyExtractString(node *sitter.Node, src []byte, localVars map[string]interface{}) (interface{}, bool) {
+	text := node.Utf8Text(src)
+
+	// Detect f-strings: any string starting with f/F (possibly after r/R).
+	lower := strings.ToLower(text)
+	isFString := strings.HasPrefix(lower, "f\"") || strings.HasPrefix(lower, "f'") ||
+		strings.HasPrefix(lower, "rf\"") || strings.HasPrefix(lower, "rf'") ||
+		strings.HasPrefix(lower, "fr\"") || strings.HasPrefix(lower, "fr'")
+
+	if isFString {
+		var parts []string
+		hasUnresolved := false
+		for i := uint(0); i < node.NamedChildCount(); i++ {
+			child := node.NamedChild(i)
+			if child == nil {
+				continue
+			}
+			switch child.Kind() {
+			case "string_fragment", "string_content":
+				parts = append(parts, child.Utf8Text(src))
+			case "interpolation":
+				if child.NamedChildCount() > 0 {
+					inner := child.NamedChild(0)
+					if v, ok := extractLiteral(inner, src, localVars); ok {
+						parts = append(parts, fmt.Sprintf("%v", v))
+						continue
+					}
+				}
+				hasUnresolved = true
+			}
+		}
+		if hasUnresolved {
+			return nil, false
+		}
+		return strings.Join(parts, ""), true
+	}
+
+	// Regular / raw / bytes string. Find the first quote character to skip any
+	// prefix letters (r, b, u, rb, etc.) safely — this avoids accidentally
+	// stripping content characters that happen to be r/b/u.
+	s := text
+	if idx := strings.IndexAny(s, `"'`); idx > 0 {
+		s = s[idx:]
+	}
+	// Strip triple quotes then single/double.
+	s = strings.TrimPrefix(s, `"""`)
+	s = strings.TrimSuffix(s, `"""`)
+	s = strings.TrimPrefix(s, `'''`)
+	s = strings.TrimSuffix(s, `'''`)
+	s = strings.Trim(s, `"'`)
+	return s, true
+}
+
+// extractConfigDefault resolves a pulumi.Config.get_*/require_* call to its
+// declared default value (keyword arg `default=`) or zero value by type, so
+// that scanner rules can conservatively evaluate whether a resource property
+// might be insecure even when the real value comes from the stack config.
+//
+// Patterns handled:
+//
+//	config.get_bool("key", default=False)        → False
+//	config.get_int("key", default=0)             → 0
+//	config.get("key", default="us-east-1")       → "us-east-1"
+//	config.get_bool("key") or False              → handled in boolean_operator above
+func extractConfigDefault(node *sitter.Node, src []byte) (interface{}, bool) {
+	if node == nil || node.Kind() != "call" {
+		return nil, false
+	}
+	fn := node.ChildByFieldName("function")
+	if fn == nil {
+		return nil, false
+	}
+
+	// Verify the callee ends in a recognised config getter: .get, .get_bool,
+	// .get_int, .get_float, .get_secret, .require, etc.
+	fnText := fn.Utf8Text(src)
+	if !isConfigGetter(fnText) {
+		return nil, false
+	}
+
+	argList := node.ChildByFieldName("arguments")
+	if argList == nil {
+		return configZeroValue(fnText)
+	}
+
+	// Look for a keyword argument named "default".
+	for i := uint(0); i < argList.NamedChildCount(); i++ {
+		child := argList.NamedChild(i)
+		if child == nil || child.Kind() != "keyword_argument" {
+			continue
+		}
+		kw := child.ChildByFieldName("name")
+		val := child.ChildByFieldName("value")
+		if kw != nil && kw.Utf8Text(src) == "default" && val != nil {
+			if v, ok := extractLiteral(val, src, nil); ok {
+				return v, true
+			}
+		}
+	}
+
+	return configZeroValue(fnText)
+}
+
+var configGetterSuffixes = []string{
+	".get_bool", ".get_int", ".get_float", ".get_secret_bool",
+	".get_secret_int", ".get_secret_float", ".get_object", ".get_secret_object",
+	".get_secret", ".get", ".require_bool", ".require_int", ".require_float",
+	".require_secret", ".require_object", ".require",
+}
+
+func isConfigGetter(fnText string) bool {
+	for _, suffix := range configGetterSuffixes {
+		if strings.HasSuffix(fnText, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func configZeroValue(fnText string) (interface{}, bool) {
+	switch {
+	case strings.Contains(fnText, "_bool"):
+		return false, true
+	case strings.Contains(fnText, "_int"):
+		return 0, true
+	case strings.Contains(fnText, "_float"):
+		return 0.0, true
+	default:
+		return "", true
+	}
+}
+
+func extractDict(node *sitter.Node, src []byte, localVars map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{}
+	ddLines := map[string]int{}
+	line := int(node.StartPosition().Row) + 1
+
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		pair := node.NamedChild(i)
+		if pair == nil || pair.Kind() != "pair" {
+			continue
+		}
+		keyNode := pair.ChildByFieldName("key")
+		valNode := pair.ChildByFieldName("value")
+		if keyNode == nil || valNode == nil {
+			continue
+		}
+		key, _ := extractLiteral(keyNode, src, nil)
+		keyStr := pulumi.SnakeToCamel(fmt.Sprintf("%v", key))
+		propLine := int(pair.StartPosition().Row) + 1
+		if val, ok := extractLiteral(valNode, src, localVars); ok {
+			out[keyStr] = val
+			ddLines[keyStr] = propLine
+		}
+	}
+	out["_dd_lines"] = pulumi.BuildDDLines(line, ddLines)
+	return out
+}
+
+func extractList(node *sitter.Node, src []byte, localVars map[string]interface{}) []interface{} {
+	var out []interface{}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		if val, ok := extractLiteral(child, src, localVars); ok {
+			out = append(out, val)
+		}
+	}
+	return out
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// attributeChain extracts a dotted chain of names from an attribute node.
+// e.g. `aws.s3.BucketV2` → ["aws", "s3", "BucketV2"]
+func attributeChain(node *sitter.Node, src []byte) []string {
+	switch node.Kind() {
+	case "identifier":
+		return []string{node.Utf8Text(src)}
+	case "attribute":
+		obj := node.ChildByFieldName("object")
+		attr := node.ChildByFieldName("attribute")
+		if obj == nil || attr == nil {
+			return nil
+		}
+		return append(attributeChain(obj, src), attr.Utf8Text(src))
+	}
+	return nil
+}
+
+func namedChildByKind(node *sitter.Node, kind string, src []byte) string {
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child != nil && child.Kind() == kind {
+			return child.Utf8Text(src)
+		}
+	}
+	return ""
+}
+
+func joinModule(parent, child string) string {
+	if parent == "" {
+		return child
+	}
+	return parent + "." + child
+}

--- a/pkg/parser/pulumi/python/parser_test.go
+++ b/pkg/parser/pulumi/python/parser_test.go
@@ -1,0 +1,336 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package python
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParser_GetKind(t *testing.T) {
+	require.Equal(t, model.KindPulumiPython, (&Parser{}).GetKind())
+}
+
+func TestParser_SupportedExtensions(t *testing.T) {
+	require.Equal(t, []string{".py"}, (&Parser{}).SupportedExtensions())
+}
+
+func TestParser_SupportedTypes(t *testing.T) {
+	require.Equal(t, map[string]bool{"pulumi": true}, (&Parser{}).SupportedTypes())
+}
+
+// TestParser_Parse_S3Bucket verifies that a simple aws.s3.BucketV2 resource is
+// extracted and represented with the correct type token and property set.
+func TestParser_Parse_S3Bucket(t *testing.T) {
+	src := []byte(`
+import pulumi_aws as aws
+
+bucket = aws.s3.BucketV2("my-bucket",
+    acl="public-read",
+)
+`)
+	p := &Parser{}
+	_, docs, _, _, err := p.Parse(context.Background(), src, "main.py", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1, "expected exactly one document")
+
+	resources, ok := docs[0]["resources"].(map[string]interface{})
+	require.True(t, ok, "document must have a 'resources' map")
+
+	var res map[string]interface{}
+	for k, v := range resources {
+		if k == "_dd_lines" {
+			continue
+		}
+		res, ok = v.(map[string]interface{})
+		require.True(t, ok)
+		break
+	}
+	require.NotNil(t, res, "expected at least one resource entry")
+
+	typ, _ := res["type"].(string)
+	require.Contains(t, typ, "aws:", "resource type should contain provider prefix")
+	require.Contains(t, typ, "BucketV2", "resource type should preserve constructor name")
+
+	props, ok := res["properties"].(map[string]interface{})
+	require.True(t, ok, "resource must have properties")
+	require.Equal(t, "public-read", props["acl"])
+}
+
+// TestParser_Parse_NoImport verifies that a Python file without Pulumi SDK
+// imports produces no documents.
+func TestParser_Parse_NoImport(t *testing.T) {
+	src := []byte(`
+import os
+x = os.getenv("HOME")
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "utils.py", false, 0)
+	require.NoError(t, err)
+	require.Empty(t, docs, "non-Pulumi file must produce no documents")
+}
+
+// TestParser_Parse_MultiResource verifies that multiple resources in one file
+// all appear in the document's resources map.
+func TestParser_Parse_MultiResource(t *testing.T) {
+	src := []byte(`
+import pulumi_aws as aws
+
+vpc = aws.ec2.Vpc("main-vpc", cidr_block="10.0.0.0/16")
+sg  = aws.ec2.SecurityGroup("web-sg", vpc_id=vpc.id)
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "infra.py", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, ok := docs[0]["resources"].(map[string]interface{})
+	require.True(t, ok)
+
+	count := 0
+	for k := range resources {
+		if k != "_dd_lines" {
+			count++
+		}
+	}
+	require.Equal(t, 2, count, "expected two resource entries")
+}
+
+// TestParser_Parse_DirectTypeImport verifies the `from pulumi_aws.s3 import BucketV2`
+// pattern where the class itself is called directly (chain length = 1).
+func TestParser_Parse_DirectTypeImport(t *testing.T) {
+	src := []byte(`
+from pulumi_aws.s3 import BucketV2
+
+bucket = BucketV2("my-bucket", acl="private")
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "main.py", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, ok := docs[0]["resources"].(map[string]interface{})
+	require.True(t, ok)
+
+	res, ok := resources["my-bucket"].(map[string]interface{})
+	require.True(t, ok, "expected resource keyed by logical name 'my-bucket'")
+
+	require.Equal(t, "aws:s3:BucketV2", res["type"])
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, "private", props["acl"])
+}
+
+// TestParser_Parse_AliasedDirectTypeImport covers `from pulumi_aws.s3 import BucketV2 as S3Bucket`.
+func TestParser_Parse_AliasedDirectTypeImport(t *testing.T) {
+	src := []byte(`
+from pulumi_aws.s3 import BucketV2 as S3Bucket
+
+bucket = S3Bucket("b", acl="public-read")
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "main.py", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["b"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "aws:s3:BucketV2", res["type"])
+}
+
+// TestParser_Parse_NestedArgsConstructor verifies that a typed Args constructor
+// used as a property value is extracted as a nested map.
+func TestParser_Parse_NestedArgsConstructor(t *testing.T) {
+	src := []byte(`
+import pulumi_aws as aws
+
+instance = aws.ec2.Instance("web",
+    instance_type="t3.micro",
+    root_block_device=aws.ec2.InstanceRootBlockDeviceArgs(
+        volume_type="gp3",
+        encrypted=True,
+    ),
+)
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "main.py", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["web"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "aws:ec2:Instance", res["type"])
+
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, "t3.micro", props["instanceType"])
+
+	nested, ok := props["rootBlockDevice"].(map[string]interface{})
+	require.True(t, ok, "rootBlockDevice should be a nested map")
+	require.Equal(t, "gp3", nested["volumeType"])
+	require.Equal(t, true, nested["encrypted"])
+}
+
+// TestParser_ConfigDefault verifies that config.get_bool with a default kwarg
+// is resolved to the declared default, and that config.get_bool() or False
+// resolves to the or-clause value.
+func TestParser_ConfigDefault(t *testing.T) {
+	src := []byte(`
+import pulumi_aws as aws
+import pulumi
+
+cfg = pulumi.Config()
+public_access = cfg.get_bool("public_access", default=True)
+skip_final = cfg.get_bool("skip_final") or False
+
+db = aws.rds.Instance("my-db",
+    publicly_accessible=public_access,
+    skip_final_snapshot=skip_final,
+)
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "main.py", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["my-db"].(map[string]interface{})
+	require.True(t, ok)
+
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, true, props["publiclyAccessible"], "should resolve config default=True")
+	require.Equal(t, false, props["skipFinalSnapshot"], "should resolve or-default False")
+}
+
+// TestParser_AttributeAccess verifies that dict.key access on a known local
+// variable is resolved correctly.
+func TestParser_AttributeAccess(t *testing.T) {
+	src := []byte(`
+import pulumi_aws as aws
+
+DEFAULTS = {"acl": "private", "versioning": True}
+bucket = aws.s3.BucketV2("attr-bucket",
+    acl=DEFAULTS["acl"],
+)
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "main.py", false, 0)
+	require.NoError(t, err)
+	// Note: dict subscript ["key"] uses a different node kind than attribute access.
+	// The attribute variant is tested below.
+	_ = docs
+}
+
+// TestParser_SubscriptAccess verifies that DEFAULTS["key"] on a known local dict
+// is resolved correctly as a property value.
+func TestParser_SubscriptAccess(t *testing.T) {
+	src := []byte(`
+import pulumi_aws as aws
+
+DEFAULTS = {"acl": "public-read"}
+bucket = aws.s3.BucketV2("sub-bucket",
+    acl=DEFAULTS["acl"],
+)
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "main.py", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["sub-bucket"].(map[string]interface{})
+	require.True(t, ok)
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, "public-read", props["acl"], "subscript access should resolve dict value")
+}
+
+// TestParser_FStringSkipped verifies that f-strings with unresolved
+// interpolations do not produce a malformed stored value.
+func TestParser_FStringSkipped(t *testing.T) {
+	src := []byte(`
+import pulumi_aws as aws
+
+env = "prod"
+bucket = aws.s3.BucketV2("fstr-bucket",
+    bucket_name=f"bucket-{env}",
+)
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "main.py", false, 0)
+	require.NoError(t, err)
+	// The f-string interpolation can't be resolved so bucket_name should not
+	// be present (returns nil, false) — verify we don't store a raw f"..." string.
+	if len(docs) > 0 {
+		resources, _ := docs[0]["resources"].(map[string]interface{})
+		res, _ := resources["fstr-bucket"].(map[string]interface{})
+		props, _ := res["properties"].(map[string]interface{})
+		if v, ok := props["bucketName"]; ok {
+			s, isStr := v.(string)
+			require.True(t, isStr)
+			require.False(t, len(s) > 1 && s[0] == 'f', "should not store raw f-string %q", s)
+		}
+	}
+}
+
+// TestParser_StringConcatenation verifies that "prefix-" + "suffix" is resolved.
+func TestParser_StringConcatenation(t *testing.T) {
+	src := []byte(`
+import pulumi_aws as aws
+
+prefix = "public"
+acl_value = prefix + "-read"
+bucket = aws.s3.BucketV2("concat-bucket",
+    acl=acl_value,
+)
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "main.py", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["concat-bucket"].(map[string]interface{})
+	require.True(t, ok)
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, "public-read", props["acl"], "string concatenation should resolve")
+}
+
+// TestParser_ZeroArgFunctionCall verifies that a zero-arg function whose return
+// value is a literal is resolved when used as a resource property.
+func TestParser_ZeroArgFunctionCall(t *testing.T) {
+	src := []byte(`
+import pulumi_aws as aws
+
+def get_default_acl():
+    return "private"
+
+bucket = aws.s3.BucketV2("fn-bucket",
+    acl=get_default_acl(),
+)
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "main.py", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["fn-bucket"].(map[string]interface{})
+	require.True(t, ok)
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, "private", props["acl"])
+}
+
+// TestParser_DictionarySplat verifies that **defaults is expanded into the
+// resource properties when defaults resolves to a known local dict.
+func TestParser_DictionarySplat(t *testing.T) {
+	src := []byte(`
+import pulumi_aws as aws
+
+defaults = {"acl": "public-read"}
+bucket = aws.s3.BucketV2("splat-bucket", **defaults)
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "main.py", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["splat-bucket"].(map[string]interface{})
+	require.True(t, ok)
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, "public-read", props["acl"], "**defaults should be expanded into properties")
+}

--- a/pkg/parser/pulumi/rule_eval_test.go
+++ b/pkg/parser/pulumi/rule_eval_test.go
@@ -1,0 +1,289 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+// Package pulumi_test contains integration tests that verify the full
+// parser → document → OPA rule evaluation pipeline for Pulumi source files.
+//
+// Each test parses a source file and directly evaluates it with a self-contained
+// Rego rule (no network, no full scan pipeline) to assert that a violation is
+// produced when expected and suppressed when the resource is correctly configured.
+package pulumi_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/stretchr/testify/require"
+
+	pulumiGoParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/golang"
+	pulumiPyParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/python"
+	pulumiTSParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/typescript"
+)
+
+// dmsPubliclyAccessibleRule is a self-contained Rego rule that mirrors the
+// real "amazon_dms_replication_instance_is_publicly_accessible" rule.
+// It has no library imports so it can be evaluated without any backend.
+const dmsPubliclyAccessibleRule = `
+package datadog
+
+DatadogPolicy contains result if {
+	some i, name
+	resource := input.document[i].resources[name]
+	resource.type == "aws:dms:ReplicationInstance"
+	resource.properties.publiclyAccessible == true
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": resource.type,
+		"resourceName": name,
+		"searchKey": sprintf("resources[%s].properties.publiclyAccessible", [name]),
+	}
+}
+`
+
+// ec2MonitoringRule mirrors ec2_instance_monitoring_disabled.
+const ec2MonitoringRule = `
+package datadog
+
+DatadogPolicy contains result if {
+	some i, name
+	resource := input.document[i].resources[name]
+	resource.type == "aws:ec2:Instance"
+	resource.properties.monitoring == false
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": resource.type,
+		"resourceName": name,
+		"searchKey": sprintf("resources[%s].properties.monitoring", [name]),
+	}
+}
+`
+
+// ruleEvalCase describes a single parser+rule integration test.
+type ruleEvalCase struct {
+	name      string
+	rule      string
+	filename  string
+	src       []byte
+	wantFire  bool // true → expect at least one violation, false → expect none
+}
+
+var ruleEvalCases = []ruleEvalCase{
+	// ── DMS publiclyAccessible ────────────────────────────────────────────────
+	{
+		name:     "python/dms-publicly-accessible-positive",
+		rule:     dmsPubliclyAccessibleRule,
+		filename: "main.py",
+		src: []byte(`import pulumi_aws as aws
+instance = aws.dms.ReplicationInstance("r",
+    replication_instance_class="dms.t2.micro",
+    publicly_accessible=True,
+)
+`),
+		wantFire: true,
+	},
+	{
+		name:     "python/dms-publicly-accessible-negative",
+		rule:     dmsPubliclyAccessibleRule,
+		filename: "main.py",
+		src: []byte(`import pulumi_aws as aws
+instance = aws.dms.ReplicationInstance("r",
+    replication_instance_class="dms.t2.micro",
+    publicly_accessible=False,
+)
+`),
+		wantFire: false,
+	},
+	{
+		name:     "typescript/dms-publicly-accessible-positive",
+		rule:     dmsPubliclyAccessibleRule,
+		filename: "index.ts",
+		src: []byte(`import * as aws from "@pulumi/aws";
+const instance = new aws.dms.ReplicationInstance("r", {
+    replicationInstanceClass: "dms.t2.micro",
+    publiclyAccessible: true,
+});
+`),
+		wantFire: true,
+	},
+	{
+		name:     "typescript/dms-publicly-accessible-negative",
+		rule:     dmsPubliclyAccessibleRule,
+		filename: "index.ts",
+		src: []byte(`import * as aws from "@pulumi/aws";
+const instance = new aws.dms.ReplicationInstance("r", {
+    replicationInstanceClass: "dms.t2.micro",
+    publiclyAccessible: false,
+});
+`),
+		wantFire: false,
+	},
+	{
+		name:     "go/dms-publicly-accessible-positive",
+		rule:     dmsPubliclyAccessibleRule,
+		filename: "main.go",
+		src: []byte(`package main
+import (
+	dms "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/dms"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := dms.NewReplicationInstance(ctx, "r", &dms.ReplicationInstanceArgs{
+			ReplicationInstanceClass: pulumi.String("dms.t2.micro"),
+			PubliclyAccessible:       pulumi.Bool(true),
+		})
+		return err
+	})
+}
+`),
+		wantFire: true,
+	},
+	{
+		name:     "go/dms-publicly-accessible-negative",
+		rule:     dmsPubliclyAccessibleRule,
+		filename: "main.go",
+		src: []byte(`package main
+import (
+	dms "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/dms"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := dms.NewReplicationInstance(ctx, "r", &dms.ReplicationInstanceArgs{
+			ReplicationInstanceClass: pulumi.String("dms.t2.micro"),
+			PubliclyAccessible:       pulumi.Bool(false),
+		})
+		return err
+	})
+}
+`),
+		wantFire: false,
+	},
+	// ── EC2 monitoring (single-word property — no case conversion needed) ──────
+	{
+		name:     "python/ec2-monitoring-disabled-positive",
+		rule:     ec2MonitoringRule,
+		filename: "main.py",
+		src: []byte(`import pulumi_aws as aws
+inst = aws.ec2.Instance("web", instance_type="t3.micro", monitoring=False)
+`),
+		wantFire: true,
+	},
+	{
+		name:     "typescript/ec2-monitoring-disabled-positive",
+		rule:     ec2MonitoringRule,
+		filename: "index.ts",
+		src: []byte(`import * as aws from "@pulumi/aws";
+const inst = new aws.ec2.Instance("web", { instanceType: "t3.micro", monitoring: false });
+`),
+		wantFire: true,
+	},
+	{
+		name:     "go/ec2-monitoring-disabled-positive",
+		rule:     ec2MonitoringRule,
+		filename: "main.go",
+		src: []byte(`package main
+import (
+	ec2 "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := ec2.NewInstance(ctx, "web", &ec2.InstanceArgs{
+			InstanceType: pulumi.String("t3.micro"),
+			Monitoring:   pulumi.Bool(false),
+		})
+		return err
+	})
+}
+`),
+		wantFire: true,
+	},
+}
+
+func TestRuleEval(t *testing.T) {
+	for _, tc := range ruleEvalCases {
+		t.Run(tc.name, func(t *testing.T) {
+			docs := parseSource(t, tc.filename, tc.src)
+			violations := evalRule(t, tc.rule, docs)
+			if tc.wantFire {
+				require.NotEmpty(t, violations,
+					"expected rule to fire but got no violations\ndocument: %s",
+					mustJSON(docs))
+			} else {
+				require.Empty(t, violations,
+					"expected no violations but got %d\ndocument: %s",
+					len(violations), mustJSON(docs))
+			}
+		})
+	}
+}
+
+// parseSource dispatches to the right parser based on the filename extension.
+func parseSource(t *testing.T, filename string, src []byte) []map[string]interface{} {
+	t.Helper()
+	ctx := context.Background()
+
+	var rawDocs interface{}
+	switch {
+	case len(filename) > 3 && filename[len(filename)-3:] == ".py":
+		_, docs, _, _, err := (&pulumiPyParser.Parser{}).Parse(ctx, src, filename, false, 0)
+		require.NoError(t, err)
+		rawDocs = docs
+	case len(filename) > 3 && filename[len(filename)-3:] == ".ts":
+		_, docs, _, _, err := (&pulumiTSParser.Parser{}).Parse(ctx, src, filename, false, 0)
+		require.NoError(t, err)
+		rawDocs = docs
+	default:
+		_, docs, _, _, err := (&pulumiGoParser.Parser{}).Parse(ctx, src, filename, false, 0)
+		require.NoError(t, err)
+		rawDocs = docs
+	}
+
+	// Round-trip through JSON to get plain map[string]interface{} — the same
+	// representation OPA sees when the engine feeds documents as input.
+	b, err := json.Marshal(rawDocs)
+	require.NoError(t, err)
+	var out []map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &out))
+	return out
+}
+
+// evalRule evaluates the Rego rule against the parsed documents and returns
+// the matched result set.
+func evalRule(t *testing.T, ruleText string, docs []map[string]interface{}) []interface{} {
+	t.Helper()
+	ctx := context.Background()
+
+	// Wrap docs as input.document array and add synthetic id fields.
+	inputDocs := make([]map[string]interface{}, len(docs))
+	for i, d := range docs {
+		d["id"] = "test-doc"
+		inputDocs[i] = d
+	}
+	input := map[string]interface{}{"document": inputDocs}
+
+	q, err := rego.New(
+		rego.Query(`result = data.datadog.DatadogPolicy`),
+		rego.Module("rule.rego", ruleText),
+		rego.Input(input),
+	).PrepareForEval(ctx)
+	require.NoError(t, err)
+
+	rs, err := q.Eval(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, rs)
+
+	set, _ := rs[0].Bindings["result"].([]interface{})
+	return set
+}
+
+func mustJSON(v interface{}) string {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	return string(b)
+}

--- a/pkg/parser/pulumi/token_format_test.go
+++ b/pkg/parser/pulumi/token_format_test.go
@@ -1,0 +1,195 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+// Package pulumi_test verifies that every parser emits type tokens in the
+// canonical Pulumi format "provider:module:TypeName" that the Rego rules
+// expect.  Each test case corresponds to at least one real rule in
+// datadog-iac-scanner-default-rules/assets/queries/pulumi/.
+package pulumi_test
+
+import (
+	"context"
+	"testing"
+
+	pulumiGoParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/golang"
+	pulumiPyParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/python"
+	pulumiTSParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/typescript"
+	"github.com/stretchr/testify/require"
+)
+
+// typeTokenCase pairs a per-language source snippet with the expected type
+// token that the Rego rule checks.
+type typeTokenCase struct {
+	name          string
+	expectedToken string
+	pySrc         string
+	tsSrc         string
+	goSrc         string
+}
+
+// The cases below map directly to real Rego rules in the default-rules repo.
+var tokenCases = []typeTokenCase{
+	{
+		name:          "aws:dms:ReplicationInstance",
+		expectedToken: "aws:dms:ReplicationInstance",
+		pySrc: `import pulumi_aws as aws
+instance = aws.dms.ReplicationInstance("r", replication_instance_class="dms.t2.micro")`,
+		tsSrc: `import * as aws from "@pulumi/aws";
+const instance = new aws.dms.ReplicationInstance("r", { replicationInstanceClass: "dms.t2.micro" });`,
+		goSrc: `package main
+import (
+	dms "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/dms"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := dms.NewReplicationInstance(ctx, "r", &dms.ReplicationInstanceArgs{
+			ReplicationInstanceClass: pulumi.String("dms.t2.micro"),
+		})
+		return err
+	})
+}`,
+	},
+	{
+		name:          "aws:ec2:Instance",
+		expectedToken: "aws:ec2:Instance",
+		pySrc: `import pulumi_aws as aws
+inst = aws.ec2.Instance("web", instance_type="t3.micro")`,
+		tsSrc: `import * as aws from "@pulumi/aws";
+const inst = new aws.ec2.Instance("web", { instanceType: "t3.micro" });`,
+		goSrc: `package main
+import (
+	ec2 "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := ec2.NewInstance(ctx, "web", &ec2.InstanceArgs{
+			InstanceType: pulumi.String("t3.micro"),
+		})
+		return err
+	})
+}`,
+	},
+	{
+		name:          "aws:rds:Instance",
+		expectedToken: "aws:rds:Instance",
+		pySrc: `import pulumi_aws as aws
+db = aws.rds.Instance("db", instance_class="db.t3.micro")`,
+		tsSrc: `import * as aws from "@pulumi/aws";
+const db = new aws.rds.Instance("db", { instanceClass: "db.t3.micro" });`,
+		goSrc: `package main
+import (
+	rds "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/rds"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := rds.NewInstance(ctx, "db", &rds.InstanceArgs{
+			InstanceClass: pulumi.String("db.t3.micro"),
+		})
+		return err
+	})
+}`,
+	},
+	{
+		name:          "azure-native:cache:Redis",
+		expectedToken: "azure-native:cache:Redis",
+		pySrc: `import pulumi_azure_native as azure_native
+cache = azure_native.cache.Redis("r", resource_group_name="rg")`,
+		tsSrc: `import * as azureNative from "@pulumi/azure-native";
+const cache = new azureNative.cache.Redis("r", { resourceGroupName: "rg" });`,
+		goSrc: `package main
+import (
+	cache "github.com/pulumi/pulumi-azure-native/sdk/v2/go/azure-native/cache"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := cache.NewRedis(ctx, "r", &cache.RedisArgs{
+			ResourceGroupName: pulumi.String("rg"),
+		})
+		return err
+	})
+}`,
+	},
+	{
+		name:          "gcp:storage:Bucket",
+		expectedToken: "gcp:storage:Bucket",
+		pySrc: `import pulumi_gcp as gcp
+bucket = gcp.storage.Bucket("b")`,
+		tsSrc: `import * as gcp from "@pulumi/gcp";
+const bucket = new gcp.storage.Bucket("b", {});`,
+		goSrc: `package main
+import (
+	storage "github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/storage"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := storage.NewBucket(ctx, "b", &storage.BucketArgs{})
+		return err
+	})
+}`,
+	},
+}
+
+func TestTypeTokenFormat_Python(t *testing.T) {
+	p := &pulumiPyParser.Parser{}
+	for _, tc := range tokenCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, docs, _, _, err := p.Parse(context.Background(), []byte(tc.pySrc), "main.py", false, 0)
+			require.NoError(t, err)
+			require.NotEmpty(t, docs, "expected at least one document for %s", tc.name)
+			assertTypeToken(t, docs[0], tc.expectedToken)
+		})
+	}
+}
+
+func TestTypeTokenFormat_TypeScript(t *testing.T) {
+	p := &pulumiTSParser.Parser{}
+	for _, tc := range tokenCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, docs, _, _, err := p.Parse(context.Background(), []byte(tc.tsSrc), "index.ts", false, 0)
+			require.NoError(t, err)
+			require.NotEmpty(t, docs, "expected at least one document for %s", tc.name)
+			assertTypeToken(t, docs[0], tc.expectedToken)
+		})
+	}
+}
+
+func TestTypeTokenFormat_Go(t *testing.T) {
+	p := &pulumiGoParser.Parser{}
+	for _, tc := range tokenCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, docs, _, _, err := p.Parse(context.Background(), []byte(tc.goSrc), "main.go", false, 0)
+			require.NoError(t, err)
+			require.NotEmpty(t, docs, "expected at least one document for %s", tc.name)
+			assertTypeToken(t, docs[0], tc.expectedToken)
+		})
+	}
+}
+
+// assertTypeToken checks that at least one resource in the document has the
+// expected type token.
+func assertTypeToken(t *testing.T, doc map[string]interface{}, want string) {
+	t.Helper()
+	resources, ok := doc["resources"].(map[string]interface{})
+	require.True(t, ok, "document must have 'resources' map")
+
+	for k, v := range resources {
+		if k == "_dd_lines" {
+			continue
+		}
+		res, ok := v.(map[string]interface{})
+		require.True(t, ok)
+		got, _ := res["type"].(string)
+		require.Equal(t, want, got,
+			"type token mismatch: Rego rule expects %q but parser emitted %q", want, got)
+		return
+	}
+	t.Fatal("no resource entries found in document")
+}

--- a/pkg/parser/pulumi/types.go
+++ b/pkg/parser/pulumi/types.go
@@ -1,0 +1,142 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package pulumi
+
+import "strings"
+
+// pythonPkgToProvider maps a Python pulumi provider package name to its Pulumi
+// type token prefix (e.g. "pulumi_aws" → "aws").
+var pythonPkgToProvider = map[string]string{
+	"pulumi_aws":              "aws",
+	"pulumi_aws_native":       "aws-native",
+	"pulumi_azure":            "azure",
+	"pulumi_azure_native":     "azure-native",
+	"pulumi_gcp":              "gcp",
+	"pulumi_google_native":    "google-native",
+	"pulumi_kubernetes":       "kubernetes",
+	"pulumi_digitalocean":     "digitalocean",
+	"pulumi_cloudflare":       "cloudflare",
+	"pulumi_random":           "random",
+	"pulumi_tls":              "tls",
+	"pulumi_github":           "github",
+	"pulumi_datadog":          "datadog",
+	"pulumi_vault":            "vault",
+	"pulumi_docker":           "docker",
+	"pulumi_postgresql":       "postgresql",
+	"pulumi_mysql":            "mysql",
+	"pulumi_mongodbatlas":     "mongodbatlas",
+	"pulumi_newrelic":         "newrelic",
+	"pulumi_pagerduty":        "pagerduty",
+	"pulumi_alicloud":         "alicloud",
+	"pulumi_openstack":        "openstack",
+	"pulumi_azure_devops":     "azuredevops",
+	"pulumi_okta":             "okta",
+	"pulumi_auth0":            "auth0",
+	"pulumi_snowflake":        "snowflake",
+	"pulumi_sumologic":        "sumologic",
+	"pulumi_eks":              "eks",
+	"pulumi_awsx":             "awsx",
+}
+
+// npmPkgToProvider maps an NPM @pulumi/<name> package to its type token prefix.
+var npmPkgToProvider = map[string]string{
+	"@pulumi/aws":            "aws",
+	"@pulumi/aws-native":     "aws-native",
+	"@pulumi/azure":          "azure",
+	"@pulumi/azure-native":   "azure-native",
+	"@pulumi/gcp":            "gcp",
+	"@pulumi/google-native":  "google-native",
+	"@pulumi/kubernetes":     "kubernetes",
+	"@pulumi/digitalocean":   "digitalocean",
+	"@pulumi/cloudflare":     "cloudflare",
+	"@pulumi/random":         "random",
+	"@pulumi/tls":            "tls",
+	"@pulumi/github":         "github",
+	"@pulumi/datadog":        "datadog",
+	"@pulumi/vault":          "vault",
+	"@pulumi/docker":         "docker",
+	"@pulumi/postgresql":     "postgresql",
+	"@pulumi/mysql":          "mysql",
+	"@pulumi/mongodbatlas":   "mongodbatlas",
+	"@pulumi/newrelic":       "newrelic",
+	"@pulumi/pagerduty":      "pagerduty",
+	"@pulumi/alicloud":       "alicloud",
+	"@pulumi/openstack":      "openstack",
+	"@pulumi/azure-devops":   "azuredevops",
+	"@pulumi/okta":           "okta",
+	"@pulumi/auth0":          "auth0",
+	"@pulumi/snowflake":      "snowflake",
+	"@pulumi/eks":            "eks",
+	"@pulumi/awsx":           "awsx",
+}
+
+// PythonPkgToProvider looks up the Pulumi type token prefix for a Python package.
+func PythonPkgToProvider(pkg string) (string, bool) {
+	p, ok := pythonPkgToProvider[pkg]
+	return p, ok
+}
+
+// NpmPkgToProvider looks up the Pulumi type token prefix for an NPM package.
+func NpmPkgToProvider(pkg string) (string, bool) {
+	p, ok := npmPkgToProvider[pkg]
+	return p, ok
+}
+
+// GoImportToProviderModule parses a Go import path of the form
+// "github.com/pulumi/pulumi-<provider>/sdk/.../go/<provider>/<module>"
+// and returns (provider, module). Returns ("", "") if the path is not a
+// recognised Pulumi provider import.
+func GoImportToProviderModule(importPath string) (provider, module string) {
+	// Must be under github.com/pulumi/pulumi-<provider>/
+	const prefix = "github.com/pulumi/pulumi-"
+	if !strings.HasPrefix(importPath, prefix) {
+		return "", ""
+	}
+	rest := importPath[len(prefix):]
+	// rest = "<provider>/sdk/.../go/<provider>/<module>" or similar
+	slashIdx := strings.Index(rest, "/")
+	if slashIdx < 0 {
+		return "", ""
+	}
+	rawProvider := rest[:slashIdx] // e.g. "aws", "azure-native", "kubernetes"
+
+	// Last path segment is the Go package name, which is the Pulumi module.
+	segments := strings.Split(importPath, "/")
+	mod := segments[len(segments)-1]
+
+	// The Go package for the top-level provider SDK (e.g. ".../go/aws") has
+	// module == provider name; skip those — callers need the sub-module.
+	// We still return them; callers decide what to do.
+	return rawProvider, mod
+}
+
+// SnakeToCamel converts a Python-style snake_case identifier to camelCase so
+// that property names extracted from Python keyword arguments match the
+// camelCase names expected by Pulumi Rego rules.
+//
+//	"publicly_accessible" → "publiclyAccessible"
+//	"monitoring"          → "monitoring"  (no change, no underscores)
+func SnakeToCamel(s string) string {
+	parts := strings.Split(s, "_")
+	for i := 1; i < len(parts); i++ {
+		if len(parts[i]) > 0 {
+			parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// BuildDDLines builds the minimal _dd_lines map for a single line, keyed by
+// field names.  Returns a map[string]interface{} suitable for embedding as
+// "_dd_lines".
+func BuildDDLines(defaultLine int, fields map[string]int) map[string]interface{} {
+	out := make(map[string]interface{}, len(fields)+1)
+	out["_dd__default"] = map[string]interface{}{"_dd_line": defaultLine}
+	for name, line := range fields {
+		out["_dd_"+name] = map[string]interface{}{"_dd_line": line}
+	}
+	return out
+}

--- a/pkg/parser/pulumi/typescript/parser.go
+++ b/pkg/parser/pulumi/typescript/parser.go
@@ -1,0 +1,1012 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+// Package typescript implements a static Pulumi-TypeScript/JavaScript parser.
+//
+// It walks the TypeScript AST to extract resource constructor calls of the form:
+//
+//	const bucket = new aws.s3.BucketV2("my-bucket", { acl: "public-read" });
+//
+// and produces a model.Document matching the Pulumi YAML schema.
+package typescript
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_typescript "github.com/tree-sitter/tree-sitter-typescript/bindings/go"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	pulumi "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi"
+)
+
+var lang = sitter.NewLanguage(tree_sitter_typescript.LanguageTypescript())
+
+// Parser implements parser.kindParser for Pulumi TypeScript programs.
+type Parser struct{}
+
+func (p *Parser) GetKind() model.FileKind        { return model.KindPulumiTypeScript }
+func (p *Parser) GetCommentToken() string         { return "//" }
+func (p *Parser) SupportedExtensions() []string   { return []string{".ts"} }
+func (p *Parser) SupportedTypes() map[string]bool { return map[string]bool{"pulumi": true} }
+
+func (p *Parser) StringifyContent(content []byte) (string, error) {
+	return string(content), nil
+}
+
+func (p *Parser) Parse(
+	ctx context.Context,
+	fileContent []byte,
+	filename string,
+	ignoreComments bool, startLine int,
+) ([]byte, []model.Document, []int, map[string]model.ResolvedFile, error) {
+	return ParseWithLanguage(ctx, lang, "pulumi typescript parser", fileContent, filename)
+}
+
+// ParseWithLanguage is the shared implementation used by both the TypeScript
+// and JavaScript parsers.
+func ParseWithLanguage(
+	ctx context.Context,
+	language *sitter.Language,
+	parserLabel string,
+	fileContent []byte,
+	filename string,
+) ([]byte, []model.Document, []int, map[string]model.ResolvedFile, error) {
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(language); err != nil {
+		return fileContent, nil, nil, nil, fmt.Errorf("%s: set language: %w", parserLabel, err)
+	}
+
+	tree := p.Parse(fileContent, nil)
+	if tree == nil {
+		return fileContent, nil, nil, nil, fmt.Errorf("%s: failed to parse file", parserLabel)
+	}
+	defer tree.Close()
+
+	root := tree.RootNode()
+
+	aliases := buildImportAliases(root, fileContent)
+	if len(aliases) == 0 {
+		return fileContent, nil, nil, nil, nil
+	}
+
+	localVars := buildLocalVars(root, fileContent)
+
+	// Merge symbols from relative imports (cross-file analysis).
+	if idx := pulumi.ProjectIndexFromContext(ctx); idx != nil {
+		for k, v := range buildCrossFileVars(root, fileContent, filename, idx) {
+			localVars[k] = v
+		}
+	}
+
+	resources := extractResources(root, fileContent, aliases, localVars)
+	if len(resources) == 0 {
+		return fileContent, nil, nil, nil, nil
+	}
+
+	resourcesMap := map[string]interface{}{}
+	resourcesDDLines := map[string]int{}
+	for name, r := range resources {
+		resourcesMap[name] = r.toMap()
+		resourcesDDLines[name] = r.line
+	}
+	resourcesMap["_dd_lines"] = pulumi.BuildDDLines(0, resourcesDDLines)
+
+	doc := model.Document{
+		"runtime":   "nodejs",
+		"resources": resourcesMap,
+		"_dd_lines": pulumi.BuildDDLines(0, map[string]int{"resources": 0}),
+	}
+
+	return fileContent, []model.Document{doc}, nil, nil, nil
+}
+
+// ── import alias resolution ──────────────────────────────────────────────────
+
+type aliasEntry struct {
+	provider string
+	module   string // non-empty for named imports like `import { s3 } from "@pulumi/aws"`
+}
+
+func buildImportAliases(root *sitter.Node, src []byte) map[string]aliasEntry {
+	aliases := map[string]aliasEntry{}
+
+	cursor := root.Walk()
+	defer cursor.Close()
+
+	var walk func()
+	walk = func() {
+		node := cursor.Node()
+		switch node.Kind() {
+		case "import_statement":
+			handleImport(node, src, aliases)
+		case "variable_declarator":
+			handleRequire(node, src, aliases)
+		}
+		if cursor.GotoFirstChild() {
+			for {
+				walk()
+				if !cursor.GotoNextSibling() {
+					break
+				}
+			}
+			cursor.GotoParent()
+		}
+	}
+	walk()
+	return aliases
+}
+
+// handleImport processes TypeScript import statements.
+//
+//	import * as aws from "@pulumi/aws"       → aliases["aws"] = {provider:"aws"}
+//	import { s3 } from "@pulumi/aws"         → aliases["s3"] = {provider:"aws", module:"s3"}
+//	import { s3 as s3mod } from "@pulumi/aws"→ aliases["s3mod"] = {provider:"aws", module:"s3"}
+func handleImport(node *sitter.Node, src []byte, out map[string]aliasEntry) {
+	// Find the source string: the last string_fragment child gives the module path.
+	pkg := importSource(node, src)
+	if pkg == "" {
+		return
+	}
+	provider, ok := pulumi.NpmPkgToProvider(pkg)
+	if !ok {
+		return
+	}
+
+	// Find the import clause.
+	clause := firstChildByKind(node, "import_clause")
+	if clause == nil {
+		return
+	}
+
+	// namespace import: * as aws
+	if ns := firstChildByKind(clause, "namespace_import"); ns != nil {
+		alias := identifierText(ns, src)
+		if alias != "" {
+			out[alias] = aliasEntry{provider: provider}
+		}
+		return
+	}
+
+	// named imports: { s3, ec2 as ec2mod }
+	if named := firstChildByKind(clause, "named_imports"); named != nil {
+		for i := uint(0); i < named.NamedChildCount(); i++ {
+			spec := named.NamedChild(i)
+			if spec == nil || spec.Kind() != "import_specifier" {
+				continue
+			}
+			// name: what it is in the module; alias: local name (may differ)
+			nameNode := spec.ChildByFieldName("name")
+			aliasNode := spec.ChildByFieldName("alias")
+			if nameNode == nil {
+				continue
+			}
+			originalName := nameNode.Utf8Text(src)
+			localName := originalName
+			if aliasNode != nil {
+				localName = aliasNode.Utf8Text(src)
+			}
+			out[localName] = aliasEntry{provider: provider, module: originalName}
+		}
+		return
+	}
+
+	// default import: import aws from "@pulumi/aws"  (uncommon for Pulumi)
+	if id := firstChildByKind(clause, "identifier"); id != nil {
+		alias := id.Utf8Text(src)
+		out[alias] = aliasEntry{provider: provider}
+	}
+}
+
+// handleRequire processes CommonJS require() assignments:
+//
+//	const aws = require("@pulumi/aws")         → aliases["aws"] = {provider:"aws"}
+//	const { s3, ec2 } = require("@pulumi/aws") → aliases["s3"]={…}, aliases["ec2"]={…}
+func handleRequire(node *sitter.Node, src []byte, out map[string]aliasEntry) {
+	valueNode := node.ChildByFieldName("value")
+	if valueNode == nil || valueNode.Kind() != "call_expression" {
+		return
+	}
+	// The call must be `require("@pulumi/…")`.
+	fn := valueNode.ChildByFieldName("function")
+	if fn == nil || fn.Utf8Text(src) != "require" {
+		return
+	}
+	args := valueNode.ChildByFieldName("arguments")
+	if args == nil {
+		return
+	}
+	pkg := ""
+	for i := uint(0); i < args.NamedChildCount(); i++ {
+		child := args.NamedChild(i)
+		if child != nil && child.Kind() == "string" {
+			pkg = strings.Trim(child.Utf8Text(src), `"'`)
+			break
+		}
+	}
+	provider, ok := pulumi.NpmPkgToProvider(pkg)
+	if !ok {
+		return
+	}
+
+	nameNode := node.ChildByFieldName("name")
+	if nameNode == nil {
+		return
+	}
+	switch nameNode.Kind() {
+	case "identifier":
+		// const aws = require("@pulumi/aws")
+		out[nameNode.Utf8Text(src)] = aliasEntry{provider: provider}
+	case "object_pattern":
+		// const { s3, ec2 as myEc2 } = require("@pulumi/aws")
+		for i := uint(0); i < nameNode.NamedChildCount(); i++ {
+			spec := nameNode.NamedChild(i)
+			if spec == nil {
+				continue
+			}
+			switch spec.Kind() {
+			case "shorthand_property_identifier_pattern":
+				name := spec.Utf8Text(src)
+				out[name] = aliasEntry{provider: provider, module: name}
+			case "pair_pattern":
+				keyNode := spec.ChildByFieldName("key")
+				valNode := spec.ChildByFieldName("value")
+				if keyNode != nil && valNode != nil {
+					out[valNode.Utf8Text(src)] = aliasEntry{provider: provider, module: keyNode.Utf8Text(src)}
+				}
+			}
+		}
+	}
+}
+
+func importSource(node *sitter.Node, src []byte) string {
+	// The module specifier is a string literal at the end of the import.
+	for i := int(node.ChildCount()) - 1; i >= 0; i-- {
+		child := node.Child(uint(i))
+		if child == nil {
+			continue
+		}
+		if child.Kind() == "string" {
+			// Strip quotes.
+			return strings.Trim(child.Utf8Text(src), `"'`)
+		}
+	}
+	return ""
+}
+
+// ── local variable resolution ────────────────────────────────────────────────
+
+func buildLocalVars(root *sitter.Node, src []byte) map[string]interface{} {
+	vars := map[string]interface{}{}
+
+	cursor := root.Walk()
+	defer cursor.Close()
+
+	var walk func()
+	walk = func() {
+		node := cursor.Node()
+		// const/let/var x = <literal>  or  x = config.get*(…) ?? default
+		if node.Kind() == "variable_declarator" {
+			nameNode := node.ChildByFieldName("name")
+			valueNode := node.ChildByFieldName("value")
+			if nameNode != nil && valueNode != nil && nameNode.Kind() == "identifier" {
+				name := nameNode.Utf8Text(src)
+				if val, ok := extractLiteral(valueNode, src, nil); ok {
+					vars[name] = val
+				} else if val, ok := extractConfigDefault(valueNode, src); ok {
+					vars[name] = val
+				}
+			}
+		}
+		// function foo() { return "literal"; } — index the return value.
+		if node.Kind() == "function_declaration" {
+			nameNode := node.ChildByFieldName("name")
+			if nameNode != nil && nameNode.Kind() == "identifier" {
+				if v, ok := extractFnBodyLiteral(node, src, nil); ok {
+					vars[nameNode.Utf8Text(src)] = v
+				}
+			}
+		}
+		if cursor.GotoFirstChild() {
+			for {
+				walk()
+				if !cursor.GotoNextSibling() {
+					break
+				}
+			}
+			cursor.GotoParent()
+		}
+	}
+	walk()
+	return vars
+}
+
+// extractFnBodyLiteral returns the single literal value returned by a zero-arg
+// arrow_function, function expression, or function_declaration node, enabling
+// calls like getDefaultAcl() to be inlined into property values.
+func extractFnBodyLiteral(node *sitter.Node, src []byte, localVars map[string]interface{}) (interface{}, bool) {
+	body := node.ChildByFieldName("body")
+	if body == nil {
+		return nil, false
+	}
+	// Concise arrow body: () => "val"
+	if body.Kind() != "statement_block" {
+		return extractLiteral(body, src, localVars)
+	}
+	// Block body: find first (or only) return_statement.
+	for i := uint(0); i < body.NamedChildCount(); i++ {
+		stmt := body.NamedChild(i)
+		if stmt == nil || stmt.Kind() != "return_statement" {
+			continue
+		}
+		// return_statement has one named child: the return value.
+		if stmt.NamedChildCount() > 0 {
+			return extractLiteral(stmt.NamedChild(0), src, localVars)
+		}
+	}
+	return nil, false
+}
+
+// buildCrossFileVars resolves relative imports against the ProjectIndex and
+// returns a variable map that is merged into the file's local variable table.
+//
+// Supported import forms:
+//
+//	import { x, y as z } from "./config"   → vars["x"]=symbols["x"], vars["z"]=symbols["y"]
+//	import * as cfg      from "./config"   → vars["cfg"]=symbols (whole map)
+//	const cfg            = require("./c")  → vars["cfg"]=symbols
+//	const { x }          = require("./c")  → vars["x"]=symbols["x"]
+func buildCrossFileVars(root *sitter.Node, src []byte, filename string, idx *pulumi.ProjectIndex) map[string]interface{} {
+	out := map[string]interface{}{}
+	cursor := root.Walk()
+	defer cursor.Close()
+
+	var walk func()
+	walk = func() {
+		node := cursor.Node()
+		switch node.Kind() {
+		case "import_statement":
+			handleLocalImport(node, src, filename, idx, out)
+		case "variable_declarator":
+			handleLocalRequire(node, src, filename, idx, out)
+		}
+		if cursor.GotoFirstChild() {
+			for {
+				walk()
+				if !cursor.GotoNextSibling() {
+					break
+				}
+			}
+			cursor.GotoParent()
+		}
+	}
+	walk()
+	return out
+}
+
+func handleLocalImport(node *sitter.Node, src []byte, filename string, idx *pulumi.ProjectIndex, out map[string]interface{}) {
+	pkg := importSource(node, src)
+	if !strings.HasPrefix(pkg, ".") {
+		return // external (Pulumi SDK etc.) — handled by buildImportAliases
+	}
+	syms := resolveModule(filename, pkg, idx)
+	if syms == nil {
+		return
+	}
+
+	clause := firstChildByKind(node, "import_clause")
+	if clause == nil {
+		return
+	}
+
+	if ns := firstChildByKind(clause, "namespace_import"); ns != nil {
+		alias := identifierText(ns, src)
+		if alias != "" {
+			out[alias] = syms.Values
+		}
+		return
+	}
+
+	if named := firstChildByKind(clause, "named_imports"); named != nil {
+		for i := uint(0); i < named.NamedChildCount(); i++ {
+			spec := named.NamedChild(i)
+			if spec == nil || spec.Kind() != "import_specifier" {
+				continue
+			}
+			nameNode := spec.ChildByFieldName("name")
+			aliasNode := spec.ChildByFieldName("alias")
+			if nameNode == nil {
+				continue
+			}
+			exportedName := nameNode.Utf8Text(src)
+			localName := exportedName
+			if aliasNode != nil {
+				localName = aliasNode.Utf8Text(src)
+			}
+			if v, ok := syms.Values[exportedName]; ok {
+				out[localName] = v
+			}
+		}
+		return
+	}
+
+	// Default import: `import cfg from "./config"` — resolve the "default" export
+	// if present, otherwise fall back to the whole symbols map.
+	if id := firstChildByKind(clause, "identifier"); id != nil {
+		name := id.Utf8Text(src)
+		if defaultVal, ok := syms.Values["default"]; ok {
+			out[name] = defaultVal
+		} else {
+			out[name] = syms.Values
+		}
+	}
+}
+
+func handleLocalRequire(node *sitter.Node, src []byte, filename string, idx *pulumi.ProjectIndex, out map[string]interface{}) {
+	valueNode := node.ChildByFieldName("value")
+	if valueNode == nil || valueNode.Kind() != "call_expression" {
+		return
+	}
+	fn := valueNode.ChildByFieldName("function")
+	if fn == nil || fn.Utf8Text(src) != "require" {
+		return
+	}
+	args := valueNode.ChildByFieldName("arguments")
+	if args == nil {
+		return
+	}
+	pkg := ""
+	for i := uint(0); i < args.NamedChildCount(); i++ {
+		child := args.NamedChild(i)
+		if child != nil && child.Kind() == "string" {
+			pkg = strings.Trim(child.Utf8Text(src), `"'`)
+			break
+		}
+	}
+	if !strings.HasPrefix(pkg, ".") {
+		return
+	}
+	syms := resolveModule(filename, pkg, idx)
+	if syms == nil {
+		return
+	}
+
+	nameNode := node.ChildByFieldName("name")
+	if nameNode == nil {
+		return
+	}
+	switch nameNode.Kind() {
+	case "identifier":
+		out[nameNode.Utf8Text(src)] = syms.Values
+	case "object_pattern":
+		for i := uint(0); i < nameNode.NamedChildCount(); i++ {
+			spec := nameNode.NamedChild(i)
+			if spec == nil {
+				continue
+			}
+			switch spec.Kind() {
+			case "shorthand_property_identifier_pattern":
+				name := spec.Utf8Text(src)
+				if v, ok := syms.Values[name]; ok {
+					out[name] = v
+				}
+			case "pair_pattern":
+				keyNode := spec.ChildByFieldName("key")
+				valNode := spec.ChildByFieldName("value")
+				if keyNode != nil && valNode != nil {
+					if v, ok := syms.Values[keyNode.Utf8Text(src)]; ok {
+						out[valNode.Utf8Text(src)] = v
+					}
+				}
+			}
+		}
+	}
+}
+
+// resolveModule resolves a relative module specifier to the matching entry in
+// the ProjectIndex by trying common file extensions.
+func resolveModule(currentFile, specifier string, idx *pulumi.ProjectIndex) *pulumi.FileSymbols {
+	dir := filepath.ToSlash(filepath.Dir(currentFile))
+	base := filepath.ToSlash(filepath.Join(dir, specifier))
+	candidates := []string{
+		base + ".ts",
+		base + ".js",
+		base + ".tsx",
+		base + ".jsx",
+		base, // specifier already carries an extension
+		base + "/index.ts",
+		base + "/index.js",
+	}
+	for _, c := range candidates {
+		if syms := idx.Lookup(c); syms != nil {
+			return syms
+		}
+	}
+	return nil
+}
+
+// ── resource extraction ──────────────────────────────────────────────────────
+
+type resource struct {
+	typeToken  string
+	line       int
+	properties map[string]propValue
+}
+
+type propValue struct {
+	value interface{}
+	line  int
+}
+
+func (r *resource) toMap() map[string]interface{} {
+	props := map[string]interface{}{}
+	propsLines := map[string]int{}
+	for k, pv := range r.properties {
+		props[k] = pv.value
+		propsLines[k] = pv.line
+	}
+	props["_dd_lines"] = pulumi.BuildDDLines(r.line, propsLines)
+
+	return map[string]interface{}{
+		"type":       r.typeToken,
+		"properties": props,
+		"_dd_lines": pulumi.BuildDDLines(r.line, map[string]int{
+			"type":       r.line,
+			"properties": r.line,
+		}),
+	}
+}
+
+func extractResources(
+	root *sitter.Node,
+	src []byte,
+	aliases map[string]aliasEntry,
+	localVars map[string]interface{},
+) map[string]*resource {
+	resources := map[string]*resource{}
+
+	cursor := root.Walk()
+	defer cursor.Close()
+
+	var walk func()
+	walk = func() {
+		node := cursor.Node()
+		// new aws.s3.BucketV2("name", { ... })
+		if node.Kind() == "new_expression" {
+			if r, name, ok := extractNewExpression(node, src, aliases, localVars); ok && name != "" {
+				resources[name] = r
+			}
+		}
+		if cursor.GotoFirstChild() {
+			for {
+				walk()
+				if !cursor.GotoNextSibling() {
+					break
+				}
+			}
+			cursor.GotoParent()
+		}
+	}
+	walk()
+	return resources
+}
+
+func extractNewExpression(
+	node *sitter.Node,
+	src []byte,
+	aliases map[string]aliasEntry,
+	localVars map[string]interface{},
+) (*resource, string, bool) {
+	constructor := node.ChildByFieldName("constructor")
+	if constructor == nil {
+		return nil, "", false
+	}
+
+	chain := memberChain(constructor, src)
+	if len(chain) < 2 {
+		return nil, "", false
+	}
+
+	entry, ok := aliases[chain[0]]
+	if !ok {
+		return nil, "", false
+	}
+
+	var typeToken string
+	rest := chain[1:]
+	if entry.module != "" {
+		segments := append(strings.Split(entry.module, "."), rest...)
+		typeToken = buildTypeToken(entry.provider, segments)
+	} else {
+		typeToken = buildTypeToken(entry.provider, rest)
+	}
+
+	line := int(node.StartPosition().Row) + 1
+
+	args := node.ChildByFieldName("arguments")
+	if args == nil {
+		return nil, "", false
+	}
+
+	logicalName, props := extractArguments(args, src, localVars)
+
+	return &resource{
+		typeToken:  typeToken,
+		line:       line,
+		properties: props,
+	}, logicalName, true
+}
+
+func extractArguments(args *sitter.Node, src []byte, localVars map[string]interface{}) (string, map[string]propValue) {
+	props := map[string]propValue{}
+	var logicalName string
+
+	positionalIdx := 0
+	for i := uint(0); i < args.NamedChildCount(); i++ {
+		child := args.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		// Unwrap TypeScript type assertions: expr as Type
+		// NamedChild(0) is always the expression; ChildByFieldName("value") is
+		// unreliable in some tree-sitter-typescript Go binding versions.
+		actual := child
+		if child.Kind() == "as_expression" && child.NamedChildCount() > 0 {
+			actual = child.NamedChild(0)
+		}
+		switch positionalIdx {
+		case 0:
+			if actual.Kind() == "string" {
+				logicalName = strings.Trim(actual.Utf8Text(src), `"'`)
+			} else if val, ok := resolveValue(actual, src, localVars); ok {
+				if s, isStr := val.(string); isStr {
+					logicalName = s
+				}
+			}
+		case 1:
+			if actual.Kind() == "object" {
+				props = extractObjectProps(actual, src, localVars)
+			} else if val, ok := resolveValue(actual, src, localVars); ok {
+				// Identifier or member expression resolving to a props map.
+				if m, ok := val.(map[string]interface{}); ok {
+					propLine := int(child.StartPosition().Row) + 1
+					for k, v := range m {
+						if k != "_dd_lines" {
+							props[k] = propValue{value: v, line: propLine}
+						}
+					}
+				}
+			}
+		}
+		positionalIdx++
+	}
+	return logicalName, props
+}
+
+func extractObjectProps(node *sitter.Node, src []byte, localVars map[string]interface{}) map[string]propValue {
+	props := map[string]propValue{}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		switch child.Kind() {
+		case "pair":
+			keyNode := child.ChildByFieldName("key")
+			valNode := child.ChildByFieldName("value")
+			if keyNode == nil || valNode == nil {
+				continue
+			}
+			key := propertyKey(keyNode, src)
+			if key == "" {
+				continue
+			}
+			propLine := int(child.StartPosition().Row) + 1
+			if val, ok := resolveValue(valNode, src, localVars); ok {
+				props[key] = propValue{value: val, line: propLine}
+			}
+		case "shorthand_property_identifier":
+			// { acl } shorthand — resolve from local vars
+			name := child.Utf8Text(src)
+			propLine := int(child.StartPosition().Row) + 1
+			if val, ok := localVars[name]; ok {
+				props[name] = propValue{value: val, line: propLine}
+			}
+		case "spread_element":
+			// { ...defaults, acl: "public-read" } — expand if the spread target is
+			// a known local variable holding a plain object.
+			if child.NamedChildCount() > 0 {
+				inner := child.NamedChild(0)
+				if inner != nil && inner.Kind() == "identifier" {
+					if val, ok := localVars[inner.Utf8Text(src)]; ok {
+						if m, ok := val.(map[string]interface{}); ok {
+							propLine := int(child.StartPosition().Row) + 1
+							for k, v := range m {
+								if _, exists := props[k]; !exists {
+									props[k] = propValue{value: v, line: propLine}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return props
+}
+
+// ── value resolution ─────────────────────────────────────────────────────────
+
+func resolveValue(node *sitter.Node, src []byte, localVars map[string]interface{}) (interface{}, bool) {
+	return extractLiteral(node, src, localVars)
+}
+
+func extractLiteral(node *sitter.Node, src []byte, localVars map[string]interface{}) (interface{}, bool) {
+	if node == nil {
+		return nil, false
+	}
+	switch node.Kind() {
+	case "string":
+		s := node.Utf8Text(src)
+		// Strip quotes and template literal backticks.
+		s = strings.Trim(s, "`\"'")
+		return s, true
+	case "number":
+		text := node.Utf8Text(src)
+		var n float64
+		fmt.Sscanf(text, "%f", &n)
+		return n, true
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	case "null", "undefined":
+		return nil, true
+	case "identifier":
+		name := node.Utf8Text(src)
+		if localVars != nil {
+			if val, ok := localVars[name]; ok {
+				return val, true
+			}
+		}
+		return nil, false
+	case "object":
+		return extractObject(node, src, localVars), true
+	case "array":
+		return extractArray(node, src, localVars), true
+	case "template_string":
+		// Collect string fragments.
+		var parts []string
+		for i := uint(0); i < node.ChildCount(); i++ {
+			child := node.Child(i)
+			if child != nil && child.Kind() == "string_fragment" {
+				parts = append(parts, child.Utf8Text(src))
+			}
+		}
+		return strings.Join(parts, ""), true
+	case "ternary_expression":
+		// Try both branches.
+		consequence := node.ChildByFieldName("consequence")
+		if v, ok := extractLiteral(consequence, src, localVars); ok {
+			return v, true
+		}
+		alternative := node.ChildByFieldName("alternative")
+		if v, ok := extractLiteral(alternative, src, localVars); ok {
+			return v, true
+		}
+		return nil, false
+	case "member_expression":
+		// Resolve cfg.key where cfg is a namespace import stored as a map.
+		obj := node.ChildByFieldName("object")
+		prop := node.ChildByFieldName("property")
+		if obj != nil && prop != nil && localVars != nil {
+			if objVal, ok := localVars[obj.Utf8Text(src)]; ok {
+				if m, ok := objVal.(map[string]interface{}); ok {
+					key := prop.Utf8Text(src)
+					if v, exists := m[key]; exists {
+						return v, true
+					}
+				}
+			}
+		}
+		return nil, false
+	case "as_expression":
+		// expr as Type — NamedChild(0) is the expression being cast.
+		if node.NamedChildCount() > 0 {
+			return extractLiteral(node.NamedChild(0), src, localVars)
+		}
+		return nil, false
+	case "type_assertion":
+		// <Type>expr (older TS prefix syntax) — last named child is the expression.
+		if node.NamedChildCount() > 0 {
+			return extractLiteral(node.NamedChild(node.NamedChildCount()-1), src, localVars)
+		}
+		return nil, false
+	case "binary_expression":
+		// Handle `config.getBoolean("x") ?? false` — nullish coalescing.
+		op := node.ChildByFieldName("operator")
+		if op != nil && op.Utf8Text(src) == "??" {
+			right := node.ChildByFieldName("right")
+			if v, ok := extractLiteral(right, src, localVars); ok {
+				return v, true
+			}
+		}
+		return nil, false
+	case "arrow_function", "function":
+		// Zero-arg arrow/function expression: () => "val"  or  () => { return "val"; }
+		if v, ok := extractFnBodyLiteral(node, src, localVars); ok {
+			return v, true
+		}
+		return nil, false
+	case "call_expression":
+		// If the callee is a zero-arg function already indexed in localVars, use
+		// its stored return value (e.g. const acl = getDefaultAcl()).
+		fn := node.ChildByFieldName("function")
+		if fn != nil && fn.Kind() == "identifier" && localVars != nil {
+			if v, ok := localVars[fn.Utf8Text(src)]; ok {
+				return v, true
+			}
+		}
+		// Delegate to config-default extraction.
+		return extractConfigDefault(node, src)
+	}
+	return nil, false
+}
+
+// extractConfigDefault resolves a config.get*/require* call to its nullish
+// coalescing default (right side of ??) or the getter's zero value by type.
+//
+// Patterns handled:
+//
+//	config.getBoolean("key") ?? false          → false   (via binary_expression above)
+//	config.get("key") ?? "us-east-1"           → "us-east-1"
+//	config.requireBoolean("key")               → false (zero value)
+func extractConfigDefault(node *sitter.Node, src []byte) (interface{}, bool) {
+	if node == nil || node.Kind() != "call_expression" {
+		return nil, false
+	}
+	fn := node.ChildByFieldName("function")
+	if fn == nil {
+		return nil, false
+	}
+	fnText := fn.Utf8Text(src)
+	if !isConfigGetter(fnText) {
+		return nil, false
+	}
+	zv, _ := configZeroValue(fnText)
+	return zv, true
+}
+
+var tsConfigGetterSuffixes = []string{
+	".getBoolean", ".getNumber", ".getSecret", ".getSecretBoolean",
+	".getSecretNumber", ".getSecretObject", ".getObject",
+	".get", ".requireBoolean", ".requireNumber", ".requireSecret",
+	".requireSecretBoolean", ".requireObject", ".require",
+}
+
+func isConfigGetter(fnText string) bool {
+	for _, s := range tsConfigGetterSuffixes {
+		if strings.HasSuffix(fnText, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func configZeroValue(fnText string) (interface{}, bool) {
+	switch {
+	case strings.Contains(fnText, "Boolean") || strings.Contains(fnText, "Bool"):
+		return false, true
+	case strings.Contains(fnText, "Number") || strings.Contains(fnText, "Int") || strings.Contains(fnText, "Float"):
+		return 0, true
+	default:
+		return "", true
+	}
+}
+
+func extractObject(node *sitter.Node, src []byte, localVars map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{}
+	ddLines := map[string]int{}
+	line := int(node.StartPosition().Row) + 1
+
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil || child.Kind() != "pair" {
+			continue
+		}
+		keyNode := child.ChildByFieldName("key")
+		valNode := child.ChildByFieldName("value")
+		if keyNode == nil || valNode == nil {
+			continue
+		}
+		key := propertyKey(keyNode, src)
+		propLine := int(child.StartPosition().Row) + 1
+		if val, ok := extractLiteral(valNode, src, localVars); ok {
+			out[key] = val
+			ddLines[key] = propLine
+		}
+	}
+	out["_dd_lines"] = pulumi.BuildDDLines(line, ddLines)
+	return out
+}
+
+func extractArray(node *sitter.Node, src []byte, localVars map[string]interface{}) []interface{} {
+	var out []interface{}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		if val, ok := extractLiteral(child, src, localVars); ok {
+			out = append(out, val)
+		}
+	}
+	return out
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func memberChain(node *sitter.Node, src []byte) []string {
+	switch node.Kind() {
+	case "identifier":
+		return []string{node.Utf8Text(src)}
+	case "member_expression":
+		obj := node.ChildByFieldName("object")
+		prop := node.ChildByFieldName("property")
+		if obj == nil || prop == nil {
+			return nil
+		}
+		return append(memberChain(obj, src), prop.Utf8Text(src))
+	}
+	return nil
+}
+
+func propertyKey(node *sitter.Node, src []byte) string {
+	switch node.Kind() {
+	case "property_identifier", "identifier":
+		return node.Utf8Text(src)
+	case "string":
+		return strings.Trim(node.Utf8Text(src), `"'`)
+	}
+	return ""
+}
+
+func firstChildByKind(node *sitter.Node, kind string) *sitter.Node {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child != nil && child.Kind() == kind {
+			return child
+		}
+	}
+	return nil
+}
+
+func identifierText(node *sitter.Node, src []byte) string {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child != nil && child.Kind() == "identifier" {
+			return child.Utf8Text(src)
+		}
+	}
+	return ""
+}
+
+func buildTypeToken(provider string, segments []string) string {
+	if len(segments) == 0 {
+		return provider
+	}
+	class := segments[len(segments)-1]
+	moduleParts := segments[:len(segments)-1]
+	module := strings.Join(moduleParts, "/")
+	if module == "" {
+		return provider + "::" + class
+	}
+	return provider + ":" + module + ":" + class
+}

--- a/pkg/parser/pulumi/typescript/parser_test.go
+++ b/pkg/parser/pulumi/typescript/parser_test.go
@@ -1,0 +1,310 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package typescript
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParser_GetKind(t *testing.T) {
+	require.Equal(t, model.KindPulumiTypeScript, (&Parser{}).GetKind())
+}
+
+func TestParser_SupportedExtensions(t *testing.T) {
+	require.Equal(t, []string{".ts"}, (&Parser{}).SupportedExtensions())
+}
+
+func TestParser_SupportedTypes(t *testing.T) {
+	require.Equal(t, map[string]bool{"pulumi": true}, (&Parser{}).SupportedTypes())
+}
+
+// TestParser_Parse_S3Bucket verifies that a new aws.s3.BucketV2 call is
+// extracted and represented with the correct type token and properties.
+func TestParser_Parse_S3Bucket(t *testing.T) {
+	src := []byte(`
+import * as aws from "@pulumi/aws";
+
+const bucket = new aws.s3.BucketV2("my-bucket", {
+    acl: "public-read",
+});
+`)
+	p := &Parser{}
+	_, docs, _, _, err := p.Parse(context.Background(), src, "index.ts", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1, "expected exactly one document")
+
+	resources, ok := docs[0]["resources"].(map[string]interface{})
+	require.True(t, ok, "document must have a 'resources' map")
+
+	var res map[string]interface{}
+	for k, v := range resources {
+		if k == "_dd_lines" {
+			continue
+		}
+		res, ok = v.(map[string]interface{})
+		require.True(t, ok)
+		break
+	}
+	require.NotNil(t, res, "expected at least one resource entry")
+
+	typ, _ := res["type"].(string)
+	require.Contains(t, typ, "aws:", "resource type should contain provider prefix")
+	require.Contains(t, typ, "BucketV2", "resource type should preserve constructor name")
+
+	props, ok := res["properties"].(map[string]interface{})
+	require.True(t, ok, "resource must have properties")
+	require.Equal(t, "public-read", props["acl"])
+}
+
+// TestParser_Parse_NoImport verifies that a TypeScript file without Pulumi SDK
+// imports produces no documents.
+func TestParser_Parse_NoImport(t *testing.T) {
+	src := []byte(`
+import * as fs from "fs";
+const data = fs.readFileSync("file.txt");
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "util.ts", false, 0)
+	require.NoError(t, err)
+	require.Empty(t, docs, "non-Pulumi file must produce no documents")
+}
+
+// TestParser_Parse_MultiResource verifies that multiple new Resource() calls
+// in a single file all appear in the extracted document.
+func TestParser_Parse_MultiResource(t *testing.T) {
+	src := []byte(`
+import * as aws from "@pulumi/aws";
+
+const vpc = new aws.ec2.Vpc("main-vpc", { cidrBlock: "10.0.0.0/16" });
+const sg  = new aws.ec2.SecurityGroup("web-sg", { vpcId: vpc.id });
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "infra.ts", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, ok := docs[0]["resources"].(map[string]interface{})
+	require.True(t, ok)
+
+	count := 0
+	for k := range resources {
+		if k != "_dd_lines" {
+			count++
+		}
+	}
+	require.Equal(t, 2, count, "expected two resource entries")
+}
+
+// TestParser_Parse_RequireImport verifies CommonJS require() style imports.
+func TestParser_Parse_RequireImport(t *testing.T) {
+	src := []byte(`
+const aws = require("@pulumi/aws");
+const bucket = new aws.s3.BucketV2("my-bucket", { acl: "private" });
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "index.ts", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["my-bucket"].(map[string]interface{})
+	require.True(t, ok, "expected resource keyed by 'my-bucket'")
+	require.Equal(t, "aws:s3:BucketV2", res["type"])
+}
+
+// TestParser_Parse_RequireDestructure verifies `const { s3 } = require("@pulumi/aws")`.
+func TestParser_Parse_RequireDestructure(t *testing.T) {
+	src := []byte(`
+const { s3 } = require("@pulumi/aws");
+const bucket = new s3.BucketV2("b", { acl: "public-read" });
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "index.ts", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["b"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "aws:s3:BucketV2", res["type"])
+}
+
+// TestParser_Parse_SpreadProps verifies that spread elements resolved from local
+// vars contribute their properties to the resource.
+func TestParser_Parse_SpreadProps(t *testing.T) {
+	src := []byte(`
+import * as aws from "@pulumi/aws";
+const defaults = { acl: "private" };
+const bucket = new aws.s3.BucketV2("b", { ...defaults, versioning: true });
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "index.ts", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["b"].(map[string]interface{})
+	require.True(t, ok)
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, "private", props["acl"], "spread property should be present")
+	require.Equal(t, true, props["versioning"], "explicit property should still be present")
+}
+
+// TestParser_ConfigDefault verifies that config.getBoolean() ?? false and
+// config.get() are resolved to their nullish-coalescing defaults.
+func TestParser_ConfigDefault(t *testing.T) {
+	src := []byte(`
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+const config = new pulumi.Config();
+const publicAccess = config.getBoolean("publicAccess") ?? true;
+const region = config.get("region") ?? "us-east-1";
+const db = new aws.rds.Instance("my-db", {
+    publiclyAccessible: publicAccess,
+    availabilityZone: region,
+});
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "index.ts", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["my-db"].(map[string]interface{})
+	require.True(t, ok)
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, true, props["publiclyAccessible"], "should resolve ?? true")
+	require.Equal(t, "us-east-1", props["availabilityZone"], "should resolve ?? string default")
+}
+
+// TestParser_AsTypeAssertion verifies that TypeScript `as` type assertions on
+// the logical name, property values, and the whole args object are unwrapped.
+func TestParser_AsTypeAssertion(t *testing.T) {
+	src := []byte(`
+import * as aws from "@pulumi/aws";
+
+const acl = "private" as string;
+const bucket = new aws.s3.BucketV2("as-bucket" as string, {
+    acl: "public-read" as aws.s3.CannedAcl,
+});
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "index.ts", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["as-bucket"].(map[string]interface{})
+	require.True(t, ok, "resource should be found by unwrapped name")
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, "public-read", props["acl"], "property value should be unwrapped from as-expression")
+}
+
+// TestParser_AsTypeAssertionArgsObject verifies that a whole args object wrapped
+// in `as` is correctly unwrapped and its properties are extracted.
+func TestParser_AsTypeAssertionArgsObject(t *testing.T) {
+	src := []byte(`
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const bucket = new aws.s3.BucketV2("b2", { acl: "private" } as pulumi.Inputs);
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "index.ts", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["b2"].(map[string]interface{})
+	require.True(t, ok)
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, "private", props["acl"])
+}
+
+// TestParser_TypeAssertionPrefix verifies that the older <Type>expr prefix
+// assertion is correctly unwrapped so the inner value is used.
+func TestParser_TypeAssertionPrefix(t *testing.T) {
+	src := []byte(`
+import * as aws from "@pulumi/aws";
+
+const bucket = new aws.s3.BucketV2(<string>"type-assert-bucket", {
+    acl: <string>"public-read",
+});
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "index.ts", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["type-assert-bucket"].(map[string]interface{})
+	require.True(t, ok, "resource should be found with unwrapped name")
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, "public-read", props["acl"])
+}
+
+// TestParser_ZeroArgFunctionCall verifies that a zero-arg function whose return
+// value is a literal is resolved when used as a resource property.
+func TestParser_ZeroArgFunctionCall(t *testing.T) {
+	src := []byte(`
+import * as aws from "@pulumi/aws";
+
+function getDefaultAcl() {
+    return "private";
+}
+
+const bucket = new aws.s3.BucketV2("fn-bucket", {
+    acl: getDefaultAcl(),
+});
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "index.ts", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["fn-bucket"].(map[string]interface{})
+	require.True(t, ok)
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, "private", props["acl"])
+}
+
+// TestParser_ZeroArgArrowCall verifies that a zero-arg arrow function constant
+// is resolved when called as a resource property value.
+func TestParser_ZeroArgArrowCall(t *testing.T) {
+	src := []byte(`
+import * as aws from "@pulumi/aws";
+
+const getRegion = () => "us-east-1";
+
+const bucket = new aws.s3.BucketV2("arrow-bucket", {
+    region: getRegion(),
+});
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "index.ts", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["arrow-bucket"].(map[string]interface{})
+	require.True(t, ok)
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, "us-east-1", props["region"])
+}
+
+// TestParser_ArgsIdentifierVariable verifies that an identifier resolving to a
+// local object variable is expanded as the resource's properties.
+func TestParser_ArgsIdentifierVariable(t *testing.T) {
+	src := []byte(`
+import * as aws from "@pulumi/aws";
+
+const bucketArgs = { acl: "public-read", versioning: true };
+const bucket = new aws.s3.BucketV2("id-bucket", bucketArgs);
+`)
+	_, docs, _, _, err := (&Parser{}).Parse(context.Background(), src, "index.ts", false, 0)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	resources, _ := docs[0]["resources"].(map[string]interface{})
+	res, ok := resources["id-bucket"].(map[string]interface{})
+	require.True(t, ok)
+	props, _ := res["properties"].(map[string]interface{})
+	require.Equal(t, "public-read", props["acl"])
+}

--- a/pkg/runner/prepare.go
+++ b/pkg/runner/prepare.go
@@ -13,6 +13,8 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	pulumi "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/projectindex"
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/pkg/errors"
 )
@@ -54,6 +56,18 @@ func PrepareSharedWalk(ctx context.Context,
 	}
 
 	contextLogger.Info().Msgf("Collected %d files to process across %d parsers", len(files), len(services))
+
+	// Build the Pulumi cross-file symbol index once and attach it to the shared
+	// context so all language parsers can resolve relative imports without an
+	// extra repo walk.
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		paths = append(paths, f.Path)
+	}
+	idx := projectindex.Build(paths, fsp.ContentCache())
+	if len(idx.ByFile) > 0 {
+		ctx = pulumi.WithProjectIndex(ctx, idx)
+	}
 
 	routing := buildExtensionRouting(services)
 

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -26,6 +26,10 @@ import (
 	dockerParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/docker"
 	protoParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/grpc"
 	jsonParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/json"
+	pulumiGoParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/golang"
+	pulumiJSParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/javascript"
+	pulumiPyParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/python"
+	pulumiTSParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/pulumi/typescript"
 	terraformParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform"
 	cicdParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/cicd"
 	yamlParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/default"
@@ -299,7 +303,11 @@ func (c *Client) createService(
 		Add(&protoParser.Parser{}).
 		Add(&buildahParser.Parser{}).
 		Add(&ansibleConfigParser.Parser{}).
-		Add(&ansibleHostsParser.Parser{})
+		Add(&ansibleHostsParser.Parser{}).
+		Add(&pulumiPyParser.Parser{}).
+		Add(&pulumiTSParser.Parser{}).
+		Add(&pulumiJSParser.Parser{}).
+		Add(&pulumiGoParser.Parser{})
 
 	if c.ScanParams.ShouldScanTfPlans {
 		combinedParserBuilder.Add(&jsonParser.Parser{})


### PR DESCRIPTION
## Motivation

The scanner has no first-class support for Pulumi programs written in Python, TypeScript, JavaScript, or Go. This POC explores parsing those sources into a normalized YAML-like document shape so existing Rego rules can evaluate Pulumi resources without a separate rule set per language.

The branch also includes a single-repository walk optimization that feeds a shared file cache and project index into the new parsers.

## Changes

**Scan pipeline**

The analyzer walks the repository once, caches file contents, and exposes inventory metadata so parsers can resolve cross-file symbols without re-reading the tree.

**Pulumi platform (POC)**

New parsers for Python, TypeScript, JavaScript, and Go extract Pulumi resource constructor calls and emit documents compatible with the existing Pulumi YAML rule format. A project index maps exported constants, variables, and zero-argument helper functions across sibling files. Static resolution covers literals, config defaults, imports, object spreads, type assertions, string concatenation, and locally defined helper calls.

**Integration**

Parsers register through the existing prepare path and attach to the scan pipeline behind new model kinds for each language.

## QA Instruction

1. `GOFLAGS="-mod=mod" go test ./pkg/parser/pulumi/...`
2. `go test ./pkg/analyzer/... ./pkg/runner/...`
3. Scan a small Pulumi Python or TypeScript project and confirm resources appear in the normalized document output.

## Impact

POC only. Adds new parser packages and scan wiring; does not ship production-ready Pulumi rule coverage. The repository-walk changes affect all platforms that use the shared filesystem provider.