### PR TITLE
Add arguments to rule metadata

### DIFF
--- a/pkg/datadog/client.go
+++ b/pkg/datadog/client.go
@@ -264,28 +264,29 @@ type Ruleset struct {
 
 // Rule defines the structure of a rule that's stored in Datadog.
 type Rule struct {
-	ID                string         `jsonapi:"primary,iac_rule" json:"id"`
-	Name              string         `jsonapi:"attribute" json:"name"`
-	LegacyId          *string        `jsonapi:"attribute" json:"legacy_id,omitempty"`
-	ShortDescription  string         `jsonapi:"attribute" json:"short_description"`
-	Description       string         `jsonapi:"attribute" json:"description"`
-	DescriptionId     *string        `jsonapi:"attribute" json:"description_id,omitempty"`
-	Platform          string         `jsonapi:"attribute" json:"platform"`
-	Type              string         `jsonapi:"attribute" json:"type"`
-	RegoQuery         []byte         `jsonapi:"attribute" json:"rego_query"`
-	Severity          string         `jsonapi:"attribute" json:"severity"`
-	Category          string         `jsonapi:"attribute" json:"category"`
-	Provider          *string        `jsonapi:"attribute" json:"provider,omitempty"`
-	Cwe               *string        `jsonapi:"attribute" json:"cwe,omitempty"`
-	DocumentationUrl  *string        `jsonapi:"attribute" json:"documentation_url,omitempty"`
-	ProviderUrl       *string        `jsonapi:"attribute" json:"provider_url,omitempty"`
-	Aggregation       *int           `jsonapi:"attribute" json:"aggregation,omitempty"`
-	Overrides         []RuleOverride `jsonapi:"attribute" json:"overrides,omitempty"`
-	DefaultFrameworks []Framework    `jsonapi:"attribute" json:"default_frameworks,omitempty"`
-	CustomFrameworks  []Framework    `jsonapi:"attribute" json:"custom_frameworks,omitempty"`
-	Tests             *RuleTests     `jsonapi:"attribute" json:"tests,omitempty"`
-	IsTesting         bool           `jsonapi:"attribute" json:"is_testing"`
-	IsPublished       bool           `jsonapi:"attribute" json:"is_published"`
+	ID                string            `jsonapi:"primary,iac_rule" json:"id"`
+	Name              string            `jsonapi:"attribute" json:"name"`
+	LegacyId          *string           `jsonapi:"attribute" json:"legacy_id,omitempty"`
+	ShortDescription  string            `jsonapi:"attribute" json:"short_description"`
+	Description       string            `jsonapi:"attribute" json:"description"`
+	DescriptionId     *string           `jsonapi:"attribute" json:"description_id,omitempty"`
+	Platform          string            `jsonapi:"attribute" json:"platform"`
+	Type              string            `jsonapi:"attribute" json:"type"`
+	RegoQuery         []byte            `jsonapi:"attribute" json:"rego_query"`
+	Severity          string            `jsonapi:"attribute" json:"severity"`
+	Category          string            `jsonapi:"attribute" json:"category"`
+	Provider          *string           `jsonapi:"attribute" json:"provider,omitempty"`
+	Cwe               *string           `jsonapi:"attribute" json:"cwe,omitempty"`
+	Arguments         map[string]string `jsonapi:"attribute" json:"arguments,omitempty"`
+	DocumentationUrl  *string           `jsonapi:"attribute" json:"documentation_url,omitempty"`
+	ProviderUrl       *string           `jsonapi:"attribute" json:"provider_url,omitempty"`
+	Aggregation       *int              `jsonapi:"attribute" json:"aggregation,omitempty"`
+	Overrides         []RuleOverride    `jsonapi:"attribute" json:"overrides,omitempty"`
+	DefaultFrameworks []Framework       `jsonapi:"attribute" json:"default_frameworks,omitempty"`
+	CustomFrameworks  []Framework       `jsonapi:"attribute" json:"custom_frameworks,omitempty"`
+	Tests             *RuleTests        `jsonapi:"attribute" json:"tests,omitempty"`
+	IsTesting         bool              `jsonapi:"attribute" json:"is_testing"`
+	IsPublished       bool              `jsonapi:"attribute" json:"is_published"`
 }
 
 // RuleTests holds the test suite stored alongside a rule in the backend.

--- a/pkg/datadog/client.go
+++ b/pkg/datadog/client.go
@@ -264,29 +264,35 @@ type Ruleset struct {
 
 // Rule defines the structure of a rule that's stored in Datadog.
 type Rule struct {
-	ID                string            `jsonapi:"primary,iac_rule" json:"id"`
-	Name              string            `jsonapi:"attribute" json:"name"`
-	LegacyId          *string           `jsonapi:"attribute" json:"legacy_id,omitempty"`
-	ShortDescription  string            `jsonapi:"attribute" json:"short_description"`
-	Description       string            `jsonapi:"attribute" json:"description"`
-	DescriptionId     *string           `jsonapi:"attribute" json:"description_id,omitempty"`
-	Platform          string            `jsonapi:"attribute" json:"platform"`
-	Type              string            `jsonapi:"attribute" json:"type"`
-	RegoQuery         []byte            `jsonapi:"attribute" json:"rego_query"`
-	Severity          string            `jsonapi:"attribute" json:"severity"`
-	Category          string            `jsonapi:"attribute" json:"category"`
-	Provider          *string           `jsonapi:"attribute" json:"provider,omitempty"`
-	Cwe               *string           `jsonapi:"attribute" json:"cwe,omitempty"`
-	Arguments         map[string]string `jsonapi:"attribute" json:"arguments,omitempty"`
-	DocumentationUrl  *string           `jsonapi:"attribute" json:"documentation_url,omitempty"`
-	ProviderUrl       *string           `jsonapi:"attribute" json:"provider_url,omitempty"`
-	Aggregation       *int              `jsonapi:"attribute" json:"aggregation,omitempty"`
-	Overrides         []RuleOverride    `jsonapi:"attribute" json:"overrides,omitempty"`
-	DefaultFrameworks []Framework       `jsonapi:"attribute" json:"default_frameworks,omitempty"`
-	CustomFrameworks  []Framework       `jsonapi:"attribute" json:"custom_frameworks,omitempty"`
-	Tests             *RuleTests        `jsonapi:"attribute" json:"tests,omitempty"`
-	IsTesting         bool              `jsonapi:"attribute" json:"is_testing"`
-	IsPublished       bool              `jsonapi:"attribute" json:"is_published"`
+	ID                string         `jsonapi:"primary,iac_rule" json:"id"`
+	Name              string         `jsonapi:"attribute" json:"name"`
+	LegacyId          *string        `jsonapi:"attribute" json:"legacy_id,omitempty"`
+	ShortDescription  string         `jsonapi:"attribute" json:"short_description"`
+	Description       string         `jsonapi:"attribute" json:"description"`
+	DescriptionId     *string        `jsonapi:"attribute" json:"description_id,omitempty"`
+	Platform          string         `jsonapi:"attribute" json:"platform"`
+	Type              string         `jsonapi:"attribute" json:"type"`
+	RegoQuery         []byte         `jsonapi:"attribute" json:"rego_query"`
+	Severity          string         `jsonapi:"attribute" json:"severity"`
+	Category          string         `jsonapi:"attribute" json:"category"`
+	Provider          *string        `jsonapi:"attribute" json:"provider,omitempty"`
+	Cwe               *string        `jsonapi:"attribute" json:"cwe,omitempty"`
+	Arguments         []RuleArgument `jsonapi:"attribute" json:"arguments,omitempty"`
+	DocumentationUrl  *string        `jsonapi:"attribute" json:"documentation_url,omitempty"`
+	ProviderUrl       *string        `jsonapi:"attribute" json:"provider_url,omitempty"`
+	Aggregation       *int           `jsonapi:"attribute" json:"aggregation,omitempty"`
+	Overrides         []RuleOverride `jsonapi:"attribute" json:"overrides,omitempty"`
+	DefaultFrameworks []Framework    `jsonapi:"attribute" json:"default_frameworks,omitempty"`
+	CustomFrameworks  []Framework    `jsonapi:"attribute" json:"custom_frameworks,omitempty"`
+	Tests             *RuleTests     `jsonapi:"attribute" json:"tests,omitempty"`
+	IsTesting         bool           `jsonapi:"attribute" json:"is_testing"`
+	IsPublished       bool           `jsonapi:"attribute" json:"is_published"`
+}
+
+// RuleArgument describes one configurable argument exposed by a rule.
+type RuleArgument struct {
+	Name        string `jsonapi:"attribute" json:"name"`
+	Description string `jsonapi:"attribute" json:"description"`
 }
 
 // RuleTests holds the test suite stored alongside a rule in the backend.

--- a/pkg/engine/source/datadog.go
+++ b/pkg/engine/source/datadog.go
@@ -253,7 +253,7 @@ func ConvertRule(rule *datadog.Rule) model.QueryMetadata {
 		out.Metadata["cwe"] = ""
 	}
 	if len(rule.Arguments) > 0 {
-		out.Metadata["arguments"] = rule.Arguments
+		out.Metadata["arguments"] = ruleArgumentsToMeta(rule.Arguments)
 	}
 	if rule.Aggregation != nil {
 		out.Metadata["aggregation"] = *rule.Aggregation
@@ -301,6 +301,17 @@ func frameworksToMeta(fs []datadog.Framework) []any {
 			"framework_version": f.Version,
 			"requirement":       f.Requirement,
 			"control":           f.Control,
+		}
+	}
+	return result
+}
+
+func ruleArgumentsToMeta(args []datadog.RuleArgument) []any {
+	result := make([]any, len(args))
+	for i, arg := range args {
+		result[i] = map[string]any{
+			"name":        arg.Name,
+			"description": arg.Description,
 		}
 	}
 	return result

--- a/pkg/engine/source/datadog.go
+++ b/pkg/engine/source/datadog.go
@@ -252,6 +252,9 @@ func ConvertRule(rule *datadog.Rule) model.QueryMetadata {
 	} else {
 		out.Metadata["cwe"] = ""
 	}
+	if len(rule.Arguments) > 0 {
+		out.Metadata["arguments"] = rule.Arguments
+	}
 	if rule.Aggregation != nil {
 		out.Metadata["aggregation"] = *rule.Aggregation
 		out.Aggregation = *rule.Aggregation

--- a/pkg/engine/source/datadog_test.go
+++ b/pkg/engine/source/datadog_test.go
@@ -354,16 +354,22 @@ func TestConvertRuleIncludesArgumentsInMetadata(t *testing.T) {
 		Severity:         "HIGH",
 		Category:         "Best Practices",
 		Provider:         ptr("aws"),
-		Arguments: map[string]string{
-			"required_tags": `["Env"]`,
+		Arguments: []datadog.RuleArgument{
+			{
+				Name:        "required_tags",
+				Description: "Tags that must exist on the resource",
+			},
 		},
 		IsPublished: true,
 	}
 
 	query := ConvertRule(rule)
 
-	assert.Equal(t, map[string]string{
-		"required_tags": `["Env"]`,
+	assert.Equal(t, []any{
+		map[string]any{
+			"name":        "required_tags",
+			"description": "Tags that must exist on the resource",
+		},
 	}, query.Metadata["arguments"])
 }
 

--- a/pkg/engine/source/datadog_test.go
+++ b/pkg/engine/source/datadog_test.go
@@ -341,6 +341,32 @@ func TestSourceWithWantedProviders(t *testing.T) {
 	}
 }
 
+func TestConvertRuleIncludesArgumentsInMetadata(t *testing.T) {
+	rule := &datadog.Rule{
+		ID:               "terraform-aws-required-tags",
+		Name:             "required_tags",
+		ShortDescription: "Required tags are missing",
+		Description:      "Ensure required tags are present",
+		DescriptionId:    ptr("required-tags"),
+		Platform:         "Terraform",
+		Type:             "rego",
+		RegoQuery:        []byte("package datadog"),
+		Severity:         "HIGH",
+		Category:         "Best Practices",
+		Provider:         ptr("aws"),
+		Arguments: map[string]string{
+			"required_tags": `["Env"]`,
+		},
+		IsPublished: true,
+	}
+
+	query := ConvertRule(rule)
+
+	assert.Equal(t, map[string]string{
+		"required_tags": `["Env"]`,
+	}, query.Metadata["arguments"])
+}
+
 var rules = []*datadog.Rule{
 	{
 		ID:               "dockerfile-gcp-rule-1",


### PR DESCRIPTION
## Motivation

This PR is part of the effort to add rule-specific arguments management in the Infrastructure as Code scanning.
To let the backend know what rule can use what arguments, we added them to rule metadata in [this PR](https://github.com/DataDog/datadog-iac-scanner-default-rules/pull/45). The scanner then need to parse this new metadata entry for the rules checks to pass.

JIRA Ticket : [Support arguments in IaC rule configurations](https://datadoghq.atlassian.net/browse/K9CODESEC-1940)

## Changes

- Add arguments to the rule struct
- Add a conversion helper from rule to metadata and vice versa
- Add unit test for the conversion

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction
To run the new unit test, run
```
go test ./pkg/engine/source -run TestConvertRuleIncludesArgumentsInMetadata -v -count=1
```

You can also test that all source package unit tests still pass by running
```
go test ./pkg/engine/source -v -count=1
```

## Blast Radius

This PR changes metadata parsing and conversion. It should not affect scanning behavior.

## Additional Notes

I submit this contribution under the Apache-2.0 license.
