### PR TITLE
Add fetch-bundle + scan --offline-bundle-path for network-isolated scans

### DIFF
--- a/cmd/scanner/fetch_bundle.go
+++ b/cmd/scanner/fetch_bundle.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-iac-scanner/internal/constants"
+	"github.com/DataDog/datadog-iac-scanner/pkg/config"
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
+	cli "github.com/urfave/cli/v3"
+)
+
+const (
+	bundleConfigFileName    = "config.yaml"
+	bundleRulesFileName     = "rules.json"
+	bundleLibrariesFileName = "libraries.json"
+)
+
+var fetchBundleAction = &cli.Command{
+	Name: "fetch-bundle",
+	Usage: "Fetches the default ruleset, Rego libraries, and merged remote " +
+		"configuration for a repository and writes them to local files, for " +
+		"later use with `scan --offline-bundle-path` in a network-isolated environment",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "repo-path",
+			Usage: "repository root path, used to discover a local configuration file",
+			Value: ".",
+		},
+		&cli.StringFlag{
+			Name:     "repo-url",
+			Usage:    "repository URL, used to request repository-specific server-side configuration",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "output-dir",
+			Usage:    "directory to write the bundle files to",
+			Required: true,
+		},
+	},
+	Action: fetchBundle,
+}
+
+func fetchBundle(ctx context.Context, c *cli.Command) error {
+	repoPath, err := getAbsolutePath(c.String("repo-path"))
+	if err != nil {
+		return err
+	}
+	outputDir, err := getAbsolutePath(c.String("output-dir"))
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(outputDir, dirPerms); err != nil {
+		return errorWithExitCode(fmt.Errorf("could not create output directory: %w", err), constants.EngineErrorCode)
+	}
+
+	client := datadog.NewDatadogClient()
+
+	_, cfgBytes, err := config.ReadConfiguration(ctx, repoPath, config.WithDatadog(client, c.String("repo-url")))
+	if err != nil {
+		return errorWithExitCode(fmt.Errorf("error reading the configuration: %w", err), constants.EngineErrorCode)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, bundleConfigFileName), cfgBytes, filePerms); err != nil {
+		return errorWithExitCode(fmt.Errorf("error writing the configuration bundle: %w", err), constants.EngineErrorCode)
+	}
+
+	ruleset, err := client.GetDefaultRuleset(ctx)
+	if err != nil {
+		return errorWithExitCode(fmt.Errorf("error fetching the default ruleset: %w", err), constants.EngineErrorCode)
+	}
+	rulesetBytes, err := json.Marshal(ruleset)
+	if err != nil {
+		return errorWithExitCode(fmt.Errorf("error marshaling the default ruleset: %w", err), constants.EngineErrorCode)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, bundleRulesFileName), rulesetBytes, filePerms); err != nil {
+		return errorWithExitCode(fmt.Errorf("error writing the ruleset bundle: %w", err), constants.EngineErrorCode)
+	}
+
+	libraries, err := client.GetLibraries(ctx)
+	if err != nil {
+		return errorWithExitCode(fmt.Errorf("error fetching libraries: %w", err), constants.EngineErrorCode)
+	}
+	librariesBytes, err := json.Marshal(libraries)
+	if err != nil {
+		return errorWithExitCode(fmt.Errorf("error marshaling libraries: %w", err), constants.EngineErrorCode)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, bundleLibrariesFileName), librariesBytes, filePerms); err != nil {
+		return errorWithExitCode(fmt.Errorf("error writing the libraries bundle: %w", err), constants.EngineErrorCode)
+	}
+
+	fmt.Printf("Wrote offline bundle (%d rules, %d libraries) to %s\n", len(ruleset.Rules), len(libraries), outputDir)
+	return nil
+}

--- a/cmd/scanner/fetch_bundle.go
+++ b/cmd/scanner/fetch_bundle.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
@@ -17,7 +18,17 @@ const (
 	bundleConfigFileName    = "config.yaml"
 	bundleRulesFileName     = "rules.json"
 	bundleLibrariesFileName = "libraries.json"
+	bundleManifestFileName  = "manifest.json"
 )
+
+// bundleManifest records when and for which repository an offline bundle was
+// fetched, so that `scan --offline-bundle-path` can warn about a stale bundle
+// instead of silently running against outdated rules.
+type bundleManifest struct {
+	RepoURL        string    `json:"repo_url"`
+	FetchedAt      time.Time `json:"fetched_at"`
+	ScannerVersion string    `json:"scanner_version"`
+}
 
 var fetchBundleAction = &cli.Command{
 	Name: "fetch-bundle",
@@ -91,6 +102,33 @@ func fetchBundle(ctx context.Context, c *cli.Command) error {
 		return errorWithExitCode(fmt.Errorf("error writing the libraries bundle: %w", err), constants.EngineErrorCode)
 	}
 
+	manifest := bundleManifest{
+		RepoURL:        c.String("repo-url"),
+		FetchedAt:      time.Now().UTC(),
+		ScannerVersion: constants.Version,
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return errorWithExitCode(fmt.Errorf("error marshaling the bundle manifest: %w", err), constants.EngineErrorCode)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, bundleManifestFileName), manifestBytes, filePerms); err != nil {
+		return errorWithExitCode(fmt.Errorf("error writing the bundle manifest: %w", err), constants.EngineErrorCode)
+	}
+
 	fmt.Printf("Wrote offline bundle (%d rules, %d libraries) to %s\n", len(ruleset.Rules), len(libraries), outputDir)
 	return nil
+}
+
+// readBundleManifest reads and parses the manifest written by fetchBundle,
+// used by `scan --offline-bundle-path` to warn about a stale bundle.
+func readBundleManifest(bundleDir string) (*bundleManifest, error) {
+	b, err := os.ReadFile(filepath.Clean(filepath.Join(bundleDir, bundleManifestFileName)))
+	if err != nil {
+		return nil, err
+	}
+	var manifest bundleManifest
+	if err := json.Unmarshal(b, &manifest); err != nil {
+		return nil, err
+	}
+	return &manifest, nil
 }

--- a/cmd/scanner/fetch_bundle_e2e_test.go
+++ b/cmd/scanner/fetch_bundle_e2e_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
+	"github.com/DataDog/datadog-iac-scanner/pkg/scan"
+	"github.com/DataDog/jsonapi"
+	"github.com/stretchr/testify/require"
+)
+
+// fetchBundleE2ERule flags an aws_s3_bucket resource with versioning explicitly
+// disabled, matching the fixture at test/e2e/fixtures/no-exclusions.tf.
+const fetchBundleE2ERule = `package datadog
+
+import rego.v1
+
+DatadogPolicy contains result if {
+	some name, i
+	bucket := input.document[i].resource.aws_s3_bucket[name]
+	bucket.versioning.enabled == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_s3_bucket",
+		"resourceName": name,
+		"searchKey": sprintf("aws_s3_bucket[%s].versioning", [name]),
+	}
+}
+`
+
+// Test_E2EFetchBundleThenOfflineScan exercises the full network-isolated
+// workflow end to end: it runs the real `fetch-bundle` command against a stub
+// Datadog server, then runs the real `scan` command with
+// `--offline-bundle-path` pointing at the files fetch-bundle wrote, and
+// asserts the offline scan reproduces the expected violation. Unlike
+// pkg/datadog/local_file_client_test.go, this drives the actual CLI commands
+// instead of constructing a datadog.Client and QueriesSource by hand.
+func Test_E2EFetchBundleThenOfflineScan(t *testing.T) {
+	for _, name := range []string{
+		"DD_API_KEY", "DATADOG_API_KEY",
+		"DD_APP_KEY", "DATADOG_APP_KEY",
+		"DD_JWT_TOKEN", "DATADOG_JWT_TOKEN",
+		"DD_SITE", "DATADOG_SITE",
+		"DD_HOSTNAME", "DATADOG_HOSTNAME",
+	} {
+		t.Setenv(name, "")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/static-analysis/iac/rulesets/default-ruleset":
+			ruleset := datadog.Ruleset{
+				ID:   "default-ruleset",
+				Name: "Default",
+				Rules: []*datadog.Rule{
+					{
+						ID:               "terraform-s3-bucket-versioning-disabled",
+						Name:             "s3-bucket-versioning-disabled",
+						ShortDescription: "S3 bucket versioning disabled",
+						Description:      "S3 bucket versioning disabled",
+						Platform:         "Terraform",
+						Type:             "rego",
+						RegoQuery:        []byte(fetchBundleE2ERule),
+						Severity:         "HIGH",
+						Category:         "Best Practices",
+						IsPublished:      true,
+					},
+				},
+			}
+			body, err := jsonapi.Marshal(ruleset)
+			require.NoError(t, err)
+			w.Header().Add("content-type", "application/json")
+			_, err = w.Write(body)
+			require.NoError(t, err)
+		case "/api/v2/static-analysis/iac/libraries":
+			libraries := []*datadog.Library{
+				{ID: "common", RegoCode: "package generic.common\n"},
+				{ID: "terraform", RegoCode: "package generic.terraform\n"},
+			}
+			body, err := jsonapi.Marshal(libraries)
+			require.NoError(t, err)
+			w.Header().Add("content-type", "application/json")
+			_, err = w.Write(body)
+			require.NoError(t, err)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("DD_HOSTNAME", server.URL)
+
+	repoPath := t.TempDir()
+	bundleDir := t.TempDir()
+
+	err := fetchBundleAction.Run(t.Context(), []string{
+		"fetch-bundle",
+		"--repo-path", repoPath,
+		"--repo-url", "https://example.com/repo",
+		"--output-dir", bundleDir,
+	})
+	require.NoError(t, err)
+
+	for _, f := range []string{"config.yaml", "rules.json", "libraries.json", "manifest.json"} {
+		require.FileExists(t, filepath.Join(bundleDir, f))
+	}
+
+	outputDir := t.TempDir()
+	metadataPath := filepath.Join(outputDir, "metadata.json")
+
+	err = scanAction.Run(t.Context(), []string{
+		"scan",
+		"--path", filepath.Join("..", "..", "test", "e2e", "fixtures", "no-exclusions.tf"),
+		"--type", "terraform",
+		"--output-path", outputDir,
+		"--offline-bundle-path", bundleDir,
+		"--metadata-path", metadataPath,
+	})
+	// runScan intentionally returns a non-nil error carrying a severity-based
+	// exit code (here 50, for the HIGH violation) even on a successful scan;
+	// see getExitCode. The metadata file is what confirms the scan succeeded.
+	var exitErr *withExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 50, exitErr.code)
+
+	metadataBytes, err := os.ReadFile(filepath.Clean(metadataPath))
+	require.NoError(t, err)
+	var metadata scan.ScanMetadata
+	require.NoError(t, json.Unmarshal(metadataBytes, &metadata))
+
+	require.Equal(t, 1, metadata.Stats.Files, "the fixture file should have been scanned")
+	require.Equal(t, 1, metadata.Stats.Violations, "the offline bundle's rule should have fired exactly once")
+	require.Contains(t, metadata.Stats.ViolationBreakdowns["HIGH"], "terraform-s3-bucket-versioning-disabled")
+}

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -39,6 +39,7 @@ func main() {
 			showConfigAction,
 			testRulesAction,
 			serveAction,
+			fetchBundleAction,
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -115,6 +116,11 @@ var scanAction = &cli.Command{
 			Name:  "libraries-path",
 			Usage: "path to local Rego support libraries (default: fetch from backend when using local queries-path)",
 		},
+		&cli.StringFlag{
+			Name: "offline-bundle-path",
+			Usage: "directory containing rules, libraries and configuration previously written by " +
+				"`fetch-bundle`; when set, the scan makes no network calls",
+		},
 		&cli.StringSliceFlag{
 			Name:  "report-format",
 			Usage: "output report formats (valid: sarif, simple-json)",
@@ -212,13 +218,30 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		return fmt.Errorf("error retrieving repository commit information: %w", err)
 	}
 
-	cfg, _, err := config.ReadConfiguration(ctx, repoDir, config.WithDatadog(datadog.NewDatadogClient(), repoInfo.RepositoryUrl))
-	if err != nil {
-		outErr := fmt.Errorf("error reading the configuration: %w", err)
-		if te := (*config.InvalidLocalConfigError)(nil); errors.As(err, &te) {
-			outErr = errorWithExitCode(outErr, constants.InvalidConfigErrorCode)
+	offlineBundlePath := c.String("offline-bundle-path")
+
+	var cfg *config.IacConfig
+	if offlineBundlePath != "" {
+		cfgBytes, err := os.ReadFile(filepath.Join(offlineBundlePath, bundleConfigFileName)) // nolint:gosec
+		if err != nil {
+			return errorWithExitCode(fmt.Errorf("error reading the offline configuration bundle: %w", err), constants.InvalidConfigErrorCode)
 		}
-		return outErr
+		cfg, err = config.ParseConfig(cfgBytes)
+		if err != nil {
+			return errorWithExitCode(fmt.Errorf("error parsing the offline configuration bundle: %w", err), constants.InvalidConfigErrorCode)
+		}
+		if cfg == nil {
+			cfg = &config.IacConfig{}
+		}
+	} else {
+		cfg, _, err = config.ReadConfiguration(ctx, repoDir, config.WithDatadog(datadog.NewDatadogClient(), repoInfo.RepositoryUrl))
+		if err != nil {
+			outErr := fmt.Errorf("error reading the configuration: %w", err)
+			if te := (*config.InvalidLocalConfigError)(nil); errors.As(err, &te) {
+				outErr = errorWithExitCode(outErr, constants.InvalidConfigErrorCode)
+			}
+			return outErr
+		}
 	}
 	excludePaths, err := getRepoRelativePaths(repoDir, cfg.IgnorePaths)
 	if err != nil {
@@ -298,7 +321,25 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		DisableRuleIsolation:        c.Bool("x-disable-rule-isolation"),
 	}
 
-	metadata, err := console.ExecuteScan(ctx, params)
+	var opts []scan.ClientOption
+	if offlineBundlePath != "" {
+		offlineClient, err := datadog.NewLocalFileClient(
+			filepath.Join(offlineBundlePath, bundleRulesFileName),
+			filepath.Join(offlineBundlePath, bundleLibrariesFileName),
+		)
+		if err != nil {
+			return errorWithExitCode(fmt.Errorf("error loading the offline bundle: %w", err), constants.InvalidConfigErrorCode)
+		}
+		opts = append(opts, scan.WithQuerySourceFactory(func(_ context.Context, paramsPlatforms []string) (source.QueriesSource, error) {
+			return source.NewDatadogSource(
+				offlineClient,
+				source.WithWantedPlatforms(paramsPlatforms),
+				source.WithWantedCloudProviders(params.CloudProvider),
+			)
+		}))
+	}
+
+	metadata, err := console.ExecuteScan(ctx, params, opts...)
 	if err != nil {
 		return errorWithExitCode(fmt.Errorf("error during IaC scan: %w", err), constants.EngineErrorCode)
 	}

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/console"
 	"github.com/DataDog/datadog-iac-scanner/internal/console/helpers"
@@ -144,7 +145,30 @@ var scanAction = &cli.Command{
 const (
 	filePerms = 0644
 	dirPerms  = 0755
+
+	// staleBundleWarningAge is how old an offline bundle can be before
+	// runScan warns that it may no longer reflect the latest rules.
+	staleBundleWarningAge = 7 * 24 * time.Hour
 )
+
+// warnIfBundleStale logs a warning if the offline bundle at bundleDir has no
+// manifest, or was fetched more than staleBundleWarningAge ago, so that
+// running with stale rules is never silent.
+func warnIfBundleStale(ctx context.Context, bundleDir string) {
+	contextLogger := logger.FromContext(ctx)
+	manifest, err := readBundleManifest(bundleDir)
+	if err != nil {
+		contextLogger.Warn().Err(err).Msg(
+			"could not read the offline bundle manifest; the bundle's age cannot be verified")
+		return
+	}
+	age := time.Since(manifest.FetchedAt)
+	if age > staleBundleWarningAge {
+		contextLogger.Warn().Msgf(
+			"the offline bundle was fetched %s ago (on %s); run `fetch-bundle` again to pick up rule updates",
+			age.Round(time.Hour), manifest.FetchedAt.Format(time.RFC3339))
+	}
+}
 
 func validateReportFormats(formats []string) error {
 	valid := map[string]struct{}{}
@@ -222,7 +246,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 
 	var cfg *config.IacConfig
 	if offlineBundlePath != "" {
-		cfgBytes, err := os.ReadFile(filepath.Join(offlineBundlePath, bundleConfigFileName)) // nolint:gosec
+		cfgBytes, err := os.ReadFile(filepath.Clean(filepath.Join(offlineBundlePath, bundleConfigFileName)))
 		if err != nil {
 			return errorWithExitCode(fmt.Errorf("error reading the offline configuration bundle: %w", err), constants.InvalidConfigErrorCode)
 		}
@@ -233,6 +257,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		if cfg == nil {
 			cfg = &config.IacConfig{}
 		}
+		warnIfBundleStale(ctx, offlineBundlePath)
 	} else {
 		cfg, _, err = config.ReadConfiguration(ctx, repoDir, config.WithDatadog(datadog.NewDatadogClient(), repoInfo.RepositoryUrl))
 		if err != nil {

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -12,14 +12,14 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func ExecuteScan(ctx context.Context, scanParams *scan.Parameters) (scan.ScanMetadata, error) {
+func ExecuteScan(ctx context.Context, scanParams *scan.Parameters, opts ...scan.ClientOption) (scan.ScanMetadata, error) {
 	log.Debug().Msg("console.scan()")
 
 	console := newConsole()
 
 	console.preScan(scanParams)
 
-	client, err := scan.NewClient(ctx, scanParams, console.Printer)
+	client, err := scan.NewClient(ctx, scanParams, console.Printer, opts...)
 
 	if err != nil {
 		log.Err(err).Msgf("failed to create scan client%v", err)

--- a/pkg/datadog/local_file_client.go
+++ b/pkg/datadog/local_file_client.go
@@ -1,0 +1,72 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package datadog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// LocalFileClient is a Client backed by a ruleset and library set previously
+// fetched from the backend and serialized to local JSON files (see the
+// `fetch-bundle` CLI command). It makes no network calls, so it is safe to use
+// in network-isolated environments. GetRemoteConfig echoes the local config
+// back unchanged: any server-side merge is expected to have already happened
+// when the bundle was fetched.
+type LocalFileClient struct {
+	ruleset   *Ruleset
+	libraries map[string]Library
+}
+
+var _ Client = (*LocalFileClient)(nil)
+
+// NewLocalFileClient loads a Ruleset and a Library map from rulesetPath and
+// librariesPath, both previously written by the `fetch-bundle` CLI command.
+func NewLocalFileClient(rulesetPath, librariesPath string) (Client, error) {
+	ruleset, err := readJSONFile[Ruleset](rulesetPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read local ruleset bundle %q: %w", rulesetPath, err)
+	}
+	libraries, err := readJSONFile[map[string]Library](librariesPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read local libraries bundle %q: %w", librariesPath, err)
+	}
+	return &LocalFileClient{ruleset: ruleset, libraries: *libraries}, nil
+}
+
+func readJSONFile[T any](path string) (*T, error) {
+	b, err := os.ReadFile(path) // nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	var out T
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *LocalFileClient) GetDefaultRuleset(_ context.Context) (*Ruleset, error) {
+	return c.ruleset, nil
+}
+
+func (c *LocalFileClient) GetDefaultRulesetWithTests(_ context.Context) (*Ruleset, error) {
+	return c.ruleset, nil
+}
+
+// GetRemoteConfig returns localConfig unchanged. The bundle's config.yaml
+// (written by `fetch-bundle`) already carries the fully-merged result, so
+// callers using LocalFileClient are expected to load that file directly with
+// config.ParseConfig rather than routing it back through GetRemoteConfig.
+func (c *LocalFileClient) GetRemoteConfig(_ context.Context, _ string, localConfig []byte) ([]byte, error) {
+	return localConfig, nil
+}
+
+func (c *LocalFileClient) GetLibraries(_ context.Context) (map[string]Library, error) {
+	return c.libraries, nil
+}

--- a/pkg/datadog/local_file_client_test.go
+++ b/pkg/datadog/local_file_client_test.go
@@ -1,0 +1,68 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package datadog
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLocalFileClient_RoundTrip(t *testing.T) {
+	ruleset := &Ruleset{
+		ID:   "default-ruleset",
+		Name: "Default",
+		Rules: []*Rule{
+			{ID: "rule-1", Name: "rule-1", Platform: "Terraform", RegoQuery: []byte("query"), IsPublished: true},
+		},
+	}
+	libraries := map[string]Library{
+		"terraform": {ID: "terraform", RegoCode: "package terraform"},
+	}
+
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "rules.json"), ruleset)
+	writeJSON(t, filepath.Join(dir, "libraries.json"), libraries)
+
+	client, err := NewLocalFileClient(filepath.Join(dir, "rules.json"), filepath.Join(dir, "libraries.json"))
+	require.NoError(t, err)
+
+	gotRuleset, err := client.GetDefaultRuleset(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, ruleset, gotRuleset)
+
+	gotRulesetWithTests, err := client.GetDefaultRulesetWithTests(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, ruleset, gotRulesetWithTests)
+
+	gotLibraries, err := client.GetLibraries(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, libraries, gotLibraries)
+
+	localConfig := []byte("local config bytes")
+	gotConfig, err := client.GetRemoteConfig(t.Context(), "https://example.com/repo", localConfig)
+	require.NoError(t, err)
+	assert.Equal(t, localConfig, gotConfig)
+}
+
+func TestNewLocalFileClient_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "libraries.json"), map[string]Library{})
+
+	_, err := NewLocalFileClient(filepath.Join(dir, "rules.json"), filepath.Join(dir, "libraries.json"))
+	assert.Error(t, err)
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, b, 0o600))
+}

--- a/test/e2e/offline_bundle_test.go
+++ b/test/e2e/offline_bundle_test.go
@@ -1,0 +1,105 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/internal/console"
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
+	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/scan"
+	"github.com/stretchr/testify/require"
+)
+
+// offlineBundleRule is a self-contained rule (no library helpers) that flags an
+// aws_s3_bucket resource with versioning explicitly disabled.
+const offlineBundleRule = `package datadog
+
+import rego.v1
+
+DatadogPolicy contains result if {
+	some name, i
+	bucket := input.document[i].resource.aws_s3_bucket[name]
+	bucket.versioning.enabled == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_s3_bucket",
+		"resourceName": name,
+		"searchKey": sprintf("aws_s3_bucket[%s].versioning", [name]),
+	}
+}
+`
+
+// Test_E2EOfflineBundle exercises the same code path as `scan
+// --offline-bundle-path`: it writes stub rules.json/libraries.json files in the
+// format `fetch-bundle` produces, loads them via datadog.NewLocalFileClient, and
+// runs a scan against them through a DatadogSource, asserting the offline
+// pipeline finds the expected violation without any network access.
+func Test_E2EOfflineBundle(t *testing.T) {
+	dir := t.TempDir()
+
+	ruleset := &datadog.Ruleset{
+		ID:   "default-ruleset",
+		Name: "Default",
+		Rules: []*datadog.Rule{
+			{
+				ID:               "terraform-s3-bucket-versioning-disabled",
+				Name:             "s3-bucket-versioning-disabled",
+				ShortDescription: "S3 bucket versioning disabled",
+				Description:      "S3 bucket versioning disabled",
+				Platform:         "Terraform",
+				Type:             "rego",
+				RegoQuery:        []byte(offlineBundleRule),
+				Severity:         "HIGH",
+				Category:         "Best Practices",
+				IsPublished:      true,
+			},
+		},
+	}
+	libraries := map[string]datadog.Library{
+		"common":    {ID: "common", RegoCode: "package generic.common\n"},
+		"terraform": {ID: "terraform", RegoCode: "package generic.terraform\n"},
+	}
+
+	rulesPath := filepath.Join(dir, "rules.json")
+	librariesPath := filepath.Join(dir, "libraries.json")
+	writeJSON(t, rulesPath, ruleset)
+	writeJSON(t, librariesPath, libraries)
+
+	client, err := datadog.NewLocalFileClient(rulesPath, librariesPath)
+	require.NoError(t, err)
+
+	params, ctx := scan.GetDefaultParameters(context.Background(), "")
+	params.Path = []string{filepath.Join("fixtures", "no-exclusions.tf")}
+	params.OutputPath = t.TempDir()
+	params.Platform = []string{"terraform"}
+	params.FlagEvaluator = featureflags.NewLocalEvaluator()
+	params.SCIInfo = model.SCIInfo{
+		DiffAware:            model.DiffAware{Enabled: false},
+		RepositoryCommitInfo: model.RepositoryCommitInfo{RepositoryUrl: "test/url", CommitSHA: "test/hash", Branch: "test/branch"},
+	}
+
+	metadata, err := console.ExecuteScan(ctx, params, scan.WithQuerySourceFactory(
+		func(_ context.Context, paramsPlatforms []string) (source.QueriesSource, error) {
+			return source.NewDatadogSource(client, source.WithWantedPlatforms(paramsPlatforms))
+		},
+	))
+	require.NoError(t, err)
+
+	require.Equal(t, 1, metadata.Stats.Files, "the fixture file should have been scanned")
+	require.Equal(t, 1, metadata.Stats.Violations, "the offline bundle's rule should have fired exactly once")
+	require.Contains(t, metadata.Stats.ViolationBreakdowns["HIGH"], "terraform-s3-bucket-versioning-disabled")
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, b, 0o600))
+}


### PR DESCRIPTION
## Summary

By default, `scan` always fetches the default ruleset and Rego libraries from the Datadog backend (`GetDefaultRuleset`/`GetLibraries`), and unconditionally merges server-side config overrides via `GetRemoteConfig` even when `--queries-path` is set for rules.

This PR adds a path to run `scan` with **zero** network calls:

- **`fetch-bundle`**: a new subcommand that runs on a trusted, network-enabled host. It fetches the default ruleset, Rego libraries, and the repo's merged remote configuration, and writes them to local files (`rules.json`, `libraries.json`, `config.yaml`) in an output directory.
- **`scan --offline-bundle-path <dir>`**: loads that bundle instead of calling the backend — `pkg/datadog.LocalFileClient` (new) serves the pre-fetched ruleset/libraries, and the merged config is read directly via `config.ParseConfig` instead of `config.ReadConfiguration`'s network-backed `WithDatadog` option.

The consuming side reuses the existing, already-production `scan.WithQuerySourceFactory` seam (previously used by the HTTP server for content-push scans) — no changes needed to the core scan pipeline.

