### PR TITLE
[K9CODESEC-2946] Add git-based Terraform module resolvers

### DIFF
--- a/pkg/engine/source/source.go
+++ b/pkg/engine/source/source.go
@@ -104,15 +104,15 @@ func MergeModulesData(modules []tfmodules.ParsedModule, inputData string) (strin
 	}
 
 	// Iterate through generated module mappings and merge their data.
-	for _, module := range modules {
-		for provider, attrData := range module.AttributesData {
+	for i := range modules {
+		for provider, attrData := range modules[i].AttributesData {
 			providersMap, ok := commonModules[provider].(map[string]any)
 			if !ok || providersMap == nil {
 				providersMap = map[string]any{}
 				commonModules[provider] = providersMap
 			}
 
-			providersMap[module.Source] = attrData
+			providersMap[modules[i].Source] = attrData
 		}
 	}
 

--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -172,9 +172,10 @@ func (repo *bareRepo) ensureClone(ctx context.Context) error {
 		}
 		if info, err := os.Stat(repo.barePath); err == nil && info.IsDir() {
 			// Validate that the directory is a real bare repo, not a partial clone
-			// left by a killed process. gitInDir is not available here since it
-			// uses the gitexec helpers; use exec.Command directly for this one check.
-			if check := gitInDir(ctx, repo.barePath, "rev-parse", "--git-dir"); check.Run() == nil {
+			// left by a killed process. This is a local-only read (no network, no
+			// pack-file I/O) so it intentionally bypasses the acquireGitProc semaphore,
+			// which is reserved for operations that meaningfully consume system resources.
+			if gitInDir(ctx, repo.barePath, "rev-parse", "--git-dir").Run() == nil {
 				repo.cloneOK.Store(true)
 				return nil, nil
 			}
@@ -273,15 +274,15 @@ func (repo *bareRepo) fetchRef(ctx context.Context, ref string) (string, error) 
 
 		// Local fast path: if the bare clone already contains this ref (e.g. a
 		// pre-populated clone or a prior fetch), resolve it without hitting the network.
-		if tryLocal := gitInDir(ctx, repo.barePath, "rev-parse", "--verify", safeRef); tryLocal != nil {
-			if out, localErr := tryLocal.Output(); localErr == nil {
-				if resolved := strings.TrimSpace(string(out)); looksLikeSHA(resolved) {
-					repo.refMu.Lock()
-					repo.refCache[ref] = resolved
-					repo.refMu.Unlock()
-					go repo.saveBareRefCache()
-					return resolved, nil
-				}
+		// This is a local-only read so it intentionally bypasses acquireGitProc;
+		// the semaphore is acquired below only when a network fetch is needed.
+		if out, localErr := gitInDir(ctx, repo.barePath, "rev-parse", "--verify", safeRef).Output(); localErr == nil {
+			if resolved := strings.TrimSpace(string(out)); looksLikeSHA(resolved) {
+				repo.refMu.Lock()
+				repo.refCache[ref] = resolved
+				repo.refMu.Unlock()
+				go repo.saveBareRefCache()
+				return resolved, nil
 			}
 		}
 

--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -170,96 +170,109 @@ func (repo *bareRepo) ensureClone(ctx context.Context) error {
 		if repo.cloneFailed.Load() {
 			return nil, repo.cachedCloneError()
 		}
-		if info, err := os.Stat(repo.barePath); err == nil && info.IsDir() {
-			// Validate that the directory is a real bare repo, not a partial clone
-			// left by a killed process. This is a local-only read (no network, no
-			// pack-file I/O) so it intentionally bypasses the acquireGitProc semaphore,
-			// which is reserved for operations that meaningfully consume system resources.
-			if gitInDir(ctx, repo.barePath, "rev-parse", "--git-dir").Run() == nil {
-				repo.cloneOK.Store(true)
-				return nil, nil
-			}
-			// Partial or corrupt clone — remove and reclone.
-			_ = os.RemoveAll(repo.barePath)
-		}
-		var lastErr error
-		for attempt := 0; attempt < bareCloneAttempts; attempt++ {
-			if attempt > 0 {
-				backoff := time.Duration(attempt) * 500 * time.Millisecond
-				select {
-				case <-ctx.Done():
-					return nil, ctx.Err()
-				case <-time.After(backoff):
-				}
-			}
-			if err := os.MkdirAll(filepath.Dir(repo.barePath), dirPerm); err != nil {
-				lastErr = err
-				continue
-			}
-			_ = os.RemoveAll(repo.barePath)
-			release, err := acquireGitProc(ctx)
-			if err != nil {
-				lastErr = err
-				continue
-			}
-			cloneURL, urlErr := gitSafeArg(repo.cloneURL)
-			if urlErr != nil {
-				lastErr = urlErr
-				continue
-			}
-			cmd := gitCloneBare(ctx, cloneURL, repo.barePath)
-			out, cloneErr := cmd.CombinedOutput()
-			release()
-			if cloneErr == nil {
-				repo.cloneOK.Store(true)
-				return nil, nil
-			}
-			_ = os.RemoveAll(repo.barePath)
-			lastErr = fmt.Errorf("git clone --bare %s: %w\n%s", repo.cloneURL, cloneErr, bytes.TrimSpace(out))
-		}
-		repo.setCloneError(lastErr)
-		log := logger.FromContext(ctx)
-		log.Warn().Err(lastErr).Msgf("BareGitResolver: failed to clone %s after %d attempts", repo.cloneURL, bareCloneAttempts)
-		return nil, lastErr
+		return nil, repo.doClone(ctx)
 	})
 	return err
+}
+
+// doClone checks for an existing bare clone, validates it, and attempts a fresh
+// clone with retries if needed. It is always called inside the cloneSF singleflight.
+func (repo *bareRepo) doClone(ctx context.Context) error {
+	if info, err := os.Stat(repo.barePath); err == nil && info.IsDir() {
+		// Validate that the directory is a real bare repo, not a partial clone
+		// left by a killed process. This is a local-only read (no network, no
+		// pack-file I/O) so it intentionally bypasses the acquireGitProc semaphore,
+		// which is reserved for operations that meaningfully consume system resources.
+		if gitInDir(ctx, repo.barePath, "rev-parse", "--git-dir").Run() == nil {
+			repo.cloneOK.Store(true)
+			return nil
+		}
+		// Partial or corrupt clone — remove and reclone.
+		_ = os.RemoveAll(repo.barePath)
+	}
+	var lastErr error
+	for attempt := 0; attempt < bareCloneAttempts; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(attempt) * 500 * time.Millisecond
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+		if err := os.MkdirAll(filepath.Dir(repo.barePath), dirPerm); err != nil {
+			lastErr = err
+			continue
+		}
+		_ = os.RemoveAll(repo.barePath)
+		release, err := acquireGitProc(ctx)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		cloneURL, urlErr := gitSafeArg(repo.cloneURL)
+		if urlErr != nil {
+			lastErr = urlErr
+			continue
+		}
+		cmd := gitCloneBare(ctx, cloneURL, repo.barePath)
+		out, cloneErr := cmd.CombinedOutput()
+		release()
+		if cloneErr == nil {
+			repo.cloneOK.Store(true)
+			return nil
+		}
+		_ = os.RemoveAll(repo.barePath)
+		lastErr = fmt.Errorf("git clone --bare %s: %w\n%s", repo.cloneURL, cloneErr, bytes.TrimSpace(out))
+	}
+	repo.setCloneError(lastErr)
+	log := logger.FromContext(ctx)
+	log.Warn().Err(lastErr).Msgf("BareGitResolver: failed to clone %s after %d attempts", repo.cloneURL, bareCloneAttempts)
+	return lastErr
 }
 
 // fetchRef ensures ref is present and returns its canonical commit SHA.
 func (repo *bareRepo) fetchRef(ctx context.Context, ref string) (string, error) {
 	if looksLikeSHA(ref) {
-		// Fast path: SHA is stable; check locally first.
-		v, err, _ := repo.fetchSF.Do(ref, func() (interface{}, error) {
-			release, acqErr := acquireGitProc(ctx)
-			if acqErr != nil {
-				return "", acqErr
-			}
-			defer release()
-			safeRef, refErr := gitSafeArg(ref)
-			if refErr != nil {
-				return "", refErr
-			}
-			check := gitInDir(ctx, repo.barePath, "cat-file", "-t", safeRef)
-			if check.Run() == nil {
-				return ref, nil // already present
-			}
-			cmd := gitInDir(ctx, repo.barePath, "fetch", "--filter=blob:none", "origin", safeRef)
-			if out, err := cmd.CombinedOutput(); err != nil {
-				return "", fmt.Errorf("git fetch origin %s: %w\n%s", ref, err, bytes.TrimSpace(out))
-			}
-			return ref, nil
-		})
-		if err != nil {
-			return "", err
-		}
-		return v.(string), nil
+		return repo.fetchSHARef(ctx, ref)
 	}
+	return repo.fetchNamedRef(ctx, ref)
+}
 
-	// Branch/tag ref: fetch and resolve to SHA. Key on "ref:<name>" so it
-	// doesn't conflict with SHA keys.
+// fetchSHARef handles the case where ref is already a full 40-char SHA.
+// It checks that the object is locally present, fetching it from origin if not.
+func (repo *bareRepo) fetchSHARef(ctx context.Context, ref string) (string, error) {
+	v, err, _ := repo.fetchSF.Do(ref, func() (interface{}, error) {
+		release, acqErr := acquireGitProc(ctx)
+		if acqErr != nil {
+			return "", acqErr
+		}
+		defer release()
+		safeRef, refErr := gitSafeArg(ref)
+		if refErr != nil {
+			return "", refErr
+		}
+		if gitInDir(ctx, repo.barePath, "cat-file", "-t", safeRef).Run() == nil {
+			return ref, nil // already present
+		}
+		cmd := gitInDir(ctx, repo.barePath, "fetch", "--filter=blob:none", "origin", safeRef)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("git fetch origin %s: %w\n%s", ref, err, bytes.TrimSpace(out))
+		}
+		return ref, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}
+
+// fetchNamedRef handles branch/tag refs: it resolves the name to a commit SHA,
+// using an in-memory and on-disk cache to avoid unnecessary network fetches.
+func (repo *bareRepo) fetchNamedRef(ctx context.Context, ref string) (string, error) {
+	// Key on "ref:<name>" so SHA keys and name keys never collide in fetchSF.
 	v, err, _ := repo.fetchSF.Do("ref:"+ref, func() (interface{}, error) {
-		// Fast path: return the cached SHA from a previous run, skipping the network entirely.
-		// The archive extraction has its own on-disk cache keyed by SHA, so the result is stable.
+		// In-process cache: skip the network if we resolved this ref earlier.
 		repo.refMu.RLock()
 		if cachedSHA, ok := repo.refCache[ref]; ok {
 			repo.refMu.RUnlock()
@@ -302,8 +315,7 @@ func (repo *bareRepo) fetchRef(ctx context.Context, ref string) (string, error) 
 			}
 		}
 		// Resolve FETCH_HEAD to the commit SHA.
-		resolve := gitInDir(ctx, repo.barePath, "rev-parse", "FETCH_HEAD")
-		sha, revErr := resolve.Output()
+		sha, revErr := gitInDir(ctx, repo.barePath, "rev-parse", "FETCH_HEAD").Output()
 		if revErr != nil {
 			return "", fmt.Errorf("git rev-parse FETCH_HEAD: %w", revErr)
 		}

--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -52,8 +51,8 @@ type bareRepo struct {
 	cloneErrMu  sync.Mutex
 	cloneErr    error
 	cloneSF     singleflight.Group
-	fetchSF   singleflight.Group
-	extractSF singleflight.Group
+	fetchSF     singleflight.Group
+	extractSF   singleflight.Group
 
 	refMu    sync.RWMutex
 	refCache map[string]string // tag/branch ref → resolved SHA (warm from disk on init)
@@ -113,7 +112,7 @@ func (r *BareGitResolver) getOrInitRepo(repoURL string) *bareRepo {
 
 // loadBareRefCache reads the persistent ref→SHA map for a bare clone.
 func loadBareRefCache(path string) map[string]string {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return make(map[string]string)
 	}
@@ -195,7 +194,12 @@ func (repo *bareRepo) ensureClone(ctx context.Context) error {
 				lastErr = err
 				continue
 			}
-			cmd := exec.CommandContext(ctx, "git", "clone", "--bare", "--filter=blob:none", repo.cloneURL, repo.barePath) //nolint:gosec
+			cloneURL, urlErr := gitSafeArg(repo.cloneURL)
+			if urlErr != nil {
+				lastErr = urlErr
+				continue
+			}
+			cmd := gitCloneBare(ctx, cloneURL, repo.barePath)
 			out, cloneErr := cmd.CombinedOutput()
 			release()
 			if cloneErr == nil {
@@ -223,12 +227,15 @@ func (repo *bareRepo) fetchRef(ctx context.Context, ref string) (string, error) 
 				return "", acqErr
 			}
 			defer release()
-			check := exec.CommandContext(ctx, "git", "--git-dir="+repo.barePath, "cat-file", "-t", ref) //nolint:gosec
+			safeRef, refErr := gitSafeArg(ref)
+			if refErr != nil {
+				return "", refErr
+			}
+			check := gitInDir(ctx, repo.barePath, "cat-file", "-t", safeRef)
 			if check.Run() == nil {
 				return ref, nil // already present
 			}
-			cmd := exec.CommandContext(ctx, "git", "--git-dir="+repo.barePath, //nolint:gosec
-				"fetch", "--filter=blob:none", "origin", ref)
+			cmd := gitInDir(ctx, repo.barePath, "fetch", "--filter=blob:none", "origin", safeRef)
 			if out, err := cmd.CombinedOutput(); err != nil {
 				return "", fmt.Errorf("git fetch origin %s: %w\n%s", ref, err, bytes.TrimSpace(out))
 			}
@@ -257,20 +264,22 @@ func (repo *bareRepo) fetchRef(ctx context.Context, ref string) (string, error) 
 			return "", acqErr
 		}
 		defer release()
+		safeRef, refErr := gitSafeArg(ref)
+		if refErr != nil {
+			return "", refErr
+		}
 		// Shallow fetch the named ref.
-		cmd := exec.CommandContext(ctx, "git", "--git-dir="+repo.barePath, //nolint:gosec
-			"fetch", "--filter=blob:none", "--depth=1", "origin", ref)
+		cmd := gitInDir(ctx, repo.barePath, "fetch", "--filter=blob:none", "--depth=1", "origin", safeRef)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			// Retry without --depth in case the server rejects shallow fetches.
-			cmd2 := exec.CommandContext(ctx, "git", "--git-dir="+repo.barePath, //nolint:gosec
-				"fetch", "--filter=blob:none", "origin", ref)
+			cmd2 := gitInDir(ctx, repo.barePath, "fetch", "--filter=blob:none", "origin", safeRef)
 			if out2, err2 := cmd2.CombinedOutput(); err2 != nil {
 				return "", fmt.Errorf("git fetch origin %s: %w\n%s\n%s", ref, err2, bytes.TrimSpace(out), bytes.TrimSpace(out2))
 			}
 		}
 		// Resolve FETCH_HEAD to the commit SHA.
-		resolve := exec.CommandContext(ctx, "git", "--git-dir="+repo.barePath, "rev-parse", "FETCH_HEAD") //nolint:gosec
+		resolve := gitInDir(ctx, repo.barePath, "rev-parse", "FETCH_HEAD")
 		sha, revErr := resolve.Output()
 		if revErr != nil {
 			return "", fmt.Errorf("git rev-parse FETCH_HEAD: %w", revErr)
@@ -330,12 +339,16 @@ func archiveExtract(ctx context.Context, gitDir, extractBase, sha, subdir string
 	defer release()
 
 	// Stream to tar to avoid buffering the archive in memory.
-	archiveArg := sha
+	archiveArg, argErr := gitSafeArg(sha)
 	if subdir != "" {
-		archiveArg = sha + ":" + subdir
+		archiveArg, argErr = gitSafeArg(sha + ":" + subdir)
 	}
-	archive := exec.CommandContext(ctx, "git", "--git-dir="+gitDir, "archive", "--format=tar", archiveArg) //nolint:gosec
-	untar := exec.CommandContext(ctx, "tar", "-x", "-C", dest)                                             //nolint:gosec
+	if argErr != nil {
+		_ = os.RemoveAll(dest)
+		return argErr
+	}
+	archive := gitInDir(ctx, gitDir, "archive", "--format=tar", archiveArg)
+	untar := tarExtract(ctx, dest)
 
 	pr, pw := io.Pipe()
 	archive.Stdout = pw
@@ -434,8 +447,8 @@ func normalizeSCPGitSource(source string) (string, bool) {
 	if atIdx < 0 {
 		return "", false
 	}
-	user := source[:atIdx]    // e.g. "git"
-	rest := source[atIdx+1:]  // host:org/repo//subdir?ref=tag
+	user := source[:atIdx]   // e.g. "git"
+	rest := source[atIdx+1:] // host:org/repo//subdir?ref=tag
 	colonIdx := strings.IndexByte(rest, ':')
 	if colonIdx < 0 {
 		return "", false

--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -1,0 +1,576 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+)
+
+// dirPerm is the permission mode used for all directories created by resolvers.
+const dirPerm = 0o750
+
+// BareGitResolver keeps one bare clone per repo and extracts refs via git archive.
+type BareGitResolver struct {
+	// Defaults to <user-cache-dir>/datadog-iac-scanner/git-bare.
+	CacheDir string
+
+	mu    sync.Mutex
+	repos map[string]*bareRepo
+}
+
+const bareCloneAttempts = 3
+
+type bareRepo struct {
+	cloneURL     string // canonical ssh:// URL passed to git clone
+	barePath     string // path to the bare clone on disk
+	extractBase  string // base dir for per-(sha,subdir) extracted trees
+	refCachePath string // path to the persistent ref→SHA JSON file
+
+	cloneOK     atomic.Bool
+	cloneFailed atomic.Bool
+	cloneErrMu  sync.Mutex
+	cloneErr    error
+	cloneSF     singleflight.Group
+	fetchSF   singleflight.Group
+	extractSF singleflight.Group
+
+	refMu    sync.RWMutex
+	refCache map[string]string // tag/branch ref → resolved SHA (warm from disk on init)
+}
+
+func NewBareGitResolver(cacheDir string) *BareGitResolver {
+	return &BareGitResolver{
+		CacheDir: cacheDir,
+		repos:    make(map[string]*bareRepo),
+	}
+}
+
+func (r *BareGitResolver) effectiveCacheDir() string {
+	if r.CacheDir != "" {
+		return r.CacheDir
+	}
+	base, err := os.UserCacheDir()
+	if err != nil {
+		base = os.TempDir()
+	}
+	return filepath.Join(base, "datadog-iac-scanner", "git-bare")
+}
+
+func repoURLKey(normalizedRepo string) string {
+	h := sha256.Sum256([]byte(normalizedRepo))
+	return fmt.Sprintf("%x", h[:12])
+}
+
+// canonicalSSHCloneURL builds a stable ssh:// clone URL for a parsed repo URL.
+func canonicalSSHCloneURL(repoURL string) string {
+	norm := normalizeGitRepoURL(repoURL)
+	if norm == "" {
+		return repoURL
+	}
+	return "ssh://git@" + norm
+}
+
+func (r *BareGitResolver) getOrInitRepo(repoURL string) *bareRepo {
+	key := normalizeGitRepoURL(repoURL)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if repo, ok := r.repos[key]; ok {
+		return repo
+	}
+	base := filepath.Join(r.effectiveCacheDir(), repoURLKey(key))
+	refCachePath := filepath.Join(base, "refs.json")
+	repo := &bareRepo{
+		cloneURL:     canonicalSSHCloneURL(repoURL),
+		barePath:     filepath.Join(base, "repo.git"),
+		extractBase:  filepath.Join(base, "extracted"),
+		refCachePath: refCachePath,
+		refCache:     loadBareRefCache(refCachePath),
+	}
+	r.repos[key] = repo
+	return repo
+}
+
+// loadBareRefCache reads the persistent ref→SHA map for a bare clone.
+func loadBareRefCache(path string) map[string]string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return make(map[string]string)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(data, &m); err != nil {
+		return make(map[string]string)
+	}
+	return m
+}
+
+// saveBareRefCache writes the ref→SHA map atomically so concurrent runs don't corrupt it.
+func (repo *bareRepo) saveBareRefCache() {
+	repo.refMu.RLock()
+	m := make(map[string]string, len(repo.refCache))
+	for k, v := range repo.refCache {
+		m[k] = v
+	}
+	repo.refMu.RUnlock()
+
+	data, err := json.Marshal(m)
+	if err != nil {
+		return
+	}
+	tmp := repo.refCachePath + ".tmp"
+	if err := os.WriteFile(tmp, data, cacheFilePerms); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, repo.refCachePath)
+}
+
+func (repo *bareRepo) cachedCloneError() error {
+	repo.cloneErrMu.Lock()
+	defer repo.cloneErrMu.Unlock()
+	return repo.cloneErr
+}
+
+func (repo *bareRepo) setCloneError(err error) {
+	repo.cloneErrMu.Lock()
+	repo.cloneErr = err
+	repo.cloneErrMu.Unlock()
+	repo.cloneFailed.Store(true)
+}
+
+func (repo *bareRepo) ensureClone(ctx context.Context) error {
+	if repo.cloneOK.Load() {
+		return nil
+	}
+	if repo.cloneFailed.Load() {
+		return repo.cachedCloneError()
+	}
+	_, err, _ := repo.cloneSF.Do("clone", func() (interface{}, error) {
+		if repo.cloneOK.Load() {
+			return nil, nil
+		}
+		if repo.cloneFailed.Load() {
+			return nil, repo.cachedCloneError()
+		}
+		if info, err := os.Stat(repo.barePath); err == nil && info.IsDir() {
+			repo.cloneOK.Store(true)
+			return nil, nil
+		}
+		var lastErr error
+		for attempt := 0; attempt < bareCloneAttempts; attempt++ {
+			if attempt > 0 {
+				backoff := time.Duration(attempt) * 500 * time.Millisecond
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(backoff):
+				}
+			}
+			if err := os.MkdirAll(filepath.Dir(repo.barePath), dirPerm); err != nil {
+				lastErr = err
+				continue
+			}
+			_ = os.RemoveAll(repo.barePath)
+			release, err := acquireGitProc(ctx)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			cmd := exec.CommandContext(ctx, "git", "clone", "--bare", "--filter=blob:none", repo.cloneURL, repo.barePath) //nolint:gosec
+			out, cloneErr := cmd.CombinedOutput()
+			release()
+			if cloneErr == nil {
+				repo.cloneOK.Store(true)
+				return nil, nil
+			}
+			_ = os.RemoveAll(repo.barePath)
+			lastErr = fmt.Errorf("git clone --bare %s: %w\n%s", repo.cloneURL, cloneErr, bytes.TrimSpace(out))
+		}
+		repo.setCloneError(lastErr)
+		log := logger.FromContext(ctx)
+		log.Warn().Err(lastErr).Msgf("BareGitResolver: failed to clone %s after %d attempts", repo.cloneURL, bareCloneAttempts)
+		return nil, lastErr
+	})
+	return err
+}
+
+// fetchRef ensures ref is present and returns its canonical commit SHA.
+func (repo *bareRepo) fetchRef(ctx context.Context, ref string) (string, error) {
+	if looksLikeSHA(ref) {
+		// Fast path: SHA is stable; check locally first.
+		v, err, _ := repo.fetchSF.Do(ref, func() (interface{}, error) {
+			release, acqErr := acquireGitProc(ctx)
+			if acqErr != nil {
+				return "", acqErr
+			}
+			defer release()
+			check := exec.CommandContext(ctx, "git", "--git-dir="+repo.barePath, "cat-file", "-t", ref) //nolint:gosec
+			if check.Run() == nil {
+				return ref, nil // already present
+			}
+			cmd := exec.CommandContext(ctx, "git", "--git-dir="+repo.barePath, //nolint:gosec
+				"fetch", "--filter=blob:none", "origin", ref)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return "", fmt.Errorf("git fetch origin %s: %w\n%s", ref, err, bytes.TrimSpace(out))
+			}
+			return ref, nil
+		})
+		if err != nil {
+			return "", err
+		}
+		return v.(string), nil
+	}
+
+	// Branch/tag ref: fetch and resolve to SHA. Key on "ref:<name>" so it
+	// doesn't conflict with SHA keys.
+	v, err, _ := repo.fetchSF.Do("ref:"+ref, func() (interface{}, error) {
+		// Fast path: return the cached SHA from a previous run, skipping the network entirely.
+		// The archive extraction has its own on-disk cache keyed by SHA, so the result is stable.
+		repo.refMu.RLock()
+		if cachedSHA, ok := repo.refCache[ref]; ok {
+			repo.refMu.RUnlock()
+			return cachedSHA, nil
+		}
+		repo.refMu.RUnlock()
+
+		release, acqErr := acquireGitProc(ctx)
+		if acqErr != nil {
+			return "", acqErr
+		}
+		defer release()
+		// Shallow fetch the named ref.
+		cmd := exec.CommandContext(ctx, "git", "--git-dir="+repo.barePath, //nolint:gosec
+			"fetch", "--filter=blob:none", "--depth=1", "origin", ref)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			// Retry without --depth in case the server rejects shallow fetches.
+			cmd2 := exec.CommandContext(ctx, "git", "--git-dir="+repo.barePath, //nolint:gosec
+				"fetch", "--filter=blob:none", "origin", ref)
+			if out2, err2 := cmd2.CombinedOutput(); err2 != nil {
+				return "", fmt.Errorf("git fetch origin %s: %w\n%s\n%s", ref, err2, bytes.TrimSpace(out), bytes.TrimSpace(out2))
+			}
+		}
+		// Resolve FETCH_HEAD to the commit SHA.
+		resolve := exec.CommandContext(ctx, "git", "--git-dir="+repo.barePath, "rev-parse", "FETCH_HEAD") //nolint:gosec
+		sha, revErr := resolve.Output()
+		if revErr != nil {
+			return "", fmt.Errorf("git rev-parse FETCH_HEAD: %w", revErr)
+		}
+		resolved := strings.TrimSpace(string(sha))
+		if !looksLikeSHA(resolved) {
+			return "", fmt.Errorf("unexpected FETCH_HEAD value %q for ref %s", resolved, ref)
+		}
+		// Persist synchronously so subsequent in-process callers skip the fetch too,
+		// then write to disk in the background (non-critical).
+		repo.refMu.Lock()
+		repo.refCache[ref] = resolved
+		repo.refMu.Unlock()
+		go repo.saveBareRefCache()
+		return resolved, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}
+
+func archiveCacheKey(sha, subdir string) string {
+	h := sha256.Sum256([]byte(sha + ":" + subdir))
+	// sha[:8] prefix makes the directory human-readable during debugging.
+	return sha[:8] + "-" + fmt.Sprintf("%x", h[:4])
+}
+
+func archiveCacheDir(extractBase, sha, subdir string) string {
+	return filepath.Join(extractBase, archiveCacheKey(sha, subdir))
+}
+
+func cachedArchiveDir(extractBase, sha, subdir string) (string, bool) {
+	dest := archiveCacheDir(extractBase, sha, subdir)
+	info, err := os.Stat(dest)
+	return dest, err == nil && info.IsDir()
+}
+
+// archiveExtract materializes sha:subdir into a persistent local directory.
+func archiveExtract(ctx context.Context, gitDir, extractBase, sha, subdir string) error {
+	key := archiveCacheKey(sha, subdir)
+
+	dest := filepath.Join(extractBase, key)
+	if info, err := os.Stat(dest); err == nil && info.IsDir() {
+		return nil // cache hit from previous scan
+	}
+
+	if err := os.MkdirAll(dest, dirPerm); err != nil {
+		return err
+	}
+
+	release, err := acquireGitProc(ctx)
+	if err != nil {
+		_ = os.RemoveAll(dest)
+		return err
+	}
+	defer release()
+
+	// Stream to tar to avoid buffering the archive in memory.
+	archiveArg := sha
+	if subdir != "" {
+		archiveArg = sha + ":" + subdir
+	}
+	archive := exec.CommandContext(ctx, "git", "--git-dir="+gitDir, "archive", "--format=tar", archiveArg) //nolint:gosec
+	untar := exec.CommandContext(ctx, "tar", "-x", "-C", dest)                                             //nolint:gosec
+
+	pr, pw := io.Pipe()
+	archive.Stdout = pw
+	untar.Stdin = pr
+
+	var archiveErr, untarErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		archiveErr = archive.Run()
+		pw.CloseWithError(archiveErr)
+	}()
+	go func() {
+		defer wg.Done()
+		untarErr = untar.Run()
+	}()
+	wg.Wait()
+
+	if archiveErr != nil {
+		_ = os.RemoveAll(dest)
+		return fmt.Errorf("git archive %s: %w", archiveArg, archiveErr)
+	}
+	if untarErr != nil {
+		_ = os.RemoveAll(dest)
+		return fmt.Errorf("tar extract: %w", untarErr)
+	}
+	return nil
+}
+
+func (repo *bareRepo) extract(ctx context.Context, sha, subdir string) (string, error) {
+	key := archiveCacheKey(sha, subdir)
+	_, err, _ := repo.extractSF.Do(key, func() (interface{}, error) {
+		return nil, archiveExtract(ctx, repo.barePath, repo.extractBase, sha, subdir)
+	})
+	if err != nil {
+		return "", err
+	}
+	return archiveCacheDir(repo.extractBase, sha, subdir), nil
+}
+
+// Resolve implements Resolver for any git:: source that carries a ref= parameter.
+func (r *BareGitResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedModule) (Resolution, error) {
+	repoURL, subdir, ref, ok := parseGitGetterSource(mod.Source)
+	if !ok || ref == "" {
+		return Resolution{}, &tfmodules.UnresolvedError{
+			Reason: "BareGitResolver: not a git:: source with a ref= parameter",
+		}
+	}
+
+	contextLogger := logger.FromContext(ctx)
+	repo := r.getOrInitRepo(repoURL)
+
+	// SHA refs have stable extraction keys; branch/tag refs must be re-resolved.
+	if looksLikeSHA(ref) {
+		if dest, ok := cachedArchiveDir(repo.extractBase, ref, subdir); ok {
+			return Resolution{LocalPath: dest}, nil
+		}
+	}
+
+	if err := repo.ensureClone(ctx); err != nil {
+		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
+	}
+
+	sha, err := repo.fetchRef(ctx, ref)
+	if err != nil {
+		contextLogger.Warn().Err(err).Msgf("BareGitResolver: ref %q not reachable from %s", ref, repoURL)
+		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
+	}
+
+	dir, err := repo.extract(ctx, sha, subdir)
+	if err != nil {
+		contextLogger.Warn().Err(err).Msgf("BareGitResolver: archive %s:%s failed", sha, subdir)
+		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
+	}
+
+	return Resolution{LocalPath: dir}, nil
+}
+
+// normalizeSCPGitSource converts SCP-form git sources to git::ssh://git@... so
+// BareGitResolver can clone them using the same SSH credentials that would be
+// used by a native git client.  HTTPS is intentionally avoided here because SCP
+// sources typically point at private repositories that require SSH auth.
+//
+//	"git@github.com:org/repo//subdir?ref=tag"
+//	→ "git::ssh://git@github.com/org/repo//subdir?ref=tag", true
+//
+// Returns ("", false) if source is not SCP form.
+func normalizeSCPGitSource(source string) (string, bool) {
+	// Must not already carry a getter scheme prefix.
+	if strings.Contains(source, "::") {
+		return "", false
+	}
+	// SCP form: [user@]host:path — @ precedes a colon that comes before any slash.
+	atIdx := strings.IndexByte(source, '@')
+	if atIdx < 0 {
+		return "", false
+	}
+	user := source[:atIdx]    // e.g. "git"
+	rest := source[atIdx+1:]  // host:org/repo//subdir?ref=tag
+	colonIdx := strings.IndexByte(rest, ':')
+	if colonIdx < 0 {
+		return "", false
+	}
+	// Ensure the colon is a host separator, not a path colon (no slash before it).
+	if slashIdx := strings.IndexByte(rest, '/'); slashIdx >= 0 && slashIdx < colonIdx {
+		return "", false
+	}
+	host := rest[:colonIdx]
+	path := rest[colonIdx+1:] // org/repo//subdir?ref=tag
+	return "git::ssh://" + user + "@" + host + "/" + path, true
+}
+
+// normalizeImplicitGitHubSource converts Terraform's implicit GitHub module paths to git::ssh://.
+//
+//	"github.com/org/repo//subdir?ref=tag"
+//	→ "git::ssh://git@github.com/org/repo//subdir?ref=tag", true
+func normalizeImplicitGitHubSource(source string) (string, bool) {
+	if strings.Contains(source, "::") {
+		return "", false
+	}
+	if !strings.HasPrefix(source, "github.com/") {
+		return "", false
+	}
+	// Require a subdir marker or ref= so registry short forms are not matched.
+	if !strings.Contains(source, "//") && !strings.Contains(source, "ref=") {
+		return "", false
+	}
+	return "git::ssh://git@" + source, true
+}
+
+// normalizeHTTPGitToSSH rewrites git::http(s)://host/... to git::ssh://git@host/...
+// so git clones use SSH credentials instead of unauthenticated HTTPS.
+func normalizeHTTPGitToSSH(source string) (string, bool) {
+	const prefix = "git::"
+	if !strings.HasPrefix(source, prefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(source, prefix)
+	if strings.HasPrefix(rest, "ssh://") {
+		return "", false
+	}
+	for _, scheme := range []string{"https://", "http://"} {
+		if strings.HasPrefix(rest, scheme) {
+			return prefix + "ssh://git@" + strings.TrimPrefix(rest, scheme), true
+		}
+	}
+	return "", false
+}
+
+// normalizeGitModuleSource applies all git source normalizations used by resolvers.
+func normalizeGitModuleSource(source string) (string, bool) {
+	if source == "" {
+		return "", false
+	}
+	original := source
+	if normalized, ok := normalizeSCPGitSource(source); ok {
+		source = normalized
+	} else if normalized, ok := normalizeImplicitGitHubSource(source); ok {
+		source = normalized
+	}
+	if strings.HasPrefix(source, "git::") {
+		if normalized, ok := normalizeHTTPGitToSSH(source); ok {
+			source = normalized
+		}
+	}
+	return source, source != original
+}
+
+// parseGitGetterSource parses a go-getter git source into its canonical components.
+// Sources are normalized via normalizeGitModuleSource before parsing.
+//
+//	"git::https://github.com/org/repo.git//path/to/mod?ref=abc123"
+//	→ repoURL="ssh://git@github.com/org/repo.git", subdir="path/to/mod", ref="abc123"
+func parseGitGetterSource(source string) (repoURL, subdir, ref string, ok bool) {
+	if normalized, changed := normalizeGitModuleSource(source); changed {
+		source = normalized
+	}
+	const prefix = "git::"
+	if !strings.HasPrefix(source, prefix) {
+		return "", "", "", false
+	}
+	s := strings.TrimPrefix(source, prefix)
+
+	// Parse query string first (url.Parse handles ? correctly).
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", "", "", false
+	}
+	ref = u.Query().Get("ref")
+	u.RawQuery = ""
+
+	// go-getter separates repo URL from subdir with //. Split on u.Path so we
+	// don't accidentally match the // in the URL scheme (e.g. https://).
+	if idx := strings.Index(u.Path, "//"); idx >= 0 {
+		subdir = u.Path[idx+2:]
+		u.Path = u.Path[:idx]
+	}
+
+	repoURL = u.String()
+	ok = repoURL != ""
+	return
+}
+
+// normalizeGitRepoURL strips scheme prefixes, trailing .git, and trailing slashes
+// so that URLs referring to the same repo compare equal regardless of transport.
+//
+//	"https://github.com/org/repo.git"  →  "github.com/org/repo"
+//	"git@github.com:org/repo.git"      →  "github.com/org/repo"
+//	"ssh://git@github.com/org/repo"    →  "github.com/org/repo"
+func normalizeGitRepoURL(raw string) string {
+	// Strip getter protocol prefix (git::, etc.)
+	if idx := strings.Index(raw, "::"); idx != -1 {
+		raw = raw[idx+2:]
+	}
+	// Strip query string.
+	if idx := strings.Index(raw, "?"); idx != -1 {
+		raw = raw[:idx]
+	}
+	// Strip the transport scheme BEFORE removing the go-getter subdir separator.
+	// Otherwise the "//" in "https://" is mistaken for the subdir marker and the
+	// URL collapses to "https:", so https sources never match SCP-form remotes.
+	for _, scheme := range []string{"https://", "http://", "ssh://", "git://"} {
+		raw = strings.TrimPrefix(raw, scheme)
+	}
+	// SCP-style git@host:org/repo → host/org/repo
+	if at := strings.IndexByte(raw, '@'); at != -1 {
+		after := raw[at+1:]
+		raw = strings.Replace(after, ":", "/", 1)
+	}
+	// Strip the go-getter subdir separator, now unambiguous after scheme removal.
+	if idx := strings.Index(raw, "//"); idx != -1 {
+		raw = raw[:idx]
+	}
+	raw = strings.TrimSuffix(raw, ".git")
+	raw = strings.TrimSuffix(raw, "/")
+	return raw
+}

--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -259,15 +259,30 @@ func (repo *bareRepo) fetchRef(ctx context.Context, ref string) (string, error) 
 		}
 		repo.refMu.RUnlock()
 
+		safeRef, refErr := gitSafeArg(ref)
+		if refErr != nil {
+			return "", refErr
+		}
+
+		// Local fast path: if the bare clone already contains this ref (e.g. a
+		// pre-populated clone or a prior fetch), resolve it without hitting the network.
+		if tryLocal := gitInDir(ctx, repo.barePath, "rev-parse", "--verify", safeRef); tryLocal != nil {
+			if out, localErr := tryLocal.Output(); localErr == nil {
+				if resolved := strings.TrimSpace(string(out)); looksLikeSHA(resolved) {
+					repo.refMu.Lock()
+					repo.refCache[ref] = resolved
+					repo.refMu.Unlock()
+					go repo.saveBareRefCache()
+					return resolved, nil
+				}
+			}
+		}
+
 		release, acqErr := acquireGitProc(ctx)
 		if acqErr != nil {
 			return "", acqErr
 		}
 		defer release()
-		safeRef, refErr := gitSafeArg(ref)
-		if refErr != nil {
-			return "", refErr
-		}
 		// Shallow fetch the named ref.
 		cmd := gitInDir(ctx, repo.barePath, "fetch", "--filter=blob:none", "--depth=1", "origin", safeRef)
 		out, err := cmd.CombinedOutput()
@@ -319,36 +334,43 @@ func cachedArchiveDir(extractBase, sha, subdir string) (string, bool) {
 }
 
 // archiveExtract materializes sha:subdir into a persistent local directory.
+// It extracts into a temp dir and renames atomically so a partial extraction
+// from a prior crash is never mistaken for a complete cache entry.
 func archiveExtract(ctx context.Context, gitDir, extractBase, sha, subdir string) error {
 	key := archiveCacheKey(sha, subdir)
-
 	dest := filepath.Join(extractBase, key)
+
 	if info, err := os.Stat(dest); err == nil && info.IsDir() {
-		return nil // cache hit from previous scan
+		return nil // cache hit from a previous scan
 	}
 
-	if err := os.MkdirAll(dest, dirPerm); err != nil {
+	if err := os.MkdirAll(extractBase, dirPerm); err != nil {
 		return err
+	}
+
+	// Extract into a sibling temp dir; rename to dest only on full success.
+	tmp, err := os.MkdirTemp(extractBase, ".tmp-extract-")
+	if err != nil {
+		return fmt.Errorf("creating extract temp dir: %w", err)
 	}
 
 	release, err := acquireGitProc(ctx)
 	if err != nil {
-		_ = os.RemoveAll(dest)
+		_ = os.RemoveAll(tmp)
 		return err
 	}
 	defer release()
 
-	// Stream to tar to avoid buffering the archive in memory.
 	archiveArg, argErr := gitSafeArg(sha)
 	if subdir != "" {
 		archiveArg, argErr = gitSafeArg(sha + ":" + subdir)
 	}
 	if argErr != nil {
-		_ = os.RemoveAll(dest)
+		_ = os.RemoveAll(tmp)
 		return argErr
 	}
 	archive := gitInDir(ctx, gitDir, "archive", "--format=tar", archiveArg)
-	untar := tarExtract(ctx, dest)
+	untar := tarExtract(ctx, tmp)
 
 	pr, pw := io.Pipe()
 	archive.Stdout = pw
@@ -369,12 +391,20 @@ func archiveExtract(ctx context.Context, gitDir, extractBase, sha, subdir string
 	wg.Wait()
 
 	if archiveErr != nil {
-		_ = os.RemoveAll(dest)
+		_ = os.RemoveAll(tmp)
 		return fmt.Errorf("git archive %s: %w", archiveArg, archiveErr)
 	}
 	if untarErr != nil {
-		_ = os.RemoveAll(dest)
+		_ = os.RemoveAll(tmp)
 		return fmt.Errorf("tar extract: %w", untarErr)
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		_ = os.RemoveAll(tmp)
+		// Another process may have won the race; accept if dest is now present.
+		if info, statErr := os.Stat(dest); statErr == nil && info.IsDir() {
+			return nil
+		}
+		return fmt.Errorf("publishing extract cache entry: %w", err)
 	}
 	return nil
 }

--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -171,8 +171,15 @@ func (repo *bareRepo) ensureClone(ctx context.Context) error {
 			return nil, repo.cachedCloneError()
 		}
 		if info, err := os.Stat(repo.barePath); err == nil && info.IsDir() {
-			repo.cloneOK.Store(true)
-			return nil, nil
+			// Validate that the directory is a real bare repo, not a partial clone
+			// left by a killed process. gitInDir is not available here since it
+			// uses the gitexec helpers; use exec.Command directly for this one check.
+			if check := gitInDir(ctx, repo.barePath, "rev-parse", "--git-dir"); check.Run() == nil {
+				repo.cloneOK.Store(true)
+				return nil, nil
+			}
+			// Partial or corrupt clone — remove and reclone.
+			_ = os.RemoveAll(repo.barePath)
 		}
 		var lastErr error
 		for attempt := 0; attempt < bareCloneAttempts; attempt++ {

--- a/pkg/parser/terraform/modules/resolver/baregit_test.go
+++ b/pkg/parser/terraform/modules/resolver/baregit_test.go
@@ -1,0 +1,164 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeGitRepoURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"https with .git", "https://github.com/org/repo.git", "github.com/org/repo"},
+		{"https without .git", "https://github.com/org/repo", "github.com/org/repo"},
+		{"scp form", "git@github.com:org/repo.git", "github.com/org/repo"},
+		{"ssh form", "ssh://git@github.com/org/repo.git", "github.com/org/repo"},
+		{"git getter prefix", "git::https://github.com/org/repo.git", "github.com/org/repo"},
+		{"with subdir", "https://github.com/org/repo.git//modules/child", "github.com/org/repo"},
+		{"with subdir and query", "git::https://github.com/org/repo.git//mods/x?ref=v1.0", "github.com/org/repo"},
+		{"trailing slash", "https://github.com/org/repo/", "github.com/org/repo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeGitRepoURL(tc.in); got != tc.want {
+				t.Errorf("normalizeGitRepoURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeGitRepoURLSchemeMatchesSCP guards the regression where an https
+// source and an SCP-form remote for the same repo normalized to different keys
+// (the "//" in "https://" was wrongly treated as the subdir separator),
+// causing every self-referential git module to miss the local checkout.
+func TestNormalizeGitRepoURLSchemeMatchesSCP(t *testing.T) {
+	https := normalizeGitRepoURL("https://github.com/org/repo.git")
+	scp := normalizeGitRepoURL("git@github.com:org/repo.git")
+	if https != scp {
+		t.Fatalf("https form %q must normalize equal to scp form %q", https, scp)
+	}
+}
+
+func TestParseGitGetterSourceHTTPSGitHubToSSH(t *testing.T) {
+	in := "git::https://github.com/DataDog/vault-platform.git//terraform/aws/external-iam?ref=v1.9.4-17"
+	repoURL, subdir, ref, ok := parseGitGetterSource(in)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if repoURL != "ssh://git@github.com/DataDog/vault-platform.git" {
+		t.Errorf("repoURL = %q, want ssh URL", repoURL)
+	}
+	if subdir != "terraform/aws/external-iam" {
+		t.Errorf("subdir = %q", subdir)
+	}
+	if ref != "v1.9.4-17" {
+		t.Errorf("ref = %q", ref)
+	}
+}
+
+func TestNormalizeSCPGitSource(t *testing.T) {
+	in := "git@github.com:DataDog/vault-platform//terraform/aws/external-iam?ref=v1.8.2-17"
+	got, ok := normalizeSCPGitSource(in)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	want := "git::ssh://git@github.com/DataDog/vault-platform//terraform/aws/external-iam?ref=v1.8.2-17"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeHTTPGitToSSH(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			"github",
+			"git::https://github.com/DataDog/k8s-platform.git//terraform/modules/datacenter?ref=abc",
+			"git::ssh://git@github.com/DataDog/k8s-platform.git//terraform/modules/datacenter?ref=abc",
+		},
+		{
+			"gitlab",
+			"git::https://gitlab.com/org/repo//modules/x?ref=v1",
+			"git::ssh://git@gitlab.com/org/repo//modules/x?ref=v1",
+		},
+		{
+			"ghe",
+			"git::https://github.datadoghq.com/org/repo?ref=main",
+			"git::ssh://git@github.datadoghq.com/org/repo?ref=main",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := normalizeHTTPGitToSSH(tc.in)
+			if !ok {
+				t.Fatal("expected ok")
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+	_, ok := normalizeHTTPGitToSSH("git::ssh://git@github.com/org/repo?ref=main")
+	if ok {
+		t.Error("already-ssh source should not normalize again")
+	}
+}
+
+func TestNormalizeImplicitGitHubSource(t *testing.T) {
+	in := "github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam//identity-domains?ref=release-0.3.0"
+	got, ok := normalizeImplicitGitHubSource(in)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	want := "git::ssh://git@github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam//identity-domains?ref=release-0.3.0"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	_, ok = normalizeImplicitGitHubSource("aws-ia/eks-blueprints-addon/aws")
+	if ok {
+		t.Error("registry short form should not match")
+	}
+}
+
+func TestNormalizeGitModuleSource(t *testing.T) {
+	scp := "git@github.com:DataDog/vault-platform//terraform/aws/external-iam?ref=v1.8.2-17"
+	got, ok := normalizeGitModuleSource(scp)
+	if !ok {
+		t.Fatal("expected scp normalization")
+	}
+	if !strings.HasPrefix(got, "git::ssh://git@github.com/DataDog/vault-platform") {
+		t.Errorf("scp: got %q", got)
+	}
+
+	https := "git::https://github.com/DataDog/vault-platform.git//terraform/aws/external-iam?ref=v1.9.4-17"
+	got, ok = normalizeGitModuleSource(https)
+	if !ok {
+		t.Fatal("expected https normalization")
+	}
+	_, subdir, ref, ok := parseGitGetterSource(https)
+	if !ok || ref != "v1.9.4-17" || subdir != "terraform/aws/external-iam" {
+		t.Fatalf("parse after https: ok=%v subdir=%q ref=%q", ok, subdir, ref)
+	}
+}
+
+func TestBareRepoKeyDedupesGitSuffix(t *testing.T) {
+	withGit := canonicalSSHCloneURL("ssh://git@github.com/DataDog/vault-platform.git")
+	withoutGit := canonicalSSHCloneURL("ssh://git@github.com/DataDog/vault-platform")
+	if withGit != withoutGit {
+		t.Fatalf("canonical clone URLs differ: %q vs %q", withGit, withoutGit)
+	}
+	if normalizeGitRepoURL("ssh://git@github.com/DataDog/vault-platform.git") !=
+		normalizeGitRepoURL("git@github.com:DataDog/vault-platform") {
+		t.Fatal("normalized repo keys should match across spellings")
+	}
+}

--- a/pkg/parser/terraform/modules/resolver/cache.go
+++ b/pkg/parser/terraform/modules/resolver/cache.go
@@ -20,7 +20,7 @@ const cacheDirPerms = 0o700
 // moduleCache is a content-addressed on-disk module store ($XDG_CACHE_HOME/.../modules).
 type moduleCache struct {
 	dir string
-	sf  singleflight.Group
+	sf  singleflight.Group //nolint:unused
 }
 
 // NewModuleCache creates ~/.cache/.../modules (or XDG_CACHE_HOME) and returns it.
@@ -41,7 +41,8 @@ func NewModuleCache() (*moduleCache, error) {
 }
 
 // moduleCacheKey is sha256(source + NUL + version) hex.
-func moduleCacheKey(source, version string) string {
+// Used by lookup and store, which are wired in the gogetter resolver (next stacked PR).
+func moduleCacheKey(source, version string) string { //nolint:unused
 	h := sha256.New()
 	_, _ = h.Write([]byte(source))
 	_, _ = h.Write([]byte{0})
@@ -50,7 +51,7 @@ func moduleCacheKey(source, version string) string {
 }
 
 // lookup returns a cache hit directory for (source, version), if any.
-func (c *moduleCache) lookup(source, version string) (localDir string, ok bool) {
+func (c *moduleCache) lookup(source, version string) (localDir string, ok bool) { //nolint:unused
 	dir := filepath.Join(c.dir, moduleCacheKey(source, version))
 	if info, err := os.Stat(dir); err == nil && info.IsDir() {
 		return dir, true
@@ -63,7 +64,7 @@ func (c *moduleCache) lookup(source, version string) (localDir string, ok bool) 
 // concurrent callers with the same key wait and share the result, which avoids the
 // Windows file-locking errors that arise when multiple goroutines race to rename
 // different temp dirs onto the same destination directory.
-func (c *moduleCache) store(source, version, srcDir string) (string, error) {
+func (c *moduleCache) store(source, version, srcDir string) (string, error) { //nolint:unused
 	key := moduleCacheKey(source, version)
 	dst := filepath.Join(c.dir, key)
 	if info, err := os.Stat(dst); err == nil && info.IsDir() {

--- a/pkg/parser/terraform/modules/resolver/git_module.go
+++ b/pkg/parser/terraform/modules/resolver/git_module.go
@@ -20,16 +20,3 @@ func GitModuleResolveKey(source, version string) (string, bool) {
 	}
 	return normalizeGitRepoURL(repoURL) + "\x00" + ref + "\x00" + subdir, true
 }
-
-// bareGitOwnsSource reports whether BareGitResolver handles this module source.
-func bareGitOwnsSource(source string) bool {
-	repoURL, _, ref, ok := parseGitGetterSource(source)
-	if !ok || ref == "" {
-		return false
-	}
-	// Local file:// git repos stay on go-getter (small, used in unit tests).
-	if strings.HasPrefix(repoURL, "file://") {
-		return false
-	}
-	return true
-}

--- a/pkg/parser/terraform/modules/resolver/git_module.go
+++ b/pkg/parser/terraform/modules/resolver/git_module.go
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import "strings"
+
+// GitModuleResolveKey returns a canonical cache key for pinned git module sources.
+// Identical content folds transport spellings (https vs ssh, .git suffix) into one key.
+// Returns false when the source is not a git:: module with ref= (not BareGit-owned).
+func GitModuleResolveKey(source, version string) (string, bool) {
+	repoURL, subdir, ref, ok := parseGitGetterSource(source)
+	if !ok || ref == "" {
+		return "", false
+	}
+	if v := strings.TrimSpace(version); v != "" && v != ref {
+		ref = ref + "\x00" + v
+	}
+	return normalizeGitRepoURL(repoURL) + "\x00" + ref + "\x00" + subdir, true
+}
+
+// bareGitOwnsSource reports whether BareGitResolver handles this module source.
+func bareGitOwnsSource(source string) bool {
+	repoURL, _, ref, ok := parseGitGetterSource(source)
+	if !ok || ref == "" {
+		return false
+	}
+	// Local file:// git repos stay on go-getter (small, used in unit tests).
+	if strings.HasPrefix(repoURL, "file://") {
+		return false
+	}
+	return true
+}

--- a/pkg/parser/terraform/modules/resolver/git_module_test.go
+++ b/pkg/parser/terraform/modules/resolver/git_module_test.go
@@ -1,0 +1,78 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"testing"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+)
+
+func TestGitModuleResolveKeyFoldsTransport(t *testing.T) {
+	https := "git::https://github.com/org/repo.git//terraform-modules/aws-bucket?ref=aws-bucket_v7.1.2"
+	ssh := "git::ssh://git@github.com/org/repo//terraform-modules/aws-bucket?ref=aws-bucket_v7.1.2"
+	scp := "git@github.com:org/repo//terraform-modules/aws-bucket?ref=aws-bucket_v7.1.2"
+
+	keyHTTPS, ok := GitModuleResolveKey(https, "")
+	if !ok {
+		t.Fatal("expected https key")
+	}
+	keySSH, ok := GitModuleResolveKey(ssh, "")
+	if !ok {
+		t.Fatal("expected ssh key")
+	}
+	keySCP, ok := GitModuleResolveKey(scp, "")
+	if !ok {
+		t.Fatal("expected scp key")
+	}
+	if keyHTTPS != keySSH || keyHTTPS != keySCP {
+		t.Fatalf("keys differ:\n  https=%q\n  ssh=%q\n  scp=%q", keyHTTPS, keySSH, keySCP)
+	}
+	want := "github.com/org/repo\x00aws-bucket_v7.1.2\x00terraform-modules/aws-bucket"
+	if keyHTTPS != want {
+		t.Fatalf("key = %q, want %q", keyHTTPS, want)
+	}
+}
+
+func TestGitModuleResolveKeyDifferentSubdirs(t *testing.T) {
+	a, ok := GitModuleResolveKey("git::https://github.com/org/repo//mods/a?ref=v1", "")
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	b, ok := GitModuleResolveKey("git::https://github.com/org/repo//mods/b?ref=v1", "")
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if a == b {
+		t.Fatal("different subdirs must not share a resolve key")
+	}
+}
+
+func TestBareGitOwnsSource(t *testing.T) {
+	if !bareGitOwnsSource("git::https://github.com/org/repo//sub?ref=v1") {
+		t.Fatal("git:: with ref should be bare-git owned")
+	}
+	if bareGitOwnsSource("git::https://github.com/org/repo//sub") {
+		t.Fatal("git:: without ref is not bare-git owned")
+	}
+	if bareGitOwnsSource("registry.terraform.io/org/name/aws") {
+		t.Fatal("registry source is not bare-git owned")
+	}
+}
+
+func TestGoGetterRejectsBareGitSources(t *testing.T) {
+	r := NewGoGetterResolver(NewGoGetterConfig())
+	_, err := r.Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source:  "git::https://github.com/org/repo.git//sub?ref=v1.0.0",
+		IsLocal: false,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !tfmodules.IsUnresolved(err) {
+		t.Fatalf("expected UnresolvedError, got %v", err)
+	}
+}

--- a/pkg/parser/terraform/modules/resolver/git_module_test.go
+++ b/pkg/parser/terraform/modules/resolver/git_module_test.go
@@ -7,8 +7,6 @@ package resolver
 
 import (
 	"testing"
-
-	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
 
 func TestGitModuleResolveKeyFoldsTransport(t *testing.T) {
@@ -60,19 +58,5 @@ func TestBareGitOwnsSource(t *testing.T) {
 	}
 	if bareGitOwnsSource("registry.terraform.io/org/name/aws") {
 		t.Fatal("registry source is not bare-git owned")
-	}
-}
-
-func TestGoGetterRejectsBareGitSources(t *testing.T) {
-	r := NewGoGetterResolver(NewGoGetterConfig())
-	_, err := r.Resolve(t.Context(), &tfmodules.ParsedModule{
-		Source:  "git::https://github.com/org/repo.git//sub?ref=v1.0.0",
-		IsLocal: false,
-	})
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if !tfmodules.IsUnresolved(err) {
-		t.Fatalf("expected UnresolvedError, got %v", err)
 	}
 }

--- a/pkg/parser/terraform/modules/resolver/git_module_test.go
+++ b/pkg/parser/terraform/modules/resolver/git_module_test.go
@@ -48,15 +48,3 @@ func TestGitModuleResolveKeyDifferentSubdirs(t *testing.T) {
 		t.Fatal("different subdirs must not share a resolve key")
 	}
 }
-
-func TestBareGitOwnsSource(t *testing.T) {
-	if !bareGitOwnsSource("git::https://github.com/org/repo//sub?ref=v1") {
-		t.Fatal("git:: with ref should be bare-git owned")
-	}
-	if bareGitOwnsSource("git::https://github.com/org/repo//sub") {
-		t.Fatal("git:: without ref is not bare-git owned")
-	}
-	if bareGitOwnsSource("registry.terraform.io/org/name/aws") {
-		t.Fatal("registry source is not bare-git owned")
-	}
-}

--- a/pkg/parser/terraform/modules/resolver/gitexec.go
+++ b/pkg/parser/terraform/modules/resolver/gitexec.go
@@ -7,7 +7,11 @@ package resolver
 
 import (
 	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 const (
@@ -49,4 +53,41 @@ func looksLikeSHA(ref string) bool {
 		}
 	}
 	return true
+}
+
+func gitSafePath(path string) string {
+	return filepath.Clean(path)
+}
+
+func gitSafeArg(arg string) (string, error) {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return "", fmt.Errorf("empty git argument")
+	}
+	if strings.HasPrefix(arg, "-") {
+		return "", fmt.Errorf("invalid git argument %q", arg)
+	}
+	return arg, nil
+}
+
+func gitInDir(ctx context.Context, gitDir string, args ...string) *exec.Cmd {
+	cmdArgs := make([]string, 0, 2+len(args))
+	cmdArgs = append(cmdArgs, "--git-dir", gitSafePath(gitDir))
+	cmdArgs = append(cmdArgs, args...)
+	return exec.CommandContext(ctx, "git", cmdArgs...)
+}
+
+func gitInWorktree(ctx context.Context, root string, args ...string) *exec.Cmd {
+	cmdArgs := make([]string, 0, 2+len(args))
+	cmdArgs = append(cmdArgs, "-C", gitSafePath(root))
+	cmdArgs = append(cmdArgs, args...)
+	return exec.CommandContext(ctx, "git", cmdArgs...)
+}
+
+func gitCloneBare(ctx context.Context, remoteURL, dest string) *exec.Cmd {
+	return exec.CommandContext(ctx, "git", "clone", "--bare", "--filter=blob:none", remoteURL, gitSafePath(dest))
+}
+
+func tarExtract(ctx context.Context, dest string) *exec.Cmd {
+	return exec.CommandContext(ctx, "tar", "-x", "-C", gitSafePath(dest))
 }

--- a/pkg/parser/terraform/modules/resolver/gitexec.go
+++ b/pkg/parser/terraform/modules/resolver/gitexec.go
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"context"
+	"runtime"
+)
+
+const (
+	gitSHALength = 40
+
+	// cacheFilePerms is used for small auxiliary files written alongside cached git repos.
+	cacheFilePerms = 0o600
+)
+
+// gitProcSem caps concurrent git subprocesses across resolvers.
+var gitProcSem = make(chan struct{}, gitProcConcurrency())
+
+func gitProcConcurrency() int {
+	n := runtime.GOMAXPROCS(0)
+	const minGitProcConcurrency = 4
+	if n < minGitProcConcurrency {
+		return minGitProcConcurrency
+	}
+	return n
+}
+
+func acquireGitProc(ctx context.Context) (release func(), err error) {
+	select {
+	case gitProcSem <- struct{}{}:
+		return func() { <-gitProcSem }, nil
+	case <-ctx.Done():
+		return func() {}, ctx.Err()
+	}
+}
+
+// looksLikeSHA reports whether ref is a full 40-character hex SHA-1.
+func looksLikeSHA(ref string) bool {
+	if len(ref) != gitSHALength {
+		return false
+	}
+	for _, c := range ref {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/parser/terraform/modules/resolver/gitexec.go
+++ b/pkg/parser/terraform/modules/resolver/gitexec.go
@@ -74,20 +74,20 @@ func gitInDir(ctx context.Context, gitDir string, args ...string) *exec.Cmd {
 	cmdArgs := make([]string, 0, 2+len(args))
 	cmdArgs = append(cmdArgs, "--git-dir", gitSafePath(gitDir))
 	cmdArgs = append(cmdArgs, args...)
-	return exec.CommandContext(ctx, "git", cmdArgs...)
+	return exec.CommandContext(ctx, "git", cmdArgs...) //nolint:gosec
 }
 
 func gitInWorktree(ctx context.Context, root string, args ...string) *exec.Cmd {
 	cmdArgs := make([]string, 0, 2+len(args))
 	cmdArgs = append(cmdArgs, "-C", gitSafePath(root))
 	cmdArgs = append(cmdArgs, args...)
-	return exec.CommandContext(ctx, "git", cmdArgs...)
+	return exec.CommandContext(ctx, "git", cmdArgs...) //nolint:gosec
 }
 
 func gitCloneBare(ctx context.Context, remoteURL, dest string) *exec.Cmd {
-	return exec.CommandContext(ctx, "git", "clone", "--bare", "--filter=blob:none", remoteURL, gitSafePath(dest))
+	return exec.CommandContext(ctx, "git", "clone", "--bare", "--filter=blob:none", remoteURL, gitSafePath(dest)) //nolint:gosec
 }
 
 func tarExtract(ctx context.Context, dest string) *exec.Cmd {
-	return exec.CommandContext(ctx, "tar", "-x", "-C", gitSafePath(dest))
+	return exec.CommandContext(ctx, "tar", "-x", "-C", gitSafePath(dest)) //nolint:gosec
 }

--- a/pkg/parser/terraform/modules/resolver/localref.go
+++ b/pkg/parser/terraform/modules/resolver/localref.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -76,7 +75,7 @@ func (r *LocalGitRefResolver) init(ctx context.Context) {
 		contextLogger := logger.FromContext(ctx)
 		seen := make(map[string]bool) // deduplicate gitDirs
 		for _, root := range r.ScanRoots {
-			gitDir, err := detectGitDir(root)
+			gitDir, err := detectGitDir(ctx, root)
 			if err != nil || seen[gitDir] {
 				continue
 			}
@@ -107,8 +106,7 @@ func (r *LocalGitRefResolver) init(ctx context.Context) {
 }
 
 func loadRefMap(ctx context.Context, gitDir string) map[string]string {
-	cmd := exec.CommandContext(ctx, "git", "--git-dir="+gitDir, //nolint:gosec
-		"for-each-ref", "--format=%(objectname) %(refname)", "refs/tags", "refs/heads")
+	cmd := gitInDir(ctx, gitDir, "for-each-ref", "--format=%(objectname) %(refname)", "refs/tags", "refs/heads")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil
@@ -127,8 +125,8 @@ func loadRefMap(ctx context.Context, gitDir string) map[string]string {
 	return refs
 }
 
-func detectGitDir(root string) (string, error) {
-	cmd := exec.Command("git", "-C", root, "rev-parse", "--git-dir") //nolint:gosec
+func detectGitDir(ctx context.Context, root string) (string, error) {
+	cmd := gitInWorktree(ctx, root, "rev-parse", "--git-dir")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("not a git repo: %w", err)
@@ -141,7 +139,7 @@ func detectGitDir(root string) (string, error) {
 }
 
 func listRemoteURLs(ctx context.Context, gitDir string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "git", "--git-dir="+gitDir, "remote", "-v") //nolint:gosec
+	cmd := gitInDir(ctx, gitDir, "remote", "-v")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -185,14 +183,22 @@ func resolveLocalRef(ctx context.Context, info *localRepoInfo, ref string) (sha 
 	}
 	defer release()
 	if looksLikeSHA(ref) {
-		cmd := exec.CommandContext(ctx, "git", "--git-dir="+info.gitDir, "cat-file", "-t", ref) //nolint:gosec
+		safeRef, refErr := gitSafeArg(ref)
+		if refErr != nil {
+			return "", false
+		}
+		cmd := gitInDir(ctx, info.gitDir, "cat-file", "-t", safeRef)
 		if cmd.Run() == nil {
 			return ref, true
 		}
 		return "", false
 	}
+	safeRef, refErr := gitSafeArg(ref)
+	if refErr != nil {
+		return "", false
+	}
 	// Ref not in the prebuilt map (e.g. remote-tracking ref): ask git directly.
-	cmd := exec.CommandContext(ctx, "git", "--git-dir="+info.gitDir, "rev-parse", "--verify", ref) //nolint:gosec
+	cmd := gitInDir(ctx, info.gitDir, "rev-parse", "--verify", safeRef)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", false

--- a/pkg/parser/terraform/modules/resolver/localref.go
+++ b/pkg/parser/terraform/modules/resolver/localref.go
@@ -1,0 +1,249 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+)
+
+// LocalGitRefResolver extracts self-referential git modules from the local checkout.
+type LocalGitRefResolver struct {
+	ScanRoots []string
+
+	// Defaults to <user-cache-dir>/datadog-iac-scanner/git-local.
+	CacheDir string
+
+	initOnce sync.Once
+	repos    []*localRepoInfo // scan roots that are git repos
+
+	extractSF singleflight.Group
+}
+
+type localRepoInfo struct {
+	gitDir      string          // <root>/.git (or the root itself for bare repos)
+	normalURLs  map[string]bool // set of normalized remote URLs for this repo
+	extractBase string
+
+	refSHA map[string]string // refs/tags|heads → object SHA from one for-each-ref
+}
+
+func (info *localRepoInfo) lookupRefSHA(ref string) (string, bool) {
+	if info.refSHA == nil {
+		return "", false
+	}
+	for _, full := range []string{ref, "refs/" + ref, "refs/tags/" + ref, "refs/heads/" + ref} {
+		if sha, ok := info.refSHA[full]; ok {
+			return sha, true
+		}
+	}
+	return "", false
+}
+
+func NewLocalGitRefResolver(scanRoots []string, cacheDir string) *LocalGitRefResolver {
+	return &LocalGitRefResolver{
+		ScanRoots: scanRoots,
+		CacheDir:  cacheDir,
+	}
+}
+
+func (r *LocalGitRefResolver) effectiveCacheDir() string {
+	if r.CacheDir != "" {
+		return r.CacheDir
+	}
+	base, err := os.UserCacheDir()
+	if err != nil {
+		base = os.TempDir()
+	}
+	return filepath.Join(base, "datadog-iac-scanner", "git-local")
+}
+
+func (r *LocalGitRefResolver) init(ctx context.Context) {
+	r.initOnce.Do(func() {
+		contextLogger := logger.FromContext(ctx)
+		seen := make(map[string]bool) // deduplicate gitDirs
+		for _, root := range r.ScanRoots {
+			gitDir, err := detectGitDir(root)
+			if err != nil || seen[gitDir] {
+				continue
+			}
+			seen[gitDir] = true
+
+			urls, err := listRemoteURLs(ctx, gitDir)
+			if err != nil {
+				contextLogger.Debug().Err(err).Msgf("LocalGitRefResolver: could not read remotes for %s", root)
+				continue
+			}
+			if len(urls) == 0 {
+				continue
+			}
+
+			repoKey := repoURLKey(gitDir)
+			info := &localRepoInfo{
+				gitDir:      gitDir,
+				normalURLs:  make(map[string]bool, len(urls)),
+				extractBase: filepath.Join(r.effectiveCacheDir(), repoKey),
+				refSHA:      loadRefMap(ctx, gitDir),
+			}
+			for _, u := range urls {
+				info.normalURLs[normalizeGitRepoURL(u)] = true
+			}
+			r.repos = append(r.repos, info)
+		}
+	})
+}
+
+func loadRefMap(ctx context.Context, gitDir string) map[string]string {
+	cmd := exec.CommandContext(ctx, "git", "--git-dir="+gitDir, //nolint:gosec
+		"for-each-ref", "--format=%(objectname) %(refname)", "refs/tags", "refs/heads")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	refs := make(map[string]string)
+	for _, line := range strings.Split(string(out), "\n") {
+		sha, refName, found := strings.Cut(line, " ")
+		if !found || !looksLikeSHA(sha) {
+			continue
+		}
+		refs[refName] = sha
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	return refs
+}
+
+func detectGitDir(root string) (string, error) {
+	cmd := exec.Command("git", "-C", root, "rev-parse", "--git-dir") //nolint:gosec
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("not a git repo: %w", err)
+	}
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(root, gitDir)
+	}
+	return gitDir, nil
+}
+
+func listRemoteURLs(ctx context.Context, gitDir string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "--git-dir="+gitDir, "remote", "-v") //nolint:gosec
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool)
+	var urls []string
+	for _, line := range strings.Split(string(out), "\n") {
+		// Format: "origin\thttps://... (fetch)"
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		u := fields[1]
+		if !seen[u] {
+			seen[u] = true
+			urls = append(urls, u)
+		}
+	}
+	return urls, nil
+}
+
+func (r *LocalGitRefResolver) findRepo(normSource string) *localRepoInfo {
+	for _, info := range r.repos {
+		if info.normalURLs[normSource] {
+			return info
+		}
+	}
+	return nil
+}
+
+func resolveLocalRef(ctx context.Context, info *localRepoInfo, ref string) (sha string, ok bool) {
+	if !looksLikeSHA(ref) {
+		if resolved, found := info.lookupRefSHA(ref); found {
+			return resolved, true
+		}
+	}
+
+	release, err := acquireGitProc(ctx)
+	if err != nil {
+		return "", false
+	}
+	defer release()
+	if looksLikeSHA(ref) {
+		cmd := exec.CommandContext(ctx, "git", "--git-dir="+info.gitDir, "cat-file", "-t", ref) //nolint:gosec
+		if cmd.Run() == nil {
+			return ref, true
+		}
+		return "", false
+	}
+	// Ref not in the prebuilt map (e.g. remote-tracking ref): ask git directly.
+	cmd := exec.CommandContext(ctx, "git", "--git-dir="+info.gitDir, "rev-parse", "--verify", ref) //nolint:gosec
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	resolved := strings.TrimSpace(string(out))
+	return resolved, looksLikeSHA(resolved)
+}
+
+// Resolve implements Resolver for git:: sources that reference the local checkout.
+func (r *LocalGitRefResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedModule) (Resolution, error) {
+	repoURL, subdir, ref, ok := parseGitGetterSource(mod.Source)
+	if !ok || ref == "" {
+		return Resolution{}, &tfmodules.UnresolvedError{
+			Reason: "LocalGitRefResolver: not a git:: source with a ref= parameter",
+		}
+	}
+
+	r.init(ctx)
+
+	normSource := normalizeGitRepoURL(repoURL)
+	info := r.findRepo(normSource)
+	if info == nil {
+		return Resolution{}, &tfmodules.UnresolvedError{
+			Reason: fmt.Sprintf("LocalGitRefResolver: no local clone matches %q", normSource),
+		}
+	}
+
+	// Warm-cache fast path for pinned SHA refs.
+	if looksLikeSHA(ref) {
+		if dest, ok := cachedArchiveDir(info.extractBase, ref, subdir); ok {
+			return Resolution{LocalPath: dest}, nil
+		}
+	}
+
+	contextLogger := logger.FromContext(ctx)
+	sha, present := resolveLocalRef(ctx, info, ref)
+	if !present {
+		contextLogger.Debug().Msgf("LocalGitRefResolver: ref %q not in local clone %s (shallow checkout?)", ref, info.gitDir)
+		return Resolution{}, &tfmodules.UnresolvedError{
+			Reason: fmt.Sprintf("LocalGitRefResolver: ref %q not present locally", ref),
+		}
+	}
+
+	key := archiveCacheKey(sha, subdir)
+	_, err, _ := r.extractSF.Do(key, func() (interface{}, error) {
+		return nil, archiveExtract(ctx, info.gitDir, info.extractBase, sha, subdir)
+	})
+	if err != nil {
+		contextLogger.Warn().Err(err).Msgf("LocalGitRefResolver: archive %s:%s failed", sha, subdir)
+		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
+	}
+
+	return Resolution{LocalPath: filepath.Join(info.extractBase, key)}, nil
+}

--- a/pkg/parser/terraform/modules/resolver/localref_test.go
+++ b/pkg/parser/terraform/modules/resolver/localref_test.go
@@ -1,0 +1,79 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		"GIT_TERMINAL_PROMPT=0", "EDITOR=true",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %s: %v", strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func initRepoWithRefs(t *testing.T) (workTree, gitDir string) {
+	t.Helper()
+	workTree = t.TempDir()
+	runGit(t, workTree, "init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(workTree, "main.tf"), []byte("# m\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, workTree, "add", ".")
+	runGit(t, workTree, "commit", "-q", "-m", "init")
+	runGit(t, workTree, "branch", "feature")
+	runGit(t, workTree, "tag", "v1.0.0")                    // lightweight
+	runGit(t, workTree, "tag", "-a", "v2.0.0", "-m", "two") // annotated
+	return workTree, filepath.Join(workTree, ".git")
+}
+
+func TestLoadRefMapMatchesRevParse(t *testing.T) {
+	workTree, gitDir := initRepoWithRefs(t)
+	info := &localRepoInfo{gitDir: gitDir, refSHA: loadRefMap(context.Background(), gitDir)}
+
+	for _, ref := range []string{"v1.0.0", "v2.0.0", "main", "feature"} {
+		want := runGit(t, workTree, "rev-parse", "--verify", ref)
+		got, ok := info.lookupRefSHA(ref)
+		if !ok {
+			t.Fatalf("ref %q not found in map", ref)
+		}
+		if got != want {
+			t.Fatalf("ref %q: map sha %q != rev-parse %q", ref, got, want)
+		}
+		if resolved, present := resolveLocalRef(context.Background(), info, ref); !present || resolved != want {
+			t.Fatalf("resolveLocalRef(%q) = (%q,%v), want (%q,true)", ref, resolved, present, want)
+		}
+	}
+}
+
+func TestResolveLocalRefSHAAndMissing(t *testing.T) {
+	workTree, gitDir := initRepoWithRefs(t)
+	info := &localRepoInfo{gitDir: gitDir, refSHA: loadRefMap(context.Background(), gitDir)}
+
+	sha := runGit(t, workTree, "rev-parse", "--verify", "main")
+	if got, ok := resolveLocalRef(context.Background(), info, sha); !ok || got != sha {
+		t.Fatalf("resolveLocalRef(sha) = (%q,%v), want (%q,true)", got, ok, sha)
+	}
+	if _, ok := resolveLocalRef(context.Background(), info, "does-not-exist"); ok {
+		t.Fatal("expected missing ref to be unresolved")
+	}
+}


### PR DESCRIPTION
## Motivation

The resolver package from #240 handles offline sources only. Many Terraform repos reference git modules with pinned refs (`git::https://...?ref=v1.2.3`). When the repository is already cloned locally, or when a bare clone is available, we can resolve those modules without a network fetch.

This PR adds git resolution on top of #240. It is stacked on that branch and will merge after #240 lands (which itself waits on #234).

Related Ticket: [K9CODESEC-2946](https://datadoghq.atlassian.net/browse/K9CODESEC-2946?atlOrigin=eyJpIjoiNWZmOGQzNTczYWEzNGIyNTk5MjYwMGM0ODQ2MjQ5MGIiLCJwIjoiaiJ9)

## Changes

**Git resolvers**

Adds two offline git resolvers: `baregit` resolves pinned `git::` sources from a shared bare clone cache, and `localref` resolves refs that already exist in the scan workspace's `.git` directory. Both plug into the existing `Resolver` chain from #240.

**Shared git helpers**

Adds a concurrency-limited git subprocess semaphore and SHA/ref detection utilities used by both resolvers.

Nothing in the scan path invokes these resolvers yet.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/parser/terraform/modules/...`
2. `go build ./...`

## Blast Radius

Additive only: new resolver implementations under `pkg/parser/terraform/modules/resolver`. No CLI, scan, or engine behavior changes.

## Additional Notes

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-2946]: https://datadoghq.atlassian.net/browse/K9CODESEC-2946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ