### PR TITLE
Nathan.gallet/fix ci failures

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -458,9 +458,6 @@ func getRepositoryCommitInfo(repoPaths []string) (*model.RepositoryCommitInfo, s
 			}
 		}
 	}
-	if out.Branch == "" {
-		return nil, "", errors.New("could not determine the branch name for HEAD")
-	}
 
 	return out, repoDir, nil
 }


### PR DESCRIPTION
## Summary

`Test_E2EFetchBundleThenOfflineScan` was failing in CI because `getRepositoryCommitInfo` hard-errors when the git branch name cannot be determined. This happens on release tag pushes, where GitHub Actions checks out in detached HEAD state with no remote branch pointing at the commit.

Branch is optional metadata (`omitempty` in the model) — aborting the entire scan over it is wrong. The fix removes the hard error and lets the scan continue with an empty branch.

## How to reproduce

```bash
# Simulate a commit with no remote tracking ref (same as a CI tag push)
git commit --allow-empty -m "temp"

# Run the test — fails before the fix
go test ./cmd/scanner/... -run Test_E2EFetchBundleThenOfflineScan -v -count=1
```