### PR TITLE
Handle missing HCL expression types in Terraform parsing

### DIFF
--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -119,6 +119,10 @@ func (v *engineVisitor) VisitForExpr(e *hclsyntax.ForExpr) (string, error) {
 		b.WriteString("}")
 	} else {
 		b.WriteString("[for ")
+		if e.KeyVar != "" {
+			b.WriteString(e.KeyVar)
+			b.WriteString(", ")
+		}
 		b.WriteString(e.ValVar)
 		b.WriteString(" in ")
 		b.WriteString(collStr)

--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -61,7 +61,9 @@ func (v *engineVisitor) VisitObjectCons(e *hclsyntax.ObjectConsExpr) (string, er
 	return v.e.expToStringObjectConsExpr(v.ctx, e)
 }
 func (v *engineVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (string, error) {
-	return "", fmt.Errorf("can't convert expression %T to string", e)
+	// A template join wraps the for-loop of a %{for}...%{endfor} template
+	// directive; render the underlying for-expression.
+	return v.e.ExpToString(v.ctx, e.Tuple)
 }
 func (v *engineVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (string, error) {
 	lhs, err := v.e.ExpToString(v.ctx, e.LHS)
@@ -140,13 +142,24 @@ func (v *engineVisitor) VisitSplatExpr(e *hclsyntax.SplatExpr) (string, error) {
 		return "", err
 	}
 	base := sourceStr + "[*]"
+	// e.Each is a traversal rooted at the anonymous item symbol (which renders
+	// as an empty string), so rendering it yields just the trailing traversal
+	// (e.g. ".id" for var.list[*].id, or "" for a bare var.list[*]).
 	if e.Each != nil && e.Each != e.Source {
 		eachStr, err := v.e.ExpToString(v.ctx, e.Each)
-		if err == nil && (eachStr == base || strings.HasPrefix(eachStr, base)) {
-			return eachStr, nil
+		if err == nil {
+			return base + eachStr, nil
 		}
 	}
 	return base, nil
+}
+func (v *engineVisitor) VisitAnonSymbol(e *hclsyntax.AnonSymbolExpr) (string, error) {
+	// The anonymous splat item renders as an empty string so that a trailing
+	// traversal (e.g. .id) composes onto the splat base in VisitSplatExpr.
+	return "", nil
+}
+func (v *engineVisitor) VisitExprSyntaxError(e *hclsyntax.ExprSyntaxError) (string, error) {
+	return "", fmt.Errorf("can't convert invalid expression %T to string", e)
 }
 func (v *engineVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	log := logger.FromContext(v.ctx)

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -430,6 +430,20 @@ func TestExpToString_ForExpr(t *testing.T) {
 			t.Errorf("ExpToString = %q, want %q", got, want)
 		}
 	})
+	t.Run("template_for_two_vars", func(t *testing.T) {
+		f, diags := hclsyntax.ParseConfig([]byte(`x = "%{for k, v in var.map}${k}%{endfor}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		attr := f.Body.(*hclsyntax.Body).Attributes["x"]
+		got, err := e.ExpToString(ctx, attr.Expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "[for k, v in var.map : k]"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestExpToString_UnaryOpExpr(t *testing.T) {

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -356,13 +356,33 @@ func TestExpToString_SplatExpr(t *testing.T) {
 		}
 		got, err := e.ExpToString(ctx, expr)
 		if err != nil {
-			return
+			t.Fatalf("ExpToString error: %v", err)
 		}
-		// AST may be SplatExpr (then we get "var.list[*]") or RelativeTraversalExpr (then "var.list[*].id")
-		if got != "var.list[*].id" && got != "var.list[*]" {
-			t.Errorf("ExpToString = %q", got)
+		// The anonymous splat item renders empty, so the trailing traversal
+		// composes onto the base to yield the full path.
+		if want := "var.list[*].id"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
 		}
 	})
+}
+
+func TestExpToString_TemplateJoin(t *testing.T) {
+	e := &Engine{}
+	ctx := context.Background()
+	// A %{for}...%{endfor} template directive parses to a TemplateExpr whose
+	// single part is a TemplateJoinExpr wrapping a ForExpr.
+	f, diags := hclsyntax.ParseConfig([]byte(`x = "%{for v in var.list}${v}%{endfor}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse failed: %v", diags)
+	}
+	attr := f.Body.(*hclsyntax.Body).Attributes["x"]
+	got, err := e.ExpToString(ctx, attr.Expr)
+	if err != nil {
+		t.Fatalf("ExpToString error: %v", err)
+	}
+	if want := "[for v in var.list : v]"; got != want {
+		t.Errorf("ExpToString = %q, want %q", got, want)
+	}
 }
 
 func TestExpToString_ForExpr(t *testing.T) {

--- a/pkg/builder/engine/engine_test.go
+++ b/pkg/builder/engine/engine_test.go
@@ -417,6 +417,19 @@ func TestExpToString_ForExpr(t *testing.T) {
 			t.Errorf("ExpToString = %q, want %q", got, want)
 		}
 	})
+	t.Run("tuple_for_two_vars", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`[for k, v in var.map : k]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		got, err := e.ExpToString(ctx, expr)
+		if err != nil {
+			t.Fatalf("ExpToString error: %v", err)
+		}
+		if want := "[for k, v in var.map : k]"; got != want {
+			t.Errorf("ExpToString = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestExpToString_UnaryOpExpr(t *testing.T) {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -1461,13 +1461,11 @@ func (v *inspectorExprVisitor) VisitDefault(e hclsyntax.Expression) (ast.Value, 
 func expressionToASTTemplateExpr(e *hclsyntax.TemplateExpr) ast.Value {
 	result := ""
 	for _, part := range e.Parts {
-		switch p := part.(type) {
-		case *hclsyntax.LiteralValueExpr:
-			if p.Val.Type().Equals(cty.String) {
-				result += p.Val.AsString()
-			}
-		default:
+		v, err := expressionToAST(part)
+		if err != nil || v == nil {
 			result += "${...}"
+		} else {
+			result += astValueToSimpleString(v)
 		}
 	}
 	return ast.String(result)

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -1462,10 +1462,11 @@ func expressionToASTTemplateExpr(e *hclsyntax.TemplateExpr) ast.Value {
 	result := ""
 	for _, part := range e.Parts {
 		v, err := expressionToAST(part)
-		if err != nil || v == nil {
+		s := astValueToSimpleString(v)
+		if err != nil || v == nil || s == "__UNSUPPORTED_EXPR__" || s == "__UNSUPPORTED_LITERAL__" {
 			result += "${...}"
 		} else {
-			result += astValueToSimpleString(v)
+			result += s
 		}
 	}
 	return ast.String(result)
@@ -1595,6 +1596,10 @@ func expressionToASTForExpr(e *hclsyntax.ForExpr) ast.Value {
 		b.WriteString("}")
 	} else {
 		b.WriteString("[for ")
+		if e.KeyVar != "" {
+			b.WriteString(e.KeyVar)
+			b.WriteString(", ")
+		}
 		b.WriteString(e.ValVar)
 		b.WriteString(" in ")
 		b.WriteString(collStr)

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -1430,7 +1430,9 @@ func (v *inspectorExprVisitor) VisitObjectCons(e *hclsyntax.ObjectConsExpr) (ast
 	return expressionToASTObjectConsExpr(e), nil
 }
 func (v *inspectorExprVisitor) VisitTemplateJoin(e *hclsyntax.TemplateJoinExpr) (ast.Value, error) {
-	return ast.String("__UNSUPPORTED_EXPR__"), nil
+	// A template join wraps the for-loop of a %{for}...%{endfor} template
+	// directive; render the underlying for-expression.
+	return expressionToAST(e.Tuple)
 }
 func (v *inspectorExprVisitor) VisitBinaryOp(e *hclsyntax.BinaryOpExpr) (ast.Value, error) {
 	return expressionToASTBinaryOpExpr(e), nil
@@ -1443,6 +1445,14 @@ func (v *inspectorExprVisitor) VisitForExpr(e *hclsyntax.ForExpr) (ast.Value, er
 }
 func (v *inspectorExprVisitor) VisitSplatExpr(e *hclsyntax.SplatExpr) (ast.Value, error) {
 	return expressionToASTSplatExpr(e), nil
+}
+func (v *inspectorExprVisitor) VisitAnonSymbol(e *hclsyntax.AnonSymbolExpr) (ast.Value, error) {
+	// The anonymous splat item renders as an empty string so that a trailing
+	// traversal (e.g. .id) composes onto the splat base in VisitSplatExpr.
+	return ast.String(""), nil
+}
+func (v *inspectorExprVisitor) VisitExprSyntaxError(e *hclsyntax.ExprSyntaxError) (ast.Value, error) {
+	return ast.String("__UNSUPPORTED_EXPR__"), nil
 }
 func (v *inspectorExprVisitor) VisitDefault(e hclsyntax.Expression) (ast.Value, error) {
 	return ast.String("__UNSUPPORTED_EXPR__"), nil
@@ -1605,13 +1615,13 @@ func expressionToASTForExpr(e *hclsyntax.ForExpr) ast.Value {
 func expressionToASTSplatExpr(e *hclsyntax.SplatExpr) ast.Value {
 	sourceV, _ := expressionToAST(e.Source)
 	base := astValueToSimpleString(sourceV) + "[*]"
+	// e.Each is a traversal rooted at the anonymous item symbol (which renders
+	// as an empty string), so rendering it yields just the trailing traversal
+	// (e.g. ".id" for var.list[*].id, or "" for a bare var.list[*]).
 	if e.Each != nil && e.Each != e.Source {
 		eachV, err := expressionToAST(e.Each)
 		if err == nil {
-			eachStr := astValueToSimpleString(eachV)
-			if eachStr == base || strings.HasPrefix(eachStr, base) {
-				return ast.String(eachStr)
-			}
+			return ast.String(base + astValueToSimpleString(eachV))
 		}
 	}
 	return ast.String(base)

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -1014,6 +1014,27 @@ func TestExpressionToAST_TemplateJoin(t *testing.T) {
 	}
 }
 
+func TestExpressionToAST_TemplateExpr_WithFor(t *testing.T) {
+	// Exercises the full real-world path: a string attribute with a %{for}
+	// directive parses as TemplateExpr → TemplateJoinExpr → ForExpr → inner
+	// TemplateExpr(ScopeTraversalExpr).  With the recursive fix, the template
+	// parts are rendered by expressionToAST instead of collapsing to "${...}".
+	f, diags := hclsyntax.ParseConfig([]byte(`x = "%{for v in var.list}${v}%{endfor}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse failed: %v", diags)
+	}
+	attr := f.Body.(*hclsyntax.Body).Attributes["x"]
+	val, err := expressionToAST(attr.Expr)
+	if err != nil {
+		t.Fatalf("expressionToAST error: %v", err)
+	}
+	// The for-loop body ${v} is a TemplateExpr wrapping ScopeTraversalExpr(v),
+	// which now renders as "v", giving "[for v in var.list : v]".
+	if got := val.String(); got != `"[for v in var.list : v]"` {
+		t.Errorf("expressionToAST = %s", got)
+	}
+}
+
 func TestExpressionToAST_ForExpr(t *testing.T) {
 	t.Run("tuple_for", func(t *testing.T) {
 		expr, diags := hclsyntax.ParseExpression([]byte(`[for x in var.list : x]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -1015,10 +1015,6 @@ func TestExpressionToAST_TemplateJoin(t *testing.T) {
 }
 
 func TestExpressionToAST_TemplateExpr_WithFor(t *testing.T) {
-	// Exercises the full real-world path: a string attribute with a %{for}
-	// directive parses as TemplateExpr → TemplateJoinExpr → ForExpr → inner
-	// TemplateExpr(ScopeTraversalExpr).  With the recursive fix, the template
-	// parts are rendered by expressionToAST instead of collapsing to "${...}".
 	f, diags := hclsyntax.ParseConfig([]byte(`x = "%{for v in var.list}${v}%{endfor}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
 		t.Fatalf("parse failed: %v", diags)
@@ -1028,10 +1024,41 @@ func TestExpressionToAST_TemplateExpr_WithFor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expressionToAST error: %v", err)
 	}
-	// The for-loop body ${v} is a TemplateExpr wrapping ScopeTraversalExpr(v),
-	// which now renders as "v", giving "[for v in var.list : v]".
 	if got := val.String(); got != `"[for v in var.list : v]"` {
 		t.Errorf("expressionToAST = %s", got)
+	}
+}
+
+func TestExpressionToAST_TemplateExpr_WithFor_TwoVars(t *testing.T) {
+	f, diags := hclsyntax.ParseConfig([]byte(`x = "%{for k, v in var.map}${k}%{endfor}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse failed: %v", diags)
+	}
+	attr := f.Body.(*hclsyntax.Body).Attributes["x"]
+	val, err := expressionToAST(attr.Expr)
+	if err != nil {
+		t.Fatalf("expressionToAST error: %v", err)
+	}
+	if got := val.String(); got != `"[for k, v in var.map : k]"` {
+		t.Errorf("expressionToAST = %s", got)
+	}
+}
+
+func TestExpressionToAST_TemplateExpr_UnsupportedPartFallback(t *testing.T) {
+	// ExprSyntaxError in a template part must collapse to "${...}", not leak the sentinel string.
+	// Parse a template with a literal prefix followed by a syntax error placeholder.
+	f, diags := hclsyntax.ParseConfig([]byte(`x = "prefix-${"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	if !diags.HasErrors() {
+		t.Fatal("expected parse error")
+	}
+	_ = f
+	// Construct the template manually to avoid parse-level rejection.
+	errExpr := &hclsyntax.ExprSyntaxError{}
+	val := expressionToASTTemplateExpr(&hclsyntax.TemplateExpr{
+		Parts: []hclsyntax.Expression{errExpr},
+	})
+	if got := val.String(); got != `"${...}"` {
+		t.Errorf("expressionToASTTemplateExpr = %s, want \"${...}\"", got)
 	}
 }
 
@@ -1047,6 +1074,21 @@ func TestExpressionToAST_ForExpr(t *testing.T) {
 		}
 		got := val.String()
 		want := `"[for x in var.list : x]"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
+	t.Run("tuple_for_two_vars", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`[for k, v in var.map : k]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		got := val.String()
+		want := `"[for k, v in var.map : k]"`
 		if got != want {
 			t.Errorf("expressionToAST = %s, want %s", got, want)
 		}

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -975,12 +975,43 @@ func TestExpressionToAST_SplatExpr(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expressionToAST error: %v", err)
 		}
-		// When SplatExpr is dispatched, we get source[*]. Until then we get __UNSUPPORTED_EXPR__.
 		got := val.String()
-		if got != `"var.list[*]"` && got != `"__UNSUPPORTED_EXPR__"` {
+		if got != `"var.list[*]"` {
 			t.Errorf("expressionToAST = %s", got)
 		}
 	})
+	t.Run("splat_with_traversal", func(t *testing.T) {
+		expr, diags := hclsyntax.ParseExpression([]byte(`var.list[*].id`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		val, err := expressionToAST(expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		// The anonymous splat item renders empty, so the trailing traversal
+		// composes onto the base to yield the full path.
+		if got := val.String(); got != `"var.list[*].id"` {
+			t.Errorf("expressionToAST = %s", got)
+		}
+	})
+}
+
+func TestExpressionToAST_TemplateJoin(t *testing.T) {
+	// A TemplateJoinExpr wraps the for-loop of a %{for}...%{endfor} directive.
+	// Build one directly (the parser nests it inside a TemplateExpr part) and
+	// verify it renders the underlying for-expression instead of __UNSUPPORTED_EXPR__.
+	forExpr, diags := hclsyntax.ParseExpression([]byte(`[for v in var.list : v]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse failed: %v", diags)
+	}
+	val, err := expressionToAST(&hclsyntax.TemplateJoinExpr{Tuple: forExpr})
+	if err != nil {
+		t.Fatalf("expressionToAST error: %v", err)
+	}
+	if got := val.String(); got != `"[for v in var.list : v]"` {
+		t.Errorf("expressionToAST = %s", got)
+	}
 }
 
 func TestExpressionToAST_ForExpr(t *testing.T) {

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -1015,33 +1015,36 @@ func TestExpressionToAST_TemplateJoin(t *testing.T) {
 }
 
 func TestExpressionToAST_TemplateExpr_WithFor(t *testing.T) {
-	f, diags := hclsyntax.ParseConfig([]byte(`x = "%{for v in var.list}${v}%{endfor}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
-	if diags.HasErrors() {
-		t.Fatalf("parse failed: %v", diags)
-	}
-	attr := f.Body.(*hclsyntax.Body).Attributes["x"]
-	val, err := expressionToAST(attr.Expr)
-	if err != nil {
-		t.Fatalf("expressionToAST error: %v", err)
-	}
-	if got := val.String(); got != `"[for v in var.list : v]"` {
-		t.Errorf("expressionToAST = %s", got)
-	}
-}
-
-func TestExpressionToAST_TemplateExpr_WithFor_TwoVars(t *testing.T) {
-	f, diags := hclsyntax.ParseConfig([]byte(`x = "%{for k, v in var.map}${k}%{endfor}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
-	if diags.HasErrors() {
-		t.Fatalf("parse failed: %v", diags)
-	}
-	attr := f.Body.(*hclsyntax.Body).Attributes["x"]
-	val, err := expressionToAST(attr.Expr)
-	if err != nil {
-		t.Fatalf("expressionToAST error: %v", err)
-	}
-	if got := val.String(); got != `"[for k, v in var.map : k]"` {
-		t.Errorf("expressionToAST = %s", got)
-	}
+	t.Run("one_var", func(t *testing.T) {
+		f, diags := hclsyntax.ParseConfig([]byte(`x = "%{for v in var.list}${v}%{endfor}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		attr := f.Body.(*hclsyntax.Body).Attributes["x"]
+		val, err := expressionToAST(attr.Expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		if got := val.String(); got != `"[for v in var.list : v]"` {
+			t.Errorf("expressionToAST = %s", got)
+		}
+	})
+	t.Run("template_for_two_vars", func(t *testing.T) {
+		f, diags := hclsyntax.ParseConfig([]byte(`x = "%{for k, v in var.map}${k}%{endfor}"`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Fatalf("parse failed: %v", diags)
+		}
+		attr := f.Body.(*hclsyntax.Body).Attributes["x"]
+		val, err := expressionToAST(attr.Expr)
+		if err != nil {
+			t.Fatalf("expressionToAST error: %v", err)
+		}
+		got := val.String()
+		want := `"[for k, v in var.map : k]"`
+		if got != want {
+			t.Errorf("expressionToAST = %s, want %s", got, want)
+		}
+	})
 }
 
 func TestExpressionToAST_TemplateExpr_UnsupportedPartFallback(t *testing.T) {

--- a/pkg/hclexpr/visitor.go
+++ b/pkg/hclexpr/visitor.go
@@ -27,11 +27,19 @@ type Visitor[T any] interface {
 	VisitUnaryOp(e *hclsyntax.UnaryOpExpr) (T, error)
 	VisitForExpr(e *hclsyntax.ForExpr) (T, error)
 	VisitSplatExpr(e *hclsyntax.SplatExpr) (T, error)
+	// VisitAnonSymbol handles the synthetic placeholder for the current item
+	// inside a splat's Each expression (e.g. the item in var.list[*].id).
+	VisitAnonSymbol(e *hclsyntax.AnonSymbolExpr) (T, error)
+	// VisitExprSyntaxError handles the placeholder produced for invalid or
+	// incomplete expressions that could not be parsed.
+	VisitExprSyntaxError(e *hclsyntax.ExprSyntaxError) (T, error)
 	VisitDefault(e hclsyntax.Expression) (T, error)
 }
 
 // Dispatch unwraps expr then dispatches to the appropriate Visitor method.
-// Add new expression types here and to the Visitor interface so all sites stay in sync.
+// Add new expression types here (or in dispatchComposite) and to the Visitor
+// interface so all sites stay in sync. The dispatch is split across two
+// functions purely to keep each below the cyclomatic complexity limit.
 func Dispatch[T any](expr hclsyntax.Expression, v Visitor[T]) (T, error) {
 	expr = Unwrap(expr)
 	switch e := expr.(type) {
@@ -49,6 +57,15 @@ func Dispatch[T any](expr hclsyntax.Expression, v Visitor[T]) (T, error) {
 		return v.VisitFunctionCall(e)
 	case *hclsyntax.ConditionalExpr:
 		return v.VisitConditional(e)
+	default:
+		return dispatchComposite(expr, v)
+	}
+}
+
+// dispatchComposite handles the composite, operator, and synthetic expression
+// types. It receives an already-unwrapped expression from Dispatch.
+func dispatchComposite[T any](expr hclsyntax.Expression, v Visitor[T]) (T, error) {
+	switch e := expr.(type) {
 	case *hclsyntax.TupleConsExpr:
 		return v.VisitTupleCons(e)
 	case *hclsyntax.ObjectConsExpr:
@@ -63,6 +80,10 @@ func Dispatch[T any](expr hclsyntax.Expression, v Visitor[T]) (T, error) {
 		return v.VisitForExpr(e)
 	case *hclsyntax.SplatExpr:
 		return v.VisitSplatExpr(e)
+	case *hclsyntax.AnonSymbolExpr:
+		return v.VisitAnonSymbol(e)
+	case *hclsyntax.ExprSyntaxError:
+		return v.VisitExprSyntaxError(e)
 	default:
 		return v.VisitDefault(expr)
 	}

--- a/pkg/hclexpr/visitor_test.go
+++ b/pkg/hclexpr/visitor_test.go
@@ -73,6 +73,14 @@ func (r *recordingVisitor) VisitSplatExpr(_ *hclsyntax.SplatExpr) (string, error
 	r.called = "SplatExpr"
 	return r.called, nil
 }
+func (r *recordingVisitor) VisitAnonSymbol(_ *hclsyntax.AnonSymbolExpr) (string, error) {
+	r.called = "AnonSymbol"
+	return r.called, nil
+}
+func (r *recordingVisitor) VisitExprSyntaxError(_ *hclsyntax.ExprSyntaxError) (string, error) {
+	r.called = "ExprSyntaxError"
+	return r.called, nil
+}
 func (r *recordingVisitor) VisitDefault(_ hclsyntax.Expression) (string, error) {
 	r.called = "Default"
 	return r.called, nil
@@ -107,18 +115,25 @@ func TestDispatch(t *testing.T) {
 		{"UnaryOp", `-1`, "UnaryOp"},
 		{"ForExpr", `[for x in var.list : x]`, "ForExpr"},
 		{"SplatExpr", `var.list[*]`, "SplatExpr"},
+		{"AnonSymbol", ``, "AnonSymbol"},           // synthetic; expr built in loop below
+		{"ExprSyntaxError", ``, "ExprSyntaxError"}, // synthetic; expr built in loop below
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var expr hclsyntax.Expression
-			if tt.name == "TemplateJoin" {
+			switch tt.name {
+			case "TemplateJoin":
 				forExpr, diags := hclsyntax.ParseExpression([]byte(`[for x in var.list : x]`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
 				if diags.HasErrors() {
 					t.Fatalf("parse for-expr failed: %v", diags)
 				}
 				expr = &hclsyntax.TemplateJoinExpr{Tuple: forExpr}
-			} else {
+			case "AnonSymbol":
+				expr = &hclsyntax.AnonSymbolExpr{}
+			case "ExprSyntaxError":
+				expr = &hclsyntax.ExprSyntaxError{}
+			default:
 				expr = parse(t, tt.src)
 			}
 			v := &recordingVisitor{}
@@ -175,7 +190,11 @@ func TestDispatch_UnwrapsBeforeDispatch(t *testing.T) {
 }
 
 func TestDispatch_UnknownExprType(t *testing.T) {
-	expr := &hclsyntax.AnonSymbolExpr{}
+	// A wrapper with no inner expression unwraps to nil, which no case matches,
+	// so Dispatch must fall through to VisitDefault. (A custom hclsyntax.Expression
+	// cannot be constructed outside the package, and every concrete exported type
+	// is now handled explicitly.)
+	expr := &hclsyntax.ParenthesesExpr{}
 	v := &recordingVisitor{}
 	got, _ := Dispatch[string](expr, v)
 	if got != "Default" {

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -270,6 +270,12 @@ func (v *converterExprVisitor) VisitForExpr(e *hclsyntax.ForExpr) (interface{}, 
 func (v *converterExprVisitor) VisitSplatExpr(e *hclsyntax.SplatExpr) (interface{}, error) {
 	return v.c.tryEvalExpression(e)
 }
+func (v *converterExprVisitor) VisitAnonSymbol(e *hclsyntax.AnonSymbolExpr) (interface{}, error) {
+	return v.c.tryEvalExpression(e)
+}
+func (v *converterExprVisitor) VisitExprSyntaxError(e *hclsyntax.ExprSyntaxError) (interface{}, error) {
+	return v.c.tryEvalExpression(e)
+}
 func (v *converterExprVisitor) VisitDefault(e hclsyntax.Expression) (interface{}, error) {
 	return v.c.tryEvalExpression(e)
 }
@@ -411,6 +417,12 @@ func (v *converterStringPartVisitor) VisitForExpr(e *hclsyntax.ForExpr) (string,
 }
 func (v *converterStringPartVisitor) VisitSplatExpr(e *hclsyntax.SplatExpr) (string, error) {
 	return v.c.tryEvalToString(e)
+}
+func (v *converterStringPartVisitor) VisitAnonSymbol(e *hclsyntax.AnonSymbolExpr) (string, error) {
+	return v.VisitDefault(e)
+}
+func (v *converterStringPartVisitor) VisitExprSyntaxError(e *hclsyntax.ExprSyntaxError) (string, error) {
+	return v.VisitDefault(e)
 }
 func (v *converterStringPartVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	val, _ := e.Value(&hcl.EvalContext{Variables: v.c.inputVars})

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -372,16 +372,25 @@ func (v *resolveExprVisitor) VisitSplatExpr(e *hclsyntax.SplatExpr) (string, err
 		return unresolvedPlaceholder, nil
 	}
 	base := sourceStr + "[*]"
+	// e.Each is a traversal rooted at the anonymous item symbol (which resolves
+	// to an empty string), so resolving it yields just the trailing traversal
+	// (e.g. ".id" for var.list[*].id, or "" for a bare var.list[*]).
 	if e.Each != nil && e.Each != e.Source {
 		eachStr := resolveExpr(e.Each, v.locals, v.vars)
 		if strings.HasPrefix(eachStr, "__") {
 			return unresolvedPlaceholder, nil
 		}
-		if eachStr == base || strings.HasPrefix(eachStr, base) {
-			return eachStr, nil
-		}
+		return base + eachStr, nil
 	}
 	return base, nil
+}
+func (v *resolveExprVisitor) VisitAnonSymbol(e *hclsyntax.AnonSymbolExpr) (string, error) {
+	// The anonymous splat item resolves to an empty string so that a trailing
+	// traversal (e.g. .id) composes onto the splat base in VisitSplatExpr.
+	return "", nil
+}
+func (v *resolveExprVisitor) VisitExprSyntaxError(e *hclsyntax.ExprSyntaxError) (string, error) {
+	return unresolvedPlaceholder, nil
 }
 func (v *resolveExprVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	return resolveExprDefault(e), nil


### PR DESCRIPTION
## Motivation

Terraform HCL parsing still had gaps for a few expression node types that appear in real modules. When those nodes were hit, splat traversals could lose their trailing path, template `%{for}` blocks could not be rendered, and some synthetic or invalid-expression placeholders fell through to generic unsupported handling.

## Changes

**Splat traversals**

Splat expressions with a trailing attribute or index were truncated because the anonymous splat item in the AST was not handled.

```hcl
# input
security_group_ids = aws_security_group.app[*].id

# before
"aws_security_group.app[*]"

# after
"aws_security_group.app[*].id"
```

**Template for-loops**

`%{for}` / `%{endfor}` template directives produce a `TemplateJoinExpr` in the AST. That shape was unsupported in some parsing paths.

```hcl
# input
user_data = "%{for v in var.subnets}${v.cidr}%{endfor}"

# before
"__UNSUPPORTED_EXPR__"

# after
"[for v in var.subnets : v.cidr]"
```

**Remaining HCL expression types**

`AnonSymbolExpr` (the synthetic item inside `var.list[*].id`) and `ExprSyntaxError` (placeholder for invalid or incomplete expressions) now have explicit handling in the shared HCL expression visitor instead of falling through to the default fallback.

```hcl
# splat with nested traversal
bucket = aws_s3_bucket.logs[*].bucket

# before → "aws_s3_bucket.logs[*]"
# after  → "aws_s3_bucket.logs[*].bucket"
```

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/hclexpr/... ./pkg/engine ./pkg/builder/engine/... ./pkg/parser/terraform/...`
2. Splat with traversal: parse `var.list[*].id` and confirm the rendered path is `var.list[*].id`, not `var.list[*]`.
3. Template for-loop: parse `%{for v in var.list}${v}%{endfor}` and confirm it renders as `[for v in var.list : v]`.

## Blast Radius

Datadog IaC Scanner Terraform parsing only: HCL expression rendering in the inspector, engine string conversion, module resolver, and shared `hclexpr` dispatch.

## Additional Notes

N/A

I submit this contribution under the Apache-2.0 license.