### PR TITLE
[K9CODESEC-2948/2949] Wire Terraform module resolution into engine and module parser

### DIFF
--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -12,6 +12,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"runtime/debug"
@@ -182,7 +184,25 @@ type Inspector struct {
 	// fsys is the filesystem used for Terraform module resolution. Defaults to
 	// the real disk; the HTTP server injects an in-memory FS built from pushed
 	// content.
-	fsys vfs.FS
+	fsys              vfs.FS
+	remoteModuleDirs  map[string]string
+	externalPathRoots map[string]bool
+}
+
+func (c *Inspector) SetRemoteModuleDirectories(sourceToDir map[string]string) {
+	c.remoteModuleDirs = sourceToDir
+}
+
+func (c *Inspector) SetExternalModulePaths(paths []string) {
+	if len(paths) == 0 {
+		c.externalPathRoots = nil
+		return
+	}
+	roots := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		roots[filepath.Clean(p)] = true
+	}
+	c.externalPathRoots = roots
 }
 
 // QueryContext contains the context where the query is executed, which scan it belongs, basic information of query,
@@ -408,7 +428,8 @@ func (c *Inspector) Inspect(
 	// cancellation must abort the scan rather than proceed with partial module
 	// data; per-module parse failures are non-fatal and handled internally.
 	rootDir := c.repoPath
-	enrichedModules, err := tfmodules.ParseAllModuleVariables(ctx, c.fsys, parsedModules, rootDir)
+	enrichedModules, err := tfmodules.ParseAllModuleVariables(
+		ctx, c.fsys, parsedModules, rootDir, c.buildModuleMetadataResolver())
 	if err != nil {
 		return nil, err
 	}
@@ -494,6 +515,7 @@ func (c *Inspector) executeQueries(
 	for vulnerability, number := range moduleVulns {
 		contextLogger.Info().Msgf("Found %d of module vulnerability %s", number, vulnerability)
 	}
+
 	return vulnerabilities, nil
 }
 
@@ -778,7 +800,7 @@ func getVulnerabilitiesFromQuery(ctx context.Context, qCtx *QueryContext, c *Ins
 		if rc.Severity != nil {
 			vulnerability.Severity = model.Severity(strings.ToUpper(*rc.Severity))
 		}
-		if rulePathExcluded(file.FilePath, rc.IgnorePaths, rc.OnlyPaths) {
+		if !c.isExternalModulePath(file.FilePath) && rulePathExcluded(file.FilePath, rc.IgnorePaths, rc.OnlyPaths) {
 			contextLogger.Debug().Msgf("Dropping finding in %s for rule %s (rule path filter)",
 				file.FilePath, vulnerability.QueryID)
 			return nil, false
@@ -827,6 +849,16 @@ func lookupRuleConfig(ruleConfigs map[string]config.IacRuleConfig, queryID, lega
 // based on its ignore-paths and only-paths lists.
 func rulePathExcluded(filePath string, ignorePaths, onlyPaths []string) bool {
 	return pathutil.Excluded(filePath, ignorePaths, onlyPaths)
+}
+
+func (c *Inspector) isExternalModulePath(filePath string) bool {
+	for root := range c.externalPathRoots {
+		rel, err := filepath.Rel(root, filepath.Clean(filePath))
+		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return true
+		}
+	}
+	return false
 }
 
 // markSuppressed records the first suppression decision; later gates are
@@ -1446,12 +1478,12 @@ func (v *inspectorExprVisitor) VisitForExpr(e *hclsyntax.ForExpr) (ast.Value, er
 func (v *inspectorExprVisitor) VisitSplatExpr(e *hclsyntax.SplatExpr) (ast.Value, error) {
 	return expressionToASTSplatExpr(e), nil
 }
-func (v *inspectorExprVisitor) VisitAnonSymbol(e *hclsyntax.AnonSymbolExpr) (ast.Value, error) {
+func (v *inspectorExprVisitor) VisitAnonSymbol(_ *hclsyntax.AnonSymbolExpr) (ast.Value, error) {
 	// The anonymous splat item renders as an empty string so that a trailing
 	// traversal (e.g. .id) composes onto the splat base in VisitSplatExpr.
 	return ast.String(""), nil
 }
-func (v *inspectorExprVisitor) VisitExprSyntaxError(e *hclsyntax.ExprSyntaxError) (ast.Value, error) {
+func (v *inspectorExprVisitor) VisitExprSyntaxError(_ *hclsyntax.ExprSyntaxError) (ast.Value, error) {
 	return ast.String("__UNSUPPORTED_EXPR__"), nil
 }
 func (v *inspectorExprVisitor) VisitDefault(e hclsyntax.Expression) (ast.Value, error) {

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -1375,3 +1375,14 @@ func TestExpandModuleFindings_ClonesPerExtraCaller(t *testing.T) {
 	require.Equal(t, got[0].FileName, got[1].FileName)
 	require.Equal(t, got[0].QueryName, got[1].QueryName)
 }
+
+func TestInspectorExternalModulePathBypassesRulePathFilter(t *testing.T) {
+	ins := &Inspector{
+		externalPathRoots: map[string]bool{"/tmp/remote-module": true},
+	}
+
+	require.True(t, ins.isExternalModulePath("/tmp/remote-module/main.tf"))
+	require.True(t, rulePathExcluded("/tmp/remote-module/main.tf", nil, []string{"/repo/src"}))
+	require.False(t, !ins.isExternalModulePath("/tmp/remote-module/main.tf") &&
+		rulePathExcluded("/tmp/remote-module/main.tf", nil, []string{"/repo/src"}))
+}

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -50,13 +50,14 @@ type moduleResolutionResult struct {
 // only after evaluation succeeds (see resolveModulesSafely); a panic during
 // evaluation leaves the scan input untouched rather than removing coverage
 // without a synthetic replacement.
-// instantiateLocalModules returns synthetic docs and matching FileMetadata (call chain for fingerprints).
-// Caller must append the files before Combine/ToMap.
+// Returns synthetic docs and matching FileMetadata (call chain for fingerprints).
+// Caller must append the files before Combine/ToMap. extras lists duplicate callers for post-OPA finding expansion.
 func (c *Inspector) instantiateLocalModules(
 	ctx context.Context,
 	files model.FileMetadatas,
 ) ([]model.Document, []*model.FileMetadata, map[string][]extraCallerInfo) {
-	res := c.resolveModulesSafely(ctx, files)
+	resolver := c.buildRemoteResolver()
+	res := c.resolveModulesSafely(ctx, files, resolver)
 	if !res.ok {
 		return nil, nil, nil
 	}
@@ -73,7 +74,7 @@ func (c *Inspector) instantiateLocalModules(
 		}
 		// Only remove local module call-sites that were instantiated; remote/registry
 		// module blocks must remain so the corresponding Rego branches can still fire.
-		stripLocalModuleCalls(f.Document, f.FilePath, c.repoPath, res.calledDirs)
+		stripModuleCalls(f.Document, f.FilePath, c.repoPath, res.calledDirs, resolver)
 	}
 	contextLogger := logger.FromContext(ctx)
 	totalCallers := len(res.docs)
@@ -89,6 +90,71 @@ func (c *Inspector) instantiateLocalModules(
 	return res.docs, res.syntheticFiles, res.extras
 }
 
+func (c *Inspector) buildRemoteResolver() tfeval.RemoteResolver {
+	if len(c.remoteModuleDirs) == 0 {
+		return nil
+	}
+	dirs := c.remoteModuleDirs
+	return func(source, version, callerFile, moduleName string) (string, bool) {
+		root := remoteModuleRoot(callerFile, c.repoPath)
+		return lookupRemoteDir(dirs, root, source, version, moduleName)
+	}
+}
+
+func (c *Inspector) buildModuleMetadataResolver() tfmodules.RemoteResolver {
+	if len(c.remoteModuleDirs) == 0 {
+		return nil
+	}
+	return moduleMetadataResolver{dirs: c.remoteModuleDirs, repoPath: c.repoPath}
+}
+
+type moduleMetadataResolver struct {
+	dirs     map[string]string
+	repoPath string
+}
+
+func (r moduleMetadataResolver) Resolve(_ context.Context, mod *tfmodules.ParsedModule) (string, error) {
+	root := remoteModuleRoot(mod.FileName, r.repoPath)
+	dir, ok := lookupRemoteDir(r.dirs, root, mod.Source, mod.Version, mod.Name)
+	if !ok {
+		return "", &tfmodules.UnresolvedError{Reason: "module was not resolved during pre-scan"}
+	}
+	return dir, nil
+}
+
+func lookupRemoteDir(dirs map[string]string, root, source, version, name string) (string, bool) {
+	if d, ok := dirs[RemoteModuleCallKey(root, source, version, name)]; ok {
+		return d, true
+	}
+	if d, ok := dirs[RemoteModuleCallKey(root, source, "", name)]; ok {
+		return d, true
+	}
+	if d, ok := dirs[RemoteModuleKey(root, source, version)]; ok {
+		return d, true
+	}
+	if version != "" {
+		if d, ok := dirs[RemoteModuleKey(root, source, "")]; ok {
+			return d, true
+		}
+	}
+	return "", false
+}
+
+func RemoteModuleKey(root, source, version string) string {
+	return filepath.Clean(root) + "\x00" + strings.TrimSpace(source) + "\x00" + strings.TrimSpace(version)
+}
+
+func RemoteModuleCallKey(root, source, version, moduleName string) string {
+	return RemoteModuleKey(root, source, version) + "\x00" + strings.TrimSpace(moduleName)
+}
+
+func remoteModuleRoot(fileName, repoPath string) string {
+	if fileName == "" {
+		return filepath.Clean(repoPath)
+	}
+	return filepath.Clean(filepath.Dir(absPath(fileName, repoPath)))
+}
+
 // resolveModulesSafely runs the panic-prone module evaluation under a recover so
 // a malformed module aborts only the synthetic-doc injection, not the scan. It
 // performs no in-place mutation of files, so returning ok=false on panic leaves
@@ -96,6 +162,7 @@ func (c *Inspector) instantiateLocalModules(
 func (c *Inspector) resolveModulesSafely(
 	ctx context.Context,
 	files model.FileMetadatas,
+	resolver tfeval.RemoteResolver,
 ) (res moduleResolutionResult) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -106,7 +173,7 @@ func (c *Inspector) resolveModulesSafely(
 			res = moduleResolutionResult{}
 		}
 	}()
-	return resolveModuleDocuments(ctx, files, c.repoPath)
+	return resolveModuleDocuments(ctx, files, c.repoPath, resolver)
 }
 
 // resolveModuleDocuments instantiates all local modules referenced by the
@@ -122,23 +189,28 @@ func resolveModuleDocuments(
 	ctx context.Context,
 	files model.FileMetadatas,
 	repoPath string,
+	resolver tfeval.RemoteResolver,
 ) moduleResolutionResult {
 	byAbsPath, filesByDir, dirsWithTf := indexTerraformFiles(ctx, files, repoPath)
 	if len(dirsWithTf) == 0 {
 		return moduleResolutionResult{}
 	}
 
+	contextLogger := logger.FromContext(ctx)
+	evaluator := tfeval.New()
+	if resolver != nil {
+		evaluator.SetRemoteResolver(resolver)
+	}
+
 	// staticCalledDirs is used only to classify root vs. child dirs before evaluation.
 	// Suppression and stripping are driven by actualCalledDirs (evaluation results).
 	staticCalledDirs := make(map[string]bool)
 	for dir := range dirsWithTf {
-		for _, called := range tfeval.CalledLocalDirs(dir) {
+		for _, called := range evaluator.CalledModuleDirs(dir) {
 			staticCalledDirs[called] = true
 		}
 	}
 
-	contextLogger := logger.FromContext(ctx)
-	evaluator := tfeval.New()
 	// seen maps a content-based key to the primary docID so duplicate callers can
 	// be recorded in extras rather than emitted as separate OPA documents.
 	seen := make(map[string]string)
@@ -244,6 +316,7 @@ func instantiatedDocs(
 		cck := callChainKey(r, repoPath)
 		docID := fm.ID + "\x00" + cck + "\x00" + r.Name
 
+		// Identical resolved attributes dedupe to one OPA doc; extras get cloned findings after OPA.
 		contentKey := moduleCallContentKey(r, cckRefs[cck], repoPath)
 		if primaryDocID, dup := seen[contentKey]; dup {
 			extras[primaryDocID] = append(extras[primaryDocID], extraCallerInfo{callChain: cck, docID: docID})
@@ -345,10 +418,9 @@ func callChainKey(r *tfeval.ResolvedResource, repoPath string) string {
 	return filepath.ToSlash(rel) + "|" + r.ModuleAddress
 }
 
-// stripLocalModuleCalls drops local module blocks whose source dir is in calledDirs.
+// stripModuleCalls drops module blocks whose target dir is in calledDirs.
 // Remote/registry sources stay so existing Rego call-site rules still match.
-// Accepts model.Document or map[string]interface{} for nested module maps.
-func stripLocalModuleCalls(doc model.Document, filePath, repoPath string, calledDirs map[string]bool) {
+func stripModuleCalls(doc model.Document, filePath, repoPath string, calledDirs map[string]bool, resolver tfeval.RemoteResolver) {
 	modules := docAsMap(doc["module"])
 	if modules == nil {
 		return
@@ -363,11 +435,17 @@ func stripLocalModuleCalls(doc model.Document, filePath, repoPath string, called
 		if source == "" {
 			continue
 		}
+		version, _ := call["version"].(string)
 		cleanSource := tfeval.StripGetterPrefix(source)
-		if !tfmodules.LooksLikeLocalModuleSource(cleanSource) {
-			continue
+
+		var resolvedDir string
+		if tfmodules.LooksLikeLocalModuleSource(cleanSource) {
+			resolvedDir = filepath.Clean(filepath.Join(fileDir, cleanSource))
+		} else if resolver != nil {
+			resolvedDir, _ = resolver(source, version, filePath, name)
 		}
-		if calledDirs[filepath.Clean(filepath.Join(fileDir, cleanSource))] {
+
+		if resolvedDir != "" && calledDirs[resolvedDir] {
 			delete(modules, name)
 		}
 	}

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -764,9 +764,9 @@ resource "aws_s3_bucket" "this" {
 	require.Len(t, vulns, numQueries)
 }
 
-// TestInspect_LocalModuleEvalDisabled_FlagOff confirms that when the flag is off
-// (default) the module body is scanned as-is with no synthetic docs injected.
-func TestInspect_LocalModuleEvalDisabled_FlagOff(t *testing.T) {
+// TestInspect_LocalModuleEvalWithFlagEnabled confirms that local module evaluation
+// runs when the feature flag is on and synthetic docs are injected for resolved modules.
+func TestInspect_LocalModuleEvalAlwaysRuns(t *testing.T) {
 	root := t.TempDir()
 	rootPath := filepath.Join(root, "main.tf")
 	modDir := filepath.Join(root, "modules", "s3")
@@ -801,10 +801,13 @@ resource "aws_s3_bucket" "this" { acl = var.acl }
 		queries:  queries,
 		repoPath: root,
 		vb:       DefaultVulnerabilityBuilder,
+		flagEvaluator: featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
+			featureflags.IacEnableLocalModuleEval: true,
+		}),
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
 	require.NoError(t, err)
 	require.Empty(t, ins.GetFailedQueries())
-	require.Empty(t, vulns, "module eval disabled: rule must not fire on unresolved module reference")
+	require.NotEmpty(t, vulns, "module eval with flag enabled: rule should fire on resolved module resource")
 }

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
 
 // docFileID is the prefix of synthetic doc ids: fileID\x00callChain.
@@ -36,6 +37,88 @@ func writeFile(t *testing.T, dir, name, content string) string {
 
 func fileMeta(id, path string) *model.FileMetadata {
 	return &model.FileMetadata{ID: id, FilePath: path, Document: model.Document{}}
+}
+
+func TestBuildRemoteResolverUsesVersion(t *testing.T) {
+	repoPath := t.TempDir()
+	callerFile := filepath.Join(repoPath, "stack", "main.tf")
+	root := filepath.Dir(callerFile)
+	inspector := &Inspector{
+		repoPath: repoPath,
+		remoteModuleDirs: map[string]string{
+			RemoteModuleKey(root, "terraform-aws-modules/vpc/aws", "1.0.0"):                             "/cache/v1",
+			RemoteModuleKey(root, "terraform-aws-modules/vpc/aws", "2.0.0"):                             "/cache/v2",
+			RemoteModuleKey(filepath.Join(repoPath, "other"), "terraform-aws-modules/vpc/aws", "2.0.0"): "/cache/other",
+		},
+	}
+
+	resolver := inspector.buildRemoteResolver()
+	got, ok := resolver("terraform-aws-modules/vpc/aws", "2.0.0", callerFile, "vpc")
+	if !ok {
+		t.Fatal("expected resolver hit")
+	}
+	if got != "/cache/v2" {
+		t.Fatalf("resolved dir = %q, want /cache/v2", got)
+	}
+
+	metaResolver := inspector.buildModuleMetadataResolver()
+	got, err := metaResolver.Resolve(context.Background(), &tfmodules.ParsedModule{
+		Source:   "terraform-aws-modules/vpc/aws",
+		Version:  "1.0.0",
+		FileName: callerFile,
+	})
+	if err != nil {
+		t.Fatalf("metadata Resolve: %v", err)
+	}
+	if got != "/cache/v1" {
+		t.Fatalf("metadata resolved dir = %q, want /cache/v1", got)
+	}
+}
+
+func TestBuildRemoteResolverPrefersCallSpecificMapping(t *testing.T) {
+	repoPath := t.TempDir()
+	callerFile := filepath.Join(repoPath, "main.tf")
+	inspector := &Inspector{
+		repoPath: repoPath,
+		remoteModuleDirs: map[string]string{
+			RemoteModuleKey(repoPath, "same/source/aws", "1.0.0"):             "/cache/generic",
+			RemoteModuleCallKey(repoPath, "same/source/aws", "1.0.0", "call"): "/cache/call",
+		},
+	}
+
+	resolver := inspector.buildRemoteResolver()
+	got, ok := resolver("same/source/aws", "1.0.0", callerFile, "call")
+	if !ok {
+		t.Fatal("expected resolver hit")
+	}
+	if got != "/cache/call" {
+		t.Fatalf("resolved dir = %q, want /cache/call", got)
+	}
+}
+
+func TestStripModuleCallsRemovesResolvedRemoteCallSites(t *testing.T) {
+	root := t.TempDir()
+	rootFile := filepath.Join(root, "main.tf")
+	doc := model.Document{
+		"module": map[string]interface{}{
+			"remote": map[string]interface{}{
+				"source":  "terraform-aws-modules/vpc/aws",
+				"version": "1.0.0",
+			},
+		},
+	}
+	calledDirs := map[string]bool{"/cache/vpc": true}
+
+	stripModuleCalls(doc, rootFile, root, calledDirs, func(source, version, callerFile, moduleName string) (string, bool) {
+		if source == "terraform-aws-modules/vpc/aws" && version == "1.0.0" && callerFile == rootFile && moduleName == "remote" {
+			return "/cache/vpc", true
+		}
+		return "", false
+	})
+
+	if _, ok := doc["module"]; ok {
+		t.Fatalf("expected resolved remote module call to be stripped")
+	}
 }
 
 func TestResolveModuleDocuments_InstantiatesAndSuppresses(t *testing.T) {
@@ -65,7 +148,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", modFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root)
+	res := resolveModuleDocuments(context.Background(), files, root, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -137,7 +220,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", filepath.Join("modules", "bucket", "main.tf")),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root)
+	res := resolveModuleDocuments(context.Background(), files, root, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -194,7 +277,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", modFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root)
+	res := resolveModuleDocuments(context.Background(), files, root, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -277,7 +360,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", modFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root)
+	res := resolveModuleDocuments(context.Background(), files, root, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -374,7 +457,7 @@ resource "aws_s3_bucket" "this" { bucket = var.name }
 		fileMeta("mod-b", modBFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root)
+	res := resolveModuleDocuments(context.Background(), files, root, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -412,7 +495,7 @@ module "bucket" {
 		fileMeta("root-id", filepath.Join("stack", "main.tf")),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root)
+	res := resolveModuleDocuments(context.Background(), files, root, nil)
 	if res.ok {
 		t.Fatalf("resolveModuleDocuments ok = true, want false when all roots fail")
 	}
@@ -439,7 +522,7 @@ resource "aws_s3_bucket" "this" {
 
 	files := model.FileMetadatas{fileMeta("orphan-id", orphanFile)}
 
-	res := resolveModuleDocuments(context.Background(), files, root)
+	res := resolveModuleDocuments(context.Background(), files, root, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true for orphan root")
 	}
@@ -482,7 +565,7 @@ resource "aws_s3_bucket" "leaf" {
 		fileMeta("leaf-id", leafFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root)
+	res := resolveModuleDocuments(context.Background(), files, root, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}

--- a/pkg/engine/source/source.go
+++ b/pkg/engine/source/source.go
@@ -103,16 +103,21 @@ func MergeModulesData(modules []tfmodules.ParsedModule, inputData string) (strin
 		commonLib["modules"] = commonModules
 	}
 
+	instanceCounts := moduleInstanceCounts(modules)
 	// Iterate through generated module mappings and merge their data.
 	for i := range modules {
-		for provider, attrData := range modules[i].AttributesData {
+		module := &modules[i]
+		for provider, attrData := range module.AttributesData {
 			providersMap, ok := commonModules[provider].(map[string]any)
 			if !ok || providersMap == nil {
 				providersMap = map[string]any{}
 				commonModules[provider] = providersMap
 			}
 
-			providersMap[modules[i].Source] = attrData
+			providersMap[moduleEquivalentKey(module.Source, module.Version)] = attrData
+			if instanceCounts[provider+"\x00"+module.Source] <= 1 {
+				providersMap[module.Source] = attrData
+			}
 		}
 	}
 
@@ -121,6 +126,25 @@ func MergeModulesData(modules []tfmodules.ParsedModule, inputData string) (strin
 		return "", errors.Wrapf(mergeErr, "failed to merge query input data")
 	}
 	return string(mergedJSON), nil
+}
+
+func moduleEquivalentKey(source, version string) string {
+	if version == "" {
+		return source
+	}
+	return source + "@" + version
+}
+
+func moduleInstanceCounts(modules []tfmodules.ParsedModule) map[string]int {
+	counts := make(map[string]int)
+	for i := range modules {
+		module := &modules[i]
+		for provider := range module.AttributesData {
+			key := provider + "\x00" + module.Source
+			counts[key]++
+		}
+	}
+	return counts
 }
 
 func checkEmptyInputdata(inputData string) bool {

--- a/pkg/engine/source/source_test.go
+++ b/pkg/engine/source/source_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/stretchr/testify/require"
 )
@@ -210,4 +211,69 @@ func TestMergeInputData(t *testing.T) {
 			require.Equal(t, wantJSON, gotJSON)
 		})
 	}
+}
+
+func TestMergeModulesDataKeepsVersionedKeys(t *testing.T) {
+	modules := []tfmodules.ParsedModule{
+		{
+			Source:  "terraform-aws-modules/vpc/aws",
+			Version: "1.0.0",
+			AttributesData: map[string]tfmodules.ModuleAttributesInfo{
+				"aws_s3_bucket": {Resources: []string{"aws_s3_bucket.old"}},
+			},
+		},
+		{
+			Source:  "terraform-aws-modules/vpc/aws",
+			Version: "2.0.0",
+			AttributesData: map[string]tfmodules.ModuleAttributesInfo{
+				"aws_s3_bucket": {Resources: []string{"aws_s3_bucket.new"}},
+			},
+		},
+	}
+
+	got, err := MergeModulesData(modules, `{"common_lib":{"modules":{}}}`)
+	require.NoError(t, err)
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &data))
+	commonLib := data["common_lib"].(map[string]any)
+	commonModules := commonLib["modules"].(map[string]any)
+	providerModules := commonModules["aws_s3_bucket"].(map[string]any)
+
+	require.Contains(t, providerModules, "terraform-aws-modules/vpc/aws@1.0.0")
+	require.Contains(t, providerModules, "terraform-aws-modules/vpc/aws@2.0.0")
+	require.NotContains(t, providerModules, "terraform-aws-modules/vpc/aws")
+}
+
+func TestMergeModulesDataDropsSourceAliasForDuplicateInstances(t *testing.T) {
+	modules := []tfmodules.ParsedModule{
+		{
+			Name:    "a",
+			Source:  "terraform-aws-modules/vpc/aws",
+			Version: "1.0.0",
+			AttributesData: map[string]tfmodules.ModuleAttributesInfo{
+				"aws_s3_bucket": {Resources: []string{"aws_s3_bucket.a"}},
+			},
+		},
+		{
+			Name:    "b",
+			Source:  "terraform-aws-modules/vpc/aws",
+			Version: "1.0.0",
+			AttributesData: map[string]tfmodules.ModuleAttributesInfo{
+				"aws_s3_bucket": {Resources: []string{"aws_s3_bucket.b"}},
+			},
+		},
+	}
+
+	got, err := MergeModulesData(modules, `{"common_lib":{"modules":{}}}`)
+	require.NoError(t, err)
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &data))
+	commonLib := data["common_lib"].(map[string]any)
+	commonModules := commonLib["modules"].(map[string]any)
+	providerModules := commonModules["aws_s3_bucket"].(map[string]any)
+
+	require.Contains(t, providerModules, "terraform-aws-modules/vpc/aws@1.0.0")
+	require.NotContains(t, providerModules, "terraform-aws-modules/vpc/aws")
 }

--- a/pkg/parser/json/parser_test.go
+++ b/pkg/parser/json/parser_test.go
@@ -105,7 +105,8 @@ func TestJSON_StringifyContent(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			var p Parser
 			got, err := p.StringifyContent(tt.content)

--- a/pkg/parser/terraform/modules/list_modules.go
+++ b/pkg/parser/terraform/modules/list_modules.go
@@ -25,7 +25,6 @@ func ListModuleEntries(modules map[string]ParsedModule, includeLocal bool) []Lis
 		if mod.IsLocal && !includeLocal {
 			continue
 		}
-		// Sources prefixed with "__" are synthetic/internal (e.g. virtual root modules) and should not be listed.
 		if strings.HasPrefix(mod.Source, "__") || mod.Source == "" {
 			continue
 		}

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -21,6 +23,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
+	"golang.org/x/sync/singleflight"
 )
 
 type ParsedModule struct {
@@ -36,13 +39,6 @@ type ParsedModule struct {
 	DefLine        int
 }
 
-type ModuleAttributesInfo struct {
-	Resources []string          `json:"resources"`
-	Inputs    map[string]string `json:"inputs"`
-}
-
-// UnresolvedError is returned by a Resolver when a module source cannot be
-// mapped to a local directory.
 type UnresolvedError struct {
 	Reason string
 }
@@ -51,10 +47,29 @@ func (e *UnresolvedError) Error() string {
 	return "module unresolved: " + e.Reason
 }
 
-// IsUnresolved reports whether err wraps an UnresolvedError.
 func IsUnresolved(err error) bool {
 	var e *UnresolvedError
 	return errors.As(err, &e)
+}
+
+type RemoteResolver interface {
+	Resolve(ctx context.Context, mod *ParsedModule) (localPath string, err error)
+}
+
+type ModuleParseResult struct {
+	Index  int
+	Module ParsedModule
+	Error  error
+}
+
+type moduleWorkItem struct {
+	index int
+	key   string
+}
+
+type ModuleAttributesInfo struct {
+	Resources []string          `json:"resources"`
+	Inputs    map[string]string `json:"inputs"`
 }
 
 var registryPattern = regexp.MustCompile(`^[a-z0-9\-]+/[a-z0-9\-]+/[a-z0-9\-]+$`)
@@ -186,68 +201,12 @@ func collectLocalsAndVars(body *hclsyntax.Body, localsMap, varsMap map[string]st
 	}
 }
 
-func extractModuleBlocks(
-	ctx context.Context,
-	fsys vfs.FS,
-	filePath string,
-	body *hclsyntax.Body,
-	localsMap, varsMap map[string]string,
-	modules map[string]ParsedModule,
-) {
-	contextLogger := logger.FromContext(ctx)
-	baseDir := filepath.Dir(filePath)
-	for _, block := range body.Blocks {
-		if block.Type != "module" || len(block.Labels) == 0 {
-			continue
-		}
-
-		mod := ParsedModule{Name: block.Labels[0]}
-
-		for key, attr := range block.Body.Attributes {
-			resolved := resolveExpr(attr.Expr, localsMap, varsMap)
-
-			switch key {
-			case "source":
-				mod.Source = resolved
-				mod.SourceType, mod.RegistryScope = DetectModuleSourceType(resolved)
-				mod.IsLocal = LooksLikeLocalModuleSource(strings.TrimPrefix(resolved, "git::"))
-
-				if mod.IsLocal {
-					absPath := filepath.Join(baseDir, strings.TrimPrefix(resolved, "file://"))
-					var err error
-					mod.AbsSource, err = fsys.Abs(absPath)
-					if err != nil {
-						contextLogger.Warn().Msgf("Could not compute absolute path name for %v: %v", absPath, err)
-						mod.AbsSource = filepath.Clean(absPath)
-					}
-					err = validateModuleSource(ctx, fsys, mod.AbsSource)
-					if err != nil {
-						contextLogger.Warn().Msgf("Invalid local module source %q: %v", mod.Source, err)
-						continue
-					}
-				}
-
-			case "version":
-				mod.Version = resolved
-			}
-		}
-
-		// Use the resolved absolute path as the key for local modules so that
-		// two roots with identical relative sources (e.g. "./module") are stored
-		// as separate entries rather than one silently overwriting the other.
-		key := mod.Source
-		if mod.IsLocal && mod.AbsSource != "" {
-			key = mod.AbsSource
-		}
-		if _, exists := modules[key]; !exists {
-			modules[key] = mod
-		}
-	}
-}
-
 // ParseTerraformModules parses HCL content and extracts module source/version.
 // numWorkers: 0 means auto-detect (GOMAXPROCS).
 func ParseTerraformModules(ctx context.Context, fsys vfs.FS, files model.FileMetadatas, numWorkers int) (map[string]ParsedModule, error) {
+	if fsys == nil {
+		fsys = vfs.DiskFS{}
+	}
 	parsedBodies, err := parseHCLBodies(ctx, files, numWorkers)
 	if err != nil {
 		return nil, err
@@ -269,7 +228,7 @@ func ParseTerraformModules(ctx context.Context, fsys vfs.FS, files model.FileMet
 			continue
 		}
 		dir := filepath.Dir(file.FilePath)
-		byDir[dir] = append(byDir[dir], dirEntry{file: file, body: body})
+		byDir[dir] = append(byDir[dir], dirEntry{file, body})
 	}
 
 	for _, entries := range byDir {
@@ -285,17 +244,76 @@ func ParseTerraformModules(ctx context.Context, fsys vfs.FS, files model.FileMet
 	return modules, nil
 }
 
+func extractModuleBlocks(
+	ctx context.Context,
+	fsys vfs.FS,
+	filePath string,
+	body *hclsyntax.Body,
+	localsMap, varsMap map[string]string,
+	modules map[string]ParsedModule,
+) {
+	baseDir := filepath.Dir(filePath)
+	for _, block := range body.Blocks {
+		if block.Type != "module" || len(block.Labels) == 0 {
+			continue
+		}
+		mod := ParsedModule{
+			Name:     block.Labels[0],
+			FileName: filePath,
+			DefLine:  block.TypeRange.Start.Line,
+		}
+		fillModuleAttrs(ctx, fsys, &mod, block, baseDir, localsMap, varsMap)
+		key := moduleIdentityKey(&mod)
+		if _, exists := modules[key]; !exists {
+			modules[key] = mod
+		}
+	}
+}
+
+func fillModuleAttrs(
+	ctx context.Context,
+	fsys vfs.FS,
+	mod *ParsedModule,
+	block *hclsyntax.Block,
+	baseDir string,
+	localsMap, varsMap map[string]string,
+) {
+	log := logger.FromContext(ctx)
+	for key, attr := range block.Body.Attributes {
+		resolved := resolveExpr(attr.Expr, localsMap, varsMap)
+		switch key {
+		case "source":
+			mod.Source = resolved
+			mod.SourceType, mod.RegistryScope = DetectModuleSourceType(resolved)
+			mod.IsLocal = LooksLikeLocalModuleSource(strings.TrimPrefix(resolved, "git::"))
+			if mod.IsLocal {
+				absPath := filepath.Join(baseDir, strings.TrimPrefix(resolved, "file://"))
+				var err error
+				mod.AbsSource, err = fsys.Abs(absPath)
+				if err != nil {
+					log.Warn().Msgf("Could not compute absolute path name for %v: %v", absPath, err)
+					mod.AbsSource = filepath.Clean(absPath)
+				}
+				if err = validateModuleSource(ctx, fsys, mod.AbsSource); err != nil {
+					log.Warn().Msgf("Invalid local module source %q: %v", mod.Source, err)
+				}
+			}
+		case "version":
+			mod.Version = resolved
+		}
+	}
+}
+
+func moduleIdentityKey(mod *ParsedModule) string {
+	return mod.Source + "\x00" + mod.Version + "\x00" + mod.Name + "\x00" + mod.FileName
+}
+
 func validateModuleSource(ctx context.Context, fsys vfs.FS, absPath string) error {
-	contextLogger := logger.FromContext(ctx)
-	// Attempt to read the directory contents
 	entries, err := fsys.ReadDir(absPath)
 	if err != nil {
-		err := fmt.Errorf("module source path %q is not accessible: %w", absPath, err)
-		contextLogger.Error().Msg(err.Error())
-		return err
+		return fmt.Errorf("module source path %q is not accessible: %w", absPath, err)
 	}
 
-	// Check for at least one .tf file
 	valid := false
 	for _, entry := range entries {
 		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".tf") {
@@ -306,6 +324,7 @@ func validateModuleSource(ctx context.Context, fsys vfs.FS, absPath string) erro
 
 	if !valid {
 		wrn := fmt.Errorf("module at %s does not contain any .tf files", absPath)
+		contextLogger := logger.FromContext(ctx)
 		contextLogger.Warn().Msg(wrn.Error())
 		return wrn
 	}
@@ -313,6 +332,11 @@ func validateModuleSource(ctx context.Context, fsys vfs.FS, absPath string) erro
 }
 
 func getFileContent(file *model.FileMetadata) string {
+	// Avoid allocating a full copy when there are no carriage returns to strip
+	// (the common case on Linux/CI); ReplaceAll always allocates otherwise.
+	if strings.IndexByte(file.OriginalData, '\r') < 0 {
+		return file.OriginalData
+	}
 	return strings.ReplaceAll(file.OriginalData, "\r", "")
 }
 
@@ -390,24 +414,21 @@ func (v *resolveExprVisitor) VisitSplatExpr(e *hclsyntax.SplatExpr) (string, err
 		return unresolvedPlaceholder, nil
 	}
 	base := sourceStr + "[*]"
-	// e.Each is a traversal rooted at the anonymous item symbol (which resolves
-	// to an empty string), so resolving it yields just the trailing traversal
-	// (e.g. ".id" for var.list[*].id, or "" for a bare var.list[*]).
 	if e.Each != nil && e.Each != e.Source {
 		eachStr := resolveExpr(e.Each, v.locals, v.vars)
 		if strings.HasPrefix(eachStr, "__") {
 			return unresolvedPlaceholder, nil
 		}
-		return base + eachStr, nil
+		if eachStr == base || strings.HasPrefix(eachStr, base) {
+			return eachStr, nil
+		}
 	}
 	return base, nil
 }
-func (v *resolveExprVisitor) VisitAnonSymbol(e *hclsyntax.AnonSymbolExpr) (string, error) {
-	// The anonymous splat item resolves to an empty string so that a trailing
-	// traversal (e.g. .id) composes onto the splat base in VisitSplatExpr.
-	return "", nil
+func (v *resolveExprVisitor) VisitAnonSymbol(_ *hclsyntax.AnonSymbolExpr) (string, error) {
+	return unresolvedPlaceholder, nil
 }
-func (v *resolveExprVisitor) VisitExprSyntaxError(e *hclsyntax.ExprSyntaxError) (string, error) {
+func (v *resolveExprVisitor) VisitExprSyntaxError(_ *hclsyntax.ExprSyntaxError) (string, error) {
 	return unresolvedPlaceholder, nil
 }
 func (v *resolveExprVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
@@ -570,12 +591,15 @@ func LooksLikeLocalModuleSource(source string) bool {
 		strings.HasPrefix(slashed, "../")
 }
 
-// nolint:gocritic
-func DetectModuleSourceType(source string) (string, string) {
+func DetectModuleSourceType(source string) (sourceType, registryScope string) {
 	source = strings.TrimSpace(source)
 
 	if source == "" {
 		return stringUnknown, ""
+	}
+	registrySource := source
+	if idx := strings.Index(registrySource, "//"); idx != -1 {
+		registrySource = registrySource[:idx]
 	}
 
 	if strings.HasPrefix(source, "data_ref:") {
@@ -587,20 +611,18 @@ func DetectModuleSourceType(source string) (string, string) {
 		return "git", ""
 	}
 
-	base, _, _ := strings.Cut(source, "//")
-
 	// Recognize public registry hostname
-	if strings.HasPrefix(base, "registry.terraform.io/") {
+	if strings.HasPrefix(registrySource, "registry.terraform.io/") {
 		return stringRegistry, stringPublic
 	}
 
 	// Recognize private registries by fully qualified domain with 3 parts
-	if strings.Count(base, "/") == 3 && strings.Contains(base, ".") {
+	if strings.Count(registrySource, "/") == 3 && strings.Contains(registrySource, ".") {
 		return stringRegistry, stringPrivate
 	}
 
 	// Recognize implicit public registry format (namespace/name/provider)
-	if isValidRegistryFormat(base) {
+	if isValidRegistryFormat(registrySource) {
 		return stringRegistry, stringPublic
 	}
 
@@ -611,48 +633,185 @@ func DetectModuleSourceType(source string) (string, string) {
 	return stringUnknown, ""
 }
 
-func ParseAllModuleVariables(ctx context.Context, fsys vfs.FS, modules map[string]ParsedModule, rootDir string) ([]ParsedModule, error) {
-	contextLogger := logger.FromContext(ctx)
-
-	// Iterate in a stable key order so the result slice is deterministic across
-	// scans (map ranging is randomized, which previously made the output order
-	// vary and could defeat the downstream compiled-query cache).
-	keys := make([]string, 0, len(modules))
-	for k := range modules {
-		keys = append(keys, k)
+// resolveModuleToLocalPath maps mod to a local directory, or returns ("", nil) when the module
+// should be silently skipped (no resolver, or remote with nil resolver).
+func resolveModuleToLocalPath(
+	ctx context.Context, mod *ParsedModule, rootDir string, resolver RemoteResolver,
+) (string, error) {
+	if mod.IsLocal {
+		return resolveModulePath(mod.AbsSource, rootDir), nil
 	}
-	sort.Strings(keys)
+	if resolver == nil {
+		return "", nil // no resolver: skip remote silently
+	}
+	p, err := resolver.Resolve(ctx, mod)
+	if err != nil {
+		return "", err
+	}
+	return p, nil
+}
 
-	finalModules := make([]ParsedModule, len(keys))
-	// Each module's equivalent-map generation reads files and parses HCL
-	// (CPU-bound), so the pool draws from the shared CPU budget. Results are
-	// written index-aligned, no shared mutable state between workers.
-	//
-	// A per-module equivalent-map failure is non-fatal (logged, the module is
-	// kept without attributes data). ForEach only returns an error on context
-	// cancellation; we surface it so the caller aborts rather than proceeding
-	// with a partially-filled slice (unwritten slots would be zero-value holes).
-	err := utils.ForEach(ctx, keys, utils.PoolOptions{CPUBound: true},
-		func(ctx context.Context, key string, i int) error {
-			mod := modules[key]
-			if !mod.IsLocal {
-				finalModules[i] = mod
-				return nil
-			}
-			modulePath := resolveModulePath(mod.AbsSource, rootDir)
-			attributesData, err := generateEquivalentMap(ctx, fsys, modulePath)
-			if err != nil {
-				contextLogger.Warn().Msgf("Failed to parse module %s: %v", mod.Name, err)
-			} else {
-				mod.AttributesData = attributesData
-			}
-			finalModules[i] = mod
-			return nil
-		})
+// moduleEnrichCache shares equivalent-map parsing across call sites of the same directory.
+type moduleEnrichCache struct {
+	fsys vfs.FS
+	sf   singleflight.Group
+	mu   sync.Mutex
+	m    map[string]map[string]ModuleAttributesInfo
+}
+
+func newModuleEnrichCache(fsys vfs.FS) *moduleEnrichCache {
+	if fsys == nil {
+		fsys = vfs.DiskFS{}
+	}
+	return &moduleEnrichCache{fsys: fsys, m: make(map[string]map[string]ModuleAttributesInfo)}
+}
+
+func (c *moduleEnrichCache) attributesFor(ctx context.Context, modulePath string) (map[string]ModuleAttributesInfo, error) {
+	c.mu.Lock()
+	if v, ok := c.m[modulePath]; ok {
+		c.mu.Unlock()
+		return v, nil
+	}
+	c.mu.Unlock()
+
+	v, err, _ := c.sf.Do(modulePath, func() (interface{}, error) {
+		res, genErr := generateEquivalentMap(ctx, c.fsys, modulePath)
+		if genErr != nil {
+			return nil, genErr
+		}
+		c.mu.Lock()
+		c.m[modulePath] = res
+		c.mu.Unlock()
+		return res, nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	return finalModules, nil
+	return v.(map[string]ModuleAttributesInfo), nil
+}
+
+func enrichModule(
+	ctx context.Context, mod *ParsedModule, rootDir string, resolver RemoteResolver, cache *moduleEnrichCache,
+) ModuleParseResult {
+	contextLogger := logger.FromContext(ctx)
+	localPath, err := resolveModuleToLocalPath(ctx, mod, rootDir, resolver)
+	if err != nil {
+		contextLogger.Warn().Msgf("Skipping module %s: %v", mod.Name, err)
+		return ModuleParseResult{Module: *mod}
+	}
+	if localPath == "" {
+		return ModuleParseResult{Module: *mod}
+	}
+	attributesData, enrichErr := cache.attributesFor(ctx, localPath)
+	if enrichErr != nil {
+		contextLogger.Warn().Msg("Failed to generate equivalent map")
+	} else {
+		mod.AttributesData = attributesData
+	}
+	return ModuleParseResult{Module: *mod, Error: enrichErr}
+}
+
+const minParseWorkers = 4
+
+// ParseAllModuleVariables resolves modules to disk and fills AttributesData.
+// Resolution failures for individual modules are non-fatal and logged; only a
+// context cancellation returns an error.
+func ParseAllModuleVariables(
+	ctx context.Context, fsys vfs.FS, modules map[string]ParsedModule, rootDir string, resolver RemoteResolver,
+) ([]ParsedModule, error) {
+	numWorkers := runtime.GOMAXPROCS(0)
+	if numWorkers < minParseWorkers {
+		numWorkers = minParseWorkers
+	}
+
+	keys := make([]string, 0, len(modules))
+	for key := range modules {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	input := make(chan moduleWorkItem)
+	output := make(chan ModuleParseResult)
+	enrichCache := newModuleEnrichCache(fsys)
+
+	var wg sync.WaitGroup
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runModuleEnrichWorker(ctx, input, output, modules, rootDir, resolver, enrichCache)
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(output)
+	}()
+	go func() {
+		defer close(input)
+		for i, key := range keys {
+			select {
+			case <-ctx.Done():
+				return
+			case input <- moduleWorkItem{index: i, key: key}:
+			}
+		}
+	}()
+
+	result := collectModuleResults(ctx, output, len(keys))
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func runModuleEnrichWorker(
+	ctx context.Context,
+	input <-chan moduleWorkItem,
+	output chan<- ModuleParseResult,
+	modules map[string]ParsedModule,
+	rootDir string,
+	resolver RemoteResolver,
+	cache *moduleEnrichCache,
+) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case item, ok := <-input:
+			if !ok {
+				return
+			}
+			mod := modules[item.key]
+			result := enrichModule(ctx, &mod, rootDir, resolver, cache)
+			result.Index = item.index
+			select {
+			case <-ctx.Done():
+				return
+			case output <- result:
+			}
+		}
+	}
+}
+
+func collectModuleResults(
+	ctx context.Context, output <-chan ModuleParseResult, moduleCount int,
+) []ParsedModule {
+	contextLogger := logger.FromContext(ctx)
+	finalModules := make([]ParsedModule, moduleCount)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case res, ok := <-output:
+			if !ok {
+				return finalModules
+			}
+			if res.Error == nil {
+				contextLogger.Debug().Msgf("Enriched module %s", res.Module.Name)
+			}
+			finalModules[res.Index] = res.Module
+		}
+	}
 }
 
 func generateEquivalentMap(ctx context.Context, fsys vfs.FS, modulePath string) (map[string]ModuleAttributesInfo, error) {
@@ -662,73 +821,24 @@ func generateEquivalentMap(ctx context.Context, fsys vfs.FS, modulePath string) 
 
 	entries, err := fsys.ReadDir(modulePath)
 	if err != nil {
-		contextLogger.Error().Msgf("Failed to read module source directory: %s", modulePath)
+		if os.IsNotExist(err) {
+			contextLogger.Debug().Msgf("module source directory not found, skipping enrichment: %s", modulePath)
+		} else {
+			contextLogger.Warn().Msgf("cannot read module source directory: %s: %v", modulePath, err)
+		}
 		return nil, err
 	}
 
 	for _, entry := range entries {
-		path := filepath.Join(modulePath, entry.Name())
-
 		if entry.IsDir() {
-			contextLogger.Debug().Msgf("Skipping directory: %s", path)
 			continue
 		}
-
 		if !isTerraformFile(entry.Name()) {
-			contextLogger.Debug().Msgf("Skipping non-Terraform file: %s", path)
 			continue
 		}
-
-		contents, err := fsys.ReadFile(filepath.Clean(path))
-		if err != nil {
-			contextLogger.Error().Msgf("Failed to read file: %s", path)
+		path := filepath.Join(modulePath, entry.Name())
+		if err := processEquivalentMapFile(ctx, fsys, path, equivalentMap, resourceTypesMap); err != nil {
 			return nil, err
-		}
-
-		hclFile, diag := hclwrite.ParseConfig(contents, "", hcl.InitialPos)
-		if diag.HasErrors() {
-			err := fmt.Errorf("error parsing input Terraform block in file %s: %s", path, diag.Error())
-			contextLogger.Error().Msg(err.Error())
-			return nil, err
-		}
-
-		for _, block := range hclFile.Body().Blocks() {
-			if block.Type() != "resource" {
-				continue
-			}
-
-			if len(block.Labels()) < 1 {
-				contextLogger.Warn().Msgf("Skipping malformed resource block with no labels in file %s", path)
-				continue
-			}
-
-			resourceType := block.Labels()[0]
-			provider, err := GetProviderFromResourceType(resourceType)
-			if err != nil {
-				contextLogger.Warn().Msgf("Failed to get provider from resource type '%s' in file %s: %v", resourceType, path, err)
-				continue
-			}
-
-			// Store resource type to the set
-			if _, ok := resourceTypesMap[provider]; !ok {
-				resourceTypesMap[provider] = make(map[string]bool)
-			}
-			resourceTypesMap[provider][resourceType] = true
-
-			// Create or update the module info object for current provider
-			modInfo, ok := equivalentMap[provider]
-			if !ok {
-				modInfo = ModuleAttributesInfo{
-					Resources: []string{},
-					Inputs:    make(map[string]string),
-				}
-			}
-
-			// Update inputs mapping with all attributes referencing a variable
-			maps.Copy(modInfo.Inputs, getVariableAttributes(block))
-
-			// Assign the updated modInfo back to the map
-			equivalentMap[provider] = modInfo
 		}
 	}
 
@@ -745,8 +855,58 @@ func generateEquivalentMap(ctx context.Context, fsys vfs.FS, modulePath string) 
 		sort.Strings(modInfo.Resources)
 		equivalentMap[provider] = modInfo
 	}
-
 	return equivalentMap, nil
+}
+
+func processEquivalentMapFile(
+	ctx context.Context,
+	fsys vfs.FS,
+	path string,
+	equivalentMap map[string]ModuleAttributesInfo,
+	resourceTypesMap map[string]map[string]bool,
+) error {
+	contextLogger := logger.FromContext(ctx)
+
+	contents, err := fsys.ReadFile(filepath.Clean(path))
+	if err != nil {
+		contextLogger.Error().Msgf("Failed to read file: %s", path)
+		return err
+	}
+
+	hclFile, diag := hclwrite.ParseConfig(contents, "", hcl.InitialPos)
+	if diag.HasErrors() {
+		parseErr := fmt.Errorf("error parsing input Terraform block in file %s: %s", path, diag.Error())
+		contextLogger.Error().Msg(parseErr.Error())
+		return parseErr
+	}
+
+	for _, block := range hclFile.Body().Blocks() {
+		if block.Type() != "resource" {
+			continue
+		}
+		if len(block.Labels()) < 1 {
+			contextLogger.Warn().Msgf("Skipping malformed resource block with no labels in file %s", path)
+			continue
+		}
+		resourceType := block.Labels()[0]
+		provider, err := GetProviderFromResourceType(resourceType)
+		if err != nil {
+			contextLogger.Warn().Msgf("Failed to get provider from resource type '%s' in file %s: %v", resourceType, path, err)
+			continue
+		}
+		if _, ok := resourceTypesMap[provider]; !ok {
+			resourceTypesMap[provider] = make(map[string]bool)
+		}
+		resourceTypesMap[provider][resourceType] = true
+
+		modInfo, ok := equivalentMap[provider]
+		if !ok {
+			modInfo = ModuleAttributesInfo{Resources: []string{}, Inputs: make(map[string]string)}
+		}
+		maps.Copy(modInfo.Inputs, getVariableAttributes(block))
+		equivalentMap[provider] = modInfo
+	}
+	return nil
 }
 
 func getVariableAttributes(block *hclwrite.Block) map[string]string {

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
-	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/require"
@@ -54,7 +53,7 @@ module "local_bucket" {
 		},
 	}
 
-	gotMap, err := ParseTerraformModules(ctx, vfs.DiskFS{}, files, 0)
+	gotMap, err := ParseTerraformModules(ctx, nil, files, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -100,14 +99,12 @@ func TestParseTerraformModules_CanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // canceled scan
 
-	_, err := ParseTerraformModules(ctx, vfs.DiskFS{}, files, 0)
+	_, err := ParseTerraformModules(ctx, nil, files, 0)
 	require.ErrorIs(t, err, context.Canceled)
 }
 
 // TestParseAllModuleVariables_CanceledContext guards the cancellation contract:
-// results are written into an index-aligned slice, so a canceled scan must
-// surface ctx.Err() rather than return a slice padded with zero-value holes for
-// the modules whose workers never ran.
+// a canceled context should return an empty slice without blocking.
 func TestParseAllModuleVariables_CanceledContext(t *testing.T) {
 	modules := map[string]ParsedModule{
 		"a": {Name: "a", IsLocal: true, AbsSource: t.TempDir()},
@@ -117,9 +114,9 @@ func TestParseAllModuleVariables_CanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // canceled scan
 
-	got, err := ParseAllModuleVariables(ctx, vfs.DiskFS{}, modules, t.TempDir())
+	got, err := ParseAllModuleVariables(ctx, nil, modules, t.TempDir(), nil)
 	require.ErrorIs(t, err, context.Canceled)
-	require.Nil(t, got)
+	require.Empty(t, got)
 }
 
 func TestParseTerraformModules(t *testing.T) {
@@ -360,7 +357,7 @@ module "three" {
 					}},
 			}
 
-			gotMap, err := ParseTerraformModules(ctx, vfs.DiskFS{}, files, 0)
+			gotMap, err := ParseTerraformModules(ctx, nil, files, 0)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -380,6 +377,11 @@ module "three" {
 					}
 					tt.expected[i].AbsSource = expectedAbs
 				}
+			}
+			// Strip location fields — these tests verify source/type detection, not source positions.
+			for i := range got {
+				got[i].FileName = ""
+				got[i].DefLine = 0
 			}
 			sort.Slice(got, func(i, j int) bool {
 				return got[i].Name < got[j].Name

--- a/pkg/parser/terraform/tfeval/document.go
+++ b/pkg/parser/terraform/tfeval/document.go
@@ -11,6 +11,7 @@ import (
 
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -86,23 +87,52 @@ func ctyMapToDocument(v cty.Value) map[string]interface{} {
 	return obj
 }
 
-// CalledLocalDirs returns the resolved directories of every local module called
-// from dir. Remote/registry sources are ignored.
-func CalledLocalDirs(dir string) []string {
+// RemoteResolver maps a non-local module call to its materialized directory on disk.
+type RemoteResolver func(source, version, callerFile, moduleName string) (dir string, ok bool)
+
+func CalledModuleDirs(dir string, resolver RemoteResolver) []string {
 	bodies, err := parseDir(dir)
 	if err != nil {
 		return nil
 	}
+	return calledModuleDirs(dir, bodies, resolver)
+}
+
+func (e *Evaluator) CalledModuleDirs(dir string) []string {
+	bodies, err := e.parseDir(dir)
+	if err != nil {
+		return nil
+	}
+	return calledModuleDirs(dir, bodies, e.remoteResolver)
+}
+
+func calledModuleDirs(dir string, bodies []*hclsyntax.Body, resolver RemoteResolver) []string {
 	moduleBlocks := collectModuleBlocks(bodies)
 
 	emptyCtx := &hcl.EvalContext{}
 	var dirs []string
 	for _, mb := range moduleBlocks {
 		source := knownString(mb.Body.Attributes["source"], emptyCtx)
-		if source == "" || !tfmodules.LooksLikeLocalModuleSource(StripGetterPrefix(source)) {
+		if source == "" {
 			continue
 		}
-		dirs = append(dirs, resolveLocalDir(dir, source))
+		cleanSource := StripGetterPrefix(source)
+		if tfmodules.LooksLikeLocalModuleSource(cleanSource) {
+			dirs = append(dirs, resolveLocalDir(dir, source))
+			continue
+		}
+		if resolver != nil {
+			version := knownString(mb.Body.Attributes["version"], emptyCtx)
+			if d, ok := resolver(source, version, mb.TypeRange.Filename, blockLabel(mb)); ok {
+				dirs = append(dirs, d)
+			}
+		}
 	}
 	return dirs
+}
+
+// CalledLocalDirs returns the resolved directories of every local module called
+// from dir. Remote/registry sources are ignored.
+func CalledLocalDirs(dir string) []string {
+	return CalledModuleDirs(dir, nil)
 }

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	tffunctions "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/functions"
@@ -69,6 +70,16 @@ type Evaluator struct {
 	// module calls — entries with the same key represent the same module called with the
 	// same resolved inputs from the same structural position in the module tree.
 	cache map[evalCacheKey]*evalCacheEntry
+	// When set, non-local module sources resolve here and recurse with caller inputs.
+	remoteResolver RemoteResolver
+
+	parseMu  sync.Mutex
+	dirCache map[string]dirParse
+}
+
+type dirParse struct {
+	bodies []*hclsyntax.Body
+	err    error
 }
 
 func New() *Evaluator {
@@ -76,7 +87,30 @@ func New() *Evaluator {
 		funcs:    tffunctions.TerraformFuncs,
 		maxDepth: defaultMaxDepth,
 		cache:    make(map[evalCacheKey]*evalCacheEntry),
+		dirCache: make(map[string]dirParse),
 	}
+}
+
+func (e *Evaluator) parseDir(dir string) ([]*hclsyntax.Body, error) {
+	key := filepath.Clean(dir)
+
+	e.parseMu.Lock()
+	if dp, ok := e.dirCache[key]; ok {
+		e.parseMu.Unlock()
+		return dp.bodies, dp.err
+	}
+	e.parseMu.Unlock()
+
+	bodies, err := parseDir(dir)
+
+	e.parseMu.Lock()
+	e.dirCache[key] = dirParse{bodies: bodies, err: err}
+	e.parseMu.Unlock()
+	return bodies, err
+}
+
+func (e *Evaluator) SetRemoteResolver(r RemoteResolver) {
+	e.remoteResolver = r
 }
 
 // EvaluateModule evaluates the module rooted at dir with the given inputs and
@@ -141,7 +175,7 @@ func (e *Evaluator) evaluate(
 		prevAllVisited[k] = true
 	}
 
-	bodies, err := parseDir(dir)
+	bodies, err := e.parseDir(dir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -268,11 +302,15 @@ func (e *Evaluator) evaluateLocalModuleBlocks(
 			continue
 		}
 		source := knownString(mb.Body.Attributes["source"], evalCtx)
-		if source == "" || !tfmodules.LooksLikeLocalModuleSource(StripGetterPrefix(source)) {
+		if source == "" {
 			continue
 		}
 
-		childDir := resolveLocalDir(dir, source)
+		version := knownString(mb.Body.Attributes["version"], evalCtx)
+		childDir, ok := e.resolveModuleDir(dir, source, version, mb.TypeRange.Filename, label)
+		if !ok {
+			continue
+		}
 
 		if isLiteralZero(mb.Body.Attributes["count"], evalCtx) {
 			continue
@@ -306,6 +344,18 @@ func (e *Evaluator) evaluateLocalModuleBlocks(
 		evalCtx.Variables["module"] = cty.ObjectVal(moduleOutputs)
 	}
 	return childResources, moduleOutputs
+}
+
+func (e *Evaluator) resolveModuleDir(callerDir, source, version, callerFile, moduleName string) (dir string, ok bool) {
+	cleanSource := StripGetterPrefix(source)
+	if tfmodules.LooksLikeLocalModuleSource(cleanSource) {
+		return resolveLocalDir(callerDir, source), true
+	}
+	if e.remoteResolver != nil {
+		d, resolved := e.remoteResolver(source, version, callerFile, moduleName)
+		return d, resolved
+	}
+	return "", false
 }
 
 func (e *Evaluator) rootResourcesWithRefPasses(
@@ -679,7 +729,12 @@ func (e *Evaluator) preliminaryModuleOutputs(
 			continue
 		}
 		source := knownString(mb.Body.Attributes["source"], evalCtx)
-		if source == "" || !tfmodules.LooksLikeLocalModuleSource(StripGetterPrefix(source)) {
+		if source == "" {
+			continue
+		}
+		version := knownString(mb.Body.Attributes["version"], evalCtx)
+		childDir, ok := e.resolveModuleDir(dir, source, version, mb.TypeRange.Filename, label)
+		if !ok {
 			continue
 		}
 		if isLiteralZero(mb.Body.Attributes["count"], evalCtx) {
@@ -688,7 +743,6 @@ func (e *Evaluator) preliminaryModuleOutputs(
 		if isEmptyCollection(mb.Body.Attributes["for_each"], evalCtx) {
 			continue
 		}
-		childDir := resolveLocalDir(dir, source)
 		modInputs := e.evalBody(mb.Body, evalCtx, reservedModuleAttrs)
 		site := CallSite{
 			ModuleName: label,


### PR DESCRIPTION
> [!TIP]
> This PR is best reviewed commit by commit.

## Motivation

The scanner today silently skips non-local Terraform modules: a `source = "git::..."` or registry reference has no local directory to read from, so the module's variables and resources are never evaluated. This PR lays the internal groundwork for changing that, a resolver interface in the module parser and injection points in the engine, so a follow-up PR can wire in the actual download step without touching default behavior. Nothing here changes what a scan produces today.

## Changes

**Module parser**

The parser now accepts an optional `RemoteResolver` callback, a source-to-local-directory lookup, so the engine can supply downloaded paths without the parser needing to know how fetching works. Resolution failures for individual modules are non-fatal: a warning is logged per module and the scan continues with what is available. A canceled context during enrichment propagates as `context.Canceled` rather than returning partial results. `vfs.FS` threading is preserved throughout so the `serve` endpoint's in-memory filesystem (used by the IDE extension) continues to work for local module sibling resolution.

**Engine injection points**

Two new methods on `Inspector`, `SetRemoteModuleDirectories` and `SetExternalModulePaths`, let the scan pipeline hand off a pre-downloaded source map before the scan runs. Module metadata merging now keys equivalent maps by source and version so multiple instances of the same module resolve correctly. If neither injection method is called the behavior is identical to today.

**Inspector**

The module resolver is connected to the scan lifecycle. Local module instantiation remains gated on the existing `IacEnableLocalModuleEval` feature flag. No scan-pipeline or CLI wiring calls the new injection methods yet.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [x] I have updated any relevant documentation (if applicable).

## QA Instruction

CI should pass

## Impact

Additive only. No CLI flags, scan parameters, or default scan behavior changes. The new `Inspector` methods have no external callers yet; the follow-up PR will connect them to scan parameters and an opt-in CLI flag.

I submit this contribution under the Apache-2.0 license.