### PR TITLE
[K9CODESEC-2948/2950] Wire Terraform remote modules into scanner

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -95,6 +95,23 @@ var scanAction = &cli.Command{
 			Value:  false,
 		},
 		&cli.BoolFlag{
+			Name:   "x-remote-modules",
+			Hidden: true,
+			Usage:  "(experimental) resolve Terraform remote modules before scanning",
+			Value:  false,
+		},
+		&cli.StringFlag{
+			Name:   "x-remote-modules-manifest",
+			Hidden: true,
+			Usage:  "(experimental) JSON manifest mapping Terraform module sources to local directories",
+		},
+		&cli.StringSliceFlag{
+			Name:   "x-remote-modules-allowed-host",
+			Hidden: true,
+			Usage:  "(experimental) host allowed for Terraform remote module downloads",
+			Value:  []string{},
+		},
+		&cli.BoolFlag{
 			Name:   "x-terraform-plan",
 			Hidden: true,
 			Usage:  "(experimental, will be removed soon) scan terraform plans",
@@ -298,6 +315,14 @@ func runScan(ctx context.Context, c *cli.Command) error {
 	if err := validateReportFormats(reportFormats); err != nil {
 		return errorWithExitCode(err, constants.InvalidConfigErrorCode)
 	}
+	if !c.Bool("x-remote-modules") &&
+		(c.String("x-remote-modules-manifest") != "" ||
+			len(c.StringSlice("x-remote-modules-allowed-host")) > 0) {
+		return errorWithExitCode(
+			errors.New("remote module resolver options require --x-remote-modules"),
+			constants.InvalidConfigErrorCode,
+		)
+	}
 
 	queriesPath := c.StringSlice("queries-path")
 	queriesPath, err = validateQueriesPaths(queriesPath)
@@ -344,6 +369,9 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		Config:                      *cfg,
 		ShouldScanTfPlans:           c.Bool("x-terraform-plan"),
 		DisableRuleIsolation:        c.Bool("x-disable-rule-isolation"),
+		EnableRemoteModules:         c.Bool("x-remote-modules"),
+		RemoteModulesManifestPath:   c.String("x-remote-modules-manifest"),
+		RemoteModulesHostAllowlist:  c.StringSlice("x-remote-modules-allowed-host"),
 	}
 
 	var opts []scan.ClientOption
@@ -563,7 +591,7 @@ func selectPlatforms(platforms []string) []string {
 func getFeatureFlagEvaluator(c *cli.Command) featureflags.FlagEvaluator {
 	overrides := map[string]bool{
 		featureflags.IaCEnableKicsParallelFileParsing: c.Bool("x-parallelparsing"),
-		featureflags.IacEnableLocalModuleEval:         c.Bool("x-local-module-eval"),
+		featureflags.IacEnableLocalModuleEval:         c.Bool("x-local-module-eval") || c.Bool("x-remote-modules"),
 	}
 	return featureflags.NewLocalEvaluatorWithOverrides(overrides)
 }

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -702,6 +702,7 @@ func enrichModule(
 	if localPath == "" {
 		return ModuleParseResult{Module: *mod}
 	}
+	mod.AbsSource = localPath
 	attributesData, enrichErr := cache.attributesFor(ctx, localPath)
 	if enrichErr != nil {
 		contextLogger.Warn().Msg("Failed to generate equivalent map")

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -58,6 +58,9 @@ type Parameters struct {
 	ShouldScanTfPlans           bool
 	DisableRuleIsolation        bool
 	UseRulesCache               bool
+	EnableRemoteModules         bool
+	RemoteModulesManifestPath   string
+	RemoteModulesHostAllowlist  []string
 }
 
 func (p *Parameters) GetEffectivePlatforms() []string {
@@ -84,11 +87,12 @@ type Client struct {
 	fsys vfs.FS
 	// inMemory marks a server (content-push) scan: initScan builds its file set
 	// from inMemoryPaths instead of walking the disk via the analyzer.
-	inMemory      bool
-	inMemoryPaths []string
-	walkInventory []string
-	chartRoots    []string
-	contentCache  map[string][]byte
+	inMemory          bool
+	inMemoryPaths     []string
+	walkInventory     []string
+	chartRoots        []string
+	contentCache      map[string][]byte
+	remoteModulePaths []string
 }
 
 // ClientOption customizes a Client at construction time.

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -78,6 +78,9 @@ func (c *Client) prepareRemoteModules(ctx context.Context, paths []string, inspe
 	remotePaths := mapValues(dirs)
 	inspector.SetExternalModulePaths(remotePaths)
 	c.remoteModulePaths = remotePaths
+	if err := c.addRemoteModuleFilesToInventory(remotePaths); err != nil {
+		return err
+	}
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Info().Msgf("Resolved %d Terraform remote module directories", len(dirs))
 	return nil
@@ -179,6 +182,50 @@ func (c *Client) collectTerraformModuleFiles(paths []string) (model.FileMetadata
 	}
 	sort.Strings(rootsSorted)
 	return files, rootsSorted, nil
+}
+
+func (c *Client) addRemoteModuleFilesToInventory(moduleDirs []string) error {
+	if len(c.walkInventory) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(c.walkInventory))
+	for _, path := range c.walkInventory {
+		seen[path] = struct{}{}
+	}
+	for _, dir := range moduleDirs {
+		err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if !strings.EqualFold(filepath.Ext(path), ".tf") {
+				return nil
+			}
+			norm := strings.ReplaceAll(path, "\\", "/")
+			if _, ok := seen[norm]; ok {
+				return nil
+			}
+			seen[norm] = struct{}{}
+			c.walkInventory = append(c.walkInventory, norm)
+			if c.contentCache != nil {
+				if _, ok := c.contentCache[norm]; !ok {
+					data, readErr := os.ReadFile(filepath.Clean(path))
+					if readErr != nil {
+						return readErr
+					}
+					c.contentCache[norm] = data
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	sort.Strings(c.walkInventory)
+	return nil
 }
 
 func moduleRoot(fileName, repoPath string) string {

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
@@ -21,44 +22,69 @@ import (
 
 type moduleResolverAdapter struct {
 	resolver tfresolver.Resolver
+	mu       sync.Mutex
+	cleanups []func()
+	once     sync.Once
 }
 
-func (r moduleResolverAdapter) Resolve(ctx context.Context, mod *tfmodules.ParsedModule) (string, error) {
+func (r *moduleResolverAdapter) Resolve(ctx context.Context, mod *tfmodules.ParsedModule) (string, error) {
 	res, err := r.resolver.Resolve(ctx, mod)
 	if err != nil {
 		return "", err
 	}
+	if res.Cleanup != nil {
+		r.mu.Lock()
+		r.cleanups = append(r.cleanups, res.Cleanup)
+		r.mu.Unlock()
+	}
 	return res.LocalPath, nil
 }
 
-func (c *Client) prepareRemoteModules(ctx context.Context, paths []string, inspector *engine.Inspector) error {
+func (r *moduleResolverAdapter) cleanup() {
+	r.once.Do(func() {
+		r.mu.Lock()
+		cleanups := append([]func(){}, r.cleanups...)
+		r.cleanups = nil
+		r.mu.Unlock()
+		for i := len(cleanups) - 1; i >= 0; i-- {
+			cleanups[i]()
+		}
+	})
+}
+
+func (c *Client) prepareRemoteModules(
+	ctx context.Context, paths []string, inspector *engine.Inspector,
+) (cleanup func(), err error) {
+	noCleanup := func() {}
 	if !c.ScanParams.EnableRemoteModules {
-		return nil
+		return noCleanup, nil
 	}
 	files, roots, err := c.collectTerraformModuleFiles(paths)
 	if err != nil {
-		return err
+		return noCleanup, err
 	}
 	if len(files) == 0 {
-		return nil
+		return noCleanup, nil
 	}
 
 	parsedModules, err := tfmodules.ParseTerraformModules(ctx, c.fsys, files, c.ScanParams.ParallelScanFlag)
 	if err != nil {
-		return err
+		return noCleanup, err
 	}
 	if len(parsedModules) == 0 {
-		return nil
+		return noCleanup, nil
 	}
 
 	resolver, err := c.buildTerraformModuleResolver(roots)
 	if err != nil {
-		return err
+		return noCleanup, err
 	}
+	adapter := &moduleResolverAdapter{resolver: resolver}
 	enriched, err := tfmodules.ParseAllModuleVariables(ctx, c.fsys, parsedModules, c.ScanParams.RepoPath,
-		moduleResolverAdapter{resolver: resolver})
+		adapter)
 	if err != nil {
-		return err
+		adapter.cleanup()
+		return noCleanup, err
 	}
 
 	dirs := make(map[string]string)
@@ -72,18 +98,19 @@ func (c *Client) prepareRemoteModules(ctx context.Context, paths []string, inspe
 		dirs[engine.RemoteModuleCallKey(root, mod.Source, mod.Version, mod.Name)] = mod.AbsSource
 	}
 	if len(dirs) == 0 {
-		return nil
+		return adapter.cleanup, nil
 	}
 	inspector.SetRemoteModuleDirectories(dirs)
 	remotePaths := mapValues(dirs)
 	inspector.SetExternalModulePaths(remotePaths)
 	c.remoteModulePaths = remotePaths
 	if err := c.addRemoteModuleFilesToInventory(remotePaths); err != nil {
-		return err
+		adapter.cleanup()
+		return noCleanup, err
 	}
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Info().Msgf("Resolved %d Terraform remote module directories", len(dirs))
-	return nil
+	return adapter.cleanup, nil
 }
 
 func (c *Client) buildTerraformModuleResolver(roots []string) (tfresolver.Resolver, error) {

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -1,0 +1,205 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package scan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine"
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	tfresolver "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+)
+
+type moduleResolverAdapter struct {
+	resolver tfresolver.Resolver
+}
+
+func (r moduleResolverAdapter) Resolve(ctx context.Context, mod *tfmodules.ParsedModule) (string, error) {
+	res, err := r.resolver.Resolve(ctx, mod)
+	if err != nil {
+		return "", err
+	}
+	return res.LocalPath, nil
+}
+
+func (c *Client) prepareRemoteModules(ctx context.Context, paths []string, inspector *engine.Inspector) error {
+	if !c.ScanParams.EnableRemoteModules {
+		return nil
+	}
+	files, roots, err := c.collectTerraformModuleFiles(paths)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return nil
+	}
+
+	parsedModules, err := tfmodules.ParseTerraformModules(ctx, c.fsys, files, c.ScanParams.ParallelScanFlag)
+	if err != nil {
+		return err
+	}
+	if len(parsedModules) == 0 {
+		return nil
+	}
+
+	resolver, err := c.buildTerraformModuleResolver(roots)
+	if err != nil {
+		return err
+	}
+	enriched, err := tfmodules.ParseAllModuleVariables(ctx, c.fsys, parsedModules, c.ScanParams.RepoPath,
+		moduleResolverAdapter{resolver: resolver})
+	if err != nil {
+		return err
+	}
+
+	dirs := make(map[string]string)
+	for i := range enriched {
+		mod := &enriched[i]
+		if mod.IsLocal || mod.AbsSource == "" {
+			continue
+		}
+		root := moduleRoot(mod.FileName, c.ScanParams.RepoPath)
+		dirs[engine.RemoteModuleKey(root, mod.Source, mod.Version)] = mod.AbsSource
+		dirs[engine.RemoteModuleCallKey(root, mod.Source, mod.Version, mod.Name)] = mod.AbsSource
+	}
+	if len(dirs) == 0 {
+		return nil
+	}
+	inspector.SetRemoteModuleDirectories(dirs)
+	remotePaths := mapValues(dirs)
+	inspector.SetExternalModulePaths(remotePaths)
+	c.remoteModulePaths = remotePaths
+	contextLogger := logger.FromContext(ctx)
+	contextLogger.Info().Msgf("Resolved %d Terraform remote module directories", len(dirs))
+	return nil
+}
+
+func (c *Client) buildTerraformModuleResolver(roots []string) (tfresolver.Resolver, error) {
+	resolvers := []tfresolver.Resolver{
+		&tfresolver.DotTerraformResolver{RootDirs: roots},
+		tfresolver.NewLocalGitRefResolver(roots, ""),
+		tfresolver.NewBareGitResolver(""),
+	}
+	if c.ScanParams.RemoteModulesManifestPath != "" {
+		manifest, err := tfresolver.LoadManifest(c.ScanParams.RemoteModulesManifestPath)
+		if err != nil {
+			return nil, err
+		}
+		resolvers = append([]tfresolver.Resolver{tfresolver.NewPrefetchedResolver(manifest)}, resolvers...)
+	}
+	cfg := tfresolver.NewGoGetterConfig()
+	cfg.HostAllowlist = c.ScanParams.RemoteModulesHostAllowlist
+	cache, err := tfresolver.NewModuleCache()
+	if err != nil {
+		return nil, err
+	}
+	cfg.Cache = cache
+	resolvers = append(resolvers, tfresolver.NewGoGetterResolver(cfg))
+	return tfresolver.NewChainResolver(resolvers...), nil
+}
+
+func (c *Client) collectTerraformModuleFiles(paths []string) (model.FileMetadatas, []string, error) {
+	filesByPath := make(map[string]*model.FileMetadata)
+	roots := make(map[string]struct{})
+	addPath := func(path string) error {
+		if !strings.EqualFold(filepath.Ext(path), ".tf") {
+			return nil
+		}
+		data, ok := c.contentCache[path]
+		if !ok {
+			var err error
+			data, err = os.ReadFile(filepath.Clean(path))
+			if err != nil {
+				return err
+			}
+		}
+		filesByPath[path] = &model.FileMetadata{FilePath: path, OriginalData: string(data)}
+		roots[moduleRoot(path, c.ScanParams.RepoPath)] = struct{}{}
+		return nil
+	}
+
+	if len(c.walkInventory) > 0 {
+		for _, path := range c.walkInventory {
+			if err := addPath(path); err != nil {
+				return nil, nil, err
+			}
+		}
+	} else {
+		for _, scanPath := range paths {
+			info, err := os.Stat(scanPath)
+			if err != nil {
+				return nil, nil, err
+			}
+			if !info.IsDir() {
+				if err := addPath(scanPath); err != nil {
+					return nil, nil, err
+				}
+				continue
+			}
+			err = filepath.WalkDir(scanPath, func(path string, d os.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if d.IsDir() && strings.HasPrefix(d.Name(), ".terra") {
+					return filepath.SkipDir
+				}
+				if d.IsDir() {
+					return nil
+				}
+				return addPath(path)
+			})
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	pathsSorted := make([]string, 0, len(filesByPath))
+	for path := range filesByPath {
+		pathsSorted = append(pathsSorted, path)
+	}
+	sort.Strings(pathsSorted)
+	files := make(model.FileMetadatas, 0, len(pathsSorted))
+	for _, path := range pathsSorted {
+		files = append(files, filesByPath[path])
+	}
+
+	rootsSorted := make([]string, 0, len(roots))
+	for root := range roots {
+		rootsSorted = append(rootsSorted, root)
+	}
+	sort.Strings(rootsSorted)
+	return files, rootsSorted, nil
+}
+
+func moduleRoot(fileName, repoPath string) string {
+	if fileName == "" {
+		return filepath.Clean(repoPath)
+	}
+	if filepath.IsAbs(fileName) {
+		return filepath.Clean(filepath.Dir(fileName))
+	}
+	return filepath.Clean(filepath.Dir(filepath.Join(repoPath, fileName)))
+}
+
+func mapValues(values map[string]string) []string {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		seen[value] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for value := range seen {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -111,73 +111,91 @@ func (c *Client) buildTerraformModuleResolver(roots []string) (tfresolver.Resolv
 }
 
 func (c *Client) collectTerraformModuleFiles(paths []string) (model.FileMetadatas, []string, error) {
-	filesByPath := make(map[string]*model.FileMetadata)
-	roots := make(map[string]struct{})
-	addPath := func(path string) error {
-		if !strings.EqualFold(filepath.Ext(path), ".tf") {
-			return nil
-		}
-		data, ok := c.contentCache[path]
-		if !ok {
-			var err error
-			data, err = os.ReadFile(filepath.Clean(path))
-			if err != nil {
-				return err
-			}
-		}
-		filesByPath[path] = &model.FileMetadata{FilePath: path, OriginalData: string(data)}
-		roots[moduleRoot(path, c.ScanParams.RepoPath)] = struct{}{}
-		return nil
-	}
-
+	files := newTerraformModuleFiles(c.contentCache, c.ScanParams.RepoPath)
 	if len(c.walkInventory) > 0 {
 		for _, path := range c.walkInventory {
-			if err := addPath(path); err != nil {
+			if err := files.add(path); err != nil {
 				return nil, nil, err
 			}
 		}
-	} else {
-		for _, scanPath := range paths {
-			info, err := os.Stat(scanPath)
-			if err != nil {
-				return nil, nil, err
-			}
-			if !info.IsDir() {
-				if err := addPath(scanPath); err != nil {
-					return nil, nil, err
-				}
-				continue
-			}
-			err = filepath.WalkDir(scanPath, func(path string, d os.DirEntry, err error) error {
-				if err != nil {
-					return err
-				}
-				if d.IsDir() && strings.HasPrefix(d.Name(), ".terra") {
-					return filepath.SkipDir
-				}
-				if d.IsDir() {
-					return nil
-				}
-				return addPath(path)
-			})
-			if err != nil {
-				return nil, nil, err
-			}
+		return files.sorted()
+	}
+	for _, scanPath := range paths {
+		if err := files.addScanPath(scanPath); err != nil {
+			return nil, nil, err
 		}
 	}
+	return files.sorted()
+}
 
-	pathsSorted := make([]string, 0, len(filesByPath))
-	for path := range filesByPath {
+type terraformModuleFiles struct {
+	contentCache map[string][]byte
+	repoPath     string
+	filesByPath  map[string]*model.FileMetadata
+	roots        map[string]struct{}
+}
+
+func newTerraformModuleFiles(contentCache map[string][]byte, repoPath string) *terraformModuleFiles {
+	return &terraformModuleFiles{
+		contentCache: contentCache,
+		repoPath:     repoPath,
+		filesByPath:  make(map[string]*model.FileMetadata),
+		roots:        make(map[string]struct{}),
+	}
+}
+
+func (f *terraformModuleFiles) add(path string) error {
+	if !strings.EqualFold(filepath.Ext(path), ".tf") {
+		return nil
+	}
+	data, ok := f.contentCache[path]
+	if !ok {
+		var err error
+		data, err = os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			return err
+		}
+	}
+	f.filesByPath[path] = &model.FileMetadata{FilePath: path, OriginalData: string(data)}
+	f.roots[moduleRoot(path, f.repoPath)] = struct{}{}
+	return nil
+}
+
+func (f *terraformModuleFiles) addScanPath(scanPath string) error {
+	info, err := os.Stat(scanPath)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return f.add(scanPath)
+	}
+	return filepath.WalkDir(scanPath, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() && strings.HasPrefix(d.Name(), ".terra") {
+			return filepath.SkipDir
+		}
+		if d.IsDir() {
+			return nil
+		}
+		return f.add(path)
+	})
+}
+
+func (f *terraformModuleFiles) sorted() (model.FileMetadatas, []string, error) {
+	pathsSorted := make([]string, 0, len(f.filesByPath))
+	for path := range f.filesByPath {
 		pathsSorted = append(pathsSorted, path)
 	}
 	sort.Strings(pathsSorted)
 	files := make(model.FileMetadatas, 0, len(pathsSorted))
 	for _, path := range pathsSorted {
-		files = append(files, filesByPath[path])
+		files = append(files, f.filesByPath[path])
 	}
 
-	rootsSorted := make([]string, 0, len(roots))
-	for root := range roots {
+	rootsSorted := make([]string, 0, len(f.roots))
+	for root := range f.roots {
 		rootsSorted = append(rootsSorted, root)
 	}
 	sort.Strings(rootsSorted)
@@ -193,6 +211,7 @@ func (c *Client) addRemoteModuleFilesToInventory(moduleDirs []string) error {
 		seen[path] = struct{}{}
 	}
 	for _, dir := range moduleDirs {
+		moduleFiles := make([]string, 0)
 		err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				return err
@@ -204,24 +223,27 @@ func (c *Client) addRemoteModuleFilesToInventory(moduleDirs []string) error {
 				return nil
 			}
 			norm := strings.ReplaceAll(path, "\\", "/")
-			if _, ok := seen[norm]; ok {
-				return nil
-			}
-			seen[norm] = struct{}{}
-			c.walkInventory = append(c.walkInventory, norm)
-			if c.contentCache != nil {
-				if _, ok := c.contentCache[norm]; !ok {
-					data, readErr := os.ReadFile(filepath.Clean(path))
-					if readErr != nil {
-						return readErr
-					}
-					c.contentCache[norm] = data
-				}
-			}
+			moduleFiles = append(moduleFiles, norm)
 			return nil
 		})
 		if err != nil {
 			return err
+		}
+		for _, path := range moduleFiles {
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+			c.walkInventory = append(c.walkInventory, path)
+			if c.contentCache != nil {
+				if _, ok := c.contentCache[path]; !ok {
+					data, readErr := os.ReadFile(filepath.Clean(path))
+					if readErr != nil {
+						return readErr
+					}
+					c.contentCache[path] = data
+				}
+			}
 		}
 	}
 	sort.Strings(c.walkInventory)

--- a/pkg/scan/remote_modules_test.go
+++ b/pkg/scan/remote_modules_test.go
@@ -5,15 +5,41 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
 	consolePrinter "github.com/DataDog/datadog-iac-scanner/pkg/printer"
 	"github.com/stretchr/testify/require"
 )
+
+type cleanupResolver struct {
+	cleaned *atomic.Int32
+}
+
+func (r cleanupResolver) Resolve(context.Context, *tfmodules.ParsedModule) (resolver.Resolution, error) {
+	return resolver.Resolution{
+		LocalPath: "/tmp/module",
+		Cleanup:   func() { r.cleaned.Add(1) },
+	}, nil
+}
+
+func TestModuleResolverAdapterRunsCleanupOnce(t *testing.T) {
+	var cleaned atomic.Int32
+	adapter := &moduleResolverAdapter{resolver: cleanupResolver{cleaned: &cleaned}}
+
+	path, err := adapter.Resolve(context.Background(), &tfmodules.ParsedModule{})
+	require.NoError(t, err)
+	require.Equal(t, "/tmp/module", path)
+
+	adapter.cleanup()
+	adapter.cleanup()
+	require.EqualValues(t, 1, cleaned.Load())
+}
 
 func TestRemoteModulesDisabledByDefault(t *testing.T) {
 	root := t.TempDir()

--- a/pkg/scan/remote_modules_test.go
+++ b/pkg/scan/remote_modules_test.go
@@ -40,6 +40,22 @@ func TestRemoteModulesManifestEnablesModuleInstantiation(t *testing.T) {
 	require.Equal(t, filepath.Join(moduleDir, "main.tf"), results.Results[0].FileName)
 }
 
+func TestAddRemoteModuleFilesToPrebuiltInventory(t *testing.T) {
+	root := t.TempDir()
+	moduleDir, _ := writeRemoteModuleFixture(t, root)
+	rootFile := filepath.Join(root, "main.tf")
+	moduleFile := filepath.Join(moduleDir, "main.tf")
+	client := &Client{
+		walkInventory: []string{rootFile},
+		contentCache:  map[string][]byte{rootFile: []byte("root")},
+	}
+
+	require.NoError(t, client.addRemoteModuleFilesToInventory([]string{moduleDir}))
+
+	require.ElementsMatch(t, []string{rootFile, moduleFile}, client.walkInventory)
+	require.Contains(t, client.contentCache, moduleFile)
+}
+
 func writeRemoteModuleFixture(t *testing.T, root string) (string, string) {
 	t.Helper()
 	moduleDir := filepath.Join(filepath.Dir(root), "downloaded-vpc")

--- a/pkg/scan/remote_modules_test.go
+++ b/pkg/scan/remote_modules_test.go
@@ -1,0 +1,129 @@
+package scan
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
+	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+	consolePrinter "github.com/DataDog/datadog-iac-scanner/pkg/printer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteModulesDisabledByDefault(t *testing.T) {
+	root := t.TempDir()
+	_, manifestPath := writeRemoteModuleFixture(t, root)
+
+	params := remoteModuleScanParams(root)
+	params.RemoteModulesManifestPath = manifestPath
+	params.EnableRemoteModules = false
+
+	results := executeRemoteModuleScan(t, params)
+	require.Empty(t, results.Results)
+}
+
+func TestRemoteModulesManifestEnablesModuleInstantiation(t *testing.T) {
+	root := t.TempDir()
+	moduleDir, manifestPath := writeRemoteModuleFixture(t, root)
+
+	params := remoteModuleScanParams(root)
+	params.EnableRemoteModules = true
+	params.RemoteModulesManifestPath = manifestPath
+
+	results := executeRemoteModuleScan(t, params)
+	require.NotEmpty(t, results.Results)
+	require.Equal(t, filepath.Join(moduleDir, "main.tf"), results.Results[0].FileName)
+}
+
+func writeRemoteModuleFixture(t *testing.T, root string) (string, string) {
+	t.Helper()
+	moduleDir := filepath.Join(filepath.Dir(root), "downloaded-vpc")
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte(`
+variable "cidr" {}
+resource "aws_vpc" "this" {
+  cidr_block = var.cidr
+}
+`), 0o644))
+
+	rootFile := filepath.Join(root, "main.tf")
+	require.NoError(t, os.WriteFile(rootFile, []byte(`
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.0.0"
+  cidr    = "10.0.0.0/16"
+}
+`), 0o644))
+
+	manifestPath := filepath.Join(root, "modules.json")
+	manifest := resolver.Manifest{
+		Modules: map[string]resolver.ManifestEntry{
+			"terraform-aws-modules/vpc/aws@5.0.0": {LocalPath: moduleDir, Version: "5.0.0"},
+		},
+	}
+	data, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, data, 0o644))
+	return moduleDir, manifestPath
+}
+
+func remoteModuleScanParams(root string) *Parameters {
+	return &Parameters{
+		Path:                    []string{root},
+		PreviewLines:            3,
+		CloudProvider:           []string{"aws"},
+		Platform:                []string{"Terraform"},
+		RepoPath:                root,
+		QueriesPath:             []string{root},
+		ChangedDefaultQueryPath: true,
+		ScanID:                  "remote-module-test",
+		MaxFileSizeFlag:         100,
+		MaxResolverDepth:        15,
+		FlagEvaluator: featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
+			featureflags.IacEnableLocalModuleEval: true,
+		}),
+	}
+}
+
+func executeRemoteModuleScan(t *testing.T, params *Parameters) *Results {
+	t.Helper()
+	ctx := context.Background()
+	client, err := NewClient(ctx, params, &consolePrinter.Printer{})
+	require.NoError(t, err)
+	client.querySourceFactory = func(_ context.Context, _ []string) (source.QueriesSource, error) {
+		return &stubQuerySource{queries: []model.QueryMetadata{{
+			Query: "remote-module-vpc-rule",
+			Content: `package datadog
+
+DatadogPolicy contains result if {
+	input.document[i].resource.aws_vpc[name]
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_vpc",
+		"resourceName": name,
+		"searchKey": sprintf("aws_vpc[%s]", [name]),
+	}
+}`,
+			InputData: "{}",
+			Platform:  "terraform",
+			Metadata: map[string]interface{}{
+				"id":        "remote-module-vpc-rule",
+				"legacyId":  "remote-module-vpc-rule",
+				"queryName": "Remote Module VPC Rule",
+				"severity":  "HIGH",
+				"platform":  "Terraform",
+				"category":  "Configuration",
+			},
+			Aggregation: 1,
+		}}}, nil
+	}
+	results, err := client.executeScan(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	return results
+}

--- a/pkg/scan/remote_modules_test.go
+++ b/pkg/scan/remote_modules_test.go
@@ -37,7 +37,7 @@ func TestRemoteModulesManifestEnablesModuleInstantiation(t *testing.T) {
 
 	results := executeRemoteModuleScan(t, params)
 	require.NotEmpty(t, results.Results)
-	require.Equal(t, filepath.Join(moduleDir, "main.tf"), results.Results[0].FileName)
+	require.Equal(t, filepath.ToSlash(filepath.Join(moduleDir, "main.tf")), filepath.ToSlash(results.Results[0].FileName))
 }
 
 func TestAddRemoteModuleFilesToPrebuiltInventory(t *testing.T) {
@@ -52,8 +52,16 @@ func TestAddRemoteModuleFilesToPrebuiltInventory(t *testing.T) {
 
 	require.NoError(t, client.addRemoteModuleFilesToInventory([]string{moduleDir}))
 
-	require.ElementsMatch(t, []string{rootFile, moduleFile}, client.walkInventory)
-	require.Contains(t, client.contentCache, moduleFile)
+	require.ElementsMatch(t, []string{filepath.ToSlash(rootFile), filepath.ToSlash(moduleFile)}, toSlashPaths(client.walkInventory))
+	require.Contains(t, client.contentCache, filepath.ToSlash(moduleFile))
+}
+
+func toSlashPaths(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		out = append(out, filepath.ToSlash(path))
+	}
+	return out
 }
 
 func writeRemoteModuleFixture(t *testing.T, root string) (string, string) {

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -106,6 +106,10 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := c.prepareRemoteModules(ctx, extractedPaths.Path, inspector); err != nil {
+		contextLogger.Err(err).Msg("failed to prepare Terraform remote modules")
+		return nil, err
+	}
 
 	contextLogger.Info().Msgf("Finshed inspect query source %v", querySource)
 
@@ -272,6 +276,7 @@ func (c *Client) createService(
 	flagEvaluator featureflags.FlagEvaluator,
 	filePlatform map[string]string) ([]*runner.Service, error) {
 	var filesSource provider.SourceProvider
+	paths = append(paths, c.remoteModulePaths...)
 	if c.inMemory {
 		// Content-push mode: serve the pushed files from the in-memory FS instead
 		// of walking the disk. No symlink/SameFile handling and no Helm chart

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -47,6 +47,7 @@ type executeScanParameters struct {
 	services       []*runner.Service
 	inspector      *engine.Inspector
 	extractedPaths provider.ExtractedPath
+	moduleCleanup  func()
 }
 
 func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
@@ -106,10 +107,17 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := c.prepareRemoteModules(ctx, extractedPaths.Path, inspector); err != nil {
+	moduleCleanup, err := c.prepareRemoteModules(ctx, extractedPaths.Path, inspector)
+	if err != nil {
 		contextLogger.Err(err).Msg("failed to prepare Terraform remote modules")
 		return nil, err
 	}
+	initSucceeded := false
+	defer func() {
+		if !initSucceeded {
+			moduleCleanup()
+		}
+	}()
 
 	contextLogger.Info().Msgf("Finshed inspect query source %v", querySource)
 
@@ -129,10 +137,12 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		return nil, err
 	}
 
+	initSucceeded = true
 	return &executeScanParameters{
 		services:       services,
 		inspector:      inspector,
 		extractedPaths: extractedPaths,
+		moduleCleanup:  moduleCleanup,
 	}, nil
 }
 
@@ -184,6 +194,7 @@ func (c *Client) executeScan(ctx context.Context) (*Results, error) {
 	if executeScanParameters == nil {
 		return nil, nil
 	}
+	defer executeScanParameters.moduleCleanup()
 
 	contextLogger.Info().Msg("Scan initialized")
 


### PR DESCRIPTION
> [!TIP]
> This PR is stacked on #250 and should be reviewed after that PR.

> [!NOTE]
> I have one final PR after this one to make some performance improvements, cleanup and optimizations.

## Motivation

The resolver and engine layers can now map Terraform module calls to local directories, but the scanner does not yet invoke that work before inspection. This PR adds opt-in scan-pipeline wiring so Terraform remote modules can be resolved, parsed, and evaluated without changing default scan behavior.

## Changes

**Scan pipeline**

When `--x-remote-modules` is enabled, the scanner collects Terraform files from the analyzed file set, parses module calls, resolves them through the existing resolver chain, and injects the resolved directories into the inspector before services run.

**Source inclusion**

Resolved module directories are added to the scan source paths so their Terraform files are parsed like regular scan input. The inspector marks those directories as external module paths so rule-level path filters do not drop findings just because the module content lives outside the repository subtree.

**CLI**

Hidden experimental flags expose the opt-in path: `--x-remote-modules`, `--x-remote-modules-manifest`, and `--x-remote-modules-allowed-host`. The manifest and host allowlist flags require `--x-remote-modules`. Enabling remote modules also enables the existing local-module evaluation gate because the resolved-directory path is consumed by that engine flow.

**Resolution behavior**

The resolver chain first uses local/prepared sources such as a manifest, `.terraform/modules`, and local git refs, then falls back to remote-capable resolvers. `--x-remote-modules-allowed-host` constrains go-getter and registry-style fetches when configured.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [x] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/scan ./pkg/parser/terraform/modules/... ./pkg/engine ./pkg/engine/source`
2. `go build ./cmd/scanner`
3. Scan a Terraform fixture without `--x-remote-modules` and confirm output matches the base branch.
4. Scan a Terraform fixture with `--x-remote-modules --x-remote-modules-manifest <manifest>` and confirm findings can come from the resolved module directory.

## Impact

Additive and opt-in only. Default CLI scans do not resolve or scan remote modules unless `--x-remote-modules` is passed. With that flag enabled, the scanner may read prepared module directories or fetch module content depending on the source and available resolver.

I submit this contribution under the Apache-2.0 license.