### PR TITLE
Add request-provided libraries to scanner server mode

### DIFF
--- a/cmd/scanner/serve.go
+++ b/cmd/scanner/serve.go
@@ -63,16 +63,6 @@ var serveAction = &cli.Command{
 				"into a shared compiler (rules cache + disabled rule isolation), for faster repeat " +
 				"scans at low memory",
 		},
-		&cli.StringFlag{
-			Name:  "libraries-path",
-			Value: "",
-			Usage: "path to local Rego support libraries (default: fetch from backend)",
-		},
-		&cli.StringFlag{
-			Name:  "queries-path",
-			Value: "./assets/queries",
-			Usage: "path to the default rule corpus (used only when a request omits its own rules)",
-		},
 		&cli.BoolFlag{
 			Name:   "x-parallelparsing",
 			Hidden: true,
@@ -104,8 +94,6 @@ func serve(ctx context.Context, c *cli.Command) error {
 		Port:                 c.Int("port"),
 		KeepAliveTimeout:     time.Duration(c.Int("keep-alive-timeout")) * time.Second,
 		EnableShutdown:       c.Bool("enable-shutdown"),
-		LibrariesPath:        c.String("libraries-path"),
-		QueriesPath:          c.String("queries-path"),
 		MaxConcurrentAnalyze: c.Int("max-concurrent-analyze"),
 		MaxFiles:             c.Int("max-files"),
 		MaxRequestBytes:      int64(c.Int("max-request-mib")) << 20,

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -99,6 +99,16 @@ type QueryLoader struct {
 // safe for concurrent use.
 var preparedQueryCache sync.Map // map[uint64]*rego.PreparedEvalQuery
 
+// sharedPreparedQueryCache retains one co-compiled ruleset. A single-entry
+// cache is sufficient for the long-lived server's normal workload (the latest
+// backend rules and libraries) and bounds retained memory when rules, library
+// data, or Terraform module data changes between requests.
+var sharedPreparedQueryCache struct {
+	sync.Mutex
+	key     uint64
+	queries map[int]*rego.PreparedEvalQuery
+}
+
 // hashFields computes a fast, non-cryptographic 64-bit hash of the given strings
 // joined by a NUL separator. The NUL separator keeps the field boundaries
 // unambiguous (so e.g. ("a","bc") and ("ab","c") hash differently).
@@ -134,6 +144,33 @@ func preparedCacheKey(query *model.QueryMetadata, libBase, baseDataHash uint64) 
 	binary.LittleEndian.PutUint64(buf[0:8], libBase)
 	binary.LittleEndian.PutUint64(buf[8:16], baseDataHash)
 	_, _ = h.Write(buf[:])
+	return h.Sum64()
+}
+
+// sharedCacheKey hashes everything the co-compiled prepared queries depend on.
+// Query order is significant because the shared compiler rewrites packages to
+// data.datadog.q<index>. Library code/input and the merged base store are
+// represented by the same precomputed hashes used by the isolated cache.
+func sharedCacheKey(queries []model.QueryMetadata, libraryBases, baseDataHashes map[string]uint64) uint64 {
+	var h xxhash.Digest
+	h.Reset()
+	var words [24]byte
+	binary.LittleEndian.PutUint64(words[0:8], uint64(len(queries)))
+	_, _ = h.Write(words[0:8])
+	for i := range queries {
+		query := &queries[i]
+		_, _ = h.WriteString(query.Platform)
+		_, _ = h.WriteString("\x00")
+		_, _ = h.WriteString(query.Query)
+		_, _ = h.WriteString("\x00")
+		_, _ = h.WriteString(query.Content)
+		_, _ = h.WriteString("\x00")
+		_, _ = h.WriteString(query.InputData)
+		binary.LittleEndian.PutUint64(words[0:8], uint64(i))
+		binary.LittleEndian.PutUint64(words[8:16], libraryBases[query.Platform])
+		binary.LittleEndian.PutUint64(words[16:24], baseDataHashes[query.Platform])
+		_, _ = h.Write(words[:])
+	}
 	return h.Sum64()
 }
 
@@ -460,9 +497,17 @@ func (c *Inspector) Inspect(
 	// correctness is preserved even if shared compilation partially fails.
 	var sharedQueries map[int]*rego.PreparedEvalQuery
 	if c.disableRuleIsolation {
-		sharedQueries = c.QueryLoader.loadSharedQueries(ctx, queries, baseStores)
+		cacheHit := false
+		if c.useRulesCache {
+			sharedQueries, cacheHit = c.QueryLoader.loadSharedQueriesCached(ctx, queries, baseStores, baseDataHashes)
+		} else {
+			sharedQueries = c.QueryLoader.loadSharedQueries(ctx, queries, baseStores)
+		}
 		contextLogger.Info().Msgf("Rule isolation disabled: %d/%d queries served from shared compiler",
 			len(sharedQueries), len(queries))
+		if c.useRulesCache {
+			contextLogger.Info().Msgf("Shared compiler cache hit: %t", cacheHit)
+		}
 	}
 
 	vulnerabilities, err := c.executeQueries(ctx, scanID, filesMap, payloads, queries,
@@ -1435,6 +1480,27 @@ func (q *QueryLoader) loadSharedQueries(ctx context.Context, queries []model.Que
 		}
 	}
 	return prepared
+}
+
+// loadSharedQueriesCached returns the latest matching co-compiled ruleset. The
+// lock deliberately covers a cache miss compilation so concurrent cold server
+// requests do not each build and retain an identical compiler.
+func (q *QueryLoader) loadSharedQueriesCached(ctx context.Context, queries []model.QueryMetadata,
+	baseStores map[string]storage.Store, baseDataHashes map[string]uint64,
+) (map[int]*rego.PreparedEvalQuery, bool) {
+	key := sharedCacheKey(queries, q.platformKeyBases, baseDataHashes)
+	sharedPreparedQueryCache.Lock()
+	defer sharedPreparedQueryCache.Unlock()
+	if sharedPreparedQueryCache.queries != nil && sharedPreparedQueryCache.key == key {
+		return sharedPreparedQueryCache.queries, true
+	}
+
+	prepared := q.loadSharedQueries(ctx, queries, baseStores)
+	if ctx.Err() == nil {
+		sharedPreparedQueryCache.key = key
+		sharedPreparedQueryCache.queries = prepared
+	}
+	return prepared, false
 }
 
 func parseJsonencodeHCL(ctx context.Context, input string) (ast.Value, error) {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -493,7 +493,7 @@ func (c *Inspector) Inspect(
 	// same payload for every PrepareForEval call. The per-platform data hash is
 	// folded into each compiled-query cache key so a compiled query is only
 	// reused by a later scan whose base data is byte-identical.
-	baseInputData := c.QueryLoader.precomputeBaseInputData(ctx, enrichedModules)
+	baseInputData := c.QueryLoader.precomputeBaseInputData(enrichedModules)
 	baseStores := precomputeBaseStores(baseInputData)
 	baseDataHashes := hashBaseInputData(baseInputData)
 
@@ -1233,25 +1233,24 @@ func prepareQueries(queries []model.QueryMetadata, commonLibrary source.RegoLibr
 
 // buildMergedInputData merges the platform library, common library and (when
 // present) module input data into a single JSON document for a query.
-func (q *QueryLoader) buildMergedInputData(ctx context.Context, query *model.QueryMetadata,
+func (q *QueryLoader) buildMergedInputData(query *model.QueryMetadata,
 	modules []tfmodules.ParsedModule) (string, error) {
-	contextLogger := logger.FromContext(ctx)
 	platformGeneralQuery, ok := q.platformLibraries[query.Platform]
 	if !ok {
 		return "", errors.New("failed to get platform library")
 	}
 	mergedInputData, err := source.MergeInputData(platformGeneralQuery.LibraryInputData, query.InputData)
 	if err != nil {
-		contextLogger.Debug().Msgf("Could not merge %s library input data", query.Platform)
+		return "", errors.Wrapf(err, "could not merge %s library input data", query.Platform)
 	}
 	mergedInputData, err = source.MergeInputData(q.commonLibrary.LibraryInputData, mergedInputData)
 	if err != nil {
-		contextLogger.Debug().Msg("Could not merge common library input data")
+		return "", errors.Wrap(err, "could not merge common library input data")
 	}
 	if modules != nil {
 		mergedInputData, err = source.MergeModulesData(modules, mergedInputData)
 		if err != nil {
-			contextLogger.Debug().Msg("Could not merge modules input data")
+			return "", errors.Wrap(err, "could not merge modules input data")
 		}
 	}
 	return mergedInputData, nil
@@ -1261,11 +1260,10 @@ func (q *QueryLoader) buildMergedInputData(ctx context.Context, query *model.Que
 // queries that carry no custom InputData. The common/platform library data and
 // the module payload are identical across such queries, so doing this once
 // avoids re-serializing the (potentially large) module set for every query.
-func (q *QueryLoader) precomputeBaseInputData(ctx context.Context,
-	modules []tfmodules.ParsedModule) map[string]string {
+func (q *QueryLoader) precomputeBaseInputData(modules []tfmodules.ParsedModule) map[string]string {
 	base := make(map[string]string, len(q.platformLibraries))
 	for platform := range q.platformLibraries {
-		data, err := q.buildMergedInputData(ctx, &model.QueryMetadata{Platform: platform}, modules)
+		data, err := q.buildMergedInputData(&model.QueryMetadata{Platform: platform}, modules)
 		if err != nil {
 			continue
 		}
@@ -1332,7 +1330,7 @@ func (q *QueryLoader) LoadQuery(ctx context.Context, query *model.QueryMetadata,
 		if useCache {
 			store = prebuilt
 		} else {
-			mergedInputData, err := q.buildMergedInputData(ctx, query, modules)
+			mergedInputData, err := q.buildMergedInputData(query, modules)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -46,6 +47,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/topdown"
 	"github.com/pkg/errors"
 	"github.com/zclconf/go-cty/cty"
+	"golang.org/x/sync/singleflight"
 )
 
 // Default values for inspector
@@ -107,6 +109,12 @@ var sharedPreparedQueryCache struct {
 	sync.Mutex
 	key     uint64
 	queries map[int]*rego.PreparedEvalQuery
+	flight  singleflight.Group
+}
+
+type sharedQueryCacheResult struct {
+	queries  map[int]*rego.PreparedEvalQuery
+	cacheHit bool
 }
 
 // hashFields computes a fast, non-cryptographic 64-bit hash of the given strings
@@ -1482,25 +1490,43 @@ func (q *QueryLoader) loadSharedQueries(ctx context.Context, queries []model.Que
 	return prepared
 }
 
-// loadSharedQueriesCached returns the latest matching co-compiled ruleset. The
-// lock deliberately covers a cache miss compilation so concurrent cold server
-// requests do not each build and retain an identical compiler.
+// loadSharedQueriesCached returns the latest matching co-compiled ruleset.
+// Identical cold misses are coalesced by key, while different rulesets compile
+// concurrently. The mutex protects only the bounded single-entry cache.
 func (q *QueryLoader) loadSharedQueriesCached(ctx context.Context, queries []model.QueryMetadata,
 	baseStores map[string]storage.Store, baseDataHashes map[string]uint64,
 ) (map[int]*rego.PreparedEvalQuery, bool) {
 	key := sharedCacheKey(queries, q.platformKeyBases, baseDataHashes)
 	sharedPreparedQueryCache.Lock()
-	defer sharedPreparedQueryCache.Unlock()
 	if sharedPreparedQueryCache.queries != nil && sharedPreparedQueryCache.key == key {
-		return sharedPreparedQueryCache.queries, true
+		cached := sharedPreparedQueryCache.queries
+		sharedPreparedQueryCache.Unlock()
+		return cached, true
 	}
+	sharedPreparedQueryCache.Unlock()
 
-	prepared := q.loadSharedQueries(ctx, queries, baseStores)
-	if ctx.Err() == nil {
-		sharedPreparedQueryCache.key = key
-		sharedPreparedQueryCache.queries = prepared
-	}
-	return prepared, false
+	value, _, shared := sharedPreparedQueryCache.flight.Do(strconv.FormatUint(key, 16), func() (any, error) {
+		// Another caller may have populated the cache between the initial check
+		// and this keyed singleflight call.
+		sharedPreparedQueryCache.Lock()
+		if sharedPreparedQueryCache.queries != nil && sharedPreparedQueryCache.key == key {
+			cached := sharedPreparedQueryCache.queries
+			sharedPreparedQueryCache.Unlock()
+			return sharedQueryCacheResult{queries: cached, cacheHit: true}, nil
+		}
+		sharedPreparedQueryCache.Unlock()
+
+		prepared := q.loadSharedQueries(ctx, queries, baseStores)
+		if ctx.Err() == nil {
+			sharedPreparedQueryCache.Lock()
+			sharedPreparedQueryCache.key = key
+			sharedPreparedQueryCache.queries = prepared
+			sharedPreparedQueryCache.Unlock()
+		}
+		return sharedQueryCacheResult{queries: prepared}, nil
+	})
+	result := value.(sharedQueryCacheResult)
+	return result.queries, result.cacheHit || shared
 }
 
 func parseJsonencodeHCL(ctx context.Context, input string) (ast.Value, error) {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -507,7 +507,11 @@ func (c *Inspector) Inspect(
 	if c.disableRuleIsolation {
 		cacheHit := false
 		if c.useRulesCache {
-			sharedQueries, cacheHit = c.QueryLoader.loadSharedQueriesCached(ctx, queries, baseStores, baseDataHashes)
+			sharedQueries, cacheHit, err = c.QueryLoader.loadSharedQueriesCached(
+				ctx, queries, baseStores, baseDataHashes)
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			sharedQueries = c.QueryLoader.loadSharedQueries(ctx, queries, baseStores)
 		}
@@ -1495,17 +1499,24 @@ func (q *QueryLoader) loadSharedQueries(ctx context.Context, queries []model.Que
 // concurrently. The mutex protects only the bounded single-entry cache.
 func (q *QueryLoader) loadSharedQueriesCached(ctx context.Context, queries []model.QueryMetadata,
 	baseStores map[string]storage.Store, baseDataHashes map[string]uint64,
-) (map[int]*rego.PreparedEvalQuery, bool) {
+) (preparedQueries map[int]*rego.PreparedEvalQuery, cacheHit bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
 	key := sharedCacheKey(queries, q.platformKeyBases, baseDataHashes)
 	sharedPreparedQueryCache.Lock()
 	if sharedPreparedQueryCache.queries != nil && sharedPreparedQueryCache.key == key {
 		cached := sharedPreparedQueryCache.queries
 		sharedPreparedQueryCache.Unlock()
-		return cached, true
+		return cached, true, nil
 	}
 	sharedPreparedQueryCache.Unlock()
 
-	value, _, shared := sharedPreparedQueryCache.flight.Do(strconv.FormatUint(key, 16), func() (any, error) {
+	// A compilation can be shared by several requests, so it must not inherit
+	// cancellation from whichever request happens to become the singleflight
+	// leader. Each caller still stops waiting through the select below.
+	compileCtx := context.WithoutCancel(ctx)
+	resultCh := sharedPreparedQueryCache.flight.DoChan(strconv.FormatUint(key, 16), func() (any, error) {
 		// Another caller may have populated the cache between the initial check
 		// and this keyed singleflight call.
 		sharedPreparedQueryCache.Lock()
@@ -1516,17 +1527,24 @@ func (q *QueryLoader) loadSharedQueriesCached(ctx context.Context, queries []mod
 		}
 		sharedPreparedQueryCache.Unlock()
 
-		prepared := q.loadSharedQueries(ctx, queries, baseStores)
-		if ctx.Err() == nil {
-			sharedPreparedQueryCache.Lock()
-			sharedPreparedQueryCache.key = key
-			sharedPreparedQueryCache.queries = prepared
-			sharedPreparedQueryCache.Unlock()
-		}
+		prepared := q.loadSharedQueries(compileCtx, queries, baseStores)
+		sharedPreparedQueryCache.Lock()
+		sharedPreparedQueryCache.key = key
+		sharedPreparedQueryCache.queries = prepared
+		sharedPreparedQueryCache.Unlock()
 		return sharedQueryCacheResult{queries: prepared}, nil
 	})
-	result := value.(sharedQueryCacheResult)
-	return result.queries, result.cacheHit || shared
+
+	select {
+	case <-ctx.Done():
+		return nil, false, ctx.Err()
+	case call := <-resultCh:
+		if call.Err != nil {
+			return nil, false, call.Err
+		}
+		result := call.Val.(sharedQueryCacheResult)
+		return result.queries, result.cacheHit || call.Shared, nil
+	}
 }
 
 func parseJsonencodeHCL(ctx context.Context, input string) (ast.Value, error) {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -383,10 +383,9 @@ type QueryResult struct {
 	queryID         int
 }
 
-// evalQuery loads and evaluates a single query, returning its result. A load
-// failure yields an empty result (the query is skipped, matching the previous
-// behavior); an eval failure yields a result carrying the error so the serial
-// aggregation can record it.
+// evalQuery loads and evaluates a single query, returning its result. Load and
+// evaluation failures both carry their error so the serial aggregation records
+// them in FailedQueries without terminating the rest of the scan.
 func (c *Inspector) evalQuery(ctx context.Context, scanID string, filesMap map[string]*model.FileMetadata,
 	payloads platformPayloads, queries []model.QueryMetadata, queryID int,
 	modules []tfmodules.ParsedModule, baseStores map[string]storage.Store, baseDataHashes map[string]uint64,
@@ -405,7 +404,7 @@ func (c *Inspector) evalQuery(ctx context.Context, scanID string, filesMap map[s
 	loadDur := time.Since(loadStart)
 	if err != nil {
 		contextLogger.Warn().Err(err).Msgf("failed to load query %s", queries[queryID].Query)
-		return QueryResult{queryID: queryID}
+		return QueryResult{err: err, queryID: queryID}
 	}
 
 	query := &PreparedQuery{
@@ -505,21 +504,19 @@ func (c *Inspector) Inspect(
 	// correctness is preserved even if shared compilation partially fails.
 	var sharedQueries map[int]*rego.PreparedEvalQuery
 	if c.disableRuleIsolation {
-		cacheHit := false
 		if c.useRulesCache {
+			var cacheHit bool
 			sharedQueries, cacheHit, err = c.QueryLoader.loadSharedQueriesCached(
 				ctx, queries, baseStores, baseDataHashes)
 			if err != nil {
 				return nil, err
 			}
+			contextLogger.Info().Msgf("Shared compiler cache hit: %t", cacheHit)
 		} else {
 			sharedQueries = c.QueryLoader.loadSharedQueries(ctx, queries, baseStores)
 		}
 		contextLogger.Info().Msgf("Rule isolation disabled: %d/%d queries served from shared compiler",
 			len(sharedQueries), len(queries))
-		if c.useRulesCache {
-			contextLogger.Info().Msgf("Shared compiler cache hit: %t", cacheHit)
-		}
 	}
 
 	vulnerabilities, err := c.executeQueries(ctx, scanID, filesMap, payloads, queries,

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -1495,50 +1495,61 @@ func (q *QueryLoader) loadSharedQueries(ctx context.Context, queries []model.Que
 func (q *QueryLoader) loadSharedQueriesCached(ctx context.Context, queries []model.QueryMetadata,
 	baseStores map[string]storage.Store, baseDataHashes map[string]uint64,
 ) (preparedQueries map[int]*rego.PreparedEvalQuery, cacheHit bool, err error) {
-	if err := ctx.Err(); err != nil {
-		return nil, false, err
-	}
 	key := sharedCacheKey(queries, q.platformKeyBases, baseDataHashes)
-	sharedPreparedQueryCache.Lock()
-	if sharedPreparedQueryCache.queries != nil && sharedPreparedQueryCache.key == key {
-		cached := sharedPreparedQueryCache.queries
-		sharedPreparedQueryCache.Unlock()
-		return cached, true, nil
-	}
-	sharedPreparedQueryCache.Unlock()
+	flightKey := strconv.FormatUint(key, 16)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
 
-	// A compilation can be shared by several requests, so it must not inherit
-	// cancellation from whichever request happens to become the singleflight
-	// leader. Each caller still stops waiting through the select below.
-	compileCtx := context.WithoutCancel(ctx)
-	resultCh := sharedPreparedQueryCache.flight.DoChan(strconv.FormatUint(key, 16), func() (any, error) {
-		// Another caller may have populated the cache between the initial check
-		// and this keyed singleflight call.
 		sharedPreparedQueryCache.Lock()
 		if sharedPreparedQueryCache.queries != nil && sharedPreparedQueryCache.key == key {
 			cached := sharedPreparedQueryCache.queries
 			sharedPreparedQueryCache.Unlock()
-			return sharedQueryCacheResult{queries: cached, cacheHit: true}, nil
+			return cached, true, nil
 		}
 		sharedPreparedQueryCache.Unlock()
 
-		prepared := q.loadSharedQueries(compileCtx, queries, baseStores)
-		sharedPreparedQueryCache.Lock()
-		sharedPreparedQueryCache.key = key
-		sharedPreparedQueryCache.queries = prepared
-		sharedPreparedQueryCache.Unlock()
-		return sharedQueryCacheResult{queries: prepared}, nil
-	})
+		resultCh := sharedPreparedQueryCache.flight.DoChan(flightKey, func() (any, error) {
+			// Another caller may have populated the cache between the initial check
+			// and this keyed singleflight call.
+			sharedPreparedQueryCache.Lock()
+			if sharedPreparedQueryCache.queries != nil && sharedPreparedQueryCache.key == key {
+				cached := sharedPreparedQueryCache.queries
+				sharedPreparedQueryCache.Unlock()
+				return sharedQueryCacheResult{queries: cached, cacheHit: true}, nil
+			}
+			sharedPreparedQueryCache.Unlock()
 
-	select {
-	case <-ctx.Done():
-		return nil, false, ctx.Err()
-	case call := <-resultCh:
-		if call.Err != nil {
-			return nil, false, call.Err
+			prepared := q.loadSharedQueries(ctx, queries, baseStores)
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			sharedPreparedQueryCache.Lock()
+			sharedPreparedQueryCache.key = key
+			sharedPreparedQueryCache.queries = prepared
+			sharedPreparedQueryCache.Unlock()
+			return sharedQueryCacheResult{queries: prepared}, nil
+		})
+
+		select {
+		case <-ctx.Done():
+			return nil, false, ctx.Err()
+		case call := <-resultCh:
+			if call.Err != nil {
+				if err := ctx.Err(); err != nil {
+					return nil, false, err
+				}
+				// The singleflight leader was canceled while this caller is still
+				// active. Retry so an active caller becomes the new leader.
+				if errors.Is(call.Err, context.Canceled) || errors.Is(call.Err, context.DeadlineExceeded) {
+					continue
+				}
+				return nil, false, call.Err
+			}
+			result := call.Val.(sharedQueryCacheResult)
+			return result.queries, result.cacheHit || call.Shared, nil
 		}
-		result := call.Val.(sharedQueryCacheResult)
-		return result.queries, result.cacheHit || call.Shared, nil
 	}
 }
 

--- a/pkg/engine/loadquery_cache_test.go
+++ b/pkg/engine/loadquery_cache_test.go
@@ -57,6 +57,45 @@ func clearPreparedCache() {
 	preparedQueryCache.Range(func(k, _ any) bool { preparedQueryCache.Delete(k); return true })
 }
 
+func TestBuildMergedInputData_PropagatesLibraryErrors(t *testing.T) {
+	platform := "terraform"
+	query := staticQuery(platform, "test-rule", "")
+	validLibrary := source.RegoLibraries{LibraryInputData: "{}"}
+
+	tests := []struct {
+		name       string
+		common     source.RegoLibraries
+		platform   source.RegoLibraries
+		wantErrMsg string
+	}{
+		{
+			name:       "platform library",
+			common:     validLibrary,
+			platform:   source.RegoLibraries{LibraryInputData: "null"},
+			wantErrMsg: "could not merge terraform library input data",
+		},
+		{
+			name:       "common library",
+			common:     source.RegoLibraries{LibraryInputData: "null"},
+			platform:   validLibrary,
+			wantErrMsg: "could not merge common library input data",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loader := QueryLoader{
+				commonLibrary: tt.common,
+				platformLibraries: map[string]source.RegoLibraries{
+					platform: tt.platform,
+				},
+			}
+			merged, err := loader.buildMergedInputData(&query, nil)
+			require.ErrorContains(t, err, tt.wantErrMsg)
+			require.Empty(t, merged)
+		})
+	}
+}
+
 // TestLoadQuery_CacheGate is the core of the --use-rules-cache wiring: with the
 // cache disabled, two loads of the same query must compile fresh each time; with
 // it enabled, the second load must return the cached pointer.

--- a/pkg/engine/shared_compiler_test.go
+++ b/pkg/engine/shared_compiler_test.go
@@ -9,9 +9,11 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -202,11 +204,15 @@ func TestLoadSharedQueries_ExcludesCustomInput(t *testing.T) {
 	}
 }
 
-func TestLoadSharedQueriesCache_ReusesAndInvalidates(t *testing.T) {
+func clearSharedPreparedQueryCache() {
 	sharedPreparedQueryCache.Lock()
 	sharedPreparedQueryCache.key = 0
 	sharedPreparedQueryCache.queries = nil
 	sharedPreparedQueryCache.Unlock()
+}
+
+func TestLoadSharedQueriesCache_ReusesAndInvalidates(t *testing.T) {
+	clearSharedPreparedQueryCache()
 
 	platform := "terraform"
 	query := staticQuery(platform, "static_rule", "DatadogPolicy contains result if { result := \"x\" }\n")
@@ -230,6 +236,43 @@ func TestLoadSharedQueriesCache_ReusesAndInvalidates(t *testing.T) {
 		t.Context(), []model.QueryMetadata{query}, changedStores, changedHashes)
 	require.True(t, hit)
 	require.Same(t, third[0], fourth[0])
+}
+
+func TestLoadSharedQueriesCache_ConcurrentReuse(t *testing.T) {
+	clearSharedPreparedQueryCache()
+
+	platform := "terraform"
+	query := staticQuery(platform, "static_rule", "DatadogPolicy contains result if { result := \"x\" }\n")
+	loader := newCacheTestLoader(t, platform, []model.QueryMetadata{query})
+	stores, hashes := baseStoresFor(platform, "{}")
+
+	const workers = 8
+	start := make(chan struct{})
+	results := make(chan *rego.PreparedEvalQuery, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			prepared, _ := loader.loadSharedQueriesCached(
+				t.Context(), []model.QueryMetadata{query}, stores, hashes)
+			results <- prepared[0]
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var first *rego.PreparedEvalQuery
+	for prepared := range results {
+		require.NotNil(t, prepared)
+		if first == nil {
+			first = prepared
+			continue
+		}
+		require.Same(t, first, prepared)
+	}
 }
 
 // summarize reduces findings to a comparable, order-independent multiset of the

--- a/pkg/engine/shared_compiler_test.go
+++ b/pkg/engine/shared_compiler_test.go
@@ -9,8 +9,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/rego"
@@ -211,6 +213,17 @@ func clearSharedPreparedQueryCache() {
 	sharedPreparedQueryCache.Unlock()
 }
 
+type observedDoneContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (c *observedDoneContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
+
 func TestLoadSharedQueriesCache_ReusesAndInvalidates(t *testing.T) {
 	clearSharedPreparedQueryCache()
 
@@ -219,21 +232,25 @@ func TestLoadSharedQueriesCache_ReusesAndInvalidates(t *testing.T) {
 	loader := newCacheTestLoader(t, platform, []model.QueryMetadata{query})
 	stores, hashes := baseStoresFor(platform, "{}")
 
-	first, hit := loader.loadSharedQueriesCached(t.Context(), []model.QueryMetadata{query}, stores, hashes)
+	first, hit, err := loader.loadSharedQueriesCached(t.Context(), []model.QueryMetadata{query}, stores, hashes)
+	require.NoError(t, err)
 	require.False(t, hit)
 	require.Contains(t, first, 0)
-	second, hit := loader.loadSharedQueriesCached(t.Context(), []model.QueryMetadata{query}, stores, hashes)
+	second, hit, err := loader.loadSharedQueriesCached(t.Context(), []model.QueryMetadata{query}, stores, hashes)
+	require.NoError(t, err)
 	require.True(t, hit)
 	require.Same(t, first[0], second[0])
 
 	changedStores, changedHashes := baseStoresFor(platform, `{"library_version":2}`)
-	third, hit := loader.loadSharedQueriesCached(
+	third, hit, err := loader.loadSharedQueriesCached(
 		t.Context(), []model.QueryMetadata{query}, changedStores, changedHashes)
+	require.NoError(t, err)
 	require.False(t, hit)
 	require.Contains(t, third, 0)
 	require.NotSame(t, first[0], third[0])
-	fourth, hit := loader.loadSharedQueriesCached(
+	fourth, hit, err := loader.loadSharedQueriesCached(
 		t.Context(), []model.QueryMetadata{query}, changedStores, changedHashes)
+	require.NoError(t, err)
 	require.True(t, hit)
 	require.Same(t, third[0], fourth[0])
 }
@@ -248,16 +265,20 @@ func TestLoadSharedQueriesCache_ConcurrentReuse(t *testing.T) {
 
 	const workers = 8
 	start := make(chan struct{})
-	results := make(chan *rego.PreparedEvalQuery, workers)
+	type workerResult struct {
+		prepared *rego.PreparedEvalQuery
+		err      error
+	}
+	results := make(chan workerResult, workers)
 	var wg sync.WaitGroup
 	for range workers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			<-start
-			prepared, _ := loader.loadSharedQueriesCached(
+			prepared, _, err := loader.loadSharedQueriesCached(
 				t.Context(), []model.QueryMetadata{query}, stores, hashes)
-			results <- prepared[0]
+			results <- workerResult{prepared: prepared[0], err: err}
 		}()
 	}
 	close(start)
@@ -265,14 +286,61 @@ func TestLoadSharedQueriesCache_ConcurrentReuse(t *testing.T) {
 	close(results)
 
 	var first *rego.PreparedEvalQuery
-	for prepared := range results {
-		require.NotNil(t, prepared)
+	for result := range results {
+		require.NoError(t, result.err)
+		require.NotNil(t, result.prepared)
 		if first == nil {
-			first = prepared
+			first = result.prepared
 			continue
 		}
-		require.Same(t, first, prepared)
+		require.Same(t, first, result.prepared)
 	}
+}
+
+func TestLoadSharedQueriesCache_CanceledWaiterReturns(t *testing.T) {
+	clearSharedPreparedQueryCache()
+
+	platform := "terraform"
+	query := staticQuery(platform, "static_rule", "DatadogPolicy contains result if { result := \"x\" }\n")
+	loader := newCacheTestLoader(t, platform, []model.QueryMetadata{query})
+	stores, hashes := baseStoresFor(platform, "{}")
+	key := sharedCacheKey([]model.QueryMetadata{query}, loader.platformKeyBases, hashes)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	flightDone := make(chan struct{})
+	go func() {
+		defer close(flightDone)
+		_, _, _ = sharedPreparedQueryCache.flight.Do(strconv.FormatUint(key, 16), func() (any, error) {
+			close(started)
+			<-release
+			return sharedQueryCacheResult{queries: map[int]*rego.PreparedEvalQuery{}}, nil
+		})
+	}()
+	<-started
+
+	baseCtx, cancel := context.WithCancel(t.Context())
+	ctx := &observedDoneContext{Context: baseCtx, observed: make(chan struct{})}
+	returned := make(chan error, 1)
+	go func() {
+		_, _, err := loader.loadSharedQueriesCached(ctx, []model.QueryMetadata{query}, stores, hashes)
+		returned <- err
+	}()
+	<-ctx.observed
+	cancel()
+
+	var waiterErr error
+	timedOut := false
+	select {
+	case waiterErr = <-returned:
+	case <-time.After(time.Second):
+		timedOut = true
+	}
+	close(release)
+	<-flightDone
+
+	require.False(t, timedOut, "canceled waiter remained blocked on the shared compilation")
+	require.ErrorIs(t, waiterErr, context.Canceled)
 }
 
 // summarize reduces findings to a comparable, order-independent multiset of the

--- a/pkg/engine/shared_compiler_test.go
+++ b/pkg/engine/shared_compiler_test.go
@@ -343,6 +343,52 @@ func TestLoadSharedQueriesCache_CanceledWaiterReturns(t *testing.T) {
 	require.ErrorIs(t, waiterErr, context.Canceled)
 }
 
+func TestLoadSharedQueriesCache_ActiveWaiterRetriesCanceledLeader(t *testing.T) {
+	clearSharedPreparedQueryCache()
+
+	platform := "terraform"
+	query := staticQuery(platform, "static_rule", "DatadogPolicy contains result if { result := \"x\" }\n")
+	loader := newCacheTestLoader(t, platform, []model.QueryMetadata{query})
+	stores, hashes := baseStoresFor(platform, "{}")
+	key := sharedCacheKey([]model.QueryMetadata{query}, loader.platformKeyBases, hashes)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	flightDone := make(chan struct{})
+	go func() {
+		defer close(flightDone)
+		_, _, _ = sharedPreparedQueryCache.flight.Do(strconv.FormatUint(key, 16), func() (any, error) {
+			close(started)
+			<-release
+			return nil, context.Canceled
+		})
+	}()
+	<-started
+
+	type cacheResult struct {
+		prepared map[int]*rego.PreparedEvalQuery
+		err      error
+	}
+	ctx := &observedDoneContext{Context: t.Context(), observed: make(chan struct{})}
+	returned := make(chan cacheResult, 1)
+	go func() {
+		prepared, _, err := loader.loadSharedQueriesCached(
+			ctx, []model.QueryMetadata{query}, stores, hashes)
+		returned <- cacheResult{prepared: prepared, err: err}
+	}()
+	<-ctx.observed
+	close(release)
+	<-flightDone
+
+	select {
+	case result := <-returned:
+		require.NoError(t, result.err)
+		require.Contains(t, result.prepared, 0)
+	case <-time.After(time.Second):
+		t.Fatal("active waiter did not retry after its singleflight leader was canceled")
+	}
+}
+
 // summarize reduces findings to a comparable, order-independent multiset of the
 // fields a caller/SARIF actually consumes, so the comparison is robust to
 // worker ordering.

--- a/pkg/engine/shared_compiler_test.go
+++ b/pkg/engine/shared_compiler_test.go
@@ -202,6 +202,36 @@ func TestLoadSharedQueries_ExcludesCustomInput(t *testing.T) {
 	}
 }
 
+func TestLoadSharedQueriesCache_ReusesAndInvalidates(t *testing.T) {
+	sharedPreparedQueryCache.Lock()
+	sharedPreparedQueryCache.key = 0
+	sharedPreparedQueryCache.queries = nil
+	sharedPreparedQueryCache.Unlock()
+
+	platform := "terraform"
+	query := staticQuery(platform, "static_rule", "DatadogPolicy contains result if { result := \"x\" }\n")
+	loader := newCacheTestLoader(t, platform, []model.QueryMetadata{query})
+	stores, hashes := baseStoresFor(platform, "{}")
+
+	first, hit := loader.loadSharedQueriesCached(t.Context(), []model.QueryMetadata{query}, stores, hashes)
+	require.False(t, hit)
+	require.Contains(t, first, 0)
+	second, hit := loader.loadSharedQueriesCached(t.Context(), []model.QueryMetadata{query}, stores, hashes)
+	require.True(t, hit)
+	require.Same(t, first[0], second[0])
+
+	changedStores, changedHashes := baseStoresFor(platform, `{"library_version":2}`)
+	third, hit := loader.loadSharedQueriesCached(
+		t.Context(), []model.QueryMetadata{query}, changedStores, changedHashes)
+	require.False(t, hit)
+	require.Contains(t, third, 0)
+	require.NotSame(t, first[0], third[0])
+	fourth, hit := loader.loadSharedQueriesCached(
+		t.Context(), []model.QueryMetadata{query}, changedStores, changedHashes)
+	require.True(t, hit)
+	require.Same(t, third[0], fourth[0])
+}
+
 // summarize reduces findings to a comparable, order-independent multiset of the
 // fields a caller/SARIF actually consumes, so the comparison is robust to
 // worker ordering.

--- a/pkg/engine/source/source.go
+++ b/pkg/engine/source/source.go
@@ -7,6 +7,7 @@
 package source
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 
@@ -47,6 +48,13 @@ type RegoLibraries struct {
 type QueriesSource interface {
 	GetQueries(ctx context.Context, querySelection *QueryInspectorParameters) ([]model.QueryMetadata, error)
 	GetQueryLibrary(ctx context.Context, platform string) (RegoLibraries, error)
+}
+
+// IsJSONObject reports whether inputData is valid JSON whose top-level value
+// is an object. It validates without allocating an unmarshalled map.
+func IsJSONObject(inputData string) bool {
+	data := bytes.TrimSpace([]byte(inputData))
+	return len(data) > 0 && data[0] == '{' && json.Valid(data)
 }
 
 // MergeInputData merges default input data with custom input data user defined
@@ -135,12 +143,12 @@ func MergeModulesData(modules []tfmodules.ParsedModule, inputData string) (strin
 }
 
 func parseInputDataObject(inputData string) (map[string]any, error) {
+	if !IsJSONObject(inputData) {
+		return nil, errors.New("failed to merge query input data: expected a JSON object")
+	}
 	data := map[string]any{}
 	if err := json.Unmarshal([]byte(inputData), &data); err != nil {
 		return nil, errors.Wrap(err, "failed to merge query input data")
-	}
-	if data == nil {
-		return nil, errors.New("failed to merge query input data: expected a JSON object")
 	}
 	return data, nil
 }

--- a/pkg/engine/source/source.go
+++ b/pkg/engine/source/source.go
@@ -55,19 +55,25 @@ func MergeInputData(defaultInputData, customInputData string) (string, error) {
 		return emptyInputData, nil
 	}
 	if checkEmptyInputdata(defaultInputData) {
+		if _, err := parseInputDataObject(customInputData); err != nil {
+			return "", err
+		}
 		return customInputData, nil
 	}
 	if checkEmptyInputdata(customInputData) {
+		if _, err := parseInputDataObject(defaultInputData); err != nil {
+			return "", err
+		}
 		return defaultInputData, nil
 	}
 
-	dataJSON := map[string]interface{}{}
-	customDataJSON := map[string]interface{}{}
-	if unmarshalError := json.Unmarshal([]byte(defaultInputData), &dataJSON); unmarshalError != nil {
-		return "", errors.Wrapf(unmarshalError, "failed to merge query input data")
+	dataJSON, err := parseInputDataObject(defaultInputData)
+	if err != nil {
+		return "", err
 	}
-	if unmarshalError := json.Unmarshal([]byte(customInputData), &customDataJSON); unmarshalError != nil {
-		return "", errors.Wrapf(unmarshalError, "failed to merge query input data")
+	customDataJSON, err := parseInputDataObject(customInputData)
+	if err != nil {
+		return "", err
 	}
 
 	for key, value := range customDataJSON {
@@ -85,9 +91,9 @@ func MergeModulesData(modules []tfmodules.ParsedModule, inputData string) (strin
 		inputData = emptyInputData
 	}
 
-	dataJSON := map[string]any{}
-	if unmarshalError := json.Unmarshal([]byte(inputData), &dataJSON); unmarshalError != nil {
-		return "", errors.Wrapf(unmarshalError, "failed to merge query input data")
+	dataJSON, err := parseInputDataObject(inputData)
+	if err != nil {
+		return "", err
 	}
 	// Ensure "common_lib" exists and is a map.
 	commonLib, ok := dataJSON["common_lib"].(map[string]any)
@@ -126,6 +132,17 @@ func MergeModulesData(modules []tfmodules.ParsedModule, inputData string) (strin
 		return "", errors.Wrapf(mergeErr, "failed to merge query input data")
 	}
 	return string(mergedJSON), nil
+}
+
+func parseInputDataObject(inputData string) (map[string]any, error) {
+	data := map[string]any{}
+	if err := json.Unmarshal([]byte(inputData), &data); err != nil {
+		return nil, errors.Wrap(err, "failed to merge query input data")
+	}
+	if data == nil {
+		return nil, errors.New("failed to merge query input data: expected a JSON object")
+	}
+	return data, nil
 }
 
 func moduleEquivalentKey(source, version string) string {

--- a/pkg/engine/source/source_test.go
+++ b/pkg/engine/source/source_test.go
@@ -190,6 +190,7 @@ func TestMergeInputData(t *testing.T) {
 		customData  string
 		defaultData string
 		want        string
+		wantError   bool
 	}{
 		{
 			name:        "Should merge input data strings",
@@ -197,10 +198,18 @@ func TestMergeInputData(t *testing.T) {
 			customData:  `{"test": "merge", "merge": "success"}`,
 			want:        `{"test": "merge","merge": "success"}`,
 		},
+		{name: "Reject null default", defaultData: "null", customData: `{"test":true}`, wantError: true},
+		{name: "Reject null custom", defaultData: `{"test":true}`, customData: "null", wantError: true},
+		{name: "Reject array", defaultData: "[]", customData: "{}", wantError: true},
+		{name: "Reject scalar", defaultData: "{}", customData: "1", wantError: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := MergeInputData(tt.defaultData, tt.customData)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			wantJSON := map[string]interface{}{}
 			gotJSON := map[string]interface{}{}
@@ -209,6 +218,15 @@ func TestMergeInputData(t *testing.T) {
 			err = json.Unmarshal([]byte(got), &gotJSON)
 			require.NoError(t, err)
 			require.Equal(t, wantJSON, gotJSON)
+		})
+	}
+}
+
+func TestMergeModulesDataRejectsNonObjectInput(t *testing.T) {
+	for _, inputData := range []string{"null", "[]", "1", `"value"`} {
+		t.Run(inputData, func(t *testing.T) {
+			_, err := MergeModulesData(nil, inputData)
+			require.Error(t, err)
 		})
 	}
 }

--- a/pkg/engine/source/source_test.go
+++ b/pkg/engine/source/source_test.go
@@ -183,6 +183,27 @@ dummy_test(a) {
 	}
 }
 
+func TestIsJSONObject(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "object", input: `{"key":"value"}`, want: true},
+		{name: "object with whitespace", input: " \n {} \t", want: true},
+		{name: "empty", input: ""},
+		{name: "null", input: "null"},
+		{name: "array", input: "[]"},
+		{name: "scalar", input: "1"},
+		{name: "malformed object", input: "{"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsJSONObject(tt.input))
+		})
+	}
+}
+
 // TestMergeInputData tests mergeInputData function
 func TestMergeInputData(t *testing.T) {
 	tests := []struct {

--- a/pkg/engine/source/source_test.go
+++ b/pkg/engine/source/source_test.go
@@ -202,6 +202,8 @@ func TestMergeInputData(t *testing.T) {
 		{name: "Reject null custom", defaultData: `{"test":true}`, customData: "null", wantError: true},
 		{name: "Reject array", defaultData: "[]", customData: "{}", wantError: true},
 		{name: "Reject scalar", defaultData: "{}", customData: "1", wantError: true},
+		{name: "Reject malformed default with empty custom", defaultData: "{", customData: "{}", wantError: true},
+		{name: "Reject malformed custom with empty default", defaultData: "{}", customData: "{", wantError: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -7,6 +7,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -142,6 +143,11 @@ func validateAnalyzeRequest(req *analyzeRequest, maxFiles int) error {
 	if len(req.Rules) > maxRules {
 		return errors.New("too many rules")
 	}
+	for _, rule := range req.Rules {
+		if !isInputDataObject(rule.InputData) {
+			return errors.New("invalid rule input data for " + rule.ID)
+		}
+	}
 	if err := validateLibraries(req.Libraries, req.Rules); err != nil {
 		return err
 	}
@@ -173,7 +179,7 @@ func validateLibraries(libraries []analyzeLibrary, rules []analyzeRule) error {
 		if strings.TrimSpace(library.Content) == "" {
 			return errors.New("empty library content for " + library.ID)
 		}
-		if library.InputData != "" && !json.Valid([]byte(library.InputData)) {
+		if !isInputDataObject(library.InputData) {
 			return errors.New("invalid library input data for " + library.ID)
 		}
 		if _, exists := available[id]; exists {
@@ -201,6 +207,17 @@ func normalizeLibraryInputData(inputData string) string {
 		return emptyInputData
 	}
 	return inputData
+}
+
+func isInputDataObject(inputData string) bool {
+	if inputData == "" {
+		return true
+	}
+	data := bytes.TrimSpace([]byte(inputData))
+	// json.Valid checks the complete payload without allocating an unmarshalled
+	// map; the leading brace additionally requires the top-level value to be an
+	// object, excluding valid JSON values such as null, arrays, and scalars.
+	return len(data) > 0 && data[0] == '{' && json.Valid(data)
 }
 
 func normalizePlatform(platform string) string {

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -31,6 +31,10 @@ const (
 	// default rule corpus is ~1200 rules; this is generous headroom. The file
 	// limit is configurable per-server (Config.MaxFiles), so it is passed in.
 	maxRules = defaultMaxRules
+	// A library is expected for Common and each supported platform. Keep a
+	// generous bound while preventing an accidentally unbounded request array.
+	maxLibraries   = 100
+	emptyInputData = "{}"
 	// metadataDefaultKeys is the number of fixed keys setDefault injects in
 	// toQueryMetadata (id, legacyId, queryName, severity, platform, category).
 	metadataDefaultKeys = 6
@@ -53,14 +57,23 @@ type analyzeRule struct {
 	Metadata  map[string]any `json:"metadata,omitempty"`
 }
 
+// analyzeLibrary is one shared Rego module supplied by the caller. Callers use
+// the canonical lowercase name of either "common" or a rule platform as ID.
+type analyzeLibrary struct {
+	ID        string `json:"id"`
+	Content   string `json:"content"`
+	InputData string `json:"inputData,omitempty"`
+}
+
 // analyzeRequest is the body of POST /ide/v1/iac/analyze. Content is raw (not
-// base64). Rules are pushed by the extension; an empty list falls back to the
-// embedded corpus. Config is the raw YAML of the unified config's iac section.
+// base64). Rules and their supporting libraries are pushed by the extension.
+// Config is the raw YAML of the unified config's iac section.
 type analyzeRequest struct {
-	Files    []analyzeFile `json:"files"`
-	Rules    []analyzeRule `json:"rules"`
-	Config   string        `json:"config,omitempty"`
-	Platform []string      `json:"platform,omitempty"`
+	Files     []analyzeFile    `json:"files"`
+	Rules     []analyzeRule    `json:"rules"`
+	Libraries []analyzeLibrary `json:"libraries"`
+	Config    string           `json:"config,omitempty"`
+	Platform  []string         `json:"platform,omitempty"`
 }
 
 // analyzeResponse is the body of a successful analyze. Findings are the engine's
@@ -123,8 +136,14 @@ func validateAnalyzeRequest(req *analyzeRequest, maxFiles int) error {
 	if len(req.Files) > maxFiles {
 		return errors.New("too many files")
 	}
+	if len(req.Rules) == 0 {
+		return errors.New("at least one rule is required")
+	}
 	if len(req.Rules) > maxRules {
 		return errors.New("too many rules")
+	}
+	if err := validateLibraries(req.Libraries, req.Rules); err != nil {
+		return err
 	}
 	for _, f := range req.Files {
 		if err := validateFilePath(f.Path); err != nil {
@@ -132,6 +151,53 @@ func validateAnalyzeRequest(req *analyzeRequest, maxFiles int) error {
 		}
 	}
 	return nil
+}
+
+func validateLibraries(libraries []analyzeLibrary, rules []analyzeRule) error {
+	if len(libraries) == 0 {
+		return errors.New("at least one library is required")
+	}
+	if len(libraries) > maxLibraries {
+		return errors.New("too many libraries")
+	}
+
+	available := make(map[string]struct{}, len(libraries))
+	for _, library := range libraries {
+		id := strings.TrimSpace(library.ID)
+		if id == "" {
+			return errors.New("empty library id")
+		}
+		if strings.TrimSpace(library.Content) == "" {
+			return errors.New("empty library content for " + library.ID)
+		}
+		if library.InputData != "" && !json.Valid([]byte(library.InputData)) {
+			return errors.New("invalid library input data for " + library.ID)
+		}
+		if _, exists := available[id]; exists {
+			return errors.New("duplicate library id: " + library.ID)
+		}
+		available[id] = struct{}{}
+	}
+	if _, ok := available["common"]; !ok {
+		return errors.New("common library is required")
+	}
+	for _, rule := range rules {
+		platform := strings.ToLower(strings.TrimSpace(rule.Platform))
+		if platform == "" {
+			return errors.New("empty platform for rule " + rule.ID)
+		}
+		if _, ok := available[platform]; !ok {
+			return errors.New("library is required for rule platform: " + rule.Platform)
+		}
+	}
+	return nil
+}
+
+func normalizeLibraryInputData(inputData string) string {
+	if inputData == "" {
+		return emptyInputData
+	}
+	return inputData
 }
 
 // validateFilePath rejects paths that are empty, absolute, contain a NUL byte,
@@ -188,8 +254,6 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 		CloudProvider:    []string{""},
 		Path:             memfs.Paths(),
 		RepoPath:         "", // no git in server mode
-		QueriesPath:      []string{s.cfg.QueriesPath},
-		LibrariesPath:    s.cfg.LibrariesPath,
 		PreviewLines:     3,
 		Platform:         plats,
 		DisableSecrets:   true,
@@ -212,7 +276,7 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 	client, err := scan.NewClient(ctx, params, &consolePrinter.Printer{},
 		scan.WithFS(memfs),
 		scan.WithInMemoryScan(memfs.Paths()),
-		scan.WithQuerySourceFactory(s.querySourceFactory(params, req.Rules)),
+		scan.WithQuerySourceFactory(querySourceFactory(req.Rules, req.Libraries)),
 	)
 	if err != nil {
 		return nil, err
@@ -243,29 +307,24 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 	return resp, nil
 }
 
-// querySourceFactory returns a factory that serves the request's rules (with
-// libraries loaded from the embedded corpus). When no rules are pushed it falls
-// back to the filesystem corpus directly.
-// Libraries are fetched from the backend unless --libraries-path was explicitly set.
-func (s *Server) querySourceFactory(
-	params *scan.Parameters, rules []analyzeRule,
-) func(context.Context, []string) (source.QueriesSource, error) {
-	return func(ctx context.Context, plats []string) (source.QueriesSource, error) {
-		fsSource := source.NewFilesystemSource(ctx, params.QueriesPath, plats,
-			params.CloudProvider, params.LibrariesPath, params.ExperimentalQueries)
-
-		if len(rules) == 0 {
-			return source.NewFilesystemSourceWithLibraryOverride(fsSource, s.libSource), nil
-		}
-		return &requestQuerySource{queries: toQueryMetadata(rules), libraries: s.libSource}, nil
+// querySourceFactory returns a factory that serves rules and libraries only
+// from the analyze request.
+func querySourceFactory(rules []analyzeRule, libraries []analyzeLibrary) func(
+	context.Context, []string,
+) (source.QueriesSource, error) {
+	return func(context.Context, []string) (source.QueriesSource, error) {
+		return &requestQuerySource{
+			queries:   toQueryMetadata(rules),
+			libraries: toRegoLibraries(libraries),
+		}, nil
 	}
 }
 
-// requestQuerySource serves the request's rules as queries while delegating
-// library loading to the embedded filesystem source.
+// requestQuerySource serves the request's rules and libraries without disk or
+// network access.
 type requestQuerySource struct {
 	queries   []model.QueryMetadata
-	libraries source.QueriesSource
+	libraries map[string]source.RegoLibraries
 }
 
 func (r *requestQuerySource) GetQueries(ctx context.Context, params *source.QueryInspectorParameters) ([]model.QueryMetadata, error) {
@@ -276,7 +335,22 @@ func (r *requestQuerySource) GetQueries(ctx context.Context, params *source.Quer
 }
 
 func (r *requestQuerySource) GetQueryLibrary(ctx context.Context, platform string) (source.RegoLibraries, error) {
-	return r.libraries.GetQueryLibrary(ctx, platform)
+	library, ok := r.libraries[strings.ToLower(platform)]
+	if !ok {
+		return source.RegoLibraries{}, errors.New("library not found in request: " + platform)
+	}
+	return library, nil
+}
+
+func toRegoLibraries(libraries []analyzeLibrary) map[string]source.RegoLibraries {
+	out := make(map[string]source.RegoLibraries, len(libraries))
+	for _, library := range libraries {
+		out[strings.TrimSpace(library.ID)] = source.RegoLibraries{
+			LibraryCode:      library.Content,
+			LibraryInputData: normalizeLibraryInputData(library.InputData),
+		}
+	}
+	return out
 }
 
 // toQueryMetadata converts request rules into engine query metadata, filling the
@@ -286,7 +360,7 @@ func toQueryMetadata(rules []analyzeRule) []model.QueryMetadata {
 	for _, rule := range rules {
 		inputData := rule.InputData
 		if inputData == "" {
-			inputData = "{}"
+			inputData = emptyInputData
 		}
 		// Copy the caller's metadata into a fresh map so this function never
 		// mutates the request value (which may be shared/read concurrently).

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -7,7 +7,6 @@
 package server
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -144,7 +143,7 @@ func validateAnalyzeRequest(req *analyzeRequest, maxFiles int) error {
 		return errors.New("too many rules")
 	}
 	for _, rule := range req.Rules {
-		if !isInputDataObject(rule.InputData) {
+		if !isOptionalInputDataObject(rule.InputData) {
 			return errors.New("invalid rule input data for " + rule.ID)
 		}
 	}
@@ -179,7 +178,7 @@ func validateLibraries(libraries []analyzeLibrary, rules []analyzeRule) error {
 		if strings.TrimSpace(library.Content) == "" {
 			return errors.New("empty library content for " + library.ID)
 		}
-		if !isInputDataObject(library.InputData) {
+		if !isOptionalInputDataObject(library.InputData) {
 			return errors.New("invalid library input data for " + library.ID)
 		}
 		if _, exists := available[id]; exists {
@@ -209,15 +208,10 @@ func normalizeInputData(inputData string) string {
 	return inputData
 }
 
-func isInputDataObject(inputData string) bool {
-	if inputData == "" {
-		return true
-	}
-	data := bytes.TrimSpace([]byte(inputData))
-	// json.Valid checks the complete payload without allocating an unmarshalled
-	// map; the leading brace additionally requires the top-level value to be an
-	// object, excluding valid JSON values such as null, arrays, and scalars.
-	return len(data) > 0 && data[0] == '{' && json.Valid(data)
+// isOptionalInputDataObject accepts an omitted input-data value because the
+// request conversion normalizes it to {} before passing it to the engine.
+func isOptionalInputDataObject(inputData string) bool {
+	return inputData == "" || source.IsJSONObject(inputData)
 }
 
 func normalizePlatform(platform string) string {

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -167,6 +167,9 @@ func validateLibraries(libraries []analyzeLibrary, rules []analyzeRule) error {
 		if id == "" {
 			return errors.New("empty library id")
 		}
+		if library.ID != normalizePlatform(library.ID) {
+			return errors.New("library id must be canonical lowercase: " + library.ID)
+		}
 		if strings.TrimSpace(library.Content) == "" {
 			return errors.New("empty library content for " + library.ID)
 		}
@@ -182,7 +185,7 @@ func validateLibraries(libraries []analyzeLibrary, rules []analyzeRule) error {
 		return errors.New("common library is required")
 	}
 	for _, rule := range rules {
-		platform := strings.ToLower(strings.TrimSpace(rule.Platform))
+		platform := normalizePlatform(rule.Platform)
 		if platform == "" {
 			return errors.New("empty platform for rule " + rule.ID)
 		}
@@ -198,6 +201,10 @@ func normalizeLibraryInputData(inputData string) string {
 		return emptyInputData
 	}
 	return inputData
+}
+
+func normalizePlatform(platform string) string {
+	return strings.ToLower(strings.TrimSpace(platform))
 }
 
 // validateFilePath rejects paths that are empty, absolute, contain a NUL byte,
@@ -245,7 +252,10 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 		}
 	}
 
-	plats := req.Platform
+	plats := make([]string, len(req.Platform))
+	for i, platform := range req.Platform {
+		plats[i] = normalizePlatform(platform)
+	}
 	if len(plats) == 0 {
 		plats = platforms.Supported
 	}
@@ -335,7 +345,7 @@ func (r *requestQuerySource) GetQueries(ctx context.Context, params *source.Quer
 }
 
 func (r *requestQuerySource) GetQueryLibrary(ctx context.Context, platform string) (source.RegoLibraries, error) {
-	library, ok := r.libraries[strings.ToLower(platform)]
+	library, ok := r.libraries[normalizePlatform(platform)]
 	if !ok {
 		return source.RegoLibraries{}, errors.New("library not found in request: " + platform)
 	}
@@ -345,7 +355,7 @@ func (r *requestQuerySource) GetQueryLibrary(ctx context.Context, platform strin
 func toRegoLibraries(libraries []analyzeLibrary) map[string]source.RegoLibraries {
 	out := make(map[string]source.RegoLibraries, len(libraries))
 	for _, library := range libraries {
-		out[strings.TrimSpace(library.ID)] = source.RegoLibraries{
+		out[library.ID] = source.RegoLibraries{
 			LibraryCode:      library.Content,
 			LibraryInputData: normalizeLibraryInputData(library.InputData),
 		}
@@ -358,6 +368,7 @@ func toRegoLibraries(libraries []analyzeLibrary) map[string]source.RegoLibraries
 func toQueryMetadata(rules []analyzeRule) []model.QueryMetadata {
 	out := make([]model.QueryMetadata, 0, len(rules))
 	for _, rule := range rules {
+		platform := normalizePlatform(rule.Platform)
 		inputData := rule.InputData
 		if inputData == "" {
 			inputData = emptyInputData
@@ -370,14 +381,14 @@ func toQueryMetadata(rules []analyzeRule) []model.QueryMetadata {
 		setDefault(metadata, "legacyId", rule.ID)
 		setDefault(metadata, "queryName", rule.ID)
 		setDefault(metadata, "severity", "INFO")
-		setDefault(metadata, "platform", rule.Platform)
+		setDefault(metadata, "platform", platform)
 		setDefault(metadata, "category", "Best Practices")
 
 		out = append(out, model.QueryMetadata{
 			Query:     rule.ID,
 			Content:   rule.Content,
 			InputData: inputData,
-			Platform:  rule.Platform,
+			Platform:  platform,
 			Metadata:  metadata,
 		})
 	}

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -202,7 +202,7 @@ func validateLibraries(libraries []analyzeLibrary, rules []analyzeRule) error {
 	return nil
 }
 
-func normalizeLibraryInputData(inputData string) string {
+func normalizeInputData(inputData string) string {
 	if inputData == "" {
 		return emptyInputData
 	}
@@ -250,6 +250,7 @@ func validateFilePath(p string) error {
 // network access. It returns the findings plus the list of files the engine
 // referenced but did not receive.
 func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResponse, error) {
+	contextLogger := logger.FromContext(ctx)
 	files := make(map[string][]byte, len(req.Files))
 	for _, f := range req.Files {
 		files[f.Path] = []byte(f.Content)
@@ -326,6 +327,9 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 		resp.Findings = res.Results
 	}
 	if len(res.FailedQueries) > 0 {
+		contextLogger.Warn().
+			Int("failed_query_count", len(res.FailedQueries)).
+			Msg("IaC analysis completed with failed queries")
 		resp.FailedQueries = make(map[string]string, len(res.FailedQueries))
 		for q, e := range res.FailedQueries {
 			resp.FailedQueries[q] = e.Error()
@@ -374,7 +378,7 @@ func toRegoLibraries(libraries []analyzeLibrary) map[string]source.RegoLibraries
 	for _, library := range libraries {
 		out[library.ID] = source.RegoLibraries{
 			LibraryCode:      library.Content,
-			LibraryInputData: normalizeLibraryInputData(library.InputData),
+			LibraryInputData: normalizeInputData(library.InputData),
 		}
 	}
 	return out
@@ -386,10 +390,6 @@ func toQueryMetadata(rules []analyzeRule) []model.QueryMetadata {
 	out := make([]model.QueryMetadata, 0, len(rules))
 	for _, rule := range rules {
 		platform := normalizePlatform(rule.Platform)
-		inputData := rule.InputData
-		if inputData == "" {
-			inputData = emptyInputData
-		}
 		// Copy the caller's metadata into a fresh map so this function never
 		// mutates the request value (which may be shared/read concurrently).
 		metadata := make(map[string]any, len(rule.Metadata)+metadataDefaultKeys)
@@ -404,7 +404,7 @@ func toQueryMetadata(rules []analyzeRule) []model.QueryMetadata {
 		out = append(out, model.QueryMetadata{
 			Query:     rule.ID,
 			Content:   rule.Content,
-			InputData: inputData,
+			InputData: normalizeInputData(rule.InputData),
 			Platform:  platform,
 			Metadata:  metadata,
 		})

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -13,63 +13,90 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
-// repoRoot returns the module root relative to this package (pkg/server).
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	return filepath.Join(wd, "..", "..")
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func newTestServer(t *testing.T) *Server {
 	t.Helper()
-	root := repoRoot(t)
-	libs := filepath.Join(root, "assets", "libraries")
-	if _, err := os.Stat(libs); err != nil {
-		t.Skipf("assets/libraries not found (%v); skipping engine-backed test", err)
-	}
-	return New(&Config{
-		LibrariesPath: libs,
-		QueriesPath:   filepath.Join(root, "assets", "queries"),
-	})
+	return New(&Config{})
 }
 
-// teamTagRule loads the real Terraform "Team tag" rule from the e2e fixtures so
-// the test exercises a production-shaped rule without a network fetch.
-func teamTagRule(t *testing.T) analyzeRule {
-	t.Helper()
-	root := repoRoot(t)
-	regoPath := filepath.Join(root, "test", "e2e", "testdata", "rules", "terraform", "team_tag_not_present", "query.rego")
-	content, err := os.ReadFile(regoPath)
-	if err != nil {
-		t.Skipf("rule fixture not found (%v); skipping", err)
-	}
+const syntheticRuleID = "test-terraform-resource-missing-owner"
+
+// syntheticRule imports both test-only pushed libraries. Its identifiers and
+// behavior are deliberately unrelated to the production rule corpus.
+func syntheticRule() analyzeRule {
 	return analyzeRule{
-		ID:       "terraform-aws-team-tag-not-present",
+		ID:       syntheticRuleID,
 		Platform: "terraform",
-		Content:  string(content),
+		Content: `package datadog
+
+import rego.v1
+
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
+
+DatadogPolicy contains result if {
+	common_lib.library_enabled
+	resource := input.document[i].resource[resource_type][name]
+	not common_lib.has_owner(resource)
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": resource_type,
+		"resourceName": tf_lib.display_name(resource_type, name),
+		"searchKey": sprintf("%s[%s].labels.owner", [resource_type, name]),
+	}
+}`,
 		Metadata: map[string]any{
-			"id":        "terraform-aws-team-tag-not-present",
-			"queryName": "Team tag missing on AWS resource",
-			"severity":  "LOW",
+			"id":        syntheticRuleID,
+			"queryName": "Synthetic missing owner label",
+			"severity":  "INFO",
 			"platform":  "Terraform",
-			"category":  "Best Practices",
+			"category":  "Test",
+		},
+	}
+}
+
+func testLibraries(enabled bool) []analyzeLibrary {
+	return []analyzeLibrary{
+		{
+			ID: "common",
+			Content: `package generic.common
+
+import rego.v1
+
+library_enabled if data.test.enabled
+
+has_owner(resource) if resource.labels.owner`,
+			InputData: fmt.Sprintf(`{"test":{"enabled":%t}}`, enabled),
+		},
+		{
+			ID: "terraform",
+			Content: `package generic.terraform
+
+import rego.v1
+
+display_name(resource_type, name) := sprintf("%s.%s", [resource_type, name])`,
 		},
 	}
 }
 
 func postAnalyze(t *testing.T, s *Server, req analyzeRequest) (*analyzeResponse, int) {
 	t.Helper()
+	if len(req.Libraries) == 0 {
+		req.Libraries = testLibraries(true)
+	}
 	out, err := s.analyze(context.Background(), &req)
 	if err != nil {
 		t.Fatalf("analyze: %v", err)
@@ -79,11 +106,11 @@ func postAnalyze(t *testing.T, s *Server, req analyzeRequest) (*analyzeResponse,
 
 // TestAnalyze_ContentPush_TerraformFinding verifies the full content-push path:
 // a pushed Terraform file plus its sibling variables file are scanned in memory
-// (no disk), a real rule fires, and same-directory siblings resolve without
+// (no disk), a synthetic rule fires, and same-directory siblings resolve without
 // being reported missing.
 func TestAnalyze_ContentPush_TerraformFinding(t *testing.T) {
 	s := newTestServer(t)
-	rule := teamTagRule(t)
+	rule := syntheticRule()
 
 	req := analyzeRequest{
 		Files: []analyzeFile{
@@ -99,11 +126,11 @@ func TestAnalyze_ContentPush_TerraformFinding(t *testing.T) {
 	out, _ := postAnalyze(t, s, req)
 
 	if len(out.Findings) == 0 {
-		t.Fatalf("expected at least one finding for an AWS resource missing a Team tag, got none")
+		t.Fatalf("expected at least one synthetic finding, got none; failed queries: %v", out.FailedQueries)
 	}
 	var found bool
 	for _, f := range out.Findings {
-		if f.QueryID == "terraform-aws-team-tag-not-present" {
+		if f.QueryID == syntheticRuleID {
 			found = true
 			if f.FileName != "infra/main.tf" {
 				t.Errorf("finding fileName = %q, want infra/main.tf", f.FileName)
@@ -111,7 +138,7 @@ func TestAnalyze_ContentPush_TerraformFinding(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("expected the team-tag rule to fire; findings = %+v", out.Findings)
+		t.Errorf("expected the synthetic rule to fire; findings = %+v", out.Findings)
 	}
 	// Same-directory siblings resolve via the in-memory glob, so nothing is
 	// reported missing.
@@ -125,7 +152,7 @@ func TestAnalyze_ContentPush_TerraformFinding(t *testing.T) {
 // workspace-relative path (the hybrid escalation signal).
 func TestAnalyze_MissingModuleEscalation(t *testing.T) {
 	s := newTestServer(t)
-	rule := teamTagRule(t)
+	rule := syntheticRule()
 
 	req := analyzeRequest{
 		Files: []analyzeFile{
@@ -159,8 +186,8 @@ resource "aws_s3_bucket" "b" { bucket = "x" }`},
 // single server serves many IDE workspaces/windows, so the result must not
 // depend on where the binary was launched.
 func TestAnalyze_MissingFilesCWDIndependent(t *testing.T) {
-	s := newTestServer(t) // resolves an absolute libraries path before we chdir
-	rule := teamTagRule(t)
+	s := newTestServer(t)
+	rule := syntheticRule()
 	req := analyzeRequest{
 		Files: []analyzeFile{{Path: "infra/main.tf", Content: `module "net" {
   source = "../modules/networking"
@@ -185,19 +212,58 @@ func TestAnalyze_Validation(t *testing.T) {
 	ts := httptest.NewServer(s.http.Handler)
 	defer ts.Close()
 
+	validRule := analyzeRule{ID: "test-rule", Platform: "terraform", Content: "package datadog"}
+	validLibraries := []analyzeLibrary{
+		{ID: "common", Content: "package generic.common"},
+		{ID: "terraform", Content: "package generic.terraform"},
+	}
 	cases := []struct {
 		name string
-		body string
+		req  analyzeRequest
+		body string // used only for malformed input
 		want int
 	}{
-		{"empty files", `{"files":[],"rules":[]}`, http.StatusBadRequest},
-		{"path traversal", `{"files":[{"path":"../escape.tf","content":"x"}],"rules":[]}`, http.StatusBadRequest},
-		{"absolute path", `{"files":[{"path":"/etc/passwd","content":"x"}],"rules":[]}`, http.StatusBadRequest},
-		{"malformed json", `{`, http.StatusBadRequest},
+		{
+			name: "empty files",
+			req:  analyzeRequest{Rules: []analyzeRule{validRule}, Libraries: validLibraries},
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "empty rules",
+			req: analyzeRequest{
+				Files: []analyzeFile{{Path: "main.tf", Content: "x"}}, Libraries: validLibraries,
+			},
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "path traversal",
+			req: analyzeRequest{
+				Files: []analyzeFile{{Path: "../escape.tf", Content: "x"}},
+				Rules: []analyzeRule{validRule}, Libraries: validLibraries,
+			},
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "absolute path",
+			req: analyzeRequest{
+				Files: []analyzeFile{{Path: "/etc/passwd", Content: "x"}},
+				Rules: []analyzeRule{validRule}, Libraries: validLibraries,
+			},
+			want: http.StatusBadRequest,
+		},
+		{name: "malformed json", body: `{`, want: http.StatusBadRequest},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			resp, err := http.Post(ts.URL+"/ide/v1/iac/analyze", "application/json", strings.NewReader(tc.body))
+			body := []byte(tc.body)
+			if tc.body == "" {
+				var err error
+				body, err = json.Marshal(tc.req)
+				if err != nil {
+					t.Fatalf("marshal request: %v", err)
+				}
+			}
+			resp, err := http.Post(ts.URL+"/ide/v1/iac/analyze", "application/json", bytes.NewReader(body))
 			if err != nil {
 				t.Fatalf("post: %v", err)
 			}
@@ -206,6 +272,119 @@ func TestAnalyze_Validation(t *testing.T) {
 				t.Errorf("status = %d, want %d", resp.StatusCode, tc.want)
 			}
 		})
+	}
+}
+
+func TestValidateAnalyzeRequest_Libraries(t *testing.T) {
+	base := analyzeRequest{
+		Files: []analyzeFile{{Path: "main.tf", Content: "resource"}},
+		Rules: []analyzeRule{{ID: "rule", Platform: "Terraform", Content: "package datadog"}},
+	}
+	tests := []struct {
+		name      string
+		libraries []analyzeLibrary
+		wantError string
+	}{
+		{name: "missing", wantError: "at least one library is required"},
+		{
+			name: "missing common",
+			libraries: []analyzeLibrary{
+				{ID: "terraform", Content: "package generic.terraform"},
+			},
+			wantError: "common library is required",
+		},
+		{
+			name: "missing platform",
+			libraries: []analyzeLibrary{
+				{ID: "common", Content: "package generic.common"},
+			},
+			wantError: "library is required for rule platform: Terraform",
+		},
+		{
+			name: "duplicate id",
+			libraries: []analyzeLibrary{
+				{ID: "common", Content: "package generic.common"},
+				{ID: "common", Content: "package generic.common"},
+				{ID: "terraform", Content: "package generic.terraform"},
+			},
+			wantError: "duplicate library id: common",
+		},
+		{
+			name: "invalid input data",
+			libraries: []analyzeLibrary{
+				{ID: "common", Content: "package generic.common", InputData: "{"},
+				{ID: "terraform", Content: "package generic.terraform"},
+			},
+			wantError: "invalid library input data for common",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := base
+			req.Libraries = tt.libraries
+			err := validateAnalyzeRequest(&req, defaultMaxFiles)
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("validateAnalyzeRequest() error = %v", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantError {
+				t.Fatalf("validateAnalyzeRequest() error = %v, want %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestAnalyze_RequestLibrariesInvalidateSharedRuleCache(t *testing.T) {
+	s := New(&Config{UseRulesCache: true, DisableRuleIsolation: true})
+	req := analyzeRequest{
+		Files: []analyzeFile{{
+			Path:    "infra/main.tf",
+			Content: `resource "aws_s3_bucket" "b" { bucket = "x" }`,
+		}},
+		Rules:     []analyzeRule{syntheticRule()},
+		Libraries: testLibraries(true),
+		Platform:  []string{"terraform"},
+	}
+
+	enabled, _ := postAnalyze(t, s, req)
+	if len(enabled.Findings) == 0 {
+		t.Fatal("expected a finding when pushed library input enables the rule")
+	}
+
+	req.Libraries = testLibraries(false)
+	disabled, _ := postAnalyze(t, s, req)
+	if len(disabled.Findings) != 0 {
+		t.Fatalf("stale cached rule used old library input; findings: %+v", disabled.Findings)
+	}
+}
+
+func TestAnalyze_RequestLibrariesDoNotCallBackend(t *testing.T) {
+	originalClient := http.DefaultClient
+	var requests atomic.Int64
+	http.DefaultClient = &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return nil, fmt.Errorf("unexpected outbound request to %s", req.URL)
+	})}
+	t.Cleanup(func() { http.DefaultClient = originalClient })
+
+	s := New(&Config{})
+	out, _ := postAnalyze(t, s, analyzeRequest{
+		Files: []analyzeFile{{
+			Path:    "infra/main.tf",
+			Content: `resource "aws_s3_bucket" "b" { bucket = "x" }`,
+		}},
+		Rules:     []analyzeRule{syntheticRule()},
+		Libraries: testLibraries(true),
+		Platform:  []string{"terraform"},
+	})
+	if len(out.Findings) == 0 {
+		t.Fatal("expected request-supplied rules and libraries to produce a finding")
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("server mode made %d outbound HTTP requests, want 0", got)
 	}
 }
 
@@ -308,7 +487,7 @@ func TestLifecycle_Contract(t *testing.T) {
 // goroutines). Run with `go test -race` to surface data races.
 func TestAnalyze_Concurrent(t *testing.T) {
 	s := newTestServer(t)
-	rule := teamTagRule(t)
+	rule := syntheticRule()
 
 	files := make([]analyzeFile, 0, 6)
 	for i := range 6 {
@@ -327,7 +506,9 @@ func TestAnalyze_Concurrent(t *testing.T) {
 		r.ID = fmt.Sprintf("%s-%d", rule.ID, i)
 		rules = append(rules, r)
 	}
-	req := analyzeRequest{Files: files, Rules: rules, Platform: []string{"terraform"}}
+	req := analyzeRequest{
+		Files: files, Rules: rules, Libraries: testLibraries(true), Platform: []string{"terraform"},
+	}
 
 	const n = 12
 	var wg sync.WaitGroup
@@ -359,7 +540,7 @@ func TestAnalyze_Concurrent(t *testing.T) {
 // must fall back to the empty IaC config rather than dereferencing nil.
 func TestAnalyze_ConfigWithoutIacSection(t *testing.T) {
 	s := newTestServer(t)
-	rule := teamTagRule(t)
+	rule := syntheticRule()
 
 	req := analyzeRequest{
 		Files:    []analyzeFile{{Path: "infra/main.tf", Content: `resource "aws_s3_bucket" "b" { bucket = "x" }`}},
@@ -380,18 +561,18 @@ func TestAnalyze_ConfigWithoutIacSection(t *testing.T) {
 // applies.
 func TestAnalyze_ConfigIgnoreRulePushedRule(t *testing.T) {
 	s := newTestServer(t)
-	rule := teamTagRule(t)
+	rule := syntheticRule()
 
 	req := analyzeRequest{
 		Files:    []analyzeFile{{Path: "infra/main.tf", Content: `resource "aws_s3_bucket" "b" { bucket = "x" }`}},
 		Rules:    []analyzeRule{rule},
 		Platform: []string{"terraform"},
-		Config:   "schema-version: v1.3\niac:\n  ignore-rules:\n    - terraform-aws-team-tag-not-present\n",
+		Config:   "schema-version: v1.3\niac:\n  ignore-rules:\n    - " + syntheticRuleID + "\n",
 	}
 
 	out, _ := postAnalyze(t, s, req)
 	for _, f := range out.Findings {
-		if f.QueryID == "terraform-aws-team-tag-not-present" {
+		if f.QueryID == syntheticRuleID {
 			t.Errorf("ignore-rules should have suppressed the pushed rule, but it fired: %+v", f)
 		}
 	}
@@ -402,7 +583,7 @@ func TestAnalyze_ConfigIgnoreRulePushedRule(t *testing.T) {
 // path, mirroring the disk scanner's behavior.
 func TestAnalyze_ConfigIgnorePaths(t *testing.T) {
 	s := newTestServer(t)
-	rule := teamTagRule(t)
+	rule := syntheticRule()
 	body := `resource "aws_s3_bucket" "b" { bucket = "x" }`
 
 	// Baseline: without filters the rule fires on infra/main.tf.
@@ -487,7 +668,7 @@ func TestAnalyze_ConcurrencyLimit(t *testing.T) {
 // block ranges from the first parse and report an incorrect finding line.
 func TestAnalyze_HCLCacheIsolatedBetweenRequests(t *testing.T) {
 	s := newTestServer(t)
-	rule := teamTagRule(t)
+	rule := syntheticRule()
 
 	// Request 1: resource is at line 1.
 	req1 := analyzeRequest{

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -325,6 +325,14 @@ func TestValidateAnalyzeRequest_Libraries(t *testing.T) {
 			},
 			wantError: "invalid library input data for common",
 		},
+		{
+			name: "non-object input data",
+			libraries: []analyzeLibrary{
+				{ID: "common", Content: "package generic.common", InputData: "null"},
+				{ID: "terraform", Content: "package generic.terraform"},
+			},
+			wantError: "invalid library input data for common",
+		},
 	}
 
 	for _, tt := range tests {
@@ -340,6 +348,24 @@ func TestValidateAnalyzeRequest_Libraries(t *testing.T) {
 			}
 			if err == nil || err.Error() != tt.wantError {
 				t.Fatalf("validateAnalyzeRequest() error = %v, want %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateAnalyzeRequest_RuleInputDataMustBeObject(t *testing.T) {
+	for _, inputData := range []string{"null", "[]", "1", `"value"`} {
+		t.Run(inputData, func(t *testing.T) {
+			req := analyzeRequest{
+				Files: []analyzeFile{{Path: "main.tf", Content: "resource"}},
+				Rules: []analyzeRule{{
+					ID: "test-rule", Platform: "terraform", Content: "package datadog", InputData: inputData,
+				}},
+				Libraries: testLibraries(true),
+			}
+			err := validateAnalyzeRequest(&req, defaultMaxFiles)
+			if err == nil || err.Error() != "invalid rule input data for test-rule" {
+				t.Fatalf("validateAnalyzeRequest() error = %v", err)
 			}
 		})
 	}

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -301,6 +301,14 @@ func TestValidateAnalyzeRequest_Libraries(t *testing.T) {
 			wantError: "library is required for rule platform: Terraform",
 		},
 		{
+			name: "noncanonical id",
+			libraries: []analyzeLibrary{
+				{ID: "Common", Content: "package generic.common"},
+				{ID: "terraform", Content: "package generic.terraform"},
+			},
+			wantError: "library id must be canonical lowercase: Common",
+		},
+		{
 			name: "duplicate id",
 			libraries: []analyzeLibrary{
 				{ID: "common", Content: "package generic.common"},
@@ -334,6 +342,29 @@ func TestValidateAnalyzeRequest_Libraries(t *testing.T) {
 				t.Fatalf("validateAnalyzeRequest() error = %v, want %q", err, tt.wantError)
 			}
 		})
+	}
+}
+
+func TestAnalyze_NormalizesRuleAndScanPlatforms(t *testing.T) {
+	s := newTestServer(t)
+	rule := syntheticRule()
+	rule.Platform = " Terraform "
+	req := analyzeRequest{
+		Files: []analyzeFile{{
+			Path:    "infra/main.tf",
+			Content: `resource "test_widget" "example" {}`,
+		}},
+		Rules:     []analyzeRule{rule},
+		Libraries: testLibraries(true),
+		Platform:  []string{" Terraform "},
+	}
+	if err := validateAnalyzeRequest(&req, defaultMaxFiles); err != nil {
+		t.Fatalf("validateAnalyzeRequest() error = %v", err)
+	}
+
+	out, _ := postAnalyze(t, s, req)
+	if len(out.Findings) != 1 || out.Findings[0].QueryID != syntheticRuleID {
+		t.Fatalf("normalized platform request returned findings %+v", out.Findings)
 	}
 }
 

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -19,6 +19,9 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	engineSource "github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
+	"github.com/rs/zerolog"
 )
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)
@@ -280,12 +283,24 @@ func TestValidateAnalyzeRequest_Libraries(t *testing.T) {
 		Files: []analyzeFile{{Path: "main.tf", Content: "resource"}},
 		Rules: []analyzeRule{{ID: "rule", Platform: "Terraform", Content: "package datadog"}},
 	}
+	tooManyLibraries := make([]analyzeLibrary, maxLibraries+1)
 	tests := []struct {
 		name      string
 		libraries []analyzeLibrary
 		wantError string
 	}{
 		{name: "missing", wantError: "at least one library is required"},
+		{name: "too many", libraries: tooManyLibraries, wantError: "too many libraries"},
+		{
+			name:      "empty id",
+			libraries: []analyzeLibrary{{Content: "package generic.common"}},
+			wantError: "empty library id",
+		},
+		{
+			name:      "empty content",
+			libraries: []analyzeLibrary{{ID: "common", Content: " "}},
+			wantError: "empty library content for common",
+		},
 		{
 			name: "missing common",
 			libraries: []analyzeLibrary{
@@ -353,6 +368,34 @@ func TestValidateAnalyzeRequest_Libraries(t *testing.T) {
 	}
 }
 
+func TestValidateAnalyzeRequest_RuleBoundaries(t *testing.T) {
+	validRequest := func() analyzeRequest {
+		return analyzeRequest{
+			Files:     []analyzeFile{{Path: "main.tf", Content: "resource"}},
+			Rules:     []analyzeRule{{ID: "test-rule", Platform: "terraform", Content: "package datadog"}},
+			Libraries: testLibraries(true),
+		}
+	}
+
+	t.Run("too many rules", func(t *testing.T) {
+		req := validRequest()
+		req.Rules = make([]analyzeRule, maxRules+1)
+		err := validateAnalyzeRequest(&req, defaultMaxFiles)
+		if err == nil || err.Error() != "too many rules" {
+			t.Fatalf("validateAnalyzeRequest() error = %v", err)
+		}
+	})
+
+	t.Run("empty rule platform", func(t *testing.T) {
+		req := validRequest()
+		req.Rules[0].Platform = " "
+		err := validateAnalyzeRequest(&req, defaultMaxFiles)
+		if err == nil || err.Error() != "empty platform for rule test-rule" {
+			t.Fatalf("validateAnalyzeRequest() error = %v", err)
+		}
+	})
+}
+
 func TestValidateAnalyzeRequest_RuleInputDataMustBeObject(t *testing.T) {
 	for _, inputData := range []string{"null", "[]", "1", `"value"`} {
 		t.Run(inputData, func(t *testing.T) {
@@ -391,6 +434,40 @@ func TestAnalyze_NormalizesRuleAndScanPlatforms(t *testing.T) {
 	out, _ := postAnalyze(t, s, req)
 	if len(out.Findings) != 1 || out.Findings[0].QueryID != syntheticRuleID {
 		t.Fatalf("normalized platform request returned findings %+v", out.Findings)
+	}
+}
+
+func TestRequestQuerySource_MissingLibrary(t *testing.T) {
+	source := &requestQuerySource{libraries: map[string]engineSource.RegoLibraries{
+		"common": {},
+	}}
+	_, err := source.GetQueryLibrary(t.Context(), "terraform")
+	if err == nil || err.Error() != "library not found in request: terraform" {
+		t.Fatalf("GetQueryLibrary() error = %v", err)
+	}
+}
+
+func TestAnalyze_MissingPlatformLibraryReportedAsFailedQuery(t *testing.T) {
+	s := newTestServer(t)
+	req := analyzeRequest{
+		Files: []analyzeFile{{
+			Path:    "infra/main.tf",
+			Content: `resource "test_widget" "example" {}`,
+		}},
+		Rules: []analyzeRule{syntheticRule()},
+		Libraries: []analyzeLibrary{
+			{ID: "common", Content: "package generic.common\nimport rego.v1"},
+		},
+		Platform: []string{"terraform"},
+	}
+
+	out, err := s.analyze(t.Context(), &req)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	failed, ok := out.FailedQueries[syntheticRuleID]
+	if !ok || !strings.Contains(failed, "failed to get platform library") {
+		t.Fatalf("failed queries = %v", out.FailedQueries)
 	}
 }
 
@@ -442,6 +519,39 @@ func TestAnalyze_RequestLibrariesDoNotCallBackend(t *testing.T) {
 	}
 	if got := requests.Load(); got != 0 {
 		t.Fatalf("server mode made %d outbound HTTP requests, want 0", got)
+	}
+}
+
+func TestAnalyze_LogsFailedQueryCount(t *testing.T) {
+	s := newTestServer(t)
+	rule := syntheticRule()
+	rule.Content = `package datadog
+
+import rego.v1
+
+DatadogPolicy contains "invalid-result"`
+	req := analyzeRequest{
+		Files: []analyzeFile{{
+			Path:    "infra/main.tf",
+			Content: `resource "test_widget" "example" {}`,
+		}},
+		Rules:     []analyzeRule{rule},
+		Libraries: testLibraries(true),
+		Platform:  []string{"terraform"},
+	}
+
+	var logs bytes.Buffer
+	ctx := zerolog.New(&logs).WithContext(t.Context())
+	out, err := s.analyze(ctx, &req)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if len(out.FailedQueries) != 1 {
+		t.Fatalf("failed queries = %v, want one", out.FailedQueries)
+	}
+	if !strings.Contains(logs.String(), `"level":"warn"`) ||
+		!strings.Contains(logs.String(), `"failed_query_count":1`) {
+		t.Fatalf("missing failed-query warning in logs: %s", logs.String())
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -38,8 +38,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/constants"
-	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
-	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/rs/zerolog/log"
 )
@@ -86,8 +84,6 @@ type Config struct {
 	Port             int           // listen port (default 8000)
 	KeepAliveTimeout time.Duration // idle timeout; 0 disables auto-shutdown
 	EnableShutdown   bool          // gate for the /shutdown endpoint
-	LibrariesPath    string        // Rego support libraries
-	QueriesPath      string        // default rule corpus (used only when a request omits rules)
 	// MaxConcurrentAnalyze caps simultaneous /analyze scans. <= 0 applies
 	// defaultMaxConcurrentAnalyze.
 	MaxConcurrentAnalyze int
@@ -139,11 +135,6 @@ type Server struct {
 	// keepAlivePollInterval and is overridable in tests.
 	pollInterval time.Duration
 
-	// libSource is the QueriesSource used for library lookups across all requests.
-	// When --libraries-path is set it reads from disk; otherwise it fetches from
-	// the backend once and caches the result via DatadogSource.librariesOnce.
-	libSource source.QueriesSource
-
 	// shutdownCh is closed exactly once to trigger graceful shutdown (by
 	// /shutdown, the keep-alive monitor, or a canceled context).
 	shutdownCh   chan struct{}
@@ -157,9 +148,6 @@ func New(cfg *Config) *Server {
 	}
 	if cfg.Port == 0 {
 		cfg.Port = 8000
-	}
-	if cfg.QueriesPath == "" {
-		cfg.QueriesPath = "./assets/queries"
 	}
 	if cfg.MaxConcurrentAnalyze <= 0 {
 		cfg.MaxConcurrentAnalyze = defaultMaxConcurrentAnalyze
@@ -176,16 +164,8 @@ func New(cfg *Config) *Server {
 	if cfg.MaxRequestBytes <= 0 {
 		cfg.MaxRequestBytes = defaultMaxRequestBytes
 	}
-	var libSource source.QueriesSource
-	if cfg.LibrariesPath != "" {
-		libSource = source.NewFilesystemSource(context.Background(), []string{}, []string{}, []string{}, cfg.LibrariesPath, false)
-	} else {
-		libSource, _ = source.NewDatadogSource(datadog.NewDatadogClient())
-	}
-
 	s := &Server{
 		cfg:          *cfg,
-		libSource:    libSource,
 		analyzeSem:   make(chan struct{}, cfg.MaxConcurrentAnalyze),
 		pollInterval: keepAlivePollInterval,
 		shutdownCh:   make(chan struct{}),


### PR DESCRIPTION
## Motivation

Server mode did not support Rego libraries supplied by the caller after the shared IaC libraries moved to the backend. Unlike rules, libraries still depended on scanner-side filesystem or backend loading.

This PR makes server-mode analysis self-contained: files, rules, and supporting libraries are all supplied in the analyze request.

JIRA Ticket: [K9CODESEC-3288](https://datadoghq.atlassian.net/browse/K9CODESEC-3288)

## Changes

- Added libraries to the server analyze request.
- Added validation for required common and platform libraries.
- Required rules and libraries to be present in every analyze request.
- Removed server-side rule and library filesystem fallbacks.
- Removed the server `--queries-path` and `--libraries-path` options.
- Ensured server analysis does not fetch libraries from the backend.
- Added bounded caching for the shared compiled ruleset used by `--x-use-rules-cache`.
- Added cache invalidation when rules, libraries, or their input data change.
- Added self-contained tests using synthetic rules and libraries.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [x] I have updated any relevant documentation (if applicable).

## QA Instruction

1. Build the scanner
2. Start server mode
3. Send an analyze request
4. Verify

## Blast Radius

This changes only Datadog IaC Scanner server mode and clients constructing its analyze requests. Those clients must now include both rules and libraries.

The regular scanner CLI and backend library endpoint are not changed.

I submit this contribution under the Apache-2.0 license.


[K9CODESEC-3288]: https://datadoghq.atlassian.net/browse/K9CODESEC-3288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ