### PR TITLE
[K9CODESEC-3289] Emit Terraform module instantiation telemetry

### DIFF
--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -403,7 +403,9 @@ func (c *Inspector) Inspect(
 	// Terraform local-module instantiation is gated so it can be disabled remotely.
 	var moduleDocs []model.Document
 	var moduleExtras map[string][]extraCallerInfo
-	if c.flagEvaluator != nil && c.flagEvaluator.EvaluateWithOrg(featureflags.IacEnableLocalModuleEval) {
+	if shouldInstantiateLocalModules(platforms, files) &&
+		c.flagEvaluator != nil &&
+		c.flagEvaluator.EvaluateWithOrg(featureflags.IacEnableLocalModuleEval) {
 		var syntheticFiles []*model.FileMetadata
 		moduleDocs, syntheticFiles, moduleExtras = c.instantiateLocalModules(ctx, files)
 		files = append(files, syntheticFiles...)
@@ -517,6 +519,19 @@ func (c *Inspector) executeQueries(
 	}
 
 	return vulnerabilities, nil
+}
+
+func shouldInstantiateLocalModules(platforms []string, files model.FileMetadatas) bool {
+	for _, platform := range platforms {
+		if strings.EqualFold(platform, "Terraform") {
+			for _, file := range files {
+				if file != nil && isTerraformFile(file.FilePath) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // expandModuleFindings clones findings from deduplicated OPA docs back to each

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -58,6 +58,16 @@ func (c *Inspector) instantiateLocalModules(
 ) ([]model.Document, []*model.FileMetadata, map[string][]extraCallerInfo) {
 	resolver := c.buildRemoteResolver()
 	res := c.resolveModulesSafely(ctx, files, resolver)
+	totalCallers := instantiatedModuleResourceCount(&res)
+	contextLogger := logger.FromContext(ctx)
+	contextLogger.Info().
+		Int("module_resources_instantiated", totalCallers).
+		Msgf(
+			"Instantiated %d module resources (%d unique OPA docs, %d deduplicated callers)",
+			totalCallers,
+			len(res.docs),
+			totalCallers-len(res.docs),
+		)
 	if !res.ok {
 		return nil, nil, nil
 	}
@@ -76,18 +86,15 @@ func (c *Inspector) instantiateLocalModules(
 		// module blocks must remain so the corresponding Rego branches can still fire.
 		stripModuleCalls(f.Document, f.FilePath, c.repoPath, res.calledDirs, resolver)
 	}
-	contextLogger := logger.FromContext(ctx)
-	totalCallers := len(res.docs)
-	for _, ex := range res.extras {
-		totalCallers += len(ex)
-	}
-	if totalCallers > 0 {
-		contextLogger.Info().Msgf("Instantiated %d module resources (%d unique OPA docs, %d deduplicated callers)",
-			totalCallers, len(res.docs), totalCallers-len(res.docs))
-	} else {
-		contextLogger.Debug().Msg("Instantiated 0 local module resources")
-	}
 	return res.docs, res.syntheticFiles, res.extras
+}
+
+func instantiatedModuleResourceCount(res *moduleResolutionResult) int {
+	count := len(res.docs)
+	for _, extras := range res.extras {
+		count += len(extras)
+	}
+	return count
 }
 
 func (c *Inspector) buildRemoteResolver() tfeval.RemoteResolver {

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -6,6 +6,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/rs/zerolog"
 )
 
 // docFileID is the prefix of synthetic doc ids: fileID\x00callChain.
@@ -619,10 +621,84 @@ module "bucket" {
 	ins := newTestInspector(t, inspectorOpts{
 		repoPath: root,
 	})
-	if docs, synthetic, extras := ins.instantiateLocalModules(context.Background(), files); docs != nil || synthetic != nil || extras != nil {
+	var logs bytes.Buffer
+	ctx := zerolog.New(&logs).WithContext(context.Background())
+	if docs, synthetic, extras := ins.instantiateLocalModules(ctx, files); docs != nil || synthetic != nil || extras != nil {
 		t.Fatalf("instantiateLocalModules = (%#v, %#v, %#v), want nil when resolve aborts", docs, synthetic, extras)
 	}
 	if _, has := rootFM.Document["module"]; !has {
 		t.Fatalf("expected module block preserved on root when evaluation failed")
+	}
+	if !strings.Contains(logs.String(), `"module_resources_instantiated":0`) {
+		t.Fatalf("expected zero instantiated resources in structured log, got %q", logs.String())
+	}
+}
+
+func TestInstantiatedModuleResourceCountIncludesDeduplicatedCallers(t *testing.T) {
+	res := moduleResolutionResult{
+		docs: []model.Document{{}, {}},
+		extras: map[string][]extraCallerInfo{
+			"first":  {{}, {}},
+			"second": {{}},
+		},
+	}
+
+	if got := instantiatedModuleResourceCount(&res); got != 5 {
+		t.Fatalf("instantiatedModuleResourceCount() = %d, want 5", got)
+	}
+}
+
+func TestShouldInstantiateLocalModules(t *testing.T) {
+	tests := []struct {
+		name      string
+		platforms []string
+		files     model.FileMetadatas
+		want      bool
+	}{
+		{
+			name:      "Terraform configuration",
+			platforms: []string{"Terraform"},
+			files:     model.FileMetadatas{{FilePath: "main.tf"}},
+			want:      true,
+		},
+		{
+			name:      "mixed platforms",
+			platforms: []string{"Dockerfile", "Terraform"},
+			files:     model.FileMetadatas{{FilePath: "main.tf"}},
+			want:      true,
+		},
+		{
+			name:      "case insensitive",
+			platforms: []string{"terraform"},
+			files:     model.FileMetadatas{{FilePath: "main.tf"}},
+			want:      true,
+		},
+		{
+			name:      "Terraform plan JSON",
+			platforms: []string{"Terraform"},
+			files:     model.FileMetadatas{{FilePath: "plan.json"}},
+			want:      false,
+		},
+		{
+			name:      "other platform",
+			platforms: []string{"Kubernetes"},
+			files:     model.FileMetadatas{{FilePath: "main.tf"}},
+			want:      false,
+		},
+		{name: "empty", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldInstantiateLocalModules(tt.platforms, tt.files); got != tt.want {
+				t.Fatalf(
+					"shouldInstantiateLocalModules(%v, %v) = %t, want %t",
+					tt.platforms,
+					tt.files,
+					got,
+					tt.want,
+				)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Motivation

Large Terraform module expansions can exhaust scan execution budgets without an early machine-readable signal. Expose the instantiated resource count in structured logs so embedding consumers can react immediately.

Related ticket: [K9CODESEC-3289](https://datadoghq.atlassian.net/browse/K9CODESEC-3289)

## Changes

**Resolver**

After module resolution, emit one structured info log with `module_resources_instantiated`, counting unique synthetic documents plus deduplicated callers. The count is source-agnostic and will include manifest-backed modules once remote module support ships. Restrict to Terraform configuration scans and emit zero when resolution produces no instances.

## Author Checklist

Relevant unit tests were added, existing tests pass, and documentation or staging validation is not applicable.

## QA Instruction

1. `go test ./pkg/engine ./pkg/scan -count=1`
2. `golangci-lint run -c .golangci.yml --timeout 20m`

## Impact

Structured info logs only for Terraform configuration scans when module evaluation is enabled. Embedding consumers can read `module_resources_instantiated` without parsing log messages.

## Additional Notes

N/A

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-3289]: https://datadoghq.atlassian.net/browse/K9CODESEC-3289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ