### PR TITLE
Print release checksums JSON in release pipeline

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -57,6 +57,10 @@ jobs:
           set -euo pipefail
           checksum_file=$(cat dist/artifacts.json | jq -r '.[] | select (.type=="Checksum") | .path')
           echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
+      - name: Print release checksums JSON
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/gen-checksums.sh "${{ github.ref_name }}"
   # Uncomment when repository is public
   # provenance:
   #   needs: [goreleaser]

--- a/scripts/gen-checksums.sh
+++ b/scripts/gen-checksums.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Builds a {version, sha256: {platform: hash}} JSON blob from a GitHub
+# release's checksums.txt asset (published by GoReleaser).
+#
+# Usage: scripts/gen-checksums.sh [tag]
+#   tag defaults to the latest release if omitted.
+set -euo pipefail
+
+REPO="DataDog/datadog-iac-scanner"
+TAG="${1:-}"
+
+if [[ -z "$TAG" ]]; then
+  TAG=$(gh release view --repo "$REPO" --json tagName -q .tagName)
+fi
+
+gh release download "$TAG" --repo "$REPO" \
+  -p 'datadog-iac-scanner_checksums.txt' -O - \
+  | awk '{print $2, $1}' \
+  | jq -R -n --arg version "$TAG" '
+      [inputs | split(" ")]
+      | map(select(.[0] | test("darwin|linux")))
+      | map({(.[0] | capture("datadog-iac-scanner_(?<plat>darwin_arm64|darwin_amd64|linux_arm64|linux_amd64)").plat): .[1]})
+      | add as $sha256
+      | {version: $version, sha256: $sha256}
+    '


### PR DESCRIPTION
## Summary

- Add `scripts/gen-checksums.sh`, which builds a `{version, sha256: {platform: hash}}` JSON blob from the `datadog-iac-scanner_checksums.txt` asset that GoReleaser already publishes on each GitHub release (via `gh release download` + `jq`). Only the `darwin_{amd64,arm64}` and `linux_{amd64,arm64}` archives are included; the Windows artifact is excluded to match the target manifest shape.
- Wire the script into the `goreleaser` job of `.github/workflows/release-new-version.yml`, running right after GoReleaser publishes the release, so the checksums JSON is printed directly in the pipeline logs for easy copy/paste (e.g. into a downstream installer manifest).
