### PR TITLE
Onboard datadog-iac-scanner to DDCI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,32 @@
+variables:
+  GIT_DEPTH: 1
+
+stages:
+  - verify
+
+ddci-hello-pr-comment:
+  stage: verify
+  rules:
+    # Pre-merge (pull request) builds only.
+    - if: $DDCI_REQUEST_KIND == "REQUEST_KIND_CHANGE_REQUEST"
+  tags: ["arch:amd64"]
+  image:
+    name: "registry.ddbuild.io/images/pr-commenter:3"
+    entrypoint: [""] # bypass the image's default entrypoint; we call curl directly
+  variables:
+    # Not using the entrypoint script for the pr-commenter image
+    FF_KUBERNETES_HONOR_ENTRYPOINT: false
+  # Verification only, this must never block a PR while we are onboarding.
+  allow_failure: true
+  script:
+    - |
+      PAYLOAD=$(printf '{"org":"DataDog","repo":"datadog-iac-scanner","commit":"%s","header":"DDCI onboarding","message":"%s"}' \
+        "${CI_COMMIT_SHA}" \
+        "👋 Hello from DDCI. Integration is working for datadog-iac-scanner.")
+    - |
+      curl --fail --show-error --silent \
+        https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment \
+        -H "$(authanywhere)" \
+        -H "X-DdOrigin: gitlab-ci" \
+        -X PATCH \
+        -d "${PAYLOAD}"


### PR DESCRIPTION
## Motivation

First step of onboarding datadog-iac-scanner to DDCI. Today CI runs entirely on GitHub Actions; DDCI doesn't orchestrate this repo yet. This PR adds a minimal "hello world" pipeline to verify the GitHub → DDCI → GitLab → pr-commenter → GitHub loop before building out real PR-gate and release tasks.

JIRA Ticket: https://datadoghq.atlassian.net/browse/K9CODESEC-3295

## Changes

- Add .gitlab-ci.yml with a single job ddci-hello-pr-comment that posts (upserts) a comment on each PR via the internal pr-commenter service, authenticated with authanywhere (no secret/token).
- Runs only on pre-merge requests ($DDCI_REQUEST_KIND == "REQUEST_KIND_CHANGE_REQUEST") and is allow_failure: true, so it can never block a PR.
- Sets GIT_DEPTH: 1.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Not enabled on server-side yet. After enabling we should see PR comment in for each PR.

## Blast Radius

CI-only, scoped to this repo.

I submit this contribution under the Apache-2.0 license.
