### PR TITLE
Fix GitHub Security failed checks for datadog-iac-scanner repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "gomod"
+    directory: "/.github/scripts/report"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "pip"
+    directory: "/.github/scripts/lint-licenses"
+    schedule:
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      gh-actions-packages:
+        patterns:
+          - "*"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    environment: coverage
     env:
       CARGO_TERM_COLOR: always
     steps:


### PR DESCRIPTION
## Motivation

Address failing GitHub security settings scanner checks flagged for this repo.

JIRA Ticket [K9CODESEC-3703](https://datadoghq.atlassian.net/browse/K9CODESEC-3703)

## Changes

- Added `.github/dependabot.yml` to enable version updates (`github-actions`, `gomod`)
- Scoped `DD_API_KEY` in `coverage.yml` behind a GitHub Environment (`environment: coverage`) so the secret is protected rather than a plain repo-level secret.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Push a commit to this branch and confirm the `coverage` job still runs and the "Upload coverage to Datadog" step succeeds with `DD_API_KEY` resolved via the `coverage` environment. Also confirm Dependabot picks up the new config under Insights > Dependency graph > Dependabot.

## Blast Radius

CI only, no product code changes. Affects the `Code Coverage` GitHub Actions workflow for this repo and adds automated dependency update PRs.

## Additional Notes

Remaining flagged checks are being handled separately via GitHub repo settings, not in this PR.

I submit this contribution under the Apache-2.0 license.


[K9CODESEC-3703]: https://datadoghq.atlassian.net/browse/K9CODESEC-3703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ