### PR TITLE
Reuse backend ruleset/library models in server analyze and unify rule platform with library ID

### DIFF
--- a/pkg/engine/source/datadog.go
+++ b/pkg/engine/source/datadog.go
@@ -222,7 +222,7 @@ func ConvertRule(rule *datadog.Rule) model.QueryMetadata {
 			"severity":        rule.Severity,
 			"category":        rule.Category,
 		},
-		Platform:     getPlatform(rule.Platform),
+		Platform:     GetPlatform(rule.Platform),
 		Aggregation:  1,
 		Experimental: rule.IsTesting,
 	}

--- a/pkg/engine/source/filesystem.go
+++ b/pkg/engine/source/filesystem.go
@@ -436,7 +436,7 @@ func parseQuery(ctx context.Context, queryName string, queryContent, metadataCon
 		return model.QueryMetadata{}, err
 	}
 
-	platform := getPlatform(metadata["platform"].(string))
+	platform := GetPlatform(metadata["platform"].(string))
 
 	aggregation := 1
 	if agg, ok := metadata["aggregation"]; ok {

--- a/pkg/engine/source/filesystem_test.go
+++ b/pkg/engine/source/filesystem_test.go
@@ -118,8 +118,8 @@ func Test_getPlatform(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getPlatform(tt.args.PlatformInMetadata); got != tt.want {
-				t.Errorf("getPlatform() = %v, want %v", got, tt.want)
+			if got := GetPlatform(tt.args.PlatformInMetadata); got != tt.want {
+				t.Errorf("GetPlatform() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/engine/source/platforms.go
+++ b/pkg/engine/source/platforms.go
@@ -2,6 +2,10 @@ package source
 
 import "strings"
 
+// PlatformUnknown is the sentinel GetPlatform returns for an unrecognized
+// backend platform name.
+const PlatformUnknown = "unknown"
+
 type supportedPlatforms map[string]string
 
 var supPlatforms = &supportedPlatforms{
@@ -29,7 +33,7 @@ func GetPlatform(metadataPlatform string) string {
 	if p, ok := (*supPlatforms)[metadataPlatform]; ok {
 		return p
 	}
-	return "unknown"
+	return PlatformUnknown
 }
 
 // LibraryName maps a user-facing platform name (case-insensitive) to the

--- a/pkg/engine/source/platforms.go
+++ b/pkg/engine/source/platforms.go
@@ -23,7 +23,9 @@ var supPlatforms = &supportedPlatforms{
 	"CICD":                    "cicd",
 }
 
-func getPlatform(metadataPlatform string) string {
+// GetPlatform maps a backend platform name (e.g. "Kubernetes") to the engine's
+// platform key (e.g. "k8s"), returning "unknown" when unrecognized.
+func GetPlatform(metadataPlatform string) string {
 	if p, ok := (*supPlatforms)[metadataPlatform]; ok {
 		return p
 	}

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -118,13 +118,14 @@ func validateAnalyzeRequest(req *analyzeRequest, maxFiles int) error {
 		return errors.New("too many files")
 	}
 	rules := req.Ruleset.Rules
-	if len(rules) == 0 {
-		return errors.New("at least one rule is required")
-	}
 	if len(rules) > maxRules {
 		return errors.New("too many rules")
 	}
-	if err := validateLibraries(req.Libraries, rules); err != nil {
+	nonNil := nonNilRules(rules)
+	if len(nonNil) == 0 {
+		return errors.New("at least one rule is required")
+	}
+	if err := validateLibraries(req.Libraries, nonNil); err != nil {
 		return err
 	}
 	for _, f := range req.Files {
@@ -133,6 +134,30 @@ func validateAnalyzeRequest(req *analyzeRequest, maxFiles int) error {
 		}
 	}
 	return nil
+}
+
+func nonNilRules(rules []*datadog.Rule) []*datadog.Rule {
+	out := make([]*datadog.Rule, 0, len(rules))
+	for _, rule := range rules {
+		if rule != nil {
+			out = append(out, rule)
+		}
+	}
+	return out
+}
+
+// publishedRules further narrows nonNilRules to published rules, mirroring
+// DatadogSource.filterRules's !rule.IsPublished guard so pushed rulesets
+// can't surface findings a normal backend-driven scan would suppress.
+func publishedRules(rules []*datadog.Rule) []*datadog.Rule {
+	nonNil := nonNilRules(rules)
+	out := make([]*datadog.Rule, 0, len(nonNil))
+	for _, rule := range nonNil {
+		if rule.IsPublished {
+			out = append(out, rule)
+		}
+	}
+	return out
 }
 
 func validateLibraries(libraries []datadog.Library, rules []*datadog.Rule) error {
@@ -161,13 +186,14 @@ func validateLibraries(libraries []datadog.Library, rules []*datadog.Rule) error
 		return errors.New("common library is required")
 	}
 	for _, rule := range rules {
-		if rule == nil {
-			continue
-		}
 		if strings.TrimSpace(rule.Platform) == "" {
 			return errors.New("empty platform for rule " + rule.ID)
 		}
-		if _, ok := available[ruleLibraryKey(rule.Platform)]; !ok {
+		key, err := ruleLibraryKey(rule.Platform)
+		if err != nil {
+			return err
+		}
+		if _, ok := available[key]; !ok {
 			return errors.New("library is required for rule platform: " + rule.Platform)
 		}
 	}
@@ -193,9 +219,17 @@ func normalizePlatform(platform string) string {
 }
 
 // ruleLibraryKey maps a rule's backend platform (e.g. "Kubernetes") to the
-// normalized key of the library its queries look up (e.g. "k8s").
-func ruleLibraryKey(platform string) string {
-	return normalizePlatform(source.GetPlatform(strings.TrimSpace(platform)))
+// normalized key of the library its queries look up (e.g. "k8s"). It fails
+// explicitly when the platform is unrecognized (including casing mismatches
+// such as "terraform" vs "Terraform") instead of silently falling through to
+// "unknown", which would otherwise surface a misleading "library is required"
+// error for the original platform name.
+func ruleLibraryKey(platform string) (string, error) {
+	mapped := source.GetPlatform(strings.TrimSpace(platform))
+	if mapped == source.PlatformUnknown {
+		return "", errors.New("unsupported rule platform: " + platform)
+	}
+	return normalizePlatform(mapped), nil
 }
 
 // validateFilePath rejects paths that are empty, absolute, contain a NUL byte,
@@ -361,11 +395,9 @@ func toRegoLibraries(libraries []datadog.Library) map[string]source.RegoLibrarie
 // toQueryMetadata converts request rules into engine query metadata via the
 // shared Datadog API conversion.
 func toQueryMetadata(rules []*datadog.Rule) []model.QueryMetadata {
-	out := make([]model.QueryMetadata, 0, len(rules))
-	for _, rule := range rules {
-		if rule == nil {
-			continue
-		}
+	usable := publishedRules(rules)
+	out := make([]model.QueryMetadata, 0, len(usable))
+	for _, rule := range usable {
 		// Copy so trimming the platform does not mutate the shared request value.
 		r := *rule
 		r.Platform = strings.TrimSpace(r.Platform)

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -10,12 +10,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"maps"
 	"net/http"
 	"path/filepath"
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
@@ -35,9 +35,8 @@ const (
 	// generous bound while preventing an accidentally unbounded request array.
 	maxLibraries   = 100
 	emptyInputData = "{}"
-	// metadataDefaultKeys is the number of fixed keys setDefault injects in
-	// toQueryMetadata (id, legacyId, queryName, severity, platform, category).
-	metadataDefaultKeys = 6
+	// commonLibraryID is the id of the shared library every scan requires.
+	commonLibraryID = "common"
 )
 
 // analyzeFile is a single pushed file: a workspace-relative path and its raw
@@ -47,33 +46,15 @@ type analyzeFile struct {
 	Content string `json:"content"`
 }
 
-// analyzeRule is a single Rego rule supplied by the caller. Mirrors the shape
-// the extension already builds for the engine.
-type analyzeRule struct {
-	ID        string         `json:"id"`
-	Platform  string         `json:"platform"`
-	Content   string         `json:"content"`
-	InputData string         `json:"inputData,omitempty"`
-	Metadata  map[string]any `json:"metadata,omitempty"`
-}
-
-// analyzeLibrary is one shared Rego module supplied by the caller. Callers use
-// the canonical lowercase name of either "common" or a rule platform as ID.
-type analyzeLibrary struct {
-	ID        string `json:"id"`
-	Content   string `json:"content"`
-	InputData string `json:"inputData,omitempty"`
-}
-
-// analyzeRequest is the body of POST /ide/v1/iac/analyze. Content is raw (not
-// base64). Rules and their supporting libraries are pushed by the extension.
-// Config is the raw YAML of the unified config's iac section.
+// analyzeRequest is the body of POST /ide/v1/iac/analyze. Ruleset and Libraries
+// use the backend data models. Config is the raw YAML of the unified config's
+// iac section.
 type analyzeRequest struct {
-	Files     []analyzeFile    `json:"files"`
-	Rules     []analyzeRule    `json:"rules"`
-	Libraries []analyzeLibrary `json:"libraries"`
-	Config    string           `json:"config,omitempty"`
-	Platform  []string         `json:"platform,omitempty"`
+	Files     []analyzeFile     `json:"files"`
+	Ruleset   datadog.Ruleset   `json:"ruleset"`
+	Libraries []datadog.Library `json:"libraries"`
+	Config    string            `json:"config,omitempty"`
+	Platform  []string          `json:"platform,omitempty"`
 }
 
 // analyzeResponse is the body of a successful analyze. Findings are the engine's
@@ -136,18 +117,14 @@ func validateAnalyzeRequest(req *analyzeRequest, maxFiles int) error {
 	if len(req.Files) > maxFiles {
 		return errors.New("too many files")
 	}
-	if len(req.Rules) == 0 {
+	rules := req.Ruleset.Rules
+	if len(rules) == 0 {
 		return errors.New("at least one rule is required")
 	}
-	if len(req.Rules) > maxRules {
+	if len(rules) > maxRules {
 		return errors.New("too many rules")
 	}
-	for _, rule := range req.Rules {
-		if !isOptionalInputDataObject(rule.InputData) {
-			return errors.New("invalid rule input data for " + rule.ID)
-		}
-	}
-	if err := validateLibraries(req.Libraries, req.Rules); err != nil {
+	if err := validateLibraries(req.Libraries, rules); err != nil {
 		return err
 	}
 	for _, f := range req.Files {
@@ -158,7 +135,7 @@ func validateAnalyzeRequest(req *analyzeRequest, maxFiles int) error {
 	return nil
 }
 
-func validateLibraries(libraries []analyzeLibrary, rules []analyzeRule) error {
+func validateLibraries(libraries []datadog.Library, rules []*datadog.Rule) error {
 	if len(libraries) == 0 {
 		return errors.New("at least one library is required")
 	}
@@ -168,33 +145,29 @@ func validateLibraries(libraries []analyzeLibrary, rules []analyzeRule) error {
 
 	available := make(map[string]struct{}, len(libraries))
 	for _, library := range libraries {
-		id := strings.TrimSpace(library.ID)
+		id := normalizePlatform(library.ID)
 		if id == "" {
 			return errors.New("empty library id")
 		}
-		if library.ID != normalizePlatform(library.ID) {
-			return errors.New("library id must be canonical lowercase: " + library.ID)
-		}
-		if strings.TrimSpace(library.Content) == "" {
+		if strings.TrimSpace(library.RegoCode) == "" {
 			return errors.New("empty library content for " + library.ID)
 		}
 		if !isOptionalInputDataObject(library.InputData) {
 			return errors.New("invalid library input data for " + library.ID)
 		}
-		if _, exists := available[id]; exists {
-			return errors.New("duplicate library id: " + library.ID)
-		}
 		available[id] = struct{}{}
 	}
-	if _, ok := available["common"]; !ok {
+	if _, ok := available[commonLibraryID]; !ok {
 		return errors.New("common library is required")
 	}
 	for _, rule := range rules {
-		platform := normalizePlatform(rule.Platform)
-		if platform == "" {
+		if rule == nil {
+			continue
+		}
+		if strings.TrimSpace(rule.Platform) == "" {
 			return errors.New("empty platform for rule " + rule.ID)
 		}
-		if _, ok := available[platform]; !ok {
+		if _, ok := available[ruleLibraryKey(rule.Platform)]; !ok {
 			return errors.New("library is required for rule platform: " + rule.Platform)
 		}
 	}
@@ -214,8 +187,15 @@ func isOptionalInputDataObject(inputData string) bool {
 	return inputData == "" || source.IsJSONObject(inputData)
 }
 
+// normalizePlatform lowercases and trims a library key for consistent comparison.
 func normalizePlatform(platform string) string {
 	return strings.ToLower(strings.TrimSpace(platform))
+}
+
+// ruleLibraryKey maps a rule's backend platform (e.g. "Kubernetes") to the
+// normalized key of the library its queries look up (e.g. "k8s").
+func ruleLibraryKey(platform string) string {
+	return normalizePlatform(source.GetPlatform(strings.TrimSpace(platform)))
 }
 
 // validateFilePath rejects paths that are empty, absolute, contain a NUL byte,
@@ -298,7 +278,7 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 	client, err := scan.NewClient(ctx, params, &consolePrinter.Printer{},
 		scan.WithFS(memfs),
 		scan.WithInMemoryScan(memfs.Paths()),
-		scan.WithQuerySourceFactory(querySourceFactory(req.Rules, req.Libraries)),
+		scan.WithQuerySourceFactory(querySourceFactory(req.Ruleset.Rules, req.Libraries)),
 	)
 	if err != nil {
 		return nil, err
@@ -334,7 +314,7 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 
 // querySourceFactory returns a factory that serves rules and libraries only
 // from the analyze request.
-func querySourceFactory(rules []analyzeRule, libraries []analyzeLibrary) func(
+func querySourceFactory(rules []*datadog.Rule, libraries []datadog.Library) func(
 	context.Context, []string,
 ) (source.QueriesSource, error) {
 	return func(context.Context, []string) (source.QueriesSource, error) {
@@ -367,49 +347,31 @@ func (r *requestQuerySource) GetQueryLibrary(ctx context.Context, platform strin
 	return library, nil
 }
 
-func toRegoLibraries(libraries []analyzeLibrary) map[string]source.RegoLibraries {
+func toRegoLibraries(libraries []datadog.Library) map[string]source.RegoLibraries {
 	out := make(map[string]source.RegoLibraries, len(libraries))
 	for _, library := range libraries {
-		out[library.ID] = source.RegoLibraries{
-			LibraryCode:      library.Content,
+		out[normalizePlatform(library.ID)] = source.RegoLibraries{
+			LibraryCode:      library.RegoCode,
 			LibraryInputData: normalizeInputData(library.InputData),
 		}
 	}
 	return out
 }
 
-// toQueryMetadata converts request rules into engine query metadata, filling the
-// metadata fields the vulnerability builder expects when the caller omits them.
-func toQueryMetadata(rules []analyzeRule) []model.QueryMetadata {
+// toQueryMetadata converts request rules into engine query metadata via the
+// shared Datadog API conversion.
+func toQueryMetadata(rules []*datadog.Rule) []model.QueryMetadata {
 	out := make([]model.QueryMetadata, 0, len(rules))
 	for _, rule := range rules {
-		platform := normalizePlatform(rule.Platform)
-		// Copy the caller's metadata into a fresh map so this function never
-		// mutates the request value (which may be shared/read concurrently).
-		metadata := make(map[string]any, len(rule.Metadata)+metadataDefaultKeys)
-		maps.Copy(metadata, rule.Metadata)
-		setDefault(metadata, "id", rule.ID)
-		setDefault(metadata, "legacyId", rule.ID)
-		setDefault(metadata, "queryName", rule.ID)
-		setDefault(metadata, "severity", "INFO")
-		setDefault(metadata, "platform", platform)
-		setDefault(metadata, "category", "Best Practices")
-
-		out = append(out, model.QueryMetadata{
-			Query:     rule.ID,
-			Content:   rule.Content,
-			InputData: normalizeInputData(rule.InputData),
-			Platform:  platform,
-			Metadata:  metadata,
-		})
+		if rule == nil {
+			continue
+		}
+		// Copy so trimming the platform does not mutate the shared request value.
+		r := *rule
+		r.Platform = strings.TrimSpace(r.Platform)
+		out = append(out, source.ConvertRule(&r))
 	}
 	return out
-}
-
-func setDefault(m map[string]any, key string, value any) {
-	if _, ok := m[key]; !ok {
-		m[key] = value
-	}
 }
 
 // compile-time assertion that requestQuerySource satisfies the engine interface.

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	engineSource "github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/rs/zerolog"
 )
@@ -39,11 +40,16 @@ const syntheticRuleID = "test-terraform-resource-missing-owner"
 
 // syntheticRule imports both test-only pushed libraries. Its identifiers and
 // behavior are deliberately unrelated to the production rule corpus.
-func syntheticRule() analyzeRule {
-	return analyzeRule{
-		ID:       syntheticRuleID,
-		Platform: "terraform",
-		Content: `package datadog
+func syntheticRule() datadog.Rule {
+	return datadog.Rule{
+		ID:               syntheticRuleID,
+		Name:             syntheticRuleID,
+		ShortDescription: "Synthetic missing owner label",
+		Platform:         "Terraform",
+		Severity:         "INFO",
+		Category:         "Test",
+		IsPublished:      true,
+		RegoQuery: []byte(`package datadog
 
 import rego.v1
 
@@ -60,22 +66,15 @@ DatadogPolicy contains result if {
 		"resourceName": tf_lib.display_name(resource_type, name),
 		"searchKey": sprintf("%s[%s].labels.owner", [resource_type, name]),
 	}
-}`,
-		Metadata: map[string]any{
-			"id":        syntheticRuleID,
-			"queryName": "Synthetic missing owner label",
-			"severity":  "INFO",
-			"platform":  "Terraform",
-			"category":  "Test",
-		},
+}`),
 	}
 }
 
-func testLibraries(enabled bool) []analyzeLibrary {
-	return []analyzeLibrary{
+func testLibraries(enabled bool) []datadog.Library {
+	return []datadog.Library{
 		{
 			ID: "common",
-			Content: `package generic.common
+			RegoCode: `package generic.common
 
 import rego.v1
 
@@ -86,13 +85,22 @@ has_owner(resource) if resource.labels.owner`,
 		},
 		{
 			ID: "terraform",
-			Content: `package generic.terraform
+			RegoCode: `package generic.terraform
 
 import rego.v1
 
 display_name(resource_type, name) := sprintf("%s.%s", [resource_type, name])`,
 		},
 	}
+}
+
+// ruleset wraps rule values in the request's [datadog.Ruleset] shape.
+func ruleset(rules ...datadog.Rule) datadog.Ruleset {
+	ptrs := make([]*datadog.Rule, len(rules))
+	for i := range rules {
+		ptrs[i] = &rules[i]
+	}
+	return datadog.Ruleset{Rules: ptrs}
 }
 
 func postAnalyze(t *testing.T, s *Server, req analyzeRequest) (*analyzeResponse, int) {
@@ -122,7 +130,7 @@ func TestAnalyze_ContentPush_TerraformFinding(t *testing.T) {
 }`},
 			{Path: "infra/variables.tf", Content: `variable "bucket_name" { default = "my-bucket" }`},
 		},
-		Rules:    []analyzeRule{rule},
+		Ruleset:  ruleset(rule),
 		Platform: []string{"terraform"},
 	}
 
@@ -164,7 +172,7 @@ func TestAnalyze_MissingModuleEscalation(t *testing.T) {
 }
 resource "aws_s3_bucket" "b" { bucket = "x" }`},
 		},
-		Rules:    []analyzeRule{rule},
+		Ruleset:  ruleset(rule),
 		Platform: []string{"terraform"},
 	}
 
@@ -196,7 +204,7 @@ func TestAnalyze_MissingFilesCWDIndependent(t *testing.T) {
   source = "../modules/networking"
 }
 resource "aws_s3_bucket" "b" { bucket = "x" }`}},
-		Rules:    []analyzeRule{rule},
+		Ruleset:  ruleset(rule),
 		Platform: []string{"terraform"},
 	}
 
@@ -215,10 +223,10 @@ func TestAnalyze_Validation(t *testing.T) {
 	ts := httptest.NewServer(s.http.Handler)
 	defer ts.Close()
 
-	validRule := analyzeRule{ID: "test-rule", Platform: "terraform", Content: "package datadog"}
-	validLibraries := []analyzeLibrary{
-		{ID: "common", Content: "package generic.common"},
-		{ID: "terraform", Content: "package generic.terraform"},
+	validRule := datadog.Rule{ID: "test-rule", Name: "test-rule", Platform: "Terraform", RegoQuery: []byte("package datadog")}
+	validLibraries := []datadog.Library{
+		{ID: "common", RegoCode: "package generic.common"},
+		{ID: "terraform", RegoCode: "package generic.terraform"},
 	}
 	cases := []struct {
 		name string
@@ -228,7 +236,7 @@ func TestAnalyze_Validation(t *testing.T) {
 	}{
 		{
 			name: "empty files",
-			req:  analyzeRequest{Rules: []analyzeRule{validRule}, Libraries: validLibraries},
+			req:  analyzeRequest{Ruleset: ruleset(validRule), Libraries: validLibraries},
 			want: http.StatusBadRequest,
 		},
 		{
@@ -241,16 +249,16 @@ func TestAnalyze_Validation(t *testing.T) {
 		{
 			name: "path traversal",
 			req: analyzeRequest{
-				Files: []analyzeFile{{Path: "../escape.tf", Content: "x"}},
-				Rules: []analyzeRule{validRule}, Libraries: validLibraries,
+				Files:   []analyzeFile{{Path: "../escape.tf", Content: "x"}},
+				Ruleset: ruleset(validRule), Libraries: validLibraries,
 			},
 			want: http.StatusBadRequest,
 		},
 		{
 			name: "absolute path",
 			req: analyzeRequest{
-				Files: []analyzeFile{{Path: "/etc/passwd", Content: "x"}},
-				Rules: []analyzeRule{validRule}, Libraries: validLibraries,
+				Files:   []analyzeFile{{Path: "/etc/passwd", Content: "x"}},
+				Ruleset: ruleset(validRule), Libraries: validLibraries,
 			},
 			want: http.StatusBadRequest,
 		},
@@ -280,71 +288,54 @@ func TestAnalyze_Validation(t *testing.T) {
 
 func TestValidateAnalyzeRequest_Libraries(t *testing.T) {
 	base := analyzeRequest{
-		Files: []analyzeFile{{Path: "main.tf", Content: "resource"}},
-		Rules: []analyzeRule{{ID: "rule", Platform: "Terraform", Content: "package datadog"}},
+		Files:   []analyzeFile{{Path: "main.tf", Content: "resource"}},
+		Ruleset: ruleset(datadog.Rule{ID: "rule", Name: "rule", Platform: "Terraform", RegoQuery: []byte("package datadog")}),
 	}
-	tooManyLibraries := make([]analyzeLibrary, maxLibraries+1)
+	tooManyLibraries := make([]datadog.Library, maxLibraries+1)
 	tests := []struct {
 		name      string
-		libraries []analyzeLibrary
+		libraries []datadog.Library
 		wantError string
 	}{
 		{name: "missing", wantError: "at least one library is required"},
 		{name: "too many", libraries: tooManyLibraries, wantError: "too many libraries"},
 		{
 			name:      "empty id",
-			libraries: []analyzeLibrary{{Content: "package generic.common"}},
+			libraries: []datadog.Library{{RegoCode: "package generic.common"}},
 			wantError: "empty library id",
 		},
 		{
 			name:      "empty content",
-			libraries: []analyzeLibrary{{ID: "common", Content: " "}},
+			libraries: []datadog.Library{{ID: "common", RegoCode: " "}},
 			wantError: "empty library content for common",
 		},
 		{
 			name: "missing common",
-			libraries: []analyzeLibrary{
-				{ID: "terraform", Content: "package generic.terraform"},
+			libraries: []datadog.Library{
+				{ID: "terraform", RegoCode: "package generic.terraform"},
 			},
 			wantError: "common library is required",
 		},
 		{
 			name: "missing platform",
-			libraries: []analyzeLibrary{
-				{ID: "common", Content: "package generic.common"},
+			libraries: []datadog.Library{
+				{ID: "common", RegoCode: "package generic.common"},
 			},
 			wantError: "library is required for rule platform: Terraform",
 		},
 		{
-			name: "noncanonical id",
-			libraries: []analyzeLibrary{
-				{ID: "Common", Content: "package generic.common"},
-				{ID: "terraform", Content: "package generic.terraform"},
-			},
-			wantError: "library id must be canonical lowercase: Common",
-		},
-		{
-			name: "duplicate id",
-			libraries: []analyzeLibrary{
-				{ID: "common", Content: "package generic.common"},
-				{ID: "common", Content: "package generic.common"},
-				{ID: "terraform", Content: "package generic.terraform"},
-			},
-			wantError: "duplicate library id: common",
-		},
-		{
 			name: "invalid input data",
-			libraries: []analyzeLibrary{
-				{ID: "common", Content: "package generic.common", InputData: "{"},
-				{ID: "terraform", Content: "package generic.terraform"},
+			libraries: []datadog.Library{
+				{ID: "common", RegoCode: "package generic.common", InputData: "{"},
+				{ID: "terraform", RegoCode: "package generic.terraform"},
 			},
 			wantError: "invalid library input data for common",
 		},
 		{
 			name: "non-object input data",
-			libraries: []analyzeLibrary{
-				{ID: "common", Content: "package generic.common", InputData: "null"},
-				{ID: "terraform", Content: "package generic.terraform"},
+			libraries: []datadog.Library{
+				{ID: "common", RegoCode: "package generic.common", InputData: "null"},
+				{ID: "terraform", RegoCode: "package generic.terraform"},
 			},
 			wantError: "invalid library input data for common",
 		},
@@ -372,14 +363,14 @@ func TestValidateAnalyzeRequest_RuleBoundaries(t *testing.T) {
 	validRequest := func() analyzeRequest {
 		return analyzeRequest{
 			Files:     []analyzeFile{{Path: "main.tf", Content: "resource"}},
-			Rules:     []analyzeRule{{ID: "test-rule", Platform: "terraform", Content: "package datadog"}},
+			Ruleset:   ruleset(datadog.Rule{ID: "test-rule", Name: "test-rule", Platform: "Terraform", RegoQuery: []byte("package datadog")}),
 			Libraries: testLibraries(true),
 		}
 	}
 
 	t.Run("too many rules", func(t *testing.T) {
 		req := validRequest()
-		req.Rules = make([]analyzeRule, maxRules+1)
+		req.Ruleset.Rules = make([]*datadog.Rule, maxRules+1)
 		err := validateAnalyzeRequest(&req, defaultMaxFiles)
 		if err == nil || err.Error() != "too many rules" {
 			t.Fatalf("validateAnalyzeRequest() error = %v", err)
@@ -388,7 +379,7 @@ func TestValidateAnalyzeRequest_RuleBoundaries(t *testing.T) {
 
 	t.Run("empty rule platform", func(t *testing.T) {
 		req := validRequest()
-		req.Rules[0].Platform = " "
+		req.Ruleset.Rules[0].Platform = " "
 		err := validateAnalyzeRequest(&req, defaultMaxFiles)
 		if err == nil || err.Error() != "empty platform for rule test-rule" {
 			t.Fatalf("validateAnalyzeRequest() error = %v", err)
@@ -396,21 +387,21 @@ func TestValidateAnalyzeRequest_RuleBoundaries(t *testing.T) {
 	})
 }
 
-func TestValidateAnalyzeRequest_RuleInputDataMustBeObject(t *testing.T) {
-	for _, inputData := range []string{"null", "[]", "1", `"value"`} {
-		t.Run(inputData, func(t *testing.T) {
-			req := analyzeRequest{
-				Files: []analyzeFile{{Path: "main.tf", Content: "resource"}},
-				Rules: []analyzeRule{{
-					ID: "test-rule", Platform: "terraform", Content: "package datadog", InputData: inputData,
-				}},
-				Libraries: testLibraries(true),
-			}
-			err := validateAnalyzeRequest(&req, defaultMaxFiles)
-			if err == nil || err.Error() != "invalid rule input data for test-rule" {
-				t.Fatalf("validateAnalyzeRequest() error = %v", err)
-			}
-		})
+// TestValidateAnalyzeRequest_LibraryIDNormalization verifies library ids match
+// case-insensitively and that keys collapsing to the same normalized value
+// ("cloudFormation"/"cloudformation") are not rejected as duplicates.
+func TestValidateAnalyzeRequest_LibraryIDNormalization(t *testing.T) {
+	req := analyzeRequest{
+		Files:   []analyzeFile{{Path: "main.tf", Content: "resource"}},
+		Ruleset: ruleset(datadog.Rule{ID: "cfn-rule", Name: "cfn-rule", Platform: "CloudFormation", RegoQuery: []byte("package datadog")}),
+		Libraries: []datadog.Library{
+			{ID: "Common", RegoCode: "package generic.common"},
+			{ID: "cloudFormation", RegoCode: "package generic.cloudformation"},
+			{ID: "cloudformation", RegoCode: "package generic.cloudformation"},
+		},
+	}
+	if err := validateAnalyzeRequest(&req, defaultMaxFiles); err != nil {
+		t.Fatalf("validateAnalyzeRequest() error = %v, want nil", err)
 	}
 }
 
@@ -423,7 +414,7 @@ func TestAnalyze_NormalizesRuleAndScanPlatforms(t *testing.T) {
 			Path:    "infra/main.tf",
 			Content: `resource "test_widget" "example" {}`,
 		}},
-		Rules:     []analyzeRule{rule},
+		Ruleset:   ruleset(rule),
 		Libraries: testLibraries(true),
 		Platform:  []string{" Terraform "},
 	}
@@ -454,9 +445,9 @@ func TestAnalyze_MissingPlatformLibraryReportedAsFailedQuery(t *testing.T) {
 			Path:    "infra/main.tf",
 			Content: `resource "test_widget" "example" {}`,
 		}},
-		Rules: []analyzeRule{syntheticRule()},
-		Libraries: []analyzeLibrary{
-			{ID: "common", Content: "package generic.common\nimport rego.v1"},
+		Ruleset: ruleset(syntheticRule()),
+		Libraries: []datadog.Library{
+			{ID: "common", RegoCode: "package generic.common\nimport rego.v1"},
 		},
 		Platform: []string{"terraform"},
 	}
@@ -478,7 +469,7 @@ func TestAnalyze_RequestLibrariesInvalidateSharedRuleCache(t *testing.T) {
 			Path:    "infra/main.tf",
 			Content: `resource "aws_s3_bucket" "b" { bucket = "x" }`,
 		}},
-		Rules:     []analyzeRule{syntheticRule()},
+		Ruleset:   ruleset(syntheticRule()),
 		Libraries: testLibraries(true),
 		Platform:  []string{"terraform"},
 	}
@@ -510,7 +501,7 @@ func TestAnalyze_RequestLibrariesDoNotCallBackend(t *testing.T) {
 			Path:    "infra/main.tf",
 			Content: `resource "aws_s3_bucket" "b" { bucket = "x" }`,
 		}},
-		Rules:     []analyzeRule{syntheticRule()},
+		Ruleset:   ruleset(syntheticRule()),
 		Libraries: testLibraries(true),
 		Platform:  []string{"terraform"},
 	})
@@ -525,17 +516,17 @@ func TestAnalyze_RequestLibrariesDoNotCallBackend(t *testing.T) {
 func TestAnalyze_LogsFailedQueryCount(t *testing.T) {
 	s := newTestServer(t)
 	rule := syntheticRule()
-	rule.Content = `package datadog
+	rule.RegoQuery = []byte(`package datadog
 
 import rego.v1
 
-DatadogPolicy contains "invalid-result"`
+DatadogPolicy contains "invalid-result"`)
 	req := analyzeRequest{
 		Files: []analyzeFile{{
 			Path:    "infra/main.tf",
 			Content: `resource "test_widget" "example" {}`,
 		}},
-		Rules:     []analyzeRule{rule},
+		Ruleset:   ruleset(rule),
 		Libraries: testLibraries(true),
 		Platform:  []string{"terraform"},
 	}
@@ -667,14 +658,15 @@ func TestAnalyze_Concurrent(t *testing.T) {
 	// across multiple worker goroutines, producing findings concurrently — this
 	// exercises the shared per-request engine state (failedQueries, the shared
 	// line detector) that earlier raced under -race.
-	rules := make([]analyzeRule, 0, 8)
+	rules := make([]datadog.Rule, 0, 8)
 	for i := range 8 {
 		r := rule
 		r.ID = fmt.Sprintf("%s-%d", rule.ID, i)
+		r.Name = r.ID
 		rules = append(rules, r)
 	}
 	req := analyzeRequest{
-		Files: files, Rules: rules, Libraries: testLibraries(true), Platform: []string{"terraform"},
+		Files: files, Ruleset: ruleset(rules...), Libraries: testLibraries(true), Platform: []string{"terraform"},
 	}
 
 	const n = 12
@@ -711,7 +703,7 @@ func TestAnalyze_ConfigWithoutIacSection(t *testing.T) {
 
 	req := analyzeRequest{
 		Files:    []analyzeFile{{Path: "infra/main.tf", Content: `resource "aws_s3_bucket" "b" { bucket = "x" }`}},
-		Rules:    []analyzeRule{rule},
+		Ruleset:  ruleset(rule),
 		Platform: []string{"terraform"},
 		Config:   "schema-version: v1.3\nsecrets:\n  enabled: true\n",
 	}
@@ -732,7 +724,7 @@ func TestAnalyze_ConfigIgnoreRulePushedRule(t *testing.T) {
 
 	req := analyzeRequest{
 		Files:    []analyzeFile{{Path: "infra/main.tf", Content: `resource "aws_s3_bucket" "b" { bucket = "x" }`}},
-		Rules:    []analyzeRule{rule},
+		Ruleset:  ruleset(rule),
 		Platform: []string{"terraform"},
 		Config:   "schema-version: v1.3\niac:\n  ignore-rules:\n    - " + syntheticRuleID + "\n",
 	}
@@ -756,7 +748,7 @@ func TestAnalyze_ConfigIgnorePaths(t *testing.T) {
 	// Baseline: without filters the rule fires on infra/main.tf.
 	base, _ := postAnalyze(t, s, analyzeRequest{
 		Files:    []analyzeFile{{Path: "infra/main.tf", Content: body}},
-		Rules:    []analyzeRule{rule},
+		Ruleset:  ruleset(rule),
 		Platform: []string{"terraform"},
 	})
 	if len(base.Findings) == 0 {
@@ -766,7 +758,7 @@ func TestAnalyze_ConfigIgnorePaths(t *testing.T) {
 	// With ignore-paths covering infra/, the file is skipped → no findings.
 	out, _ := postAnalyze(t, s, analyzeRequest{
 		Files:    []analyzeFile{{Path: "infra/main.tf", Content: body}},
-		Rules:    []analyzeRule{rule},
+		Ruleset:  ruleset(rule),
 		Platform: []string{"terraform"},
 		Config:   "schema-version: v1.3\niac:\n  global-config:\n    ignore-paths:\n      - \"infra/**\"\n",
 	})
@@ -840,7 +832,7 @@ func TestAnalyze_HCLCacheIsolatedBetweenRequests(t *testing.T) {
 	// Request 1: resource is at line 1.
 	req1 := analyzeRequest{
 		Files:    []analyzeFile{{Path: "infra/main.tf", Content: "resource \"aws_s3_bucket\" \"b\" {\n  bucket = \"x\"\n}\n"}},
-		Rules:    []analyzeRule{rule},
+		Ruleset:  ruleset(rule),
 		Platform: []string{"terraform"},
 	}
 	out1, _ := postAnalyze(t, s, req1)
@@ -862,7 +854,7 @@ func TestAnalyze_HCLCacheIsolatedBetweenRequests(t *testing.T) {
 	// not the updated one.
 	req2 := analyzeRequest{
 		Files:    []analyzeFile{{Path: "infra/main.tf", Content: "\n\n\nresource \"aws_s3_bucket\" \"b\" {\n  bucket = \"x\"\n}\n"}},
-		Rules:    []analyzeRule{rule},
+		Ruleset:  ruleset(rule),
 		Platform: []string{"terraform"},
 	}
 	out2, _ := postAnalyze(t, s, req2)


### PR DESCRIPTION
## Motivation

The IDE integration and the IaC scanner backend already share request/response data models for rulesets and libraries. The server's `/ide/v1/iac/analyze` endpoint, however, defined its own `analyzeRule` / `analyzeLibrary` types, so the IDE had to reshape backend data before sending it. This PR reuses the backend models directly to simplify that integration, and unifies rule platform with library id so pushed rules resolve their libraries the same way backend-fetched rules do.

JIRA Ticket: [K9CODESEC-3811](https://datadoghq.atlassian.net/browse/K9CODESEC-3811)

## Changes

- Replace the bespoke `analyzeRule` / `analyzeLibrary` request types with the backend data models `datadog.Ruleset` / `datadog.Rule` / `datadog.Library`. The request body is now `{ files, ruleset, libraries, config, platform }`.
- Convert pushed rules with the shared `source.ConvertRule`, so pushed rules produce identical query metadata to rules fetched from the Datadog API. Per-rule metadata is derived from the `Rule` model; the per-rule `inputData` validation is dropped (only libraries carry input data).
- Unify rule platform with library id: export `source.GetPlatform` and use it to map a rule's backend platform (e.g. `Kubernetes`) to the library key its queries look up (e.g. `k8s`). Library keys are normalized (trim + lowercase).
- Tolerate library ids that collapse to the same normalized key (the backend exposes both `cloudFormation` and `cloudformation`) instead of rejecting them as duplicates.
- Update server tests to the new models; add a test for case-insensitive / colliding library ids.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

- POST to `/ide/v1/iac/analyze` with a body using the new shape; a `ruleset` object (`{ "rules": [ <datadog.Rule> ] }`) and a `libraries` array of `datadog.Library` objects (as returned by the backend `iac/rulesets/default-ruleset` and `iac/libraries` endpoints). Verify findings are returned as before.
- Confirm rules across platforms resolve their libraries: e.g. a `Kubernetes` rule matches the `k8s` library, and a `CloudFormation` rule matches the `cloudFormation`/`cloudformation` library.
- Confirm validation still rejects: empty files/rules/libraries, missing `common` library, and a rule whose platform has no matching library.

## Blast Radius

Datadog IaC Scanner only, specifically the server-mode analyze endpoint used by the IDE integration. No change to CLI scanning, the engine's rule evaluation, or backend services. `source.GetPlatform` was exported (previously `getPlatform`) with no behavior change.

I submit this contribution under the Apache-2.0 license.


[K9CODESEC-3811]: https://datadoghq.atlassian.net/browse/K9CODESEC-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ