### PR TITLE
Add Regression Detector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ module_support
 
 # local scanner binary
 /scanner
+
+# regression_detector runtime artifacts
+.regression-work/
+regression-comment.md

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,46 @@
+stages:
+  - verify
+
+regression-detector:
+  stage: verify
+  rules:
+    - if: $DDCI_REQUEST_KIND == "REQUEST_KIND_CHANGE_REQUEST"
+  tags: ["arch:amd64"]
+  image: registry.ddbuild.io/images/mirror/golang:1.25
+  allow_failure: true
+  id_tokens:
+    GITRETRIEVER_ID_TOKEN:
+      aud: codesync
+  variables:
+    # Baseline resolution needs full history + tags (main, latest vX.Y.Z);
+    # GIT_DEPTH: 1 is too shallow for this job specifically.
+    GIT_DEPTH: 0
+  before_script:
+    - wget -q https://binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-amd64 -O /usr/local/bin/authanywhere
+    - chmod +x /usr/local/bin/authanywhere
+  script:
+    - export GITRETRIEVER_TOKEN="${GITRETRIEVER_ID_TOKEN}"
+    - git -c http.extraHeader="Authorization: Bearer ${GITRETRIEVER_TOKEN}" clone --depth 1
+        https://gitretriever.us1.ddbuild.io/DataDog/datadog-iac-scanner-default-rules.git
+        /work/datadog-iac-scanner-default-rules
+    - python3 regression_detector/run.py --trigger scanner --repos-dir /work --output regression-comment.md
+    - |
+      PAYLOAD=$(python3 -c "
+      import json, os
+      with open('regression-comment.md') as f:
+          message = f.read()
+      print(json.dumps({
+          'org': 'DataDog',
+          'repo': 'datadog-iac-scanner',
+          'commit': os.environ['CI_COMMIT_SHA'],
+          'header': 'Regression Detector',
+          'message': message,
+      }))
+      ")
+    - |
+      curl --fail --show-error --silent \
+        https://pr-commenter.us1.ddbuild.io/internal/cit/pr-comment \
+        -H "$(authanywhere)" \
+        -H "X-DdOrigin: gitlab-ci" \
+        -X PATCH \
+        -d "${PAYLOAD}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,11 +20,7 @@ regression-detector:
     - chmod +x /usr/local/bin/authanywhere
   script:
     - export GITRETRIEVER_TOKEN="${GITRETRIEVER_ID_TOKEN}"
-    - |
-      git -c http.extraHeader="Authorization: Bearer ${GITRETRIEVER_TOKEN}" clone --depth 1 \
-        https://gitretriever.us1.ddbuild.io/DataDog/datadog-iac-scanner-default-rules.git \
-        /work/datadog-iac-scanner-default-rules
-    - python3 regression_detector/run.py --trigger scanner --repos-dir /work --output regression-comment.md
+    - python3 regression_detector/run.py --trigger scanner --remote-rules --repos-dir /work --output regression-comment.md
     - |
       PAYLOAD=$(python3 -c "
       import json, os

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,8 +20,9 @@ regression-detector:
     - chmod +x /usr/local/bin/authanywhere
   script:
     - export GITRETRIEVER_TOKEN="${GITRETRIEVER_ID_TOKEN}"
-    - git -c http.extraHeader="Authorization: Bearer ${GITRETRIEVER_TOKEN}" clone --depth 1
-        https://gitretriever.us1.ddbuild.io/DataDog/datadog-iac-scanner-default-rules.git
+    - |
+      git -c http.extraHeader="Authorization: Bearer ${GITRETRIEVER_TOKEN}" clone --depth 1 \
+        https://gitretriever.us1.ddbuild.io/DataDog/datadog-iac-scanner-default-rules.git \
         /work/datadog-iac-scanner-default-rules
     - python3 regression_detector/run.py --trigger scanner --repos-dir /work --output regression-comment.md
     - |

--- a/regression_detector/README.md
+++ b/regression_detector/README.md
@@ -1,0 +1,84 @@
+# Performance regression benchmark
+
+`run.py` scans a corpus of repositories with a **candidate** build and one or more **baselines**, measures wall time / CPU / peak memory / finding counts, and renders a Markdown PR comment with the deltas. It is the shared entry point for the regression gate in **both** the scanner and the default-rules CI pipelines; the reuse unit is this CLI, not the pipeline YAML.
+
+## What it compares
+
+| Trigger (`--trigger`) | Variable | Held fixed | Baselines |
+| --- | --- | --- | --- |
+| `scanner` | scanner binary | rules (as cloned = `main`) | scanner `main` **and** latest release tag `vX.Y.Z` |
+| `rules` | rules (`assets/`) | scanner (latest release tag) | rules `main` |
+
+Release tags are semver `vX.Y.Z` only; pre-releases (`-alpha`, etc.) are ignored. The candidate is always the PR working tree as checked out; baselines are materialised in isolated git worktrees, so the checked-out tree is never mutated.
+
+## What the pipeline must provide
+
+- The **datadog-iac-scanner** checkout containing this entrypoint, with tags + `origin/main` fetchable (the script does a best-effort fetch).
+- A **datadog-iac-scanner-default-rules** clone under `--repos-dir`.
+- The `go` toolchain (to build the scanner variants; `CGO_ENABLED=1`).
+- Corpus repos: either pre-cloned under `--repos-dir`, or reachable via gitretriever with a Bearer token in `$GITRETRIEVER_TOKEN` (in GitLab CI, mint one with an ID token: `id_tokens: {GITRETRIEVER_ID_TOKEN: {aud: codesync}}`).
+
+## Local usage (no CI, no token)
+
+The scanner checkout is discovered from the entrypoint. Other clones default to the scanner repository's parent directory, so a developer can just run:
+
+```bash
+# benchmark this scanner working tree vs main + latest tag
+python regression_detector/run.py --trigger scanner
+
+# benchmark sibling default-rules working-tree changes vs main
+python regression_detector/run.py --trigger rules
+```
+
+The candidate is your **working tree** (uncommitted changes included). Use `--repos-dir` when rules or corpus clones are not siblings of the scanner. Corpus resolution order: `<repos-dir>/<org__name>` → `<repos-dir>/<name>` → previous clone in `--work-dir` → clone from gitretriever.
+
+## CI usage
+
+```bash
+# scanner PR
+python regression_detector/run.py \
+  --trigger scanner \
+  --repos-dir /work \
+  --output       regression-comment.md
+
+# rules PR (scanner cloned alongside)
+python /work/datadog-iac-scanner/regression_detector/run.py \
+  --trigger rules \
+  --repos-dir "$(dirname "$CI_PROJECT_DIR")" \
+  --output       regression-comment.md
+```
+
+Then hand `regression-comment.md` to the pr-commenter service as the comment `message` (see the repo-level DDCI onboarding notes for the `pr-commenter` call).
+
+Options worth knowing: `--runs N` (repetitions per variant/repo; default 3), `--platforms terraform,kubernetes`, `--json-output summary.json` (machine-readable), `--work-dir` (scratch dir), `-v` (debug logging).
+
+## Public mode
+
+The rendered comment is posted on a **public** PR, so it must not disclose internal detail. Public mode redacts it:
+
+- **Repository identities** are replaced by each corpus entry's `public_name` (see `corpus.json`) instead of the real `org/name`.
+- **Finding counts** are shown as a **percentage delta only** — never the absolute number (e.g. `❌ +20.0%` rather than `120 (+20)`). Peak RSS / wall / CPU are unchanged.
+
+Public mode is **auto-enabled in CI** (whenever `$CI` is set) and off for local runs, so a developer sees the raw repo names and exact counts while the CI-posted comment stays redacted. Override the auto-detection with `--public` / `--no-public`.
+
+When public mode is on, every corpus repo **must** define a `public_name`; the run fails fast otherwise rather than risk leaking a real name. The `--json-output` summary is machine-readable and internal-only, so it is left un-redacted.
+
+## How measurements are taken
+
+Each scan is run via `os.fork`/`os.wait4`, so peak RSS (`ru_maxrss`) and CPU (`ru_utime + ru_stime`) are scoped to that single scan process, with no third-party dependency (e.g. psutil) and no `pip install` step. Wall time is `monotonic`. Finding counts, files, and rules come from the scanner's `--metadata-path` JSON (`Stats.*`). A scan is considered successful when it produces that metadata file; the scanner's non-zero severity exit codes (20 to 60) are **not** treated as failures.
+
+## Measurement fairness (run ordering)
+
+Wall/CPU/memory are sensitive to *when* in the session a scan runs, independent of the code being measured:
+
+- **Cold FS cache**: the first scan of a repo pays the disk-read cost. Mitigated by a discarded per-repo warmup scan (disable with `--no-warmup`).
+- **CPU thermal throttling / frequency scaling**: on laptops especially, later scans in a long session run slower. If each variant's repetitions ran back to back, whichever variant went first would look systematically faster.
+
+To cancel these, the harness **interleaves** variants: it runs one repetition of each variant per round and rotates the order each round, then takes the minimum wall/CPU time and median peak RSS per variant. Use `--runs 3` (default) or higher for stable numbers; treat single-digit-percent deltas as noise, especially locally. Dedicated CI runners are steadier than laptops but not immune.
+
+## Interpreting the comment
+
+- **scanner trigger:** a finding-count delta means the engine changed behaviour, usually something to justify. Time/memory increases beyond the thresholds are flagged ⚠️.
+- **rules trigger:** a finding-count delta is expected (it's the whole point); the value is spotting unintended time/memory blowups.
+
+Thresholds (`TIME_REGRESSION_PCT`, `MEM_REGRESSION_PCT`) live in `models.py`.

--- a/regression_detector/README.md
+++ b/regression_detector/README.md
@@ -6,7 +6,7 @@
 
 | Trigger (`--trigger`) | Variable | Held fixed | Baselines |
 | --- | --- | --- | --- |
-| `scanner` | scanner binary | rules (as cloned = `main`) | scanner `main` **and** latest release tag `vX.Y.Z` |
+| `scanner` | scanner binary | rules (local `main`, or the deployed ruleset with `--remote-rules`) | scanner `main` **and** latest release tag `vX.Y.Z` |
 | `rules` | rules (`assets/`) | scanner (latest release tag) | rules `main` |
 
 Release tags are semver `vX.Y.Z` only; pre-releases (`-alpha`, etc.) are ignored. The candidate is always the PR working tree as checked out; baselines are materialised in isolated git worktrees, so the checked-out tree is never mutated.
@@ -14,7 +14,7 @@ Release tags are semver `vX.Y.Z` only; pre-releases (`-alpha`, etc.) are ignored
 ## What the pipeline must provide
 
 - The **datadog-iac-scanner** checkout containing this entrypoint, with tags + `origin/main` fetchable (the script does a best-effort fetch).
-- A **datadog-iac-scanner-default-rules** clone under `--repos-dir`.
+- A **datadog-iac-scanner-default-rules** clone under `--repos-dir` — **unless** running with `--remote-rules` (see below), in which case no rules clone is needed.
 - The `go` toolchain (to build the scanner variants; `CGO_ENABLED=1`).
 - Corpus repos: either pre-cloned under `--repos-dir`, or reachable via gitretriever with a Bearer token in `$GITRETRIEVER_TOKEN` (in GitLab CI, mint one with an ID token: `id_tokens: {GITRETRIEVER_ID_TOKEN: {aud: codesync}}`).
 
@@ -34,10 +34,13 @@ The candidate is your **working tree** (uncommitted changes included). Use `--re
 
 ## CI usage
 
+The scanner trigger passes `--remote-rules`: the scanner fetches the deployed default ruleset from the Datadog backend at runtime (`api.<DD_SITE>` — default `datadoghq.com`), so no local rules checkout is needed. Remote rules are held fixed across every variant, so `--remote-rules` is scanner-only; `--trigger rules` still requires a local checkout because it varies the ruleset per variant. When no local rules checkout is found under `--repos-dir`, remote rules are used automatically.
+
 ```bash
 # scanner PR
 python regression_detector/run.py \
   --trigger scanner \
+  --remote-rules \
   --repos-dir /work \
   --output       regression-comment.md
 

--- a/regression_detector/benchmark/__init__.py
+++ b/regression_detector/benchmark/__init__.py
@@ -1,0 +1,1 @@
+"""Performance-regression benchmark package."""

--- a/regression_detector/benchmark/benchmark.py
+++ b/regression_detector/benchmark/benchmark.py
@@ -1,0 +1,567 @@
+"""Scan measurement, aggregation, and benchmark orchestration."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import statistics
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from .models import (
+    AggregatedMetrics,
+    CliArgs,
+    CorpusRepo,
+    CorpusResult,
+    RunMetrics,
+    SCANNER_REPO,
+    Trigger,
+    Variant,
+)
+from .report import json_summary, render_markdown
+from .sources import (
+    VariantAssets,
+    Worktrees,
+    ensure_fetched,
+    filesystem_safe,
+    require_repository,
+    resolve_corpus,
+    resolve_latest_release_tag,
+    short_sha,
+)
+
+log = logging.getLogger("regression")
+
+
+def measure_scan(
+    scanner_binary: Path,
+    corpus_dir: Path,
+    queries: Path,
+    libraries: Path,
+    platforms: list[str],
+    temp_dir: Path,
+) -> RunMetrics:
+    """Run one scan under rusage measurement and parse its metadata JSON."""
+    metadata_path = temp_dir / "meta.json"
+    if metadata_path.exists():
+        metadata_path.unlink()
+    log_path = temp_dir / "scan.log"
+
+    command = [
+        str(scanner_binary),
+        "scan",
+        "--path",
+        str(corpus_dir),
+        "--queries-path",
+        str(queries),
+        "--libraries-path",
+        str(libraries),
+        "--metadata-path",
+        str(metadata_path),
+    ]
+    for platform in platforms:
+        command += ["--type", platform]
+
+    exit_code, wall_s, cpu_s, peak_rss_mib = _run_measured(
+        command, str(corpus_dir), log_path
+    )
+    if not metadata_path.exists():
+        raise RuntimeError(
+            f"scan produced no metadata (exit {exit_code}); last output:\n"
+            + _tail(log_path)
+        )
+
+    metadata = _read_json_object(metadata_path)
+    stats = _object_dict(metadata.get("Stats", {}), "Stats")
+    breakdowns = _object_dict(
+        stats.get("ViolationBreakdowns") or {}, "Stats.ViolationBreakdowns"
+    )
+    return RunMetrics(
+        wall_s=wall_s,
+        cpu_s=cpu_s,
+        peak_rss_mib=peak_rss_mib,
+        findings=_as_int(stats.get("Violations", 0), "Stats.Violations"),
+        findings_by_severity=_flatten_severity(breakdowns),
+        files=_as_int(stats.get("Files", 0), "Stats.Files"),
+        rules=_as_int(stats.get("Rules", 0), "Stats.Rules"),
+    )
+
+
+def _run_measured(
+    command: list[str], cwd: str, log_path: Path
+) -> tuple[int, float, float, float]:
+    """Fork/exec a scan and return exit code, wall time, CPU time, and peak RSS."""
+    environment = os.environ.copy()
+    start = time.monotonic()
+    pid = os.fork()
+    if pid == 0:
+        try:
+            os.chdir(cwd)
+            output_fd = os.open(
+                str(log_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644
+            )
+            _ = os.dup2(output_fd, 1)
+            _ = os.dup2(output_fd, 2)
+            os.close(output_fd)
+            os.execvpe(command[0], command, environment)
+        except Exception:  # noqa: BLE001 - last resort in the forked child
+            os._exit(127)
+
+    _, status, usage = os.wait4(pid, 0)
+    wall_s = time.monotonic() - start
+    exit_code = os.waitstatus_to_exitcode(status)
+    peak_rss_mib = (
+        usage.ru_maxrss / 1024
+        if sys.platform != "darwin"
+        else usage.ru_maxrss / (1024 * 1024)
+    )
+    cpu_s = usage.ru_utime + usage.ru_stime
+    return exit_code, wall_s, cpu_s, peak_rss_mib
+
+
+def _read_json_object(path: Path) -> dict[str, object]:
+    value = cast(object, json.loads(path.read_text()))
+    return _object_dict(value, str(path))
+
+
+def _object_dict(value: object, field_name: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{field_name} must be a JSON object")
+    return cast(dict[str, object], value)
+
+
+def _as_int(value: object, field_name: str) -> int:
+    if isinstance(value, (int, float, str)):
+        return int(value)
+    raise RuntimeError(f"{field_name} must be numeric")
+
+
+def _flatten_severity(breakdowns: dict[str, object]) -> dict[str, int]:
+    """Sum ViolationBreakdowns category counts by severity."""
+    flattened: dict[str, int] = {}
+    for severity, categories_or_count in breakdowns.items():
+        if isinstance(categories_or_count, dict):
+            categories = cast(dict[str, object], categories_or_count)
+            flattened[severity] = sum(
+                _as_int(value, f"ViolationBreakdowns.{severity}")
+                for value in categories.values()
+            )
+        else:
+            flattened[severity] = _as_int(
+                categories_or_count, f"ViolationBreakdowns.{severity}"
+            )
+    return flattened
+
+
+def _tail(path: Path, line_count: int = 40) -> str:
+    try:
+        return "\n".join(path.read_text().splitlines()[-line_count:])
+    except OSError:
+        return "(no output captured)"
+
+
+def aggregate_runs(runs: list[RunMetrics]) -> AggregatedMetrics:
+    """Aggregate repeated runs and flag non-deterministic finding counts."""
+    finding_counts = {run.findings for run in runs}
+    return AggregatedMetrics(
+        wall_s=min(run.wall_s for run in runs),
+        cpu_s=min(run.cpu_s for run in runs),
+        peak_rss_mib=statistics.median(run.peak_rss_mib for run in runs),
+        findings=statistics.median_low(run.findings for run in runs),
+        findings_by_severity=runs[0].findings_by_severity,
+        files=runs[0].files,
+        rules=runs[0].rules,
+        findings_nondeterministic=len(finding_counts) > 1,
+    )
+
+
+def build_variants(trigger: Trigger, scanner_repo: str) -> list[Variant]:
+    """Build the candidate-first list of scanner/rules combinations."""
+    release_tag = resolve_latest_release_tag(scanner_repo)
+    if trigger == Trigger.SCANNER:
+        variants = [
+            Variant(
+                key="candidate",
+                name="this PR",
+                scanner_ref=None,
+                rules_ref=None,
+                is_candidate=True,
+            ),
+            Variant(
+                key="baseline-main",
+                name="main",
+                scanner_ref="origin/main",
+                rules_ref=None,
+            ),
+        ]
+        if release_tag:
+            variants.append(
+                Variant(
+                    key=f"baseline-{release_tag}",
+                    name=release_tag,
+                    scanner_ref=release_tag,
+                    rules_ref=None,
+                )
+            )
+        else:
+            log.warning(
+                "no semver release tag found; skipping the released-tag baseline"
+            )
+        return variants
+
+    scanner_ref = release_tag or "origin/main"
+    return [
+        Variant(
+            key="candidate",
+            name="this PR",
+            scanner_ref=scanner_ref,
+            rules_ref=None,
+            is_candidate=True,
+        ),
+        Variant(
+            key="baseline-main",
+            name="main",
+            scanner_ref=scanner_ref,
+            rules_ref="origin/main",
+        ),
+    ]
+
+
+@dataclass(frozen=True)
+class BenchmarkContext:
+    variants: list[Variant]
+    assets: VariantAssets
+    work_dir: Path
+    platforms: list[str]
+    runs: int
+    warmup: bool
+
+
+def run(args: CliArgs) -> str:
+    repos_dir = Path(args.repos_dir).expanduser().resolve()
+    scanner_repo = require_repository(SCANNER_REPO, "datadog-iac-scanner")
+    rules_repo = require_repository(
+        repos_dir / "datadog-iac-scanner-default-rules",
+        "datadog-iac-scanner-default-rules",
+    )
+    work_dir = Path(args.work_dir).resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    ensure_fetched(scanner_repo)
+    if args.trigger == Trigger.RULES:
+        ensure_fetched(rules_repo)
+
+    corpus = load_corpus(Path(args.corpus_config))
+    if not corpus:
+        raise RuntimeError(f"no corpus repos configured in {args.corpus_config}")
+    if args.public:
+        _require_public_names(corpus, args.corpus_config)
+
+    variants = build_variants(args.trigger, scanner_repo)
+    _set_variant_display_names(variants, args.trigger, scanner_repo, rules_repo)
+    measured_scans_per_repo = len(variants) * args.runs
+    log.info(
+        "benchmark plan: %d configured repos; %d variants x %d runs = "
+        + "%d measured scans per available repo; warmup=%s",
+        len(corpus),
+        len(variants),
+        args.runs,
+        measured_scans_per_repo,
+        "enabled" if args.warmup else "disabled",
+    )
+    log.info("benchmark variants: %s", ", ".join(v.label for v in variants))
+
+    results: list[CorpusResult] = []
+    with Worktrees(work_dir) as worktrees:
+        assets = VariantAssets(scanner_repo, rules_repo, work_dir, worktrees)
+        assets.prepare(variants)
+        context = BenchmarkContext(
+            variants=variants,
+            assets=assets,
+            work_dir=work_dir,
+            platforms=_parse_platforms(args.platforms),
+            runs=args.runs,
+            warmup=args.warmup,
+        )
+        for repo_index, corpus_repo in enumerate(corpus, start=1):
+            log.info(
+                "corpus %d/%d: resolving %s", repo_index, len(corpus), corpus_repo.repo
+            )
+            repository_path = resolve_corpus(
+                corpus_repo,
+                repos_dir=repos_dir,
+                work_dir=work_dir,
+                gitretriever_url=args.gitretriever_url,
+                gitretriever_token=args.gitretriever_token,
+            )
+            if repository_path is not None:
+                results.append(
+                    _benchmark_repository(corpus_repo, repository_path, context)
+                )
+
+    if not results:
+        raise RuntimeError(
+            "no corpus repos were available to scan (none found locally and none "
+            + "cloned); check --corpus-config, --repos-dir, or set GITRETRIEVER_TOKEN"
+        )
+
+    markdown = render_markdown(args.trigger, variants, results, args.public)
+    if args.json_output:
+        _ = Path(args.json_output).write_text(json_summary(variants, results))
+    return markdown
+
+
+def _set_variant_display_names(
+    variants: list[Variant], trigger: Trigger, scanner_repo: str, rules_repo: str
+) -> None:
+    for variant in variants:
+        variant.scanner_display = (
+            "PR"
+            if variant.is_candidate and trigger == Trigger.SCANNER
+            else short_sha(scanner_repo, variant.scanner_ref or "HEAD")
+        )
+        variant.rules_display = (
+            "PR"
+            if variant.is_candidate and trigger == Trigger.RULES
+            else short_sha(rules_repo, variant.rules_ref or "HEAD")
+        )
+
+
+def _parse_platforms(value: str) -> list[str]:
+    return [platform.strip() for platform in value.split(",") if platform.strip()]
+
+
+def _benchmark_repository(
+    corpus_repo: CorpusRepo, repository_path: Path, context: BenchmarkContext
+) -> CorpusResult:
+    started_at = time.monotonic()
+    log.info(
+        "%s: benchmark starting (%d measured scans%s)",
+        corpus_repo.repo,
+        len(context.variants) * context.runs,
+        " plus warmup" if context.warmup else "",
+    )
+    if context.warmup:
+        _warm_repository(corpus_repo, repository_path, context)
+
+    samples, failed_variants = _collect_samples(corpus_repo, repository_path, context)
+    result = _aggregate_repository(
+        corpus_repo, context.variants, samples, failed_variants
+    )
+    log.info(
+        "%s: benchmark complete (elapsed=%.1fs)",
+        corpus_repo.repo,
+        time.monotonic() - started_at,
+    )
+    return result
+
+
+def _warm_repository(
+    corpus_repo: CorpusRepo, repository_path: Path, context: BenchmarkContext
+) -> None:
+    candidate = context.variants[0]
+    temp_dir = _scan_temp_dir(context.work_dir, corpus_repo, "warmup")
+    queries, libraries = context.assets.rules_paths(candidate.rules_ref)
+    log.info("%s: warmup scan starting (variant=%s)", corpus_repo.repo, candidate.label)
+    started_at = time.monotonic()
+    try:
+        metrics = measure_scan(
+            context.assets.scanner_binary(candidate.scanner_ref),
+            repository_path,
+            queries,
+            libraries,
+            context.platforms,
+            temp_dir,
+        )
+        log.info(
+            "%s: warmup scan complete (elapsed=%.1fs, wall=%.2fs, findings=%d; discarded)",
+            corpus_repo.repo,
+            time.monotonic() - started_at,
+            metrics.wall_s,
+            metrics.findings,
+        )
+    except RuntimeError as exc:
+        log.warning(
+            "%s: warmup scan failed after %.1fs (ignored): %s",
+            corpus_repo.repo,
+            time.monotonic() - started_at,
+            exc,
+        )
+
+
+def _collect_samples(
+    corpus_repo: CorpusRepo, repository_path: Path, context: BenchmarkContext
+) -> tuple[dict[str, list[RunMetrics]], set[str]]:
+    """Measure variants in rotating order to reduce positional timing bias."""
+    samples: dict[str, list[RunMetrics]] = {
+        variant.key: [] for variant in context.variants
+    }
+    failed_variants: set[str] = set()
+    variant_count = len(context.variants)
+    total_scans = context.runs * variant_count
+
+    for run_index in range(context.runs):
+        offset = run_index % variant_count
+        run_order = context.variants[offset:] + context.variants[:offset]
+        for position, variant in enumerate(run_order):
+            scan_index = run_index * variant_count + position + 1
+            if variant.key in failed_variants:
+                log.info(
+                    "%s: scan %d/%d skipped (round %d/%d, variant=%s failed earlier)",
+                    corpus_repo.repo,
+                    scan_index,
+                    total_scans,
+                    run_index + 1,
+                    context.runs,
+                    variant.label,
+                )
+                continue
+            sample = _measure_variant(
+                corpus_repo,
+                repository_path,
+                variant,
+                context,
+                scan_index=scan_index,
+                total_scans=total_scans,
+                round_number=run_index + 1,
+            )
+            if sample is None:
+                failed_variants.add(variant.key)
+            else:
+                samples[variant.key].append(sample)
+
+    return samples, failed_variants
+
+
+def _measure_variant(
+    corpus_repo: CorpusRepo,
+    repository_path: Path,
+    variant: Variant,
+    context: BenchmarkContext,
+    *,
+    scan_index: int,
+    total_scans: int,
+    round_number: int,
+) -> RunMetrics | None:
+    temp_dir = _scan_temp_dir(
+        context.work_dir, corpus_repo, filesystem_safe(variant.key)
+    )
+    log.info(
+        "%s: scan %d/%d starting (round %d/%d, variant=%s)",
+        corpus_repo.repo,
+        scan_index,
+        total_scans,
+        round_number,
+        context.runs,
+        variant.label,
+    )
+    started_at = time.monotonic()
+    try:
+        metrics = measure_scan(
+            context.assets.scanner_binary(variant.scanner_ref),
+            repository_path,
+            *context.assets.rules_paths(variant.rules_ref),
+            context.platforms,
+            temp_dir,
+        )
+    except RuntimeError as exc:
+        log.error(
+            "%s: scan %d/%d failed after %.1fs (variant=%s): %s",
+            corpus_repo.repo,
+            scan_index,
+            total_scans,
+            time.monotonic() - started_at,
+            variant.label,
+            exc,
+        )
+        return None
+    log.info(
+        "%s: scan %d/%d complete (variant=%s, elapsed=%.1fs, wall=%.2fs, "
+        + "cpu=%.2fs, peak=%.0fMiB, findings=%d)",
+        corpus_repo.repo,
+        scan_index,
+        total_scans,
+        variant.label,
+        time.monotonic() - started_at,
+        metrics.wall_s,
+        metrics.cpu_s,
+        metrics.peak_rss_mib,
+        metrics.findings,
+    )
+    return metrics
+
+
+def _scan_temp_dir(work_dir: Path, corpus_repo: CorpusRepo, suffix: str) -> Path:
+    temp_dir = work_dir / "scan-tmp" / f"{corpus_repo.slug}__{suffix}"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    return temp_dir
+
+
+def _aggregate_repository(
+    corpus_repo: CorpusRepo,
+    variants: list[Variant],
+    samples: dict[str, list[RunMetrics]],
+    failed_variants: set[str],
+) -> CorpusResult:
+    result = CorpusResult(repo=corpus_repo.repo, public_name=corpus_repo.public_name)
+    for variant in variants:
+        variant_samples = samples[variant.key]
+        if variant.key in failed_variants or not variant_samples:
+            result.by_variant[variant.key] = None
+            continue
+
+        aggregate = aggregate_runs(variant_samples)
+        result.by_variant[variant.key] = aggregate
+        log.info(
+            "%s: summary (variant=%s, findings=%d, best wall=%.2fs, "
+            + "best cpu=%.2fs, median peak=%.0fMiB)",
+            corpus_repo.repo,
+            variant.label,
+            aggregate.findings,
+            aggregate.wall_s,
+            aggregate.cpu_s,
+            aggregate.peak_rss_mib,
+        )
+    return result
+
+
+def load_corpus(path: Path) -> list[CorpusRepo]:
+    data = _read_json_object(path)
+    corpus_value = data.get("corpus", [])
+    if not isinstance(corpus_value, list):
+        raise RuntimeError(f"{path}: corpus must be a JSON array")
+
+    repositories: list[CorpusRepo] = []
+    for entry in cast(list[object], corpus_value):
+        if isinstance(entry, str):
+            repositories.append(CorpusRepo(repo=entry))
+            continue
+
+        fields = _object_dict(entry, f"{path}: corpus entry")
+        repo = fields.get("repo")
+        ref = fields.get("ref", "")
+        public_name = fields.get("public_name", "")
+        if (
+            not isinstance(repo, str)
+            or not isinstance(ref, str)
+            or not isinstance(public_name, str)
+        ):
+            raise RuntimeError(
+                f"{path}: corpus repo, ref and public_name must be strings"
+            )
+        repositories.append(CorpusRepo(repo=repo, ref=ref, public_name=public_name))
+    return repositories
+
+
+def _require_public_names(corpus: list[CorpusRepo], corpus_config: str) -> None:
+    """Fail loudly if public mode would leak a repo lacking a public_name."""
+    missing = [repo.repo for repo in corpus if not repo.public_name]
+    if missing:
+        raise RuntimeError(
+            "public mode requires a public_name for every corpus repo; missing "
+            + f"for: {', '.join(missing)} (add it in {corpus_config})"
+        )

--- a/regression_detector/benchmark/benchmark.py
+++ b/regression_detector/benchmark/benchmark.py
@@ -28,6 +28,7 @@ from .sources import (
     Worktrees,
     ensure_fetched,
     filesystem_safe,
+    is_git_checkout,
     require_repository,
     resolve_corpus,
     resolve_latest_release_tag,
@@ -40,12 +41,17 @@ log = logging.getLogger("regression")
 def measure_scan(
     scanner_binary: Path,
     corpus_dir: Path,
-    queries: Path,
-    libraries: Path,
+    queries: Path | None,
+    libraries: Path | None,
     platforms: list[str],
     temp_dir: Path,
 ) -> RunMetrics:
-    """Run one scan under rusage measurement and parse its metadata JSON."""
+    """Run one scan under rusage measurement and parse its metadata JSON.
+
+    When ``queries``/``libraries`` are None the scanner is invoked without local
+    rule paths, so it fetches the deployed default ruleset from the Datadog
+    backend at runtime.
+    """
     metadata_path = temp_dir / "meta.json"
     if metadata_path.exists():
         metadata_path.unlink()
@@ -56,13 +62,13 @@ def measure_scan(
         "scan",
         "--path",
         str(corpus_dir),
-        "--queries-path",
-        str(queries),
-        "--libraries-path",
-        str(libraries),
         "--metadata-path",
         str(metadata_path),
     ]
+    if queries is not None:
+        command += ["--queries-path", str(queries)]
+    if libraries is not None:
+        command += ["--libraries-path", str(libraries)]
     for platform in platforms:
         command += ["--type", platform]
 
@@ -244,15 +250,30 @@ class BenchmarkContext:
 def run(args: CliArgs) -> str:
     repos_dir = Path(args.repos_dir).expanduser().resolve()
     scanner_repo = require_repository(SCANNER_REPO, "datadog-iac-scanner")
-    rules_repo = require_repository(
-        repos_dir / "datadog-iac-scanner-default-rules",
-        "datadog-iac-scanner-default-rules",
-    )
+    rules_checkout = repos_dir / "datadog-iac-scanner-default-rules"
+    use_remote_rules = args.remote_rules or not is_git_checkout(rules_checkout)
+    if use_remote_rules and args.trigger == Trigger.RULES:
+        raise RuntimeError(
+            "--trigger rules requires a local default-rules "
+            + f"checkout under {repos_dir} (looked at {rules_checkout}); remote "
+            + "rules are held fixed and cannot vary the ruleset per variant"
+        )
+    if use_remote_rules:
+        log.info(
+            "using remote rules: the scanner will fetch the deployed default "
+            + "ruleset from the Datadog backend at runtime (no rules checkout %s)",
+            "requested" if args.remote_rules else "found",
+        )
+        rules_repo = None
+    else:
+        rules_repo = require_repository(
+            rules_checkout, "datadog-iac-scanner-default-rules"
+        )
     work_dir = Path(args.work_dir).resolve()
     work_dir.mkdir(parents=True, exist_ok=True)
 
     ensure_fetched(scanner_repo)
-    if args.trigger == Trigger.RULES:
+    if args.trigger == Trigger.RULES and rules_repo is not None:
         ensure_fetched(rules_repo)
 
     corpus = load_corpus(Path(args.corpus_config))
@@ -316,7 +337,10 @@ def run(args: CliArgs) -> str:
 
 
 def _set_variant_display_names(
-    variants: list[Variant], trigger: Trigger, scanner_repo: str, rules_repo: str
+    variants: list[Variant],
+    trigger: Trigger,
+    scanner_repo: str,
+    rules_repo: str | None,
 ) -> None:
     for variant in variants:
         variant.scanner_display = (
@@ -324,11 +348,12 @@ def _set_variant_display_names(
             if variant.is_candidate and trigger == Trigger.SCANNER
             else short_sha(scanner_repo, variant.scanner_ref or "HEAD")
         )
-        variant.rules_display = (
-            "PR"
-            if variant.is_candidate and trigger == Trigger.RULES
-            else short_sha(rules_repo, variant.rules_ref or "HEAD")
-        )
+        if variant.is_candidate and trigger == Trigger.RULES:
+            variant.rules_display = "PR"
+        elif rules_repo is None:
+            variant.rules_display = "remote"
+        else:
+            variant.rules_display = short_sha(rules_repo, variant.rules_ref or "HEAD")
 
 
 def _parse_platforms(value: str) -> list[str]:
@@ -365,7 +390,7 @@ def _warm_repository(
 ) -> None:
     candidate = context.variants[0]
     temp_dir = _scan_temp_dir(context.work_dir, corpus_repo, "warmup")
-    queries, libraries = context.assets.rules_paths(candidate.rules_ref)
+    queries, libraries = context.assets.rules_paths(candidate.rules_ref) or (None, None)
     log.info("%s: warmup scan starting (variant=%s)", corpus_repo.repo, candidate.label)
     started_at = time.monotonic()
     try:
@@ -460,11 +485,13 @@ def _measure_variant(
         variant.label,
     )
     started_at = time.monotonic()
+    queries, libraries = context.assets.rules_paths(variant.rules_ref) or (None, None)
     try:
         metrics = measure_scan(
             context.assets.scanner_binary(variant.scanner_ref),
             repository_path,
-            *context.assets.rules_paths(variant.rules_ref),
+            queries,
+            libraries,
             context.platforms,
             temp_dir,
         )

--- a/regression_detector/benchmark/cli.py
+++ b/regression_detector/benchmark/cli.py
@@ -1,0 +1,144 @@
+"""Command-line interface for the performance-regression benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import shutil
+import time
+from pathlib import Path
+
+from .benchmark import run
+from .models import (
+    DEFAULT_OUTPUT,
+    DEFAULT_RUNS,
+    DEFAULT_WORK_DIR,
+    CliArgs,
+    Trigger,
+)
+
+log = logging.getLogger("regression")
+
+DESCRIPTION = """IaC scanner/rules performance-regression benchmark.
+
+Runs the scanner against a corpus of repositories under a *candidate* build and
+one or more *baselines*, measures wall time / CPU / peak memory / finding
+counts for each, and renders a Markdown PR comment summarising the deltas.
+
+The same script is invoked from both CI pipelines; only ``--trigger`` differs:
+
+  * ``--trigger scanner`` — a PR in datadog-iac-scanner. The scanner binary is
+    the variable; rules are held fixed (as cloned, i.e. main). Baselines are the
+    scanner's ``main`` branch and its latest released tag (semver ``vX.Y.Z``,
+    pre-releases like ``-alpha`` excluded).
+  * ``--trigger rules`` — a PR in datadog-iac-scanner-default-rules. The rules
+    are the variable; the scanner is held fixed (latest released tag). The only
+    baseline is the rules' ``main`` branch.
+
+Both a CI run and a local run need clones of the scanner and rules repositories,
+plus the corpus repositories. The scanner checkout is discovered from this
+entrypoint; other clones default to its parent directory.
+
+Deliberately dependency-free (Python 3.10+ stdlib only): measurement uses
+os.fork/os.wait4 rusage, so CI needs no ``pip install`` step.
+"""
+
+
+def parse_args(argv: list[str] | None = None) -> CliArgs:
+    parser = argparse.ArgumentParser(
+        description=DESCRIPTION,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    _ = parser.add_argument(
+        "--trigger",
+        required=True,
+        type=Trigger,
+        choices=list(Trigger),
+        help="which repo's PR triggered this run",
+    )
+    _ = parser.add_argument(
+        "--repos-dir",
+        help="directory containing the default-rules and optional corpus clones "
+        + "(default: scanner repository parent)",
+    )
+    _ = parser.add_argument(
+        "--corpus-config",
+        help="override the bundled corpus repository list",
+    )
+    _ = parser.add_argument(
+        "--work-dir",
+        help=f"scratch directory for worktrees, builds and clones (default: {DEFAULT_WORK_DIR})",
+    )
+    _ = parser.add_argument(
+        "--runs",
+        type=_positive_int,
+        help=f"scan repetitions per variant/repo (default: {DEFAULT_RUNS})",
+    )
+    _ = parser.add_argument(
+        "--no-warmup",
+        dest="warmup",
+        action="store_false",
+        help="skip the discarded per-repo warmup scan that warms the OS file cache",
+    )
+    _ = parser.add_argument(
+        "--platforms",
+        help="comma-separated platform types to scan (default: all)",
+    )
+    _ = parser.add_argument(
+        "--gitretriever-url",
+        help="gitretriever base URL for cloning corpus repos",
+    )
+    _ = parser.add_argument(
+        "--gitretriever-token",
+        help="gitretriever Bearer token (default: $GITRETRIEVER_TOKEN)",
+    )
+    _ = parser.add_argument(
+        "--output",
+        help=f"path to write the rendered Markdown PR comment (default: {DEFAULT_OUTPUT})",
+    )
+    _ = parser.add_argument(
+        "--json-output",
+        help="optional path to write a machine-readable JSON summary",
+    )
+    _ = parser.add_argument(
+        "--public",
+        action=argparse.BooleanOptionalAction,
+        help="redact repository identities and report finding-count changes as "
+        + "percentage deltas only, for posting to a public repo "
+        + "(default: enabled when $CI is set)",
+    )
+    _ = parser.add_argument("-v", "--verbose", action="store_true")
+    return parser.parse_args(argv, namespace=CliArgs())
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def main(argv: list[str] | None = None) -> int:
+    started_at = time.monotonic()
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    if not shutil.which("go"):
+        log.error("`go` toolchain not found on PATH; cannot build the scanner")
+        return 2
+    try:
+        markdown = run(args)
+    except RuntimeError as exc:
+        log.error(
+            "regression run failed after %.1fs: %s",
+            time.monotonic() - started_at,
+            exc,
+        )
+        return 1
+    _ = Path(args.output).write_text(markdown)
+    log.info("wrote PR comment to %s", args.output)
+    log.info("regression run complete (elapsed=%.1fs)", time.monotonic() - started_at)
+    print(markdown)
+    return 0

--- a/regression_detector/benchmark/cli.py
+++ b/regression_detector/benchmark/cli.py
@@ -28,16 +28,23 @@ counts for each, and renders a Markdown PR comment summarising the deltas.
 The same script is invoked from both CI pipelines; only ``--trigger`` differs:
 
   * ``--trigger scanner`` — a PR in datadog-iac-scanner. The scanner binary is
-    the variable; rules are held fixed (as cloned, i.e. main). Baselines are the
-    scanner's ``main`` branch and its latest released tag (semver ``vX.Y.Z``,
-    pre-releases like ``-alpha`` excluded).
+    the variable; rules are held fixed. Baselines are the scanner's ``main``
+    branch and its latest released tag (semver ``vX.Y.Z``, pre-releases like
+    ``-alpha`` excluded).
   * ``--trigger rules`` — a PR in datadog-iac-scanner-default-rules. The rules
     are the variable; the scanner is held fixed (latest released tag). The only
     baseline is the rules' ``main`` branch.
 
-Both a CI run and a local run need clones of the scanner and rules repositories,
-plus the corpus repositories. The scanner checkout is discovered from this
-entrypoint; other clones default to its parent directory.
+Rules come from a local default-rules checkout when present.
+With ``--remote-rules`` (or when no local checkout is found under --repos-dir),
+the scanner instead fetches the deployed default ruleset from the Datadog
+backend at runtime, so no rules clone is needed. Remote rules are held fixed for
+every variant, so they only apply to ``--trigger scanner``; ``--trigger rules``
+requires a local checkout because it varies the ruleset per variant.
+
+A run needs a clone of the scanner repository plus the corpus repositories, and
+(unless running with remote rules) the rules repository. The scanner checkout is
+discovered from this entrypoint; other clones default to its parent directory.
 
 Deliberately dependency-free (Python 3.10+ stdlib only): measurement uses
 os.fork/os.wait4 rusage, so CI needs no ``pip install`` step.
@@ -83,6 +90,13 @@ def parse_args(argv: list[str] | None = None) -> CliArgs:
     _ = parser.add_argument(
         "--platforms",
         help="comma-separated platform types to scan (default: all)",
+    )
+    _ = parser.add_argument(
+        "--remote-rules",
+        action="store_true",
+        help="skip the local rules checkout and let the scanner fetch the "
+        + "deployed default ruleset from the Datadog backend at runtime "
+        + "(scanner trigger only; the default when no local rules checkout is found)",
     )
     _ = parser.add_argument(
         "--gitretriever-url",

--- a/regression_detector/benchmark/models.py
+++ b/regression_detector/benchmark/models.py
@@ -1,0 +1,160 @@
+"""Shared configuration and data models for regression benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Protocol
+
+TIME_REGRESSION_PCT = 10.0
+MEM_REGRESSION_PCT = 10.0
+DEFAULT_RUNS = 3
+DEFAULT_GITRETRIEVER_URL = "https://gitretriever.us1.ddbuild.io"
+DEFAULT_WORK_DIR = "./.regression-work"
+DEFAULT_OUTPUT = "regression-comment.md"
+SCANNER_REPO = Path(__file__).resolve().parents[2]
+DEFAULT_REPOS_DIR = str(SCANNER_REPO.parent)
+DEFAULT_CORPUS_CONFIG = str(SCANNER_REPO / "regression_detector" / "corpus.json")
+
+
+class Trigger(str, Enum):
+    """Which repo's PR triggered the benchmark run."""
+
+    SCANNER = "scanner"
+    RULES = "rules"
+
+    def __str__(self) -> str:  # pyright: ignore[reportImplicitOverride]
+        return self.value
+
+
+@dataclass
+class Variant:
+    """One scanner/rules combination used to scan the corpus.
+
+    ``key`` is the stable identifier used to look up per-variant results;
+    ``name`` is the display text (e.g. "this PR", "main", "v1.2.3"), kept
+    separate so report rendering never needs to parse it back out of a
+    formatted label.
+    """
+
+    key: str
+    name: str
+    # None means "use the repository as currently checked out" (i.e. the
+    # candidate/PR working tree) rather than materializing a worktree for an
+    # explicit ref; call sites render this as "HEAD", "candidate", or "PR"
+    # as appropriate for git lookups, file naming, or display respectively.
+    scanner_ref: str | None
+    rules_ref: str | None
+    is_candidate: bool = False
+    scanner_display: str = ""
+    rules_display: str = ""
+
+    @property
+    def label(self) -> str:
+        """Human-readable heading used in logs and section titles."""
+        return (
+            f"candidate ({self.name})"
+            if self.is_candidate
+            else f"baseline: {self.name}"
+        )
+
+
+@dataclass
+class RunMetrics:
+    """Measurements from a single scan invocation."""
+
+    wall_s: float
+    cpu_s: float
+    peak_rss_mib: float
+    findings: int
+    findings_by_severity: dict[str, int]
+    files: int
+    rules: int
+
+
+@dataclass
+class AggregatedMetrics(RunMetrics):
+    """Metrics aggregated across runs for a variant and corpus repository."""
+
+    findings_nondeterministic: bool = False
+
+
+@dataclass
+class CorpusRepo:
+    repo: str
+    ref: str = ""
+    # Anonymized label shown instead of ``repo`` in public mode
+    public_name: str = ""
+
+    @property
+    def slug(self) -> str:
+        return self.repo.replace("/", "__")
+
+    @property
+    def name(self) -> str:
+        """Repository name without the organization."""
+        return self.repo.split("/")[-1]
+
+
+# Fallback label used when a public run has no configured public_name; kept
+# generic so it can never leak the real repository identity.
+REDACTED_REPO = "hidden"
+
+
+@dataclass
+class CorpusResult:
+    repo: str
+    public_name: str = ""
+    by_variant: dict[str, AggregatedMetrics | None] = field(default_factory=dict)
+
+    def display(self, public: bool) -> str:
+        """Repository label to show in the report for the given visibility."""
+        if not public:
+            return self.repo
+        return self.public_name or REDACTED_REPO
+
+
+class ComparableMetrics(Protocol):
+    """Metrics shared by per-repository aggregates and report totals."""
+
+    wall_s: float
+    cpu_s: float
+    peak_rss_mib: float
+    findings: int
+
+
+class CliArgs(argparse.Namespace):
+    """Typed namespace populated by argparse."""
+
+    trigger: Trigger
+    repos_dir: str
+    corpus_config: str
+    work_dir: str
+    runs: int
+    warmup: bool
+    platforms: str
+    gitretriever_url: str
+    gitretriever_token: str | None
+    output: str
+    json_output: str
+    public: bool
+    verbose: bool
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.trigger = Trigger.SCANNER
+        self.repos_dir = DEFAULT_REPOS_DIR
+        self.corpus_config = DEFAULT_CORPUS_CONFIG
+        self.work_dir = DEFAULT_WORK_DIR
+        self.runs = DEFAULT_RUNS
+        self.warmup = True
+        self.platforms = ""
+        self.gitretriever_url = DEFAULT_GITRETRIEVER_URL
+        self.gitretriever_token = os.environ.get("GITRETRIEVER_TOKEN")
+        self.output = DEFAULT_OUTPUT
+        self.json_output = ""
+        self.public = bool(os.environ.get("CI"))
+        self.verbose = False

--- a/regression_detector/benchmark/models.py
+++ b/regression_detector/benchmark/models.py
@@ -136,6 +136,7 @@ class CliArgs(argparse.Namespace):
     runs: int
     warmup: bool
     platforms: str
+    remote_rules: bool
     gitretriever_url: str
     gitretriever_token: str | None
     output: str
@@ -152,6 +153,7 @@ class CliArgs(argparse.Namespace):
         self.runs = DEFAULT_RUNS
         self.warmup = True
         self.platforms = ""
+        self.remote_rules = False
         self.gitretriever_url = DEFAULT_GITRETRIEVER_URL
         self.gitretriever_token = os.environ.get("GITRETRIEVER_TOKEN")
         self.output = DEFAULT_OUTPUT

--- a/regression_detector/benchmark/report.py
+++ b/regression_detector/benchmark/report.py
@@ -1,0 +1,410 @@
+"""Markdown and JSON report rendering."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+
+from .models import (
+    MEM_REGRESSION_PCT,
+    TIME_REGRESSION_PCT,
+    AggregatedMetrics,
+    ComparableMetrics,
+    CorpusResult,
+    Trigger,
+    Variant,
+)
+
+
+class Verdict(str, Enum):
+    """Classification of a repo's peak-RSS/finding-count change vs. a baseline."""
+
+    REGRESSED = "regressed"
+    IMPROVED = "improved"
+    UNCHANGED = "unchanged"
+
+
+def render_markdown(
+    trigger: Trigger,
+    variants: list[Variant],
+    results: list[CorpusResult],
+    public: bool = False,
+) -> str:
+    candidate = next(variant for variant in variants if variant.is_candidate)
+    baselines = [variant for variant in variants if not variant.is_candidate]
+
+    primary_baseline = baselines[0]
+    primary_verdicts = _classify_all(trigger, candidate, primary_baseline, results)
+    lines = [_headline(primary_verdicts), ""]
+
+    for baseline in baselines:
+        verdicts = (
+            primary_verdicts
+            if baseline is primary_baseline
+            else _classify_all(trigger, candidate, baseline, results)
+        )
+        lines.extend(
+            _comparison_section(trigger, candidate, baseline, results, verdicts, public)
+        )
+
+    if _has_nondeterministic_findings(candidate, results):
+        lines.append(
+            "> ⚠️ Finding counts varied across repeated runs on at least one repo (non-deterministic)."
+        )
+        lines.append("")
+    lines.extend(_report_footer(trigger, candidate, primary_baseline))
+    return "\n".join(lines)
+
+
+@dataclass
+class _Totals:
+    wall_s: float = 0.0
+    cpu_s: float = 0.0
+    peak_rss_mib: float = 0.0
+    findings: int = 0
+
+    def add(self, metrics: ComparableMetrics) -> None:
+        self.wall_s += metrics.wall_s
+        self.cpu_s += metrics.cpu_s
+        self.peak_rss_mib = max(self.peak_rss_mib, metrics.peak_rss_mib)
+        self.findings += metrics.findings
+
+
+def _classify(
+    trigger: Trigger, candidate: ComparableMetrics, baseline: ComparableMetrics
+) -> Verdict:
+    if trigger == Trigger.SCANNER and candidate.findings != baseline.findings:
+        return Verdict.REGRESSED
+    if baseline.peak_rss_mib <= 0:
+        return Verdict.UNCHANGED
+    percent_change = (
+        (candidate.peak_rss_mib - baseline.peak_rss_mib) / baseline.peak_rss_mib * 100.0
+    )
+    if percent_change > MEM_REGRESSION_PCT:
+        return Verdict.REGRESSED
+    if percent_change < -MEM_REGRESSION_PCT:
+        return Verdict.IMPROVED
+    return Verdict.UNCHANGED
+
+
+def _classify_all(
+    trigger: Trigger,
+    candidate: Variant,
+    baseline: Variant,
+    results: list[CorpusResult],
+) -> dict[str, Verdict]:
+    verdicts: dict[str, Verdict] = {}
+    for result in results:
+        candidate_metrics = result.by_variant.get(candidate.key)
+        baseline_metrics = result.by_variant.get(baseline.key)
+        if candidate_metrics is None or baseline_metrics is None:
+            verdicts[result.repo] = Verdict.REGRESSED
+            continue
+        verdicts[result.repo] = _classify(trigger, candidate_metrics, baseline_metrics)
+    return verdicts
+
+
+def _headline(verdicts: dict[str, Verdict]) -> str:
+    total = len(verdicts)
+    repo_label = "repo" if total == 1 else "repos"
+    regressed = sum(1 for verdict in verdicts.values() if verdict == Verdict.REGRESSED)
+    improved = sum(1 for verdict in verdicts.values() if verdict == Verdict.IMPROVED)
+    unchanged = total - regressed - improved
+    if regressed:
+        verb = "shows" if regressed == 1 else "show"
+        scope = f"{regressed} of {total}" if total > 1 else str(regressed)
+        headline = (
+            f"### ❌ {scope} {repo_label} {verb} a regression "
+            + "(peak RSS and/or finding-count change)"
+        )
+    elif improved:
+        headline = f"### ⚡ No regressions detected across {total} {repo_label} — some improved"
+    else:
+        headline = f"### ✅ No regressions detected across {total} {repo_label}"
+    counts = (
+        f"❌ {regressed} regressed · ⚡ {improved} improved · ✅ {unchanged} unchanged"
+    )
+    return headline + "\n" + counts
+
+
+def _comparison_section(
+    trigger: Trigger,
+    candidate: Variant,
+    baseline: Variant,
+    results: list[CorpusResult],
+    verdicts: dict[str, Verdict],
+    public: bool,
+) -> list[str]:
+    header = [
+        f"### Compared with `{baseline.name}`",
+        "<sub>"
+        + f"Scanner <code>{baseline.scanner_display}</code> · "
+        + f"Rules <code>{baseline.rules_display}</code>"
+        + "</sub>",
+        "",
+    ]
+    findings_tooltip = (
+        "Finding-count change from baseline, as a percentage"
+        if public
+        else "Candidate finding count and change from baseline"
+    )
+    table_header = [
+        f'|  | Repository | <span title="{findings_tooltip}">Findings</span> | '
+        + '<span title="Median peak resident memory; changes beyond the threshold are flagged">Peak RSS</span> | '
+        + '<span title="Best observed wall time; advisory only">Wall</span> | '
+        + '<span title="Best observed CPU time; advisory only">CPU</span> |',
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    candidate_totals = _Totals()
+    baseline_totals = _Totals()
+    flagged_rows: list[str] = []
+    unchanged_rows: list[str] = []
+
+    for result in results:
+        candidate_metrics = result.by_variant.get(candidate.key)
+        baseline_metrics = result.by_variant.get(baseline.key)
+        verdict = verdicts[result.repo]
+        repo_label = f"`{result.display(public)}`"
+        if candidate_metrics is None or baseline_metrics is None:
+            flagged_rows.append(
+                f"| {_VERDICT_ICON[verdict]} | {repo_label} | ❌ scan failed | – | – | – |"
+            )
+            continue
+
+        candidate_totals.add(candidate_metrics)
+        baseline_totals.add(baseline_metrics)
+        row = _comparison_row(
+            verdict,
+            repo_label,
+            trigger,
+            candidate_metrics,
+            baseline_metrics,
+            nondeterministic=candidate_metrics.findings_nondeterministic,
+            public=public,
+        )
+        if verdict == Verdict.UNCHANGED:
+            unchanged_rows.append(row)
+        else:
+            flagged_rows.append(row)
+
+    total_row = _comparison_row(
+        None,
+        "**total**",
+        trigger,
+        candidate_totals,
+        baseline_totals,
+        maximum_memory=True,
+        public=public,
+    )
+
+    lines = [*header]
+    if flagged_rows:
+        lines.extend([*table_header, *flagged_rows])
+    if unchanged_rows:
+        if not flagged_rows:
+            lines.extend(table_header)
+        else:
+            lines.append("")
+            unchanged_label = f"{len(unchanged_rows)} unchanged repo"
+            unchanged_label += "s" if len(unchanged_rows) != 1 else ""
+            lines.append("<details>")
+            lines.append(f"<summary>{unchanged_label}</summary>")
+            lines.append("")
+            lines.extend(table_header)
+        lines.extend(unchanged_rows)
+        if flagged_rows:
+            lines.append("")
+            lines.append("</details>")
+    if not flagged_rows and not unchanged_rows:
+        lines.extend(table_header)
+    lines.append(total_row)
+    lines.append("")
+    return lines
+
+
+_VERDICT_ICON = {
+    Verdict.REGRESSED: "❌",
+    Verdict.IMPROVED: "⚡",
+    Verdict.UNCHANGED: "✅",
+}
+
+
+def _comparison_row(
+    verdict: Verdict | None,
+    label: str,
+    trigger: Trigger,
+    candidate: ComparableMetrics,
+    baseline: ComparableMetrics,
+    *,
+    nondeterministic: bool = False,
+    maximum_memory: bool = False,
+    public: bool = False,
+) -> str:
+    icon = "" if verdict is None else _VERDICT_ICON[verdict]
+    return "| {icon} | {label} | {findings} | {memory} | {wall} | {cpu} |".format(
+        icon=icon,
+        label=label,
+        findings=_int_delta(
+            candidate.findings,
+            baseline.findings,
+            trigger,
+            nondeterministic=nondeterministic,
+            public=public,
+        ),
+        memory=_delta_cell(
+            candidate.peak_rss_mib,
+            baseline.peak_rss_mib,
+            "MiB",
+            MEM_REGRESSION_PCT,
+            show_max_prefix=maximum_memory,
+        ),
+        wall=_delta_cell(
+            candidate.wall_s,
+            baseline.wall_s,
+            "s",
+            TIME_REGRESSION_PCT,
+            advisory=True,
+        ),
+        cpu=_delta_cell(
+            candidate.cpu_s,
+            baseline.cpu_s,
+            "s",
+            TIME_REGRESSION_PCT,
+            advisory=True,
+        ),
+    )
+
+
+def _report_footer(trigger: Trigger, candidate: Variant, baseline: Variant) -> list[str]:
+    if trigger == Trigger.SCANNER:
+        findings_note = "A finding-count delta indicates a scanner behaviour change and should be explained."
+    else:
+        findings_note = "Finding-count changes are expected for default-rules changes."
+    return [
+        f"Comparing candidate <code>{candidate.scanner_display}</code> with "
+        + f"<code>{baseline.name}</code> <code>{baseline.scanner_display}</code>",
+        "",
+        "<details>",
+        "<summary>How to read this report</summary>",
+        "",
+        f"• {findings_note}<br />",
+        f"• Peak RSS changes beyond {MEM_REGRESSION_PCT:.0f}% are flagged; lower is better.<br />",
+        "• Wall and CPU use the best observed run and are advisory; small changes are usually noise.<br />",
+        "This comment is updated automatically when new benchmark data arrives.",
+        "</details>",
+    ]
+
+
+def _has_nondeterministic_findings(
+    candidate: Variant, results: list[CorpusResult]
+) -> bool:
+    for result in results:
+        metrics = result.by_variant.get(candidate.key)
+        if metrics is not None and metrics.findings_nondeterministic:
+            return True
+    return False
+
+
+def _int_delta(
+    candidate: int,
+    baseline: int,
+    trigger: Trigger,
+    *,
+    nondeterministic: bool = False,
+    public: bool = False,
+) -> str:
+    difference = candidate - baseline
+    if public:
+        body = _findings_percent(candidate, baseline, trigger)
+    elif difference == 0:
+        body = f"{candidate}"
+    else:
+        marker = "❌ " if trigger == Trigger.SCANNER else ""
+        body = f"{marker}{candidate} ({difference:+d})"
+    if nondeterministic:
+        body += " ⚠️nondet"
+    return body
+
+
+def _findings_percent(candidate: int, baseline: int, trigger: Trigger) -> str:
+    """Finding-count change as a percentage only — no absolute counts.
+
+    Used in public mode, where disclosing exact violation counts for internal
+    repositories is not acceptable but relative movement still needs surfacing.
+    """
+    if candidate == baseline:
+        return "no change"
+    marker = "❌ " if trigger == Trigger.SCANNER else ""
+    if baseline <= 0:
+        # No baseline findings to divide by; a percentage would be meaningless.
+        return f"{marker}new findings"
+    percent_change = (candidate - baseline) / baseline * 100.0
+    return f"{marker}{percent_change:+.1f}%"
+
+
+def _delta_cell(
+    candidate: float,
+    baseline: float,
+    unit: str,
+    warn_pct: float,
+    show_max_prefix: bool = False,
+    advisory: bool = False,
+) -> str:
+    formatted_value = _format_metric(candidate, unit)
+    prefix = "max " if show_max_prefix else ""
+    if baseline <= 0:
+        return f"{prefix}{formatted_value}"
+    percent_change = (candidate - baseline) / baseline * 100.0
+    if advisory or -warn_pct <= percent_change <= warn_pct:
+        marker = ""
+    elif percent_change > warn_pct:
+        marker = "❌ "
+    else:
+        marker = "⚡ "
+    return f"{marker}{prefix}{formatted_value} ({percent_change:+.1f}%)"
+
+
+def _format_metric(value: float, unit: str) -> str:
+    if unit == "MiB":
+        return f"{value:.0f} MiB"
+    return f"{value:.2f} {unit}"
+
+
+def json_summary(variants: list[Variant], results: list[CorpusResult]) -> str:
+    return json.dumps(
+        {
+            "variants": [_variant_json(variant) for variant in variants],
+            "results": [_corpus_result_json(result) for result in results],
+        },
+        indent=2,
+    )
+
+
+def _variant_json(variant: Variant) -> dict[str, object]:
+    return {
+        "label": variant.label,
+        "scanner": variant.scanner_display,
+        "rules": variant.rules_display,
+        "candidate": variant.is_candidate,
+    }
+
+
+def _corpus_result_json(result: CorpusResult) -> dict[str, object]:
+    variants: dict[str, object] = {
+        label: None if aggregate is None else _aggregate_json(aggregate)
+        for label, aggregate in result.by_variant.items()
+    }
+    return {"repo": result.repo, "variants": variants}
+
+
+def _aggregate_json(aggregate: AggregatedMetrics) -> dict[str, object]:
+    return {
+        "findings": aggregate.findings,
+        "findings_by_severity": aggregate.findings_by_severity,
+        "wall_s": round(aggregate.wall_s, 3),
+        "cpu_s": round(aggregate.cpu_s, 3),
+        "peak_rss_mib": round(aggregate.peak_rss_mib, 1),
+        "files": aggregate.files,
+        "rules": aggregate.rules,
+    }

--- a/regression_detector/benchmark/sources.py
+++ b/regression_detector/benchmark/sources.py
@@ -122,12 +122,12 @@ class VariantAssets:
     def __init__(
         self,
         scanner_repo: str,
-        rules_repo: str,
+        rules_repo: str | None,
         work_dir: Path,
         worktrees: Worktrees,
     ) -> None:
         self._scanner_repo: str = scanner_repo
-        self._rules_repo: str = rules_repo
+        self._rules_repo: str | None = rules_repo
         self._work_dir: Path = work_dir
         self._worktrees: Worktrees = worktrees
         self._scanner_binaries: dict[str | None, Path] = {}
@@ -194,7 +194,21 @@ class VariantAssets:
         self._scanner_binaries[ref] = binary
         return binary
 
-    def rules_paths(self, ref: str | None) -> tuple[Path, Path]:
+    def rules_paths(self, ref: str | None) -> tuple[Path, Path] | None:
+        """Return (queries, libraries) paths, or None when using remote rules.
+
+        With no local rules checkout the scanner is invoked without query or
+        library paths, so it fetches the deployed default ruleset from the
+        Datadog backend at runtime.
+        """
+        if self._rules_repo is None:
+            if ref is not None:
+                raise RuntimeError(
+                    f"cannot materialize rules ref {ref!r} without a local rules "
+                    + "checkout; remote rules cannot vary the ruleset per variant"
+                )
+            return None
+
         if ref in self._rules_paths:
             return self._rules_paths[ref]
 

--- a/regression_detector/benchmark/sources.py
+++ b/regression_detector/benchmark/sources.py
@@ -1,0 +1,287 @@
+"""Git, worktree, build, and corpus source handling."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+import time
+from pathlib import Path
+from types import TracebackType
+
+from .models import CorpusRepo, Variant
+
+log = logging.getLogger("regression")
+
+RELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+SCANNER_LDFLAGS = "-s -w"
+
+
+def run_command(
+    command: list[str],
+    *,
+    cwd: str | None = None,
+    check: bool = True,
+    display_command: list[str] | None = None,
+) -> str:
+    """Run a command and return stdout, optionally redacting its logged form."""
+    log.debug("exec: %s (cwd=%s)", " ".join(display_command or command), cwd)
+    process = subprocess.run(
+        command, cwd=cwd, text=True, capture_output=True, check=False
+    )
+    if check and process.returncode != 0:
+        shown_command = display_command or command
+        raise RuntimeError(
+            f"command failed ({process.returncode}): {' '.join(shown_command)}\n"
+            + process.stderr
+        )
+    return process.stdout
+
+
+def run_git(repo: str, *args: str, check: bool = True) -> str:
+    return run_command(["git", "-C", repo, *args], check=check)
+
+
+def short_sha(repo: str, ref: str) -> str:
+    try:
+        return run_git(repo, "rev-parse", "--short", ref).strip()
+    except RuntimeError:
+        return ref
+
+
+def ensure_fetched(repo: str) -> None:
+    """Best-effort fetch of branches and tags needed to resolve baselines."""
+    _ = run_git(repo, "fetch", "--quiet", "--tags", "origin", check=False)
+    _ = run_git(repo, "fetch", "--quiet", "origin", "main", check=False)
+
+
+def resolve_latest_release_tag(scanner_repo: str) -> str | None:
+    """Return the highest stable vMAJOR.MINOR.PATCH tag, if one exists."""
+    tag_output = run_git(scanner_repo, "tag", "--list", "v*", check=False)
+    candidates: list[tuple[tuple[int, int, int], str]] = []
+    for line in tag_output.splitlines():
+        tag = line.strip()
+        match = RELEASE_TAG_RE.match(tag)
+        if match:
+            version = (
+                int(match.group(1)),
+                int(match.group(2)),
+                int(match.group(3)),
+            )
+            candidates.append((version, tag))
+    return max(candidates)[1] if candidates else None
+
+
+class Worktrees:
+    """Create and clean up isolated git worktrees for baseline refs."""
+
+    def __init__(self, work_dir: Path):
+        self._work_dir: Path = work_dir
+        self._created: list[tuple[str, Path]] = []
+
+    def checkout(self, repo: str, ref: str, name: str) -> Path:
+        destination = self._work_dir / "worktrees" / name
+        if destination.exists():
+            return destination
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        _ = run_git(
+            repo, "worktree", "add", "--detach", "--force", str(destination), ref
+        )
+        self._created.append((repo, destination))
+        return destination
+
+    def cleanup(self) -> None:
+        for repo, destination in self._created:
+            _ = run_git(
+                repo,
+                "worktree",
+                "remove",
+                "--force",
+                str(destination),
+                check=False,
+            )
+        for repo in {repo for repo, _ in self._created}:
+            _ = run_git(repo, "worktree", "prune", check=False)
+
+    def __enter__(self) -> Worktrees:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        self.cleanup()
+
+
+class VariantAssets:
+    """Materialize and cache scanner binaries and rule paths by git ref."""
+
+    def __init__(
+        self,
+        scanner_repo: str,
+        rules_repo: str,
+        work_dir: Path,
+        worktrees: Worktrees,
+    ) -> None:
+        self._scanner_repo: str = scanner_repo
+        self._rules_repo: str = rules_repo
+        self._work_dir: Path = work_dir
+        self._worktrees: Worktrees = worktrees
+        self._scanner_binaries: dict[str | None, Path] = {}
+        self._rules_paths: dict[str | None, tuple[Path, Path]] = {}
+
+    def prepare(self, variants: list[Variant]) -> None:
+        log.info("preparing assets for %d benchmark variants", len(variants))
+        for variant in variants:
+            _ = self.scanner_binary(variant.scanner_ref)
+            _ = self.rules_paths(variant.rules_ref)
+
+    def scanner_binary(self, ref: str | None) -> Path:
+        if ref in self._scanner_binaries:
+            return self._scanner_binaries[ref]
+
+        source = (
+            self._scanner_repo
+            if ref is None
+            else str(
+                self._worktrees.checkout(
+                    self._scanner_repo, ref, f"scanner-{filesystem_safe(ref)}"
+                )
+            )
+        )
+        binary = (
+            self._work_dir / "bin" / f"scanner-{filesystem_safe(ref or 'candidate')}"
+        ).resolve()
+        binary.parent.mkdir(parents=True, exist_ok=True)
+
+        display_ref = ref or "candidate/PR"
+        log.info(
+            "scanner build starting (ref=%s, ldflags=%r) -> %s",
+            display_ref,
+            SCANNER_LDFLAGS,
+            binary,
+        )
+        started_at = time.monotonic()
+        environment = os.environ.copy()
+        environment["CGO_ENABLED"] = "1"
+        process = subprocess.run(
+            [
+                "go",
+                "build",
+                "-ldflags",
+                SCANNER_LDFLAGS,
+                "-o",
+                str(binary),
+                "./cmd/scanner",
+            ],
+            cwd=source,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if process.returncode != 0:
+            raise RuntimeError(f"scanner build failed (ref={ref}):\n{process.stderr}")
+
+        log.info(
+            "scanner build complete (ref=%s, elapsed=%.1fs)",
+            display_ref,
+            time.monotonic() - started_at,
+        )
+        self._scanner_binaries[ref] = binary
+        return binary
+
+    def rules_paths(self, ref: str | None) -> tuple[Path, Path]:
+        if ref in self._rules_paths:
+            return self._rules_paths[ref]
+
+        root = (
+            Path(self._rules_repo)
+            if ref is None
+            else self._worktrees.checkout(
+                self._rules_repo, ref, f"rules-{filesystem_safe(ref)}"
+            )
+        )
+        paths = (
+            (root / "assets" / "queries").resolve(),
+            (root / "assets" / "libraries").resolve(),
+        )
+        for path in paths:
+            if not path.is_dir():
+                raise RuntimeError(f"rules asset directory not found: {path}")
+
+        self._rules_paths[ref] = paths
+        return paths
+
+
+def filesystem_safe(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]", "_", value)
+
+
+def is_git_checkout(path: Path) -> bool:
+    """Accept regular clones and linked worktrees, whose .git entry is a file."""
+    return (path / ".git").exists()
+
+
+def require_repository(path: Path, name: str) -> str:
+    """Validate and return a repository checkout path."""
+    if not is_git_checkout(path):
+        raise RuntimeError(
+            f"{name} not found at {path}; place the clone under --repos-dir"
+        )
+    return str(path)
+
+
+def resolve_corpus(
+    corpus: CorpusRepo,
+    *,
+    repos_dir: Path,
+    work_dir: Path,
+    gitretriever_url: str,
+    gitretriever_token: str | None,
+) -> Path | None:
+    """Locate a corpus repository locally or clone it through gitretriever."""
+    destination = work_dir / "corpus" / corpus.slug
+    search_locations: list[tuple[Path, str]] = [
+        (repos_dir / corpus.slug, "using pre-cloned checkout"),
+        (repos_dir / corpus.name, "using local checkout"),
+        (destination, "reusing"),
+    ]
+
+    for path, description in search_locations:
+        if is_git_checkout(path):
+            log.info("corpus %s: %s %s", corpus.repo, description, path)
+            return path
+
+    if not gitretriever_token:
+        log.warning(
+            "corpus %s not found locally (looked in %s) and no GITRETRIEVER_TOKEN set; skipping",
+            corpus.repo,
+            repos_dir,
+        )
+        return None
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    url = f"{gitretriever_url.rstrip('/')}/{corpus.repo}.git"
+    auth_header = f"http.extraHeader=Authorization: Bearer {gitretriever_token}"
+    command = ["git", "-c", auth_header, "clone", "--depth", "1"]
+    display_command = [
+        "git",
+        "-c",
+        "http.extraHeader=Authorization: Bearer ***",
+        "clone",
+        "--depth",
+        "1",
+    ]
+    if corpus.ref:
+        command += ["--branch", corpus.ref]
+        display_command += ["--branch", corpus.ref]
+    command += [url, str(destination)]
+    display_command += [url, str(destination)]
+
+    log.info("cloning corpus %s from gitretriever", corpus.repo)
+    _ = run_command(command, display_command=display_command)
+    return destination

--- a/regression_detector/corpus.json
+++ b/regression_detector/corpus.json
@@ -1,0 +1,5 @@
+{
+  "corpus": [
+    { "repo": "DataDog/datadog-agent", "public_name": "Public Datadog Agent" }
+  ]
+}

--- a/regression_detector/run.py
+++ b/regression_detector/run.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""CI entrypoint for the IaC scanner performance-regression benchmark."""
+
+# Direct script execution intentionally imports the sibling package.
+from benchmark.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## DEMO

<img width="600" alt="image" src="https://github.com/user-attachments/assets/c9705069-d359-4368-ba14-175570775d2c" />

## Motivation

Adds a performance-regression benchmark and wires it into GitLab CI so PRs touching the scanner get an automated performance check before merge.

JIRA Ticket [K9CODESEC-3295](https://datadoghq.atlassian.net/browse/K9CODESEC-3295)

## Changes

- Added `regression_detector/` - a standalone Python CLI that benchmarks the scanner (this PR) against `main` and the latest release tag, and renders the deltas as a PR comment.
- Added a `regression-detector` job to `.gitlab-ci.yml`, gated on PR builds, that runs the benchmark and posts its output via the PR Commenting Service.
- See `regression_detector/README.md` for full usage and design details.

## Author Checklist

- [x] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [x] I have updated any relevant documentation (if applicable).

## QA Instruction

Run `python regression_detector/run.py --trigger scanner` locally against this branch and confirm it produces a sensible Markdown report with wall/CPU/memory/finding deltas. On the actual PR, confirm the `regression-detector` job runs and posts a "Regression Detector" comment.

## Blast Radius

Only this repo's CI (`datadog-iac-scanner`). No production scanner code paths are touched — this is a new, isolated dev-tooling directory plus one new GitLab CI job gated to PR builds.

I submit this contribution under the Apache-2.0 license.


[K9CODESEC-3295]: https://datadoghq.atlassian.net/browse/K9CODESEC-3295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ