### PR TITLE
Setup Regression Detector

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,9 @@ trigger-regression-detector:
     # Surface the downstream pipeline's status on this pipeline.
     strategy: depend
   variables:
+    UPSTREAM_TRIGGER: scanner
+    UPSTREAM_ORG: DataDog
+    UPSTREAM_REPO: datadog-iac-scanner
     UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
     UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,11 +5,10 @@ trigger-regression-detector:
   stage: verify
   rules:
     - if: $DDCI_REQUEST_KIND == "REQUEST_KIND_CHANGE_REQUEST"
-    - if: $CI_COMMIT_TAG
   allow_failure: true
   trigger:
     project: ddoghq/datadog-iac-regression-detector
-    branch: ilya.siamionau/K9CODESEC-3295/add-regression-detector
+    branch: main
     # Surface the downstream pipeline's status on this pipeline.
     strategy: depend
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,18 @@
+stages:
+  - verify
+
+trigger-regression-detector:
+  stage: verify
+  rules:
+    - if: $DDCI_REQUEST_KIND == "REQUEST_KIND_CHANGE_REQUEST"
+    - if: $CI_COMMIT_TAG
+  allow_failure: true
+  trigger:
+    project: ddoghq/datadog-iac-regression-detector
+    branch: ilya.siamionau/K9CODESEC-3295/add-regression-detector
+    # Surface the downstream pipeline's status on this pipeline.
+    strategy: depend
+  variables:
+    UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
+    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
+    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA


### PR DESCRIPTION
## Motivation

The scanner has no automated guard against performance regressions. A change that slows a scan down, inflates peak memory, or silently changes how many findings are produced is only noticed after it ships. We want that signal on every PR, before merge.

This PR is the upstream half of that wiring: the trigger job. The benchmark, corpus, and reporting all live downstream.

JIRA Ticket: [K9CODESEC-3295](https://datadoghq.atlassian.net/browse/K9CODESEC-3295)

## Changes

- Add `.gitlab-ci.yml` with a single `verify`-stage job, `trigger-regression-detector`.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why. — No unit tests: this PR is CI configuration only and adds no application code. The logic it triggers is tested in the companion repo; this file is verified by running the pipeline (see QA).
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable). — Not applicable; validated by running the pipeline on this PR itself.
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

PR comment appeared

## Blast Radius

Limited to `datadog-iac-scanner` CI.

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-3295]: https://datadoghq.atlassian.net/browse/K9CODESEC-3295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ