### PR TITLE
(k9-iac): Validate custom-rule platforms against the same list as scan

### DIFF
--- a/cmd/scanner/custom.go
+++ b/cmd/scanner/custom.go
@@ -6,12 +6,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
+	iacplatforms "github.com/DataDog/datadog-iac-scanner/pkg/platforms"
 	"github.com/DataDog/datadog-iac-scanner/pkg/scan"
 	cli "github.com/urfave/cli/v3"
 )
+
+// Reports an error if platform is not one of iacplatforms.Supported
+func validatePlatform(platform string) error {
+	for _, p := range iacplatforms.Supported {
+		if strings.EqualFold(p, platform) {
+			return nil
+		}
+	}
+	return fmt.Errorf("unsupported platform %q, must be one of %v", platform, iacplatforms.Supported)
+}
 
 var customAction = &cli.Command{
 	Name:  "custom",
@@ -49,6 +61,9 @@ var evaluateCustomAction = &cli.Command{
 
 func runEvaluateCustom(ctx context.Context, c *cli.Command) error {
 	platform := c.String("platform")
+	if err := validatePlatform(platform); err != nil {
+		return err
+	}
 
 	regoBytes, err := base64.StdEncoding.DecodeString(c.String("rego"))
 	if err != nil {
@@ -122,6 +137,10 @@ var validateCustomAction = &cli.Command{
 }
 
 func runValidateCustom(ctx context.Context, c *cli.Command) error {
+	if err := validatePlatform(c.String("platform")); err != nil {
+		return err
+	}
+
 	regoBytes, err := base64.StdEncoding.DecodeString(c.String("rego"))
 	if err != nil {
 		return fmt.Errorf("decoding --rego: %w", err)

--- a/cmd/scanner/custom_test.go
+++ b/cmd/scanner/custom_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	iacplatforms "github.com/DataDog/datadog-iac-scanner/pkg/platforms"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidatePlatform_SupportedPlatforms(t *testing.T) {
+	for _, p := range iacplatforms.Supported {
+		assert.NoError(t, validatePlatform(p), "platform %q", p)
+	}
+}
+
+func TestValidatePlatform_CaseInsensitive(t *testing.T) {
+	assert.NoError(t, validatePlatform("TERRAFORM"))
+	assert.NoError(t, validatePlatform("cicd"))
+}
+
+func TestValidatePlatform_Unsupported(t *testing.T) {
+	err := validatePlatform("foobar")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "foobar")
+}
+
+func TestValidatePlatform_ARMRejected(t *testing.T) {
+	err := validatePlatform("azureresourcemanager")
+	assert.Error(t, err)
+}

--- a/pkg/scan/custom_scan.go
+++ b/pkg/scan/custom_scan.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/platforms"
 	"github.com/DataDog/datadog-iac-scanner/pkg/printer"
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 )
@@ -36,26 +37,28 @@ type RegoValidationError struct {
 
 const (
 	scanTargetJSON     = "scan-target.json"
-	platformARM        = "azureresourcemanager"
 	codeMissingPackage = "missing_package"
 	datadogPackage     = "package datadog"
 )
 
-// platformTempFileName returns a temp filename whose extension the scanner's file-type
-// filter will accept for the given platform.
+// Temp-file names for all supported platforms.
+var platformExtensions = map[string]string{
+	"Terraform":      "scan-target.tf",
+	"CloudFormation": scanTargetJSON,
+	"Kubernetes":     "scan-target.yaml",
+	"Ansible":        "scan-target.yaml",
+	"CICD":           "scan-target.yaml",
+	"Dockerfile":     "Dockerfile",
+}
+
+// Returns a temp filename for the given platform's extension.
 func platformTempFileName(platform string) string {
-	switch strings.ToLower(platform) {
-	case "terraform":
-		return "scan-target.tf"
-	case "cloudformation", platformARM:
-		return scanTargetJSON
-	case "kubernetes", "ansible":
-		return "scan-target.yaml"
-	case "dockerfile":
-		return "Dockerfile"
-	default:
-		return scanTargetJSON
+	for _, supported := range platforms.Supported {
+		if strings.EqualFold(supported, platform) {
+			return platformExtensions[supported]
+		}
 	}
+	return scanTargetJSON
 }
 
 // RunCustomRegoQuery writes fileContent to a temp file and runs regoContent against it

--- a/pkg/scan/custom_scan.go
+++ b/pkg/scan/custom_scan.go
@@ -51,7 +51,7 @@ var platformExtensions = map[string]string{
 	"Dockerfile":     "Dockerfile",
 }
 
-// Returns a temp filename for the given platform's extension.
+// Returns a temp filename for all supported platforms.
 func platformTempFileName(platform string) string {
 	for _, supported := range platforms.Supported {
 		if strings.EqualFold(supported, platform) {

--- a/pkg/scan/custom_scan_test.go
+++ b/pkg/scan/custom_scan_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/platforms"
 )
 
 // stubLibSource returns minimal Rego stubs sufficient for OPA compilation in tests.
@@ -98,6 +99,30 @@ func firstWithCode(errs []RegoValidationError, code string) (RegoValidationError
 }
 
 // ── unit tests ────────────────────────────────────────────────────────────────
+
+func TestPlatformTempFileName_CoversAllSupportedPlatforms(t *testing.T) {
+	expected := map[string]string{
+		"Ansible":        "scan-target.yaml",
+		"CICD":           "scan-target.yaml",
+		"CloudFormation": scanTargetJSON,
+		"Dockerfile":     "Dockerfile",
+		"Kubernetes":     "scan-target.yaml",
+		"Terraform":      "scan-target.tf",
+	}
+	require.Len(t, platforms.Supported, len(expected),
+		"platforms.Supported changed; update the expected mapping and platformTempFileName in lockstep")
+	for _, platform := range platforms.Supported {
+		want, ok := expected[platform]
+		require.True(t, ok, "no expected temp file name for platform %q; update this test", platform)
+		assert.Equal(t, want, platformTempFileName(platform), "platform %q", platform)
+	}
+}
+
+func TestPlatformTempFileName_ARMNotSpecialCased(t *testing.T) {
+	// ARM is not part of platforms.Supported; custom rules for it are rejected at the
+	// CLI layer (validatePlatform), so this exercises the defensive default fallback.
+	assert.Equal(t, scanTargetJSON, platformTempFileName("azureresourcemanager"))
+}
 
 func TestParseImportAliases(t *testing.T) {
 	src := `


### PR DESCRIPTION
## Summary

https://datadoghq.atlassian.net/browse/K9CODESEC-3913

To validate custom rules on the UI, the validation API uses the `custom_scan` command. However, the custom scan command supports a different set of platforms than the `scan` command, when in reality should be the same. 

This change is needed for the custom rules UI where today  CICD custom-rule validation was silently failing because `cicd` wasn't handled by the old hardcoded switch.


## Changes
- `custom evaluate`/`custom validate` now validate `--platform` against `platforms.Supported`, the same list `scan` uses, instead of silently falling through to a JSON default for unrecognized platforms.
-  Added tests

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/scanner/... ./pkg/scan/...`
- [x] `golangci-lint run -c .golangci.yml --timeout 20m`