### PR TITLE
(draft) Fix JSON not used on custom command

### DIFF
--- a/cmd/scanner/test_rules.go
+++ b/cmd/scanner/test_rules.go
@@ -446,7 +446,7 @@ var (
 func getFixtureParsers(ctx context.Context) ([]*parser.Parser, error) {
 	fixtureParsersOnce.Do(func() {
 		fixtureParsers, fixtureParsersErr = parser.NewBuilder(ctx).
-			Add(&jsonParser.Parser{}).
+			Add(jsonParser.NewDefaultWithParams(true)).
 			Add(&yamlParser.Parser{}).
 			Add(terraformParser.NewDefault()).
 			Add(&bicepParser.Parser{}).

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/tfplan"
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/pkg/errors"
@@ -181,6 +182,7 @@ type regexSlice struct {
 
 type analyzerInfo struct {
 	typesFlag       []string
+	scanTfPlans     bool
 	filePath        string
 	filePlatformMap *sync.Map
 	contentCache    *sync.Map
@@ -198,6 +200,7 @@ type Analyzer struct {
 	ExcludeGitIgnore  bool
 	MaxFileSize       int
 	NumWorkers        int
+	ScanTfPlans       bool
 }
 
 // types is a map that contains the regex by type
@@ -485,6 +488,7 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 			func(ctx context.Context, filePath string, _ int) error {
 				analyzerInfo := &analyzerInfo{
 					typesFlag:       typesFlag,
+					scanTfPlans:     a.ScanTfPlans,
 					filePath:        filePath,
 					filePlatformMap: &filePlatformMap,
 					contentCache:    &contentCache,
@@ -559,7 +563,7 @@ func (a *analyzerInfo) worker(ctx context.Context, results, unwanted chan<- stri
 		return
 	}
 
-	platform := classifyFile(ctx, vfs.DiskFS{}, a.filePath, content, a.typesFlag, a.helmCache)
+	platform := classifyFile(ctx, vfs.DiskFS{}, a.filePath, content, a.typesFlag, a.scanTfPlans, a.helmCache)
 	if platform == "" {
 		unwanted <- a.filePath
 		return
@@ -639,9 +643,9 @@ func needsOverride(check bool, returnType, key, ext string) bool {
 // classifyByContent determines the platform of a content-detected file (yaml,
 // yml, json, sh) using the type regexes and the post-processing in
 // checkReturnType. It returns the platform string (lowercased) or "" when none
-// matches or the file is a non-Terraform JSON (which the scanner does not scan).
+// matches. Terraform-plan JSON is included only when scanTfPlans is true.
 // typesFlag restricts the candidate platforms; pass nil or [""] to consider all.
-func classifyByContent(ctx context.Context, path string, content []byte, ext string, typesFlag []string, hc *sync.Map) string {
+func classifyByContent(ctx context.Context, path string, content []byte, ext string, typesFlag []string, scanTfPlans bool, hc *sync.Map) string {
 	returnType := ""
 
 	// Sort map so that CloudFormation (type that as less requireds) goes last
@@ -677,10 +681,14 @@ func classifyByContent(ctx context.Context, path string, content []byte, ext str
 
 	endReturnType := checkReturnType(ctx, path, returnType, ext, content, hc)
 
-	// Only process JSON files if they are Terraform plans
-	// This will be the case until other platforms support json scanning
-	if ext == json && (endReturnType != "terraform" || returnType == cdkTf) {
-		return ""
+	if ext == json {
+		if endReturnType == terraform || returnType == cdkTf {
+			if !scanTfPlans || !tfplan.IsTerraformPlanJSON(content) {
+				return ""
+			}
+			return terraform
+		}
+		return endReturnType
 	}
 
 	return endReturnType
@@ -705,13 +713,13 @@ func containsAny(content []byte, needles [][]byte) bool {
 // classification consistent with the analyzer's. fsys is the filesystem used
 // for extension detection; pass the in-memory FS for pushed content that never
 // touches disk, or nil to default to the real disk.
-func ClassifyFile(ctx context.Context, fsys vfs.FS, path string, content []byte, typesFlag []string) string {
-	return classifyFile(ctx, fsys, path, content, typesFlag, nil)
+func ClassifyFile(ctx context.Context, fsys vfs.FS, path string, content []byte, typesFlag []string, scanTfPlans bool) string {
+	return classifyFile(ctx, fsys, path, content, typesFlag, scanTfPlans, nil)
 }
 
 // classifyFile is the internal implementation; hc is the per-scan helm cache
 // (nil disables caching, which is safe for the server/sink path).
-func classifyFile(ctx context.Context, fsys vfs.FS, path string, content []byte, typesFlag []string, hc *sync.Map) string {
+func classifyFile(ctx context.Context, fsys vfs.FS, path string, content []byte, typesFlag []string, scanTfPlans bool, hc *sync.Map) string {
 	if fsys == nil {
 		fsys = vfs.DiskFS{}
 	}
@@ -737,7 +745,7 @@ func classifyFile(ctx context.Context, fsys vfs.FS, path string, content []byte,
 	case extCfg, extConf, extIni:
 		return ansible
 	case yaml, yml, json, sh:
-		return classifyByContent(ctx, path, content, ext, typesFlag, hc)
+		return classifyByContent(ctx, path, content, ext, typesFlag, scanTfPlans, hc)
 	}
 	return ""
 }
@@ -751,11 +759,11 @@ func classifyFile(ctx context.Context, fsys vfs.FS, path string, content []byte,
 // scan, "crossplane" only when Crossplane is enabled). fsys is forwarded for
 // extension detection so the server's in-memory pushed content (not on disk) is
 // classified correctly.
-func ClassifyParsedFile(ctx context.Context, fsys vfs.FS, platforms []string, kind model.FileKind, path string, content []byte) string {
+func ClassifyParsedFile(ctx context.Context, fsys vfs.FS, platforms []string, scanTfPlans bool, kind model.FileKind, path string, content []byte) string {
 	if platform, ok := PlatformForKind(kind); ok {
 		return platform
 	}
-	return ClassifyFile(ctx, fsys, path, content, platforms)
+	return ClassifyFile(ctx, fsys, path, content, platforms, scanTfPlans)
 }
 
 // PlatformForKind returns the fixed platform for kind when known.

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -451,9 +451,59 @@ func TestClassifyFile_SwaggerOpenAPI(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "swagger.yaml")
 	require.NoError(t, os.WriteFile(path, content, 0o600))
 
-	got := ClassifyFile(context.Background(), nil, path, content, []string{""})
+	got := ClassifyFile(context.Background(), nil, path, content, []string{""}, false)
 
 	require.Equal(t, "openapi", got)
+}
+
+func TestClassifyFile_JSONTerraformGating(t *testing.T) {
+	ctx := context.Background()
+	fixturesDir := filepath.FromSlash("../../test/fixtures/tfplan_flag_test")
+	tfPlan, err := os.ReadFile(filepath.Join(fixturesDir, "tfplan.json"))
+	require.NoError(t, err)
+	cfJSON, err := os.ReadFile(filepath.Join(fixturesDir, "cloudformation.json"))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		content     []byte
+		path        string
+		platforms   []string
+		scanTfPlans bool
+		want        string
+	}{
+		{
+			name:        "cloudformation json classified without tf plan flag",
+			content:     cfJSON,
+			path:        filepath.Join(fixturesDir, "cloudformation.json"),
+			platforms:   []string{"cloudformation"},
+			scanTfPlans: false,
+			want:        "cloudformation",
+		},
+		{
+			name:        "terraform plan json rejected when flag off",
+			content:     tfPlan,
+			path:        filepath.Join(fixturesDir, "tfplan.json"),
+			platforms:   []string{"terraform"},
+			scanTfPlans: false,
+			want:        "",
+		},
+		{
+			name:        "terraform plan json classified when flag on",
+			content:     tfPlan,
+			path:        filepath.Join(fixturesDir, "tfplan.json"),
+			platforms:   []string{"terraform"},
+			scanTfPlans: true,
+			want:        "terraform",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyFile(ctx, nil, tt.path, tt.content, tt.platforms, tt.scanTfPlans)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestAnalyze_ValidSymlink(t *testing.T) {

--- a/pkg/detector/default_detect_test.go
+++ b/pkg/detector/default_detect_test.go
@@ -446,7 +446,7 @@ var OriginalDataTFPlan = `{
 
 // Test_detectLineTerraformPlan verifies attribute-level plan searchKeys.
 func Test_detectLineTerraformPlan(t *testing.T) {
-	p := &jsonParser.Parser{}
+	p := jsonParser.NewDefaultWithParams(true)
 	_, docs, _, _, err := p.Parse(context.Background(), []byte(OriginalDataTFPlan), "plan.json", false, 1)
 	require.NoError(t, err)
 	require.Len(t, docs, 1)
@@ -482,7 +482,7 @@ func Test_detectLineTerraformPlanResourceLevel(t *testing.T) {
     }
   }
 }`
-	p := &jsonParser.Parser{}
+	p := jsonParser.NewDefaultWithParams(true)
 	_, docs, _, _, err := p.Parse(context.Background(), []byte(plan), "plan.json", false, 1)
 	require.NoError(t, err)
 
@@ -521,7 +521,7 @@ func Test_detectLineTerraformPlanModuleResourceWithCountIndex(t *testing.T) {
     }
   }
 }`
-	p := &jsonParser.Parser{}
+	p := jsonParser.NewDefaultWithParams(true)
 	_, docs, _, _, err := p.Parse(context.Background(), []byte(plan), "plan.json", false, 1)
 	require.NoError(t, err)
 
@@ -575,7 +575,7 @@ func Test_detectLineTerraformPlanSiblingModulesSameTypeAndName(t *testing.T) {
     }
   }
 }`
-	p := &jsonParser.Parser{}
+	p := jsonParser.NewDefaultWithParams(true)
 	_, docs, _, _, err := p.Parse(context.Background(), []byte(plan), "plan.json", false, 1)
 	require.NoError(t, err)
 
@@ -599,7 +599,7 @@ func Test_detectLineTerraformPlanMinified(t *testing.T) {
 	// After StringifyContent pretty-prints, LinesOriginalData is multi-line.
 	// Structural lookup must fall through to text matching.
 	minified := `{"format_version":"1.0","planned_values":{"root_module":{"resources":[{"address":"alicloud_db_instance.example","type":"alicloud_db_instance","name":"example","values":{"address":"0.0.0.0/0"}}]}}}`
-	p := &jsonParser.Parser{}
+	p := jsonParser.NewDefaultWithParams(true)
 	// Parse computes _dd_lines from the minified bytes.
 	_, docs, _, _, err := p.Parse(context.Background(), []byte(minified), "plan.json", false, 1)
 	require.NoError(t, err)

--- a/pkg/parser/json/parser.go
+++ b/pkg/parser/json/parser.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/resolver/file"
+	"github.com/DataDog/datadog-iac-scanner/pkg/tfplan"
 )
 
 // Parser defines a parser type
@@ -66,7 +67,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	jLine := initializeJSONLine(resolved)
 	jsonDoc := jLine.setLineInfo(r)
 
-	if !p.scanTfPlans || !looksLikeTerraformPlan(fileContent) {
+	if !p.scanTfPlans || !tfplan.IsTerraformPlanJSON(fileContent) {
 		// JSON is not a tf plan, or tf-plan detection is disabled
 		return resolved, []model.Document{jsonDoc}, nil, resolvedFiles, nil
 	}
@@ -94,7 +95,7 @@ func (p *Parser) GetKind() model.FileKind {
 // KindForContent overrides the static kind for Terraform plan JSON so line
 // detection can resolve plan resources structurally instead of by text match.
 func (p *Parser) KindForContent(content []byte) (model.FileKind, bool) {
-	if p.scanTfPlans && looksLikeTerraformPlan(content) {
+	if p.scanTfPlans && tfplan.IsTerraformPlanJSON(content) {
 		return model.KindTerraformPlan, true
 	}
 	return "", false
@@ -124,7 +125,7 @@ func (p *Parser) GetCommentToken() string {
 
 // StringifyContent converts original content into string formatted version
 func (p *Parser) StringifyContent(content []byte) (string, error) {
-	if looksLikeTerraformPlan(content) {
+	if tfplan.IsTerraformPlanJSON(content) {
 		var out bytes.Buffer
 		if err := json.Indent(&out, content, "", "  "); err != nil {
 			return "", err
@@ -132,13 +133,4 @@ func (p *Parser) StringifyContent(content []byte) (string, error) {
 		return out.String(), nil
 	}
 	return string(content), nil
-}
-
-// looksLikeTerraformPlan is a fast byte-level heuristic that avoids a full
-// JSON parse. Both keys are required by the Terraform plan JSON spec, so their
-// co-presence is a reliable signal. Used by KindForContent and StringifyContent
-// where a full parseTFPlan call would be redundant (Parse already does it).
-func looksLikeTerraformPlan(content []byte) bool {
-	return bytes.Contains(content, []byte(`"format_version"`)) &&
-		bytes.Contains(content, []byte(`"planned_values"`))
 }

--- a/pkg/parser/json/parser.go
+++ b/pkg/parser/json/parser.go
@@ -15,7 +15,17 @@ import (
 )
 
 // Parser defines a parser type
-type Parser struct{}
+type Parser struct {
+	scanTfPlans bool
+}
+
+// NewDefaultWithParams creates a Parser. scanTfPlans controls whether this
+// parser treats "terraform" as a supported type and detects Terraform-plan
+// JSON content; other supported types (cloudformation, kubernetes, ...) are
+// unaffected.
+func NewDefaultWithParams(scanTfPlans bool) *Parser {
+	return &Parser{scanTfPlans: scanTfPlans}
+}
 
 // Resolve - replace or modifies in-memory content before parsing
 func (p *Parser) Resolve(ctx context.Context, fileContent []byte, filename string,
@@ -56,8 +66,8 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, filePath string,
 	jLine := initializeJSONLine(resolved)
 	jsonDoc := jLine.setLineInfo(r)
 
-	if !looksLikeTerraformPlan(fileContent) {
-		// JSON is not a tf plan
+	if !p.scanTfPlans || !looksLikeTerraformPlan(fileContent) {
+		// JSON is not a tf plan, or tf-plan detection is disabled
 		return resolved, []model.Document{jsonDoc}, nil, resolvedFiles, nil
 	}
 
@@ -84,22 +94,27 @@ func (p *Parser) GetKind() model.FileKind {
 // KindForContent overrides the static kind for Terraform plan JSON so line
 // detection can resolve plan resources structurally instead of by text match.
 func (p *Parser) KindForContent(content []byte) (model.FileKind, bool) {
-	if looksLikeTerraformPlan(content) {
+	if p.scanTfPlans && looksLikeTerraformPlan(content) {
 		return model.KindTerraformPlan, true
 	}
 	return "", false
 }
 
-// SupportedTypes returns types supported by this parser, which are cloudFormation
+// SupportedTypes returns the types supported by this parser. "terraform" is
+// only included when scanTfPlans is enabled, since Terraform-plan detection
+// is the only reason this parser handles that platform.
 func (p *Parser) SupportedTypes() map[string]bool {
-	return map[string]bool{
+	types := map[string]bool{
 		"ansible":              true,
 		"cloudformation":       true,
 		"openapi":              true,
 		"azureresourcemanager": true,
-		"terraform":            true,
 		"kubernetes":           true,
 	}
+	if p.scanTfPlans {
+		types["terraform"] = true
+	}
+	return types
 }
 
 // GetCommentToken return an empty string, since JSON does not have comment token

--- a/pkg/parser/json/parser_test.go
+++ b/pkg/parser/json/parser_test.go
@@ -30,17 +30,51 @@ func TestParser_SupportedExtensions(t *testing.T) {
 	require.Equal(t, []string{".json"}, p.SupportedExtensions())
 }
 
-// TestParser_SupportedExtensions tests the functions [SupportedTypes()] and all the methods called by them
+// TestParser_SupportedTypes tests that "terraform" is only supported when
+// tf-plan detection is enabled; other types are always supported.
 func TestParser_SupportedTypes(t *testing.T) {
-	p := &Parser{}
 	require.Equal(t, map[string]bool{
 		"ansible":              true,
 		"cloudformation":       true,
 		"openapi":              true,
 		"azureresourcemanager": true,
-		"terraform":            true,
 		"kubernetes":           true,
-	}, p.SupportedTypes())
+	}, NewDefaultWithParams(false).SupportedTypes())
+
+	require.Equal(t, map[string]bool{
+		"ansible":              true,
+		"cloudformation":       true,
+		"openapi":              true,
+		"azureresourcemanager": true,
+		"kubernetes":           true,
+		"terraform":            true,
+	}, NewDefaultWithParams(true).SupportedTypes())
+}
+
+// TestParser_TfPlanGating verifies tf-plan detection in KindForContent and
+// Parse is controlled by scanTfPlans, independent of parser registration.
+func TestParser_TfPlanGating(t *testing.T) {
+	ctx := context.Background()
+
+	enabled := NewDefaultWithParams(true)
+	kind, override := enabled.KindForContent([]byte(minifiedTFPlan))
+	require.True(t, override)
+	require.Equal(t, model.KindTerraformPlan, kind)
+
+	_, doc, _, _, err := enabled.Parse(ctx, []byte(minifiedTFPlan), "plan.json", false, 15)
+	require.NoError(t, err)
+	require.Len(t, doc, 1)
+	require.Contains(t, doc[0], "resource")
+
+	disabled := NewDefaultWithParams(false)
+	_, override = disabled.KindForContent([]byte(minifiedTFPlan))
+	require.False(t, override)
+
+	_, doc, _, _, err = disabled.Parse(ctx, []byte(minifiedTFPlan), "plan.json", false, 15)
+	require.NoError(t, err)
+	require.Len(t, doc, 1)
+	require.Contains(t, doc[0], "format_version")
+	require.NotContains(t, doc[0], "resource")
 }
 
 // TestParser_Parse tests the functions [Parse()] and all the methods called by them

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -82,6 +82,8 @@ type Service struct {
 	Platforms []string
 	// FilePlatform is the analyzer path → platform map, reused in the sink.
 	FilePlatform map[string]string
+	// ScanTfPlans gates terraform-plan JSON classification in the sink.
+	ScanTfPlans bool
 	// failedHelmChartDirsMu guards failedHelmChartDirs.
 	failedHelmChartDirsMu sync.RWMutex
 	// failedHelmChartDirs tracks chart directories that could not be rendered,

--- a/pkg/runner/sink.go
+++ b/pkg/runner/sink.go
@@ -123,7 +123,7 @@ func (s *Service) classifyPlatform(ctx context.Context, kind model.FileKind, fil
 	if platform, ok := s.FilePlatform[filepath.ToSlash(filename)]; ok {
 		return platform
 	}
-	return analyzer.ClassifyParsedFile(ctx, s.Parser.FS(), s.Platforms, kind, filename, content)
+	return analyzer.ClassifyParsedFile(ctx, s.Parser.FS(), s.Platforms, s.ScanTfPlans, kind, filename, content)
 }
 
 func resolveCRLFFile(fileContent []byte) []byte {

--- a/pkg/scan/custom_scan.go
+++ b/pkg/scan/custom_scan.go
@@ -93,6 +93,7 @@ func RunCustomRegoQuery(
 		MaxResolverDepth:        15,
 		FlagEvaluator:           featureflags.NewLocalEvaluator(),
 		ExcludeGitIgnore:        true,
+		ShouldScanTfPlans:       true,
 	}
 
 	c, err := NewClient(ctx, params, (*printer.Printer)(nil))

--- a/pkg/scan/custom_scan_test.go
+++ b/pkg/scan/custom_scan_test.go
@@ -3,6 +3,8 @@ package scan
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -504,4 +506,40 @@ func TestValidateRegoStructure_MissingPackage(t *testing.T) {
 	require.NotEmpty(t, errs)
 	assert.True(t, errorCodes(errs)[codeMissingPackage], "must return parse error, not recover")
 	assert.False(t, errorCodes(errs)["missing_result_field"], "recovery path must not run")
+}
+
+// ── RunCustomRegoQuery integration ────────────────────────────────────────────
+
+const cloudFormationJSONRego = `
+package datadog
+
+import rego.v1
+
+DatadogPolicy contains result if {
+	doc := input.document[i]
+	doc.Resources[name].Type == "AWS::S3::Bucket"
+	doc.Resources[name].Properties.AccessControl == "PublicRead"
+	result := {
+		"documentId":   doc.id,
+		"resourceType": "AWS::S3::Bucket",
+		"resourceName": name,
+		"searchKey":    sprintf("Resources[%s].Properties.AccessControl", [name]),
+	}
+}
+`
+
+func TestRunCustomRegoQuery_CloudFormationJSON(t *testing.T) {
+	fixture := filepath.FromSlash("../../test/fixtures/tfplan_flag_test/cloudformation.json")
+	content, err := os.ReadFile(fixture)
+	require.NoError(t, err)
+
+	vulns, failedQueries, err := RunCustomRegoQuery(
+		context.Background(),
+		"cloudformation",
+		cloudFormationJSONRego,
+		content,
+	)
+	require.NoError(t, err)
+	require.Empty(t, failedQueries, "custom rule should compile and run")
+	require.NotEmpty(t, vulns, "CloudFormation JSON should be classified and scanned via custom evaluate")
 }

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -364,6 +364,7 @@ func (c *Client) createService(
 				MaxFileSize:    c.ScanParams.MaxFileSizeFlag,
 				Platforms:      types,
 				FilePlatform:   filePlatform,
+				ScanTfPlans:    c.ScanParams.ShouldScanTfPlans,
 			},
 		)
 	}

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -330,11 +330,8 @@ func (c *Client) createService(
 		Add(&protoParser.Parser{}).
 		Add(&buildahParser.Parser{}).
 		Add(&ansibleConfigParser.Parser{}).
-		Add(&ansibleHostsParser.Parser{})
-
-	if c.ScanParams.ShouldScanTfPlans {
-		combinedParserBuilder.Add(&jsonParser.Parser{})
-	}
+		Add(&ansibleHostsParser.Parser{}).
+		Add(jsonParser.NewDefaultWithParams(c.ScanParams.ShouldScanTfPlans))
 
 	combinedParser, err := combinedParserBuilder.Build(types, cloudProviders)
 	if err != nil {

--- a/pkg/scan/tfplan_flag_test.go
+++ b/pkg/scan/tfplan_flag_test.go
@@ -13,267 +13,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestJSONParserRegistration verifies that the JSON parser is only registered when ShouldScanTfPlans is true
+func newTestClient(t *testing.T, shouldScanTfPlans bool) *Client {
+	t.Helper()
+
+	params := &Parameters{
+		PreviewLines:      3,
+		RepoPath:          t.TempDir(),
+		Path:              []string{t.TempDir()},
+		ShouldScanTfPlans: shouldScanTfPlans,
+	}
+
+	tr, err := tracker.NewTracker(params.PreviewLines)
+	require.NoError(t, err)
+
+	return &Client{
+		ScanParams:    params,
+		Tracker:       tr,
+		Storage:       storage.NewMemoryStorage(),
+		FlagEvaluator: featureflags.NewLocalEvaluator(),
+	}
+}
+
+// TestJSONParserRegistration verifies that the JSON parser is registered for
+// JSON-capable platforms like cloudformation regardless of ShouldScanTfPlans,
+// but only registered for terraform when ShouldScanTfPlans is true, since
+// that's the only reason the JSON parser handles terraform.
 func TestJSONParserRegistration(t *testing.T) {
 	tests := []struct {
-		name                    string
-		shouldScanTfPlans       bool
-		expectJSONParserPresent bool
+		name              string
+		platforms         []string
+		shouldScanTfPlans bool
+		expectJSONParser  bool
 	}{
-		{
-			name:                    "JSON parser registered when flag is true",
-			shouldScanTfPlans:       true,
-			expectJSONParserPresent: true,
-		},
-		{
-			name:                    "JSON parser not registered when flag is false",
-			shouldScanTfPlans:       false,
-			expectJSONParserPresent: false,
-		},
+		{"cloudformation, flag off", []string{"cloudformation"}, false, true},
+		{"cloudformation, flag on", []string{"cloudformation"}, true, true},
+		{"terraform, flag off", []string{"terraform"}, false, false},
+		{"terraform, flag on", []string{"terraform"}, true, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
+			client := newTestClient(t, tt.shouldScanTfPlans)
 
-			params := &Parameters{
-				PreviewLines:      3,
-				RepoPath:          t.TempDir(),
-				Path:              []string{t.TempDir()},
-				ShouldScanTfPlans: tt.shouldScanTfPlans,
-			}
-
-			tr, err := tracker.NewTracker(params.PreviewLines)
-			require.NoError(t, err)
-
-			client := &Client{
-				ScanParams:    params,
-				Tracker:       tr,
-				Storage:       storage.NewMemoryStorage(),
-				FlagEvaluator: featureflags.NewLocalEvaluator(),
-			}
-
-			// Create a mock inspector (we don't actually need to use it)
-			// We just need to test the parser registration logic
-			platforms := []string{"terraform"}
-			cloudProviders := []string{""}
-
-			// Call createService which contains the conditional JSON parser registration
 			services, err := client.createService(
-				ctx,
-				nil, // inspector - not needed for this test
-				[]string{params.Path[0]},
-				nil, // remoteModulePaths
-				client.Tracker,
-				client.Storage,
-				platforms,
-				cloudProviders,
-				client.FlagEvaluator,
-				nil,
+				ctx, nil, []string{client.ScanParams.Path[0]}, nil,
+				client.Tracker, client.Storage, tt.platforms, []string{""},
+				client.FlagEvaluator, nil,
 			)
 
 			require.NoError(t, err)
-			require.NotNil(t, services)
-
-			// Check if JSON parser is present in the services
-			jsonParserFound := false
-			for _, service := range services {
-				if service.Parser != nil && service.Parser.Parsers != nil {
-					if service.Parser.Parsers.GetKind() == model.KindJSON {
-						jsonParserFound = true
-						break
-					}
-				}
-			}
-
-			if tt.expectJSONParserPresent {
-				assert.True(t, jsonParserFound,
-					"JSON parser should be registered when ShouldScanTfPlans is true")
-			} else {
-				assert.False(t, jsonParserFound,
-					"JSON parser should not be registered when ShouldScanTfPlans is false")
-			}
+			assert.Equal(t, tt.expectJSONParser, countParsersOfType(services, model.KindJSON) > 0)
 		})
 	}
-}
-
-// TestJSONParserBuilder verifies the parser builder correctly adds JSON parser based on flag
-func TestJSONParserBuilder(t *testing.T) {
-	ctx := context.Background()
-
-	// First, create services without the flag to get baseline count
-	paramsWithoutFlag := &Parameters{
-		PreviewLines:      3,
-		RepoPath:          t.TempDir(),
-		Path:              []string{t.TempDir()},
-		ShouldScanTfPlans: false,
-	}
-
-	tr1, err := tracker.NewTracker(paramsWithoutFlag.PreviewLines)
-	require.NoError(t, err)
-
-	clientWithoutFlag := &Client{
-		ScanParams:    paramsWithoutFlag,
-		Tracker:       tr1,
-		Storage:       storage.NewMemoryStorage(),
-		FlagEvaluator: featureflags.NewLocalEvaluator(),
-	}
-
-	platforms := []string{"terraform", "kubernetes", "cloudformation"}
-	cloudProviders := []string{""}
-
-	servicesWithoutFlag, err := clientWithoutFlag.createService(
-		ctx,
-		nil,
-		[]string{paramsWithoutFlag.Path[0]},
-		nil,
-		clientWithoutFlag.Tracker,
-		clientWithoutFlag.Storage,
-		platforms,
-		cloudProviders,
-		clientWithoutFlag.FlagEvaluator,
-		nil,
-	)
-
-	require.NoError(t, err)
-	baselineCount := len(servicesWithoutFlag)
-
-	// Check that JSON parser is NOT present when flag is false
-	jsonParserFound := false
-	for _, service := range servicesWithoutFlag {
-		if service.Parser != nil && service.Parser.Parsers != nil {
-			if service.Parser.Parsers.GetKind() == model.KindJSON {
-				jsonParserFound = true
-				break
-			}
-		}
-	}
-	assert.False(t, jsonParserFound, "JSON parser should not be present when flag is false")
-
-	// Now create services with the flag enabled
-	paramsWithFlag := &Parameters{
-		PreviewLines:      3,
-		RepoPath:          t.TempDir(),
-		Path:              []string{t.TempDir()},
-		ShouldScanTfPlans: true,
-	}
-
-	tr2, err := tracker.NewTracker(paramsWithFlag.PreviewLines)
-	require.NoError(t, err)
-
-	clientWithFlag := &Client{
-		ScanParams:    paramsWithFlag,
-		Tracker:       tr2,
-		Storage:       storage.NewMemoryStorage(),
-		FlagEvaluator: featureflags.NewLocalEvaluator(),
-	}
-
-	servicesWithFlag, err := clientWithFlag.createService(
-		ctx,
-		nil,
-		[]string{paramsWithFlag.Path[0]},
-		nil,
-		clientWithFlag.Tracker,
-		clientWithFlag.Storage,
-		platforms,
-		cloudProviders,
-		clientWithFlag.FlagEvaluator,
-		nil,
-	)
-
-	require.NoError(t, err)
-	countWithFlag := len(servicesWithFlag)
-
-	// Check that JSON parser IS present when flag is true
-	jsonParserFound = false
-	for _, service := range servicesWithFlag {
-		if service.Parser != nil && service.Parser.Parsers != nil {
-			if service.Parser.Parsers.GetKind() == model.KindJSON {
-				jsonParserFound = true
-				break
-			}
-		}
-	}
-	assert.True(t, jsonParserFound, "JSON parser should be present when flag is true")
-
-	// When flag is enabled, we should have more services (JSON parser adds support for more platforms)
-	assert.GreaterOrEqual(t, countWithFlag, baselineCount,
-		"Should have at least as many parsers with flag enabled (found %d with flag vs %d without)", countWithFlag, baselineCount)
-}
-
-// TestCreateServiceWithTfPlanFlag is an integration-style test verifying the full flow
-func TestCreateServiceWithTfPlanFlag(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("services created successfully with flag enabled", func(t *testing.T) {
-		params := &Parameters{
-			PreviewLines:      3,
-			RepoPath:          t.TempDir(),
-			Path:              []string{t.TempDir()},
-			ShouldScanTfPlans: true,
-		}
-
-		tr, err := tracker.NewTracker(params.PreviewLines)
-		require.NoError(t, err)
-
-		client := &Client{
-			ScanParams:    params,
-			Tracker:       tr,
-			Storage:       storage.NewMemoryStorage(),
-			FlagEvaluator: featureflags.NewLocalEvaluator(),
-		}
-
-		services, err := client.createService(
-			ctx,
-			nil,
-			[]string{params.Path[0]},
-			nil,
-			client.Tracker,
-			client.Storage,
-			[]string{"terraform"},
-			[]string{""},
-			client.FlagEvaluator,
-			nil,
-		)
-
-		require.NoError(t, err)
-		assert.NotEmpty(t, services, "Services should be created")
-	})
-
-	t.Run("services created successfully with flag disabled", func(t *testing.T) {
-		params := &Parameters{
-			PreviewLines:      3,
-			RepoPath:          t.TempDir(),
-			Path:              []string{t.TempDir()},
-			ShouldScanTfPlans: false,
-		}
-
-		tr, err := tracker.NewTracker(params.PreviewLines)
-		require.NoError(t, err)
-
-		client := &Client{
-			ScanParams:    params,
-			Tracker:       tr,
-			Storage:       storage.NewMemoryStorage(),
-			FlagEvaluator: featureflags.NewLocalEvaluator(),
-		}
-
-		services, err := client.createService(
-			ctx,
-			nil,
-			[]string{params.Path[0]},
-			nil,
-			client.Tracker,
-			client.Storage,
-			[]string{"terraform"},
-			[]string{""},
-			client.FlagEvaluator,
-			nil,
-		)
-
-		require.NoError(t, err)
-		assert.NotEmpty(t, services, "Services should be created even without JSON parser")
-	})
 }
 
 // Helper function to count parsers of a specific type
@@ -292,45 +84,18 @@ func countParsersOfType(services []*runner.Service, parserType model.FileKind) i
 // TestJSONParserNotDoubleRegistered ensures JSON parser isn't registered multiple times
 func TestJSONParserNotDoubleRegistered(t *testing.T) {
 	ctx := context.Background()
+	client := newTestClient(t, true)
 
-	params := &Parameters{
-		PreviewLines:      3,
-		RepoPath:          t.TempDir(),
-		Path:              []string{t.TempDir()},
-		ShouldScanTfPlans: true,
-	}
-
-	tr, err := tracker.NewTracker(params.PreviewLines)
-	require.NoError(t, err)
-
-	client := &Client{
-		ScanParams:    params,
-		Tracker:       tr,
-		Storage:       storage.NewMemoryStorage(),
-		FlagEvaluator: featureflags.NewLocalEvaluator(),
-	}
-
-	// Call createService multiple times
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		services, err := client.createService(
-			ctx,
-			nil,
-			[]string{params.Path[0]},
-			nil,
-			client.Tracker,
-			client.Storage,
-			[]string{"terraform"},
-			[]string{""},
-			client.FlagEvaluator,
-			nil,
+			ctx, nil, []string{client.ScanParams.Path[0]}, nil,
+			client.Tracker, client.Storage, []string{"terraform"}, []string{""},
+			client.FlagEvaluator, nil,
 		)
 
 		require.NoError(t, err)
 		require.NotNil(t, services)
-
-		// Count JSON parsers - should only be one per service creation
-		jsonCount := countParsersOfType(services, model.KindJSON)
-		assert.LessOrEqual(t, jsonCount, 1,
+		assert.LessOrEqual(t, countParsersOfType(services, model.KindJSON), 1,
 			"Should have at most one JSON parser per service creation")
 	}
 }

--- a/pkg/tfplan/detect.go
+++ b/pkg/tfplan/detect.go
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package tfplan
+
+import "bytes"
+
+// IsTerraformPlanJSON is a fast byte-level heuristic that avoids a full JSON
+// parse. Both keys are required by the Terraform plan JSON spec, so their
+// co-presence is a reliable signal. Shared by the JSON parser and analyzer.
+func IsTerraformPlanJSON(content []byte) bool {
+	return bytes.Contains(content, []byte(`"format_version"`)) &&
+		bytes.Contains(content, []byte(`"planned_values"`))
+}


### PR DESCRIPTION
## Summary

- Always register the JSON parser and gate only `terraform` in `SupportedTypes()` behind `--x-terraform-plan`.
- Fix platform attribution for custom evaluate: invert the analyzer JSON gate so CloudFormation and other non-terraform JSON platforms classify correctly in the sink path.
- Thread `ScanTfPlans` through `ClassifyParsedFile` and enable tf-plan JSON on custom evaluate without the CLI flag.

## Test plan

- [x] `go test ./pkg/analyzer -run TestClassifyFile_JSONTerraformGating -count=1`
- [x] `go test ./pkg/scan -run 'TestRunCustomRegoQuery_CloudFormationJSON|TestJSONParserRegistration' -count=1`
- [x] `go test ./pkg/parser/json ./pkg/runner -count=1`


Made with [Cursor](https://cursor.com)