### PR TITLE
(darft) Enable JSON parser

### DIFF
--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -27,25 +27,20 @@ func TestAnalyzer_Analyze(t *testing.T) {
 		gitIgnoreFileName string
 		excludeGitIgnore  bool
 		MaxFileSize       int
+		scanTfPlans       bool
 		repoPath          string
 	}{
 		{
 			name:  "analyze_test_dir_single_path",
 			paths: []string{filepath.FromSlash("../../test/fixtures/analyzer_test")},
-			// The following test is changed by the json gating that only allows terraform plans to be scanned.
-			// It will be changed when support for json files for other platforms is added.
-			// wantTypes: []string{"ansible", "azureresourcemanager", "cicd", "cloudformation", "crossplane", "googledeploymentmanager", "knative", "kubernetes", "openapi", "pulumi", "serverlessfw", "terraform"},
-			wantTypes: []string{"ansible", "cicd", "cloudformation", "crossplane", "googledeploymentmanager", "knative", "kubernetes", "openapi", "pulumi", "serverlessfw", "terraform"},
+			wantTypes: []string{"ansible", "azureresourcemanager", "cicd", "cloudformation", "crossplane", "googledeploymentmanager", "knative", "kubernetes", "openapi", "pulumi", "serverlessfw", "terraform"},
 			wantExclude: []string{
-				filepath.FromSlash("../../test/fixtures/analyzer_test/azureResourceManager.json"),
 				filepath.FromSlash("../../test/fixtures/analyzer_test/not_openapi.json"),
-				filepath.FromSlash("../../test/fixtures/analyzer_test/openAPI.json"),
-				filepath.FromSlash("../../test/fixtures/analyzer_test/openAPI_test/openAPI.json"),
 				filepath.FromSlash("../../test/fixtures/analyzer_test/pnpm-lock.yaml"),
 				filepath.FromSlash("../../test/fixtures/analyzer_test/undetected.yaml"),
 			},
 			typesFromFlag:     []string{""},
-			wantLOC:           680, // Reduced from 819 due to JSON file exclusion
+			wantLOC:           819,
 			wantErr:           false,
 			gitIgnoreFileName: "",
 			excludeGitIgnore:  false,
@@ -83,11 +78,9 @@ func TestAnalyzer_Analyze(t *testing.T) {
 				filepath.FromSlash("../../test/fixtures/analyzer_test/openAPI_test"),
 			},
 			wantTypes: []string{"openapi"},
-			wantExclude: []string{
-				filepath.FromSlash("../../test/fixtures/analyzer_test/openAPI_test/openAPI.json"),
-			},
+			wantExclude: []string{},
 			typesFromFlag:     []string{""},
-			wantLOC:           39, // Reduced from 107 due to JSON file exclusion (107 - 68 = 39)
+			wantLOC:           107,
 			wantErr:           false,
 			gitIgnoreFileName: "",
 			excludeGitIgnore:  false,
@@ -129,7 +122,23 @@ func TestAnalyzer_Analyze(t *testing.T) {
 			wantTypes:         []string{"terraform"},
 			wantExclude:       []string{},
 			typesFromFlag:     []string{""},
+			scanTfPlans:       true,
 			wantLOC:           26,
+			wantErr:           false,
+			gitIgnoreFileName: "",
+			excludeGitIgnore:  false,
+			MaxFileSize:       -1,
+		},
+		{
+			name: "analyze_test_tfplan_flag_off",
+			paths: []string{
+				filepath.FromSlash("../../test/fixtures/tfplan"),
+			},
+			wantTypes:   []string{},
+			wantExclude: []string{filepath.FromSlash("../../test/fixtures/tfplan/tfplan.json")},
+			typesFromFlag:     []string{""},
+			scanTfPlans:       false,
+			wantLOC:           0,
 			wantErr:           false,
 			gitIgnoreFileName: "",
 			excludeGitIgnore:  false,
@@ -241,20 +250,14 @@ func TestAnalyzer_Analyze(t *testing.T) {
 		{
 			name:  "analyze_test_ignore_pnpm_lock_yaml_file",
 			paths: []string{filepath.FromSlash("../../test/fixtures/analyzer_test")},
-			// The following test is changed by the json gating that only allows terraform plans to be scanned.
-			// It will be changed when support for json files for other platforms is added.
-			// wantTypes: []string{"ansible", "azureresourcemanager", "cicd", "cloudformation", "crossplane", "googledeploymentmanager", "knative", "kubernetes", "openapi", "pulumi", "serverlessfw", "terraform"},
-			wantTypes: []string{"ansible", "cicd", "cloudformation", "crossplane", "googledeploymentmanager", "knative", "kubernetes", "openapi", "pulumi", "serverlessfw", "terraform"},
+			wantTypes: []string{"ansible", "azureresourcemanager", "cicd", "cloudformation", "crossplane", "googledeploymentmanager", "knative", "kubernetes", "openapi", "pulumi", "serverlessfw", "terraform"},
 			wantExclude: []string{
-				filepath.FromSlash("../../test/fixtures/analyzer_test/azureResourceManager.json"),
 				filepath.FromSlash("../../test/fixtures/analyzer_test/not_openapi.json"),
-				filepath.FromSlash("../../test/fixtures/analyzer_test/openAPI.json"),
-				filepath.FromSlash("../../test/fixtures/analyzer_test/openAPI_test/openAPI.json"),
 				filepath.FromSlash("../../test/fixtures/analyzer_test/pnpm-lock.yaml"),
 				filepath.FromSlash("../../test/fixtures/analyzer_test/undetected.yaml"),
 			},
 			typesFromFlag:     []string{""},
-			wantLOC:           680, // Reduced from 819 due to JSON file exclusion
+			wantLOC:           819,
 			wantErr:           false,
 			gitIgnoreFileName: "",
 			excludeGitIgnore:  false,
@@ -402,6 +405,7 @@ func TestAnalyzer_Analyze(t *testing.T) {
 				ExcludeGitIgnore:  tt.excludeGitIgnore,
 				GitIgnoreFileName: tt.gitIgnoreFileName,
 				MaxFileSize:       tt.MaxFileSize,
+				ScanTfPlans:       tt.scanTfPlans,
 			}
 
 			got, err := Analyze(ctx, analyzer)
@@ -458,52 +462,19 @@ func TestClassifyFile_SwaggerOpenAPI(t *testing.T) {
 
 func TestClassifyFile_JSONTerraformGating(t *testing.T) {
 	ctx := context.Background()
-	fixturesDir := filepath.FromSlash("../../test/fixtures/tfplan_flag_test")
-	tfPlan, err := os.ReadFile(filepath.Join(fixturesDir, "tfplan.json"))
+	tfPlan, err := os.ReadFile(filepath.FromSlash("../../test/fixtures/tfplan/tfplan.json"))
 	require.NoError(t, err)
-	cfJSON, err := os.ReadFile(filepath.Join(fixturesDir, "cloudformation.json"))
+	cfJSON, err := os.ReadFile(filepath.FromSlash("../../test/fixtures/tfplan_flag_test/cloudformation.json"))
 	require.NoError(t, err)
 
-	tests := []struct {
-		name        string
-		content     []byte
-		path        string
-		platforms   []string
-		scanTfPlans bool
-		want        string
-	}{
-		{
-			name:        "cloudformation json classified without tf plan flag",
-			content:     cfJSON,
-			path:        filepath.Join(fixturesDir, "cloudformation.json"),
-			platforms:   []string{"cloudformation"},
-			scanTfPlans: false,
-			want:        "cloudformation",
-		},
-		{
-			name:        "terraform plan json rejected when flag off",
-			content:     tfPlan,
-			path:        filepath.Join(fixturesDir, "tfplan.json"),
-			platforms:   []string{"terraform"},
-			scanTfPlans: false,
-			want:        "",
-		},
-		{
-			name:        "terraform plan json classified when flag on",
-			content:     tfPlan,
-			path:        filepath.Join(fixturesDir, "tfplan.json"),
-			platforms:   []string{"terraform"},
-			scanTfPlans: true,
-			want:        "terraform",
-		},
-	}
+	tfPath := filepath.Join(t.TempDir(), "plan.json")
+	cfPath := filepath.Join(t.TempDir(), "template.json")
+	require.NoError(t, os.WriteFile(tfPath, tfPlan, 0o600))
+	require.NoError(t, os.WriteFile(cfPath, cfJSON, 0o600))
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := ClassifyFile(ctx, nil, tt.path, tt.content, tt.platforms, tt.scanTfPlans)
-			require.Equal(t, tt.want, got)
-		})
-	}
+	require.Equal(t, "", ClassifyFile(ctx, nil, tfPath, tfPlan, []string{"terraform"}, false))
+	require.Equal(t, terraform, ClassifyFile(ctx, nil, tfPath, tfPlan, []string{"terraform"}, true))
+	require.Equal(t, "cloudformation", ClassifyFile(ctx, nil, cfPath, cfJSON, []string{"cloudformation"}, false))
 }
 
 func TestAnalyze_ValidSymlink(t *testing.T) {

--- a/pkg/parser/json/parser_test.go
+++ b/pkg/parser/json/parser_test.go
@@ -142,7 +142,8 @@ func TestJSON_StringifyContent(t *testing.T) {
 	for i := range tests {
 		tt := &tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			var p Parser
+			scanTfPlans := tt.name == "terraform plan JSON is indented"
+			p := NewDefaultWithParams(scanTfPlans)
 			got, err := p.StringifyContent(tt.content)
 			require.Equal(t, tt.wantErr, (err != nil))
 			require.Equal(t, tt.want, got)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -90,7 +90,7 @@ func TestParser_SupportedExtensions(t *testing.T) {
 func initilizeBuilder() []*Parser {
 	ctx := context.Background()
 	bd, _ := NewBuilder(ctx).
-		Add(&jsonParser.Parser{}).
+		Add(jsonParser.NewDefaultWithParams(false)).
 		Add(&yamlParser.Parser{}).
 		Add(terraformParser.NewDefault()).
 		Build([]string{""}, []string{""})
@@ -100,7 +100,7 @@ func initilizeBuilder() []*Parser {
 func TestIsValidExtension(t *testing.T) {
 	ctx := context.Background()
 	parser, _ := NewBuilder(ctx).
-		Add(&jsonParser.Parser{}).
+		Add(jsonParser.NewDefaultWithParams(false)).
 		Build([]string{""}, []string{""})
 	require.True(t, parser[0].isValidExtension(ctx, "../../test/fixtures/test_extension/test.json"), "test.json should be a valid extension")
 	require.False(t, parser[0].isValidExtension(ctx, "../../test/fixtures/test_extension/test.xml"), "test.xml should not be a valid extension")

--- a/pkg/runner/prepare_test.go
+++ b/pkg/runner/prepare_test.go
@@ -59,7 +59,7 @@ func buildParityServices(t *testing.T, ctx context.Context, paths []string) ([]*
 		Add(&buildahParser.Parser{}).
 		Add(&ansibleConfigParser.Parser{}).
 		Add(&ansibleHostsParser.Parser{}).
-		Add(&jsonParser.Parser{}).
+		Add(jsonParser.NewDefaultWithParams(false)).
 		Build([]string{""}, []string{""})
 	require.NoError(t, err)
 

--- a/pkg/runner/service_test.go
+++ b/pkg/runner/service_test.go
@@ -128,7 +128,7 @@ func createParserSourceProvider(path string) ([]*parser.Parser,
 	*provider.FileSystemSourceProvider, *resolver.Resolver) {
 	ctx := context.Background()
 	mockParser, _ := parser.NewBuilder(ctx).
-		Add(&jsonParser.Parser{}).
+		Add(jsonParser.NewDefaultWithParams(false)).
 		Add(&yamlParser.Parser{}).
 		Add(terraformParser.NewDefault()).
 		Build([]string{""}, []string{""})

--- a/pkg/scan/tfplan_flag_test.go
+++ b/pkg/scan/tfplan_flag_test.go
@@ -2,10 +2,12 @@ package scan
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/storage"
 	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
+	"github.com/DataDog/datadog-iac-scanner/pkg/analyzer"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/runner"
@@ -64,6 +66,83 @@ func TestJSONParserRegistration(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectJSONParser, countParsersOfType(services, model.KindJSON) > 0)
+		})
+	}
+}
+
+// TestAnalyzerJSONInventoryGate verifies analyzer inventory rules for JSON files.
+func TestAnalyzerJSONInventoryGate(t *testing.T) {
+	fixturesDir := filepath.FromSlash("../../test/fixtures/tfplan_flag_test")
+	tfPlan := filepath.Join(fixturesDir, "tfplan.json")
+	cfJSON := filepath.Join(fixturesDir, "cloudformation.json")
+
+	tests := []struct {
+		name        string
+		paths       []string
+		platforms   []string
+		scanTfPlans bool
+		wantInInv   []string
+		wantExc     []string
+	}{
+		{
+			name:        "cloudformation json in inventory when flag off",
+			paths:       []string{cfJSON},
+			platforms:   []string{"cloudformation"},
+			scanTfPlans: false,
+			wantInInv:   []string{cfJSON},
+		},
+		{
+			name:        "tfplan excluded when flag off and terraform only",
+			paths:       []string{tfPlan},
+			platforms:   []string{"terraform"},
+			scanTfPlans: false,
+			wantExc:     []string{tfPlan},
+		},
+		{
+			name:        "tfplan in inventory when flag on",
+			paths:       []string{tfPlan},
+			platforms:   []string{"terraform"},
+			scanTfPlans: true,
+			wantInInv:   []string{tfPlan},
+		},
+		{
+			name:        "both json files in inventory when flag on",
+			paths:       []string{fixturesDir},
+			platforms:   []string{"terraform", "cloudformation"},
+			scanTfPlans: true,
+			wantInInv:   []string{tfPlan, cfJSON},
+		},
+	}
+
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := analyzer.Analyze(ctx, &analyzer.Analyzer{
+				RepoPath:    filepath.Dir(fixturesDir),
+				Paths:       tt.paths,
+				Types:       tt.platforms,
+				MaxFileSize: -1,
+				ScanTfPlans: tt.scanTfPlans,
+			})
+			require.NoError(t, err)
+
+			inventory := make(map[string]struct{}, len(got.Inventory))
+			for _, p := range got.Inventory {
+				inventory[filepath.ToSlash(p)] = struct{}{}
+			}
+			excluded := make(map[string]struct{}, len(got.Exc))
+			for _, p := range got.Exc {
+				excluded[filepath.ToSlash(p)] = struct{}{}
+			}
+
+			for _, want := range tt.wantInInv {
+				_, ok := inventory[filepath.ToSlash(want)]
+				assert.True(t, ok, "expected %s in inventory", want)
+			}
+			for _, want := range tt.wantExc {
+				_, ok := excluded[filepath.ToSlash(want)]
+				assert.True(t, ok, "expected %s excluded", want)
+			}
 		})
 	}
 }

--- a/pkg/scan/utils.go
+++ b/pkg/scan/utils.go
@@ -63,6 +63,7 @@ func (c *Client) prepareAndAnalyzePaths(ctx context.Context) (provider.Extracted
 		ExcludeGitIgnore:  c.ScanParams.ExcludeGitIgnore,
 		MaxFileSize:       c.ScanParams.MaxFileSizeFlag,
 		NumWorkers:        c.ScanParams.ParallelScanFlag,
+		ScanTfPlans:       c.ScanParams.ShouldScanTfPlans,
 	}
 
 	var pathTypes model.AnalyzedPaths

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -68,7 +68,7 @@ func createServices(types, cloudProviders []string) (serviceSlice, *storage.Memo
 	}
 
 	combinedParser, err := parser.NewBuilder(ctx).
-		Add(&jsonParser.Parser{}).
+		Add(jsonParser.NewDefaultWithParams(false)).
 		Add(&yamlParser.Parser{}).
 		Add(terraformParser.NewDefault()).
 		Build(types, cloudProviders)

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -307,6 +307,7 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 		Config:               cfg,
 		DisableRuleIsolation: s.cfg.DisableRuleIsolation,
 		UseRulesCache:        s.cfg.UseRulesCache,
+		ShouldScanTfPlans:    true,
 	}
 
 	client, err := scan.NewClient(ctx, params, &consolePrinter.Printer{},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -113,10 +113,10 @@ func violationDiff(a, b map[string]map[string]int) map[string]int {
 	return diff
 }
 
-// Test_E2ETerraformPlanFlag verifies that:
-// 1. Terraform plan JSON files are scanned when the flag is enabled
-// 2. CloudFormation JSON files are NOT scanned (even though they are JSON)
-// 3. The flag correctly gates the JSON parser registration
+// Test_E2ETerraformPlanFlag verifies JSON platform gating:
+// 1. Terraform plan JSON is scanned only when --x-terraform-plan is enabled (CLI disk scans)
+// 2. CloudFormation and other platform JSON files are scanned regardless of the flag
+// 3. Terraform-only scans do not register the JSON parser when the flag is disabled
 func Test_E2ETerraformPlanFlag(t *testing.T) {
 	fixturesDir := filepath.Join("..", "fixtures", "tfplan_flag_test")
 
@@ -160,7 +160,7 @@ func Test_E2ETerraformPlanFlag(t *testing.T) {
 		require.Equal(t, 0, metadata.Stats.Files, "Terraform plan JSON should not be scanned when flag is disabled")
 	})
 
-	t.Run("cloudformation json not scanned even with flag enabled", func(t *testing.T) {
+	t.Run("cloudformation json scanned with flag enabled", func(t *testing.T) {
 		params, ctx := scan.GetDefaultParameters(context.Background(), "")
 		params.Path = []string{filepath.Join(fixturesDir, "cloudformation.json")}
 		params.OutputPath = t.TempDir()
@@ -176,12 +176,29 @@ func Test_E2ETerraformPlanFlag(t *testing.T) {
 		metadata, err := console.ExecuteScan(ctx, params)
 		require.NoError(t, err)
 
-		// CloudFormation JSON files should NOT be processed because the JSON parser
-		// is gated to only process Terraform JSON files
-		require.Equal(t, 0, metadata.Stats.Files, "CloudFormation JSON should not be scanned (JSON parser only processes Terraform)")
+		require.Greater(t, metadata.Stats.Files, 0, "CloudFormation JSON should be scanned when cloudformation platform is enabled")
 	})
 
-	t.Run("both files in same scan - only tfplan scanned", func(t *testing.T) {
+	t.Run("cloudformation json scanned with flag disabled", func(t *testing.T) {
+		params, ctx := scan.GetDefaultParameters(context.Background(), "")
+		params.Path = []string{filepath.Join(fixturesDir, "cloudformation.json")}
+		params.OutputPath = t.TempDir()
+		params.QueriesPath = []string{mustAbs(t, filepath.Join("..", "..", "assets", "queries"))}
+		params.ShouldScanTfPlans = false
+		params.Platform = []string{"cloudformation"}
+		params.FlagEvaluator = featureflags.NewLocalEvaluator()
+		params.SCIInfo = model.SCIInfo{
+			DiffAware:            model.DiffAware{Enabled: false},
+			RepositoryCommitInfo: model.RepositoryCommitInfo{RepositoryUrl: "test/url", CommitSHA: "test/hash", Branch: "test/branch"},
+		}
+
+		metadata, err := console.ExecuteScan(ctx, params)
+		require.NoError(t, err)
+
+		require.Greater(t, metadata.Stats.Files, 0, "CloudFormation JSON should be scanned even when tf-plan flag is disabled")
+	})
+
+	t.Run("both files in same scan - both scanned when flag enabled", func(t *testing.T) {
 		params, ctx := scan.GetDefaultParameters(context.Background(), "")
 		params.Path = []string{fixturesDir}
 		params.OutputPath = t.TempDir()
@@ -197,9 +214,6 @@ func Test_E2ETerraformPlanFlag(t *testing.T) {
 		metadata, err := console.ExecuteScan(ctx, params)
 		require.NoError(t, err)
 
-		// Should only process the Terraform plan JSON, not the CloudFormation JSON
-		// The CloudFormation JSON file is filtered out by the analyzer because
-		// it's a JSON file but not a Terraform plan
-		require.Equal(t, 1, metadata.Stats.Files, "Should scan exactly 1 file (tfplan.json), CloudFormation JSON excluded")
+		require.Equal(t, 2, metadata.Stats.Files, "Should scan both tfplan.json and cloudformation.json when flag is enabled")
 	})
 }


### PR DESCRIPTION
## Summary

- Wire `ScanTfPlans` through the analyzer for CLI disk scans so CloudFormation/K8s JSON enters inventory while terraform plan JSON stays gated by `--x-terraform-plan`.
- Always enable tf-plan JSON on the HTTP server `/analyze` path.
- Update analyzer inventory tests, e2e tf-plan flag tests, and test hygiene for `NewDefaultWithParams`.

**Depends on:** #275 (retarget to `main` after the first PR merges)

## Test plan

- [x] `go test ./pkg/analyzer ./pkg/scan -run TestAnalyzerJSONInventoryGate -count=1`
- [x] `go test ./test/e2e -run Test_E2ETerraformPlanFlag -count=1`