### PR TITLE
feat(server): accept absolute file paths in content-push mode

### DIFF
--- a/pkg/engine/provider/memory.go
+++ b/pkg/engine/provider/memory.go
@@ -48,8 +48,11 @@ func NewMemorySourceProvider(fsys vfs.FS, paths, ignorePaths, onlyPaths []string
 	return &MemorySourceProvider{fsys: fsys, paths: sorted, ignorePaths: ignorePaths, onlyPaths: onlyPaths}
 }
 
-// GetBasePaths returns the synthetic root the pushed (workspace-relative) paths
-// are reported against.
+// GetBasePaths returns a synthetic root. Pushed paths are reported back exactly
+// as they were pushed, whether relative or absolute, so there is no real base to
+// name. The server's entry point (scan.Client.Scan) never consults this: it
+// returns the raw vulnerabilities, skipping the summary step that relativizes
+// file names against a base path.
 func (m *MemorySourceProvider) GetBasePaths() []string { return []string{"."} }
 
 // GetSources feeds each pushed file whose extension a parser supports into the

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -241,8 +241,8 @@ func ruleLibraryKey(platform string) (string, error) {
 // Absolute paths are accepted. The IDE pushes one when the file it is analyzing
 // lives outside every open workspace folder (File > Open File on a lone .tf),
 // and rejecting it failed the whole request rather than that one file. Nothing
-// downstream needs the path to be relative: content-push mode serves every read
-// from the in-memory FS, and the engine has always been absolute-path clean
+// downstream needs the path to be relative: content-push mode serves pushed file
+// reads from the in-memory FS, and the engine has always been absolute-path clean
 // (the CLI absolutizes all of its input before running the same pipeline).
 //
 // The disk read this check used to stand in for is Terraform local-module

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -250,14 +250,15 @@ func ruleLibraryKey(platform string) (string, error) {
 // this check, is what bounds it. It is not the only read that escapes the
 // in-memory FS: the YAML/JSON file resolver opens paths taken from pushed
 // content. That one predates this change and is reachable with a relative path
-// as well, so path shape does not bound it either; it is tracked separately.
+// as well, so path shape does not bound it either; it is tracked separately in
+// K9CODESEC-4924.
 //
 // Known gap: config path filters (ignore-paths/only-paths) are workspace-rooted
 // patterns, so an absolute path matches none of them except a leading-"**" one.
 // Under only-paths that means excluded, not exempt, and an unscanned file is
 // indistinguishable from a clean one in the response. Accepted for now because
 // it needs a filter that no longer matches an out-of-workspace file against the
-// config of a workspace it does not belong to.
+// config of a workspace it does not belong to. Tracked in K9CODESEC-4940.
 func validateFilePath(p string) error {
 	if p == "" {
 		return errors.New("empty file path")

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -280,9 +280,9 @@ func validateFilePath(p string) error {
 // Terraform local-module evaluation is off because it reads directories derived
 // from pushed paths off the real disk: tfeval's LoadRootVars and parseDir call
 // os.ReadDir directly instead of going through the request's in-memory FS.
-// Pushed paths may be absolute, so relying
-// on this flag's default — which is remotely togglable — would leave an
-// arbitrary directory readable by a cross-origin caller. Pinning it here is
+// Pushed paths may be absolute, so do not rely on the flag's default staying
+// safe: pinning it here ensures server mode never enables an arbitrary-directory
+// read via local-module evaluation. Pinning it here is
 // what lets validateFilePath accept absolute paths.
 //
 // Parallel file parsing fans the per-file parse across CPUs; off unless the

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -39,8 +39,11 @@ const (
 	commonLibraryID = "common"
 )
 
-// analyzeFile is a single pushed file: a workspace-relative path and its raw
-// (possibly unsaved) content.
+// analyzeFile is a single pushed file: its path and its raw (possibly unsaved)
+// content. The path is workspace-relative for a file inside an IDE workspace
+// folder and absolute for one outside every folder. Both are accepted, and
+// findings and missing_files report paths in the shape they were pushed with,
+// after cleaning and forward-slashing (see vfs.MemFS).
 type analyzeFile struct {
 	Path    string `json:"path"`
 	Content string `json:"content"`
@@ -232,8 +235,29 @@ func ruleLibraryKey(platform string) (string, error) {
 	return normalizePlatform(mapped), nil
 }
 
-// validateFilePath rejects paths that are empty, absolute, contain a NUL byte,
-// or escape the workspace root via "..".
+// validateFilePath rejects paths that are empty, contain a NUL byte, or escape
+// the workspace root via "..".
+//
+// Absolute paths are accepted. The IDE pushes one when the file it is analyzing
+// lives outside every open workspace folder (File > Open File on a lone .tf),
+// and rejecting it failed the whole request rather than that one file. Nothing
+// downstream needs the path to be relative: content-push mode serves every read
+// from the in-memory FS, and the engine has always been absolute-path clean
+// (the CLI absolutizes all of its input before running the same pipeline).
+//
+// The disk read this check used to stand in for is Terraform local-module
+// evaluation, pinned off for server mode in serverFlagEvaluator. That pin, not
+// this check, is what bounds it. It is not the only read that escapes the
+// in-memory FS: the YAML/JSON file resolver opens paths taken from pushed
+// content. That one predates this change and is reachable with a relative path
+// as well, so path shape does not bound it either; it is tracked separately.
+//
+// Known gap: config path filters (ignore-paths/only-paths) are workspace-rooted
+// patterns, so an absolute path matches none of them except a leading-"**" one.
+// Under only-paths that means excluded, not exempt, and an unscanned file is
+// indistinguishable from a clean one in the response. Accepted for now because
+// it needs a filter that no longer matches an out-of-workspace file against the
+// config of a workspace it does not belong to.
 func validateFilePath(p string) error {
 	if p == "" {
 		return errors.New("empty file path")
@@ -241,16 +265,34 @@ func validateFilePath(p string) error {
 	if strings.ContainsRune(p, 0) {
 		return errors.New("file path contains NUL byte")
 	}
-	// filepath.IsAbs is OS-dependent; also reject Unix-style absolute paths on
-	// Windows (e.g. "/etc/passwd" is not absolute per Windows rules).
-	if filepath.IsAbs(p) || strings.HasPrefix(p, "/") {
-		return errors.New("file path must be workspace-relative, got absolute: " + p)
-	}
 	clean := filepath.ToSlash(filepath.Clean(p))
 	if clean == ".." || strings.HasPrefix(clean, "../") {
 		return errors.New("file path escapes the workspace: " + p)
 	}
 	return nil
+}
+
+// serverFlagEvaluator pins the feature flags content-push mode depends on.
+//
+// Helm rendering shells out to a chart on disk, which content-push mode has no
+// way to materialize, so the resolver is off.
+//
+// Terraform local-module evaluation is off because it reads directories derived
+// from pushed paths off the real disk: tfeval's LoadRootVars and parseDir call
+// os.ReadDir directly instead of going through the request's in-memory FS.
+// Pushed paths may be absolute, so relying
+// on this flag's default — which is remotely togglable — would leave an
+// arbitrary directory readable by a cross-origin caller. Pinning it here is
+// what lets validateFilePath accept absolute paths.
+//
+// Parallel file parsing fans the per-file parse across CPUs; off unless the
+// server opts in via --x-parallelparsing.
+func serverFlagEvaluator(parallelParsing bool) featureflags.FlagEvaluator {
+	return featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
+		featureflags.IacEnableKicsHelmResolver:        false,
+		featureflags.IacEnableLocalModuleEval:         false,
+		featureflags.IaCEnableKicsParallelFileParsing: parallelParsing,
+	})
 }
 
 // analyze runs the content-push scan: build an in-memory FS from the pushed
@@ -287,23 +329,16 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 	}
 
 	params := &scan.Parameters{
-		CloudProvider:    []string{""},
-		Path:             memfs.Paths(),
-		RepoPath:         "", // no git in server mode
-		PreviewLines:     3,
-		Platform:         plats,
-		DisableSecrets:   true,
-		ScanID:           "serve",
-		MaxFileSizeFlag:  100,
-		MaxResolverDepth: 15,
-		// Helm rendering shells out to a chart on disk, which content-push mode
-		// has no way to materialize, so disable the resolver. Parallel file
-		// parsing fans the per-file parse across CPUs; enabled by default and
-		// can be disabled with --x-parallelparsing=false.
-		FlagEvaluator: featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
-			featureflags.IacEnableKicsHelmResolver:        false,
-			featureflags.IaCEnableKicsParallelFileParsing: s.cfg.ParallelParsing,
-		}),
+		CloudProvider:        []string{""},
+		Path:                 memfs.Paths(),
+		RepoPath:             "", // no git in server mode
+		PreviewLines:         3,
+		Platform:             plats,
+		DisableSecrets:       true,
+		ScanID:               "serve",
+		MaxFileSizeFlag:      100,
+		MaxResolverDepth:     15,
+		FlagEvaluator:        serverFlagEvaluator(s.cfg.ParallelParsing),
 		Config:               cfg,
 		DisableRuleIsolation: s.cfg.DisableRuleIsolation,
 		UseRulesCache:        s.cfg.UseRulesCache,

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -282,11 +282,11 @@ func validateFilePath(p string) error {
 // os.ReadDir directly instead of going through the request's in-memory FS.
 // Pushed paths may be absolute, so do not rely on the flag's default staying
 // safe: pinning it here ensures server mode never enables an arbitrary-directory
-// read via local-module evaluation. Pinning it here is
-// what lets validateFilePath accept absolute paths.
+// read via local-module evaluation, and is what lets validateFilePath accept
+// absolute paths.
 //
-// Parallel file parsing fans the per-file parse across CPUs; off unless the
-// server opts in via --x-parallelparsing.
+// Parallel file parsing fans the per-file parse across CPUs; enabled by default
+// and can be disabled with --x-parallelparsing=false.
 func serverFlagEvaluator(parallelParsing bool) featureflags.FlagEvaluator {
 	return featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
 		featureflags.IacEnableKicsHelmResolver:        false,

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	engineSource "github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
+	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/rs/zerolog"
 )
 
@@ -161,6 +162,11 @@ func TestAnalyze_ContentPush_TerraformFinding(t *testing.T) {
 // TestAnalyze_MissingModuleEscalation verifies a Terraform module pointing at a
 // directory that was not pushed is reported in missing_files as a clean
 // workspace-relative path (the hybrid escalation signal).
+//
+// Relative in, relative out: this pins how the pushed paths' own shape is
+// preserved, not a global "missing_files are never absolute" invariant. Push
+// absolute paths and missing_files come back absolute — see
+// TestAnalyze_AbsolutePathMissingModuleEscalation.
 func TestAnalyze_MissingModuleEscalation(t *testing.T) {
 	s := newTestServer(t)
 	rule := syntheticRule()
@@ -184,7 +190,7 @@ resource "aws_s3_bucket" "b" { bucket = "x" }`},
 			sawModule = true
 		}
 		if filepath.IsAbs(m) {
-			t.Errorf("missing path should be workspace-relative, got absolute: %q", m)
+			t.Errorf("relative input should produce relative missing paths, got absolute: %q", m)
 		}
 	}
 	if !sawModule {
@@ -192,10 +198,11 @@ resource "aws_s3_bucket" "b" { bucket = "x" }`},
 	}
 }
 
-// TestAnalyze_MissingFilesCWDIndependent proves missing_files are
-// workspace-relative regardless of the server process's working directory. A
-// single server serves many IDE workspaces/windows, so the result must not
-// depend on where the binary was launched.
+// TestAnalyze_MissingFilesCWDIndependent proves missing_files derived from
+// relative input stay workspace-relative regardless of the server process's
+// working directory. A single server serves many IDE workspaces/windows, so the
+// result must not depend on where the binary was launched. CWD-independence is
+// the property this pins; the relative shape just follows the input's.
 func TestAnalyze_MissingFilesCWDIndependent(t *testing.T) {
 	s := newTestServer(t)
 	rule := syntheticRule()
@@ -214,6 +221,194 @@ resource "aws_s3_bucket" "b" { bucket = "x" }`}},
 	out, _ := postAnalyze(t, s, req)
 	if len(out.MissingFiles) != 1 || out.MissingFiles[0] != "modules/networking" {
 		t.Errorf("missing_files = %v, want [modules/networking] (workspace-relative, CWD-independent)", out.MissingFiles)
+	}
+}
+
+// TestAnalyze_ContentPush_AbsolutePathFinding is the absolute-path twin of
+// TestAnalyze_ContentPush_TerraformFinding: a file outside every IDE workspace
+// folder is pushed under its absolute path, and must scan exactly like a
+// workspace-relative one.
+//
+// The FileName assertion is a cross-process contract. The extension keeps only
+// the findings whose fileName equals the path it pushed (an exact string
+// compare), so an echo that differs by so much as a separator silently drops
+// every finding for the file and it renders as clean. The contract is equality
+// after MemFS normalization (filepath.Clean + ToSlash), not byte identity: the
+// paths used here are already normalized, which is what the IDE sends (VS Code's
+// uri.path is always forward-slash, even on Windows).
+func TestAnalyze_ContentPush_AbsolutePathFinding(t *testing.T) {
+	s := newTestServer(t)
+	rule := syntheticRule()
+
+	const target = "/tmp/ws/main.tf"
+	req := analyzeRequest{
+		Files: []analyzeFile{
+			{Path: target, Content: `resource "aws_s3_bucket" "b" {
+  bucket = var.bucket_name
+}`},
+			{Path: "/tmp/ws/variables.tf", Content: `variable "bucket_name" { default = "my-bucket" }`},
+		},
+		Ruleset:  ruleset(rule),
+		Platform: []string{"terraform"},
+	}
+
+	out, _ := postAnalyze(t, s, req)
+
+	var found bool
+	for _, f := range out.Findings {
+		if f.QueryID == syntheticRuleID {
+			found = true
+			if f.FileName != target {
+				t.Errorf("finding fileName = %q, want %q echoed back unchanged", f.FileName, target)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected the synthetic rule to fire on an absolute path; findings = %+v, failed queries: %v",
+			out.Findings, out.FailedQueries)
+	}
+	// Sibling resolution works off the absolute directory too.
+	if len(out.MissingFiles) != 0 {
+		t.Errorf("expected no missing files for same-dir siblings, got %v", out.MissingFiles)
+	}
+}
+
+// TestAnalyze_AbsolutePathMissingModuleEscalation pins the other half of the
+// echo contract: missing_files keeps the shape of the paths that were pushed, so
+// absolute input escalates as absolute paths. The IDE resolves these against a
+// workspace folder, and there is none for an out-of-workspace file, so it
+// declines to escalate and the analysis stays best-effort — findings on the file
+// itself, no cross-directory module enrichment.
+func TestAnalyze_AbsolutePathMissingModuleEscalation(t *testing.T) {
+	s := newTestServer(t)
+
+	req := analyzeRequest{
+		Files: []analyzeFile{
+			{Path: "/tmp/ws/infra/main.tf", Content: `module "net" {
+  source = "../modules/networking"
+}
+resource "aws_s3_bucket" "b" { bucket = "x" }`},
+		},
+		Ruleset:  ruleset(syntheticRule()),
+		Platform: []string{"terraform"},
+	}
+
+	out, _ := postAnalyze(t, s, req)
+
+	var sawModule bool
+	for _, m := range out.MissingFiles {
+		if m == "/tmp/ws/modules/networking" {
+			sawModule = true
+		}
+	}
+	if !sawModule {
+		t.Errorf("expected /tmp/ws/modules/networking in missing_files, got %v", out.MissingFiles)
+	}
+}
+
+// TestAnalyze_MixedAbsoluteAndRelativePaths pins mixing as defined rather than
+// accidental. The extension cannot produce such a request — a path's shape
+// follows its directory, and every file in a request comes from one directory —
+// but validation is per-path, so mixing is what the server does by default, and
+// other API clients are not bound by the extension's fileset construction.
+// Rejecting it would mean one odd path failing the whole request, which is the
+// failure mode dropping the absolute-path check exists to remove.
+func TestAnalyze_MixedAbsoluteAndRelativePaths(t *testing.T) {
+	s := newTestServer(t)
+	body := `resource "aws_s3_bucket" "b" { bucket = "x" }`
+
+	req := analyzeRequest{
+		Files: []analyzeFile{
+			{Path: "/tmp/ws/absolute.tf", Content: body},
+			{Path: "infra/relative.tf", Content: body},
+		},
+		Ruleset:   ruleset(syntheticRule()),
+		Libraries: testLibraries(true),
+		Platform:  []string{"terraform"},
+	}
+	if err := validateAnalyzeRequest(&req, defaultMaxFiles); err != nil {
+		t.Fatalf("validateAnalyzeRequest() error = %v, want a mixed request to be accepted", err)
+	}
+
+	out, _ := postAnalyze(t, s, req)
+
+	got := make(map[string]bool, len(out.Findings))
+	for _, f := range out.Findings {
+		if f.QueryID == syntheticRuleID {
+			got[f.FileName] = true
+		}
+	}
+	for _, want := range []string{"/tmp/ws/absolute.tf", "infra/relative.tf"} {
+		if !got[want] {
+			t.Errorf("expected a finding for %q, got findings for %v", want, got)
+		}
+	}
+}
+
+// TestServerFlagEvaluator pins the flags server mode depends on. The
+// local-module-eval pin is what makes accepting absolute paths defensible: it is
+// the only thing keeping tfeval's direct os.ReadDir off directories derived from
+// pushed paths, which would otherwise be an arbitrary-directory read on a server
+// reachable cross-origin. If this test fails, validateFilePath's acceptance of
+// absolute paths is no longer safe.
+func TestServerFlagEvaluator(t *testing.T) {
+	evaluator := serverFlagEvaluator(false)
+
+	if evaluator.EvaluateWithOrg(featureflags.IacEnableLocalModuleEval) {
+		t.Error("IacEnableLocalModuleEval must be pinned false in server mode: " +
+			"local module evaluation reads directories derived from pushed paths off the real disk")
+	}
+	if evaluator.EvaluateWithOrg(featureflags.IacEnableKicsHelmResolver) {
+		t.Error("IacEnableKicsHelmResolver must be pinned false in server mode: " +
+			"Helm rendering needs a chart on disk, which content-push mode cannot materialize")
+	}
+	// Each flag is read through the same method its production call site uses,
+	// so this keeps holding if server mode ever gets an evaluator whose methods
+	// do not all resolve to the same value.
+	if evaluator.EvaluateWithOrgAndEnv(featureflags.IaCEnableKicsParallelFileParsing) {
+		t.Error("parallel file parsing should be off unless the server opts in")
+	}
+	if !serverFlagEvaluator(true).EvaluateWithOrgAndEnv(featureflags.IaCEnableKicsParallelFileParsing) {
+		t.Error("parallel file parsing should follow the server's --x-parallelparsing setting")
+	}
+}
+
+// TestValidateFilePath specifies the accepted path shapes directly, without a
+// scan or an HTTP round trip.
+func TestValidateFilePath(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		wantError bool
+	}{
+		{name: "workspace-relative", path: "infra/main.tf"},
+		{name: "bare file name", path: "main.tf"},
+		{name: "dot-relative", path: "./infra/main.tf"},
+		// Absolute paths are what an out-of-workspace file looks like.
+		{name: "posix absolute", path: "/tmp/ws/main.tf"},
+		{name: "windows drive qualified", path: "C:/ws/main.tf"},
+		{name: "vscode windows uri path", path: "/c:/ws/main.tf"},
+		// Clean collapses interior "..", so these stay inside their own root.
+		{name: "absolute with interior dotdot", path: "/tmp/ws/../ws/main.tf"},
+		{name: "relative with interior dotdot", path: "infra/../infra/main.tf"},
+		// Escaping a relative root is still refused.
+		{name: "dotdot", path: "..", wantError: true},
+		{name: "leading dotdot", path: "../escape.tf", wantError: true},
+		{name: "dotdot after cleaning", path: "infra/../../escape.tf", wantError: true},
+		{name: "empty", path: "", wantError: true},
+		{name: "NUL byte", path: "infra/ma\x00in.tf", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFilePath(tt.path)
+			if tt.wantError && err == nil {
+				t.Fatalf("validateFilePath(%q) = nil, want an error", tt.path)
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("validateFilePath(%q) = %v, want nil", tt.path, err)
+			}
+		})
 	}
 }
 
@@ -255,12 +450,16 @@ func TestAnalyze_Validation(t *testing.T) {
 			want: http.StatusBadRequest,
 		},
 		{
+			// An absolute path is accepted: the IDE pushes one for a file that
+			// lives outside every workspace folder. Uses a .tf path so the case
+			// exercises a real scan rather than whatever an extensionless file
+			// happens to do.
 			name: "absolute path",
 			req: analyzeRequest{
-				Files:   []analyzeFile{{Path: "/etc/passwd", Content: "x"}},
+				Files:   []analyzeFile{{Path: "/tmp/ws/main.tf", Content: `resource "aws_s3_bucket" "b" { bucket = "x" }`}},
 				Ruleset: ruleset(validRule), Libraries: validLibraries,
 			},
-			want: http.StatusBadRequest,
+			want: http.StatusOK,
 		},
 		{name: "malformed json", body: `{`, want: http.StatusBadRequest},
 	}

--- a/pkg/vfs/memfs.go
+++ b/pkg/vfs/memfs.go
@@ -115,6 +115,12 @@ func (m *MemFS) ReadDir(name string) ([]fs.DirEntry, error) {
 		}
 		if seg, _, found := strings.Cut(rel, "/"); found {
 			// A descendant: its first path segment is an immediate subdirectory.
+			// An absolute key under dir "." has an empty first segment ("" for
+			// "/ws/main.tf"), which names no directory — skip it rather than
+			// synthesizing an entry called "".
+			if seg == "" {
+				continue
+			}
 			if _, ok := children[seg]; !ok {
 				children[seg] = childInfo{isDir: true}
 			}
@@ -167,9 +173,12 @@ func (m *MemFS) Glob(pattern string) ([]string, error) {
 	return out, nil
 }
 
-// Abs keeps the path workspace-relative. This keeps Terraform module
-// and missing-file paths relative to the request's own workspace, which is
-// correct even when a single server process serves many IDE workspaces.
+// Abs normalizes rather than resolving against the process working directory,
+// so a path keeps the shape it was pushed with. Relative paths stay relative to
+// the request's own workspace, which is what makes Terraform module and
+// missing-file paths correct even when a single server process serves many IDE
+// workspaces; absolute paths (a file outside every workspace folder) stay
+// absolute, which is self-disambiguating.
 func (m *MemFS) Abs(name string) (string, error) {
 	return normalize(name), nil
 }

--- a/pkg/vfs/memfs.go
+++ b/pkg/vfs/memfs.go
@@ -210,9 +210,15 @@ func (m *MemFS) MissingFiles() []string {
 }
 
 // underDir returns the path of p relative to dir if p is a strict descendant of
-// dir (a non-empty remainder after the "dir/" prefix).
+// dir (a non-empty remainder after the "dir/" prefix). dir may already end in
+// "/" (e.g. the root "/" or a Windows drive root "C:/"); avoid doubling the
+// separator in that case, since "dir/" + "/" matches no key.
 func underDir(p, dir string) (string, bool) {
-	if after, ok := strings.CutPrefix(p, dir+"/"); ok && after != "" {
+	prefix := dir + "/"
+	if strings.HasSuffix(dir, "/") {
+		prefix = dir
+	}
+	if after, ok := strings.CutPrefix(p, prefix); ok && after != "" {
 		return after, true
 	}
 	return "", false

--- a/pkg/vfs/memfs_test.go
+++ b/pkg/vfs/memfs_test.go
@@ -123,6 +123,49 @@ func TestMemFS_ReadDir(t *testing.T) {
 	}
 }
 
+// TestMemFS_ReadDirAbsoluteKeys covers the keys the server sees when the IDE
+// analyzes a file that lives outside every workspace folder.
+//
+// The case worth pinning is ReadDir("."): synthesizing a directory's children
+// takes each key's first path segment, and an absolute key's first segment is
+// empty ("" for "/tmp/ws/main.tf"), which names no directory. There must be no
+// entry called "" — a caller iterating the listing would go on to read a path
+// that cannot exist. Nothing in the Terraform readers reaches ReadDir(".") with
+// absolute keys today (every directory they derive from an absolute key stays
+// absolute), so this guards a latent edge rather than a live one.
+func TestMemFS_ReadDirAbsoluteKeys(t *testing.T) {
+	m := NewMemFS(map[string][]byte{
+		"/tmp/ws/main.tf":             []byte(`resource "aws_s3_bucket" "b" {}`),
+		"/tmp/ws/variables.tf":        []byte(`variable "name" {}`),
+		"/tmp/ws/modules/net/main.tf": []byte(`resource "x" "y" {}`),
+	})
+
+	entries, err := m.ReadDir("/tmp/ws")
+	if err != nil {
+		t.Fatalf("ReadDir /tmp/ws: %v", err)
+	}
+	got := map[string]bool{}
+	for _, e := range entries {
+		got[e.Name()] = e.IsDir()
+	}
+	want := map[string]bool{"main.tf": false, "variables.tf": false, "modules": true}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ReadDir /tmp/ws = %v, want %v", got, want)
+	}
+
+	// "." holds nothing when every key is absolute: it must report a miss, not
+	// a listing containing an unnamed directory.
+	rootEntries, err := m.ReadDir(".")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("ReadDir \".\" over absolute keys = (%v, %v), want ErrNotExist", rootEntries, err)
+	}
+	for _, e := range rootEntries {
+		if e.Name() == "" {
+			t.Errorf("ReadDir \".\" synthesized an entry with an empty name from an absolute key")
+		}
+	}
+}
+
 func TestMemFS_Paths(t *testing.T) {
 	m := newTestMemFS()
 	want := []string{"infra/main.tf", "infra/modules/net/main.tf", "infra/prod.auto.tfvars", "infra/variables.tf", "root.tf"}

--- a/pkg/vfs/memfs_test.go
+++ b/pkg/vfs/memfs_test.go
@@ -164,6 +164,23 @@ func TestMemFS_ReadDirAbsoluteKeys(t *testing.T) {
 			t.Errorf("ReadDir \".\" synthesized an entry with an empty name from an absolute key")
 		}
 	}
+
+	// "/" is the mirror image of ".": the directory itself already ends in the
+	// separator underDir would otherwise append, so it must list "tmp" as a
+	// child rather than reporting a miss (reachable via a "../" source from a
+	// file pushed at, e.g., "/ws/main.tf").
+	slashEntries, err := m.ReadDir("/")
+	if err != nil {
+		t.Fatalf("ReadDir \"/\": %v", err)
+	}
+	slashGot := map[string]bool{}
+	for _, e := range slashEntries {
+		slashGot[e.Name()] = e.IsDir()
+	}
+	slashWant := map[string]bool{"tmp": true}
+	if !reflect.DeepEqual(slashGot, slashWant) {
+		t.Errorf("ReadDir \"/\" = %v, want %v", slashGot, slashWant)
+	}
 }
 
 func TestMemFS_Paths(t *testing.T) {


### PR DESCRIPTION
Pairs with [datadog-vscode#2472](https://github.com/DataDog/datadog-vscode/pull/2472)
(K9CODESEC-3287), which is what surfaced this.

## The bug

VS Code lets you open a scannable file that is not inside any open workspace folder — File > Open File
on a lone `Dockerfile`, or a `.tf` from another repo while a different project is open. For those, the
extension cannot shorten the path and pushes an absolute one.

`validateFilePath` rejected absolute paths, and it runs per-file inside `validateAnalyzeRequest`, so a
single such file **failed the entire analyze request** with a 400. The extension caught the error, hit
`if (!response) return []`, and rendered the file with **zero findings** — indistinguishable from
clean. Failed analyses are not cached, so the doomed request was re-issued on every edit and refresh
for as long as the file stayed open.

Low trigger frequency, bad failure direction: a guaranteed failure on a plausible user action, failing
toward "your infrastructure is clean".

## What this PR changes

**Drops the absolute-path branch in `validateFilePath`.** The empty, NUL, and `..` checks stay.
`filepath.Clean` collapses interior `..` for absolute input, so only a *relative* path escaping its
root is still refused.

**Pins `IacEnableLocalModuleEval: false` for server mode.** This is the part that makes the deletion
defensible, and reviewers should weight it more than the deletion itself. See "Why this is safe".

**Extracts the flag overrides into `serverFlagEvaluator(parallelParsing bool)`.** They were inline in
the `scan.Parameters` literal, where a test cannot assert on them. Behaviour for the two pre-existing
flags is unchanged; the extraction exists so the new pin cannot silently regress.

**Fixes `MemFS.ReadDir` synthesizing a directory entry named `""`.** An absolute key under dir `"."`
has an empty first path segment, which named no directory. Latent, not live — see "Kept as-is" for
why it was fixed anyway.

**Tests and doc comments.** Enumerated below.

## Why this is safe

### The engine has always been absolute-path clean

The CLI does not merely tolerate absolute paths, it *mandates* them: it converts every input with
`filepath.Abs` up front and then runs the same engine. The server was the only caller forbidding what
the rest of the product requires everywhere.

### The check was a proxy for a flag, and now the flag holds it directly

The real hazard behind the absolute-path check was `resolveModuleDocuments` → `tfeval.LoadRootVars`,
which does a genuine `os.ReadDir` on directories derived from pushed paths — bounded to the working
directory's subtree with relative paths, unbounded with absolute ones.

It was unreachable in server mode **only because a remotely-togglable flag happened to default to
`false`**. The `serve` command does not even expose `--x-local-module-eval` (only `scan` does), so the
default was doing all the work. Pinning it moves the guarantee to where it actually lives, and makes
the path-shape check redundant rather than load-bearing.

Note this is a **net security improvement over `main`**: today that flag is one remote toggle away from
enabling an unbounded directory read in server mode. After this PR it is pinned and asserted by a test.

### Why not keep the `..` check as a half-measure

"Drop the absolute check, keep `..`" does not hold together. `..` exists to keep a *relative* path
bounded inside a root; once absolute paths are allowed, nothing needs `..` to reach anywhere. The
posture is close to binary, which is exactly why the guarantee belongs at the flag.

## Pre-existing issue found while reviewing this (please read)

**The YAML/JSON file resolver reads arbitrary files off disk. It is not introduced by this PR, and
this PR does not widen it. It is called out because the code and comments previously claimed an
invariant that does not hold.**

`file.Resolver` substitutes referenced file contents into the parsed document via `os.Open`
(`pkg/resolver/file/file.go:364`), bypassing the request's `vfs.FS` entirely. Two properties make it
wider than the name suggests:

- **Not limited to `$ref`.** `yamlWalk` recurses into *every scalar node* and tries to resolve each as
  a path. `$ref` only controls whether `RefMetadata` is attached afterwards.
- **Ignores `resolveReferences`.** That flag short-circuits only for OpenAPI-looking documents.

Reproduced end-to-end over a real `POST /ide/v1/iac/analyze`, default config, no flags. A pushed
ConfigMap with a plain scalar `x: ../secret.yaml` returned the unpushed file's contents in the response
body.

### Evidence that this PR does not make it worse

The same canary test replayed in a worktree at the merge base (`2349ce54`):

| Pushed path | Reference | This branch | Base `2349ce54` |
| --- | --- | --- | --- |
| `/tmp/ws/main.yaml` | `../secret.yaml` | leaks | **400** — old absolute check |
| `main.yaml` | `../` ×40 + `tmp/secret.yaml` | leaks | **leaks** |

Row 2 settles it: no absolute path involved, and it leaks on `main` today. The reason is that
**overshooting `../` past the filesystem root is clamped to `/`**, so a relative path is already a
fully reliable absolute-anchor primitive, independent of the server's working directory. Absolute
paths are more legible; they reach nothing new.

### Severity bounds

`findFilePath` requires the target's extension to be in the calling parser's list — YAML resolves only
`.yaml`/`.yml`, JSON only `.json`. So `/etc/passwd`, `~/.kube/config`, `~/.aws/credentials`, and
`~/.ssh/id_rsa` are **not** reachable. Still reachable: `~/.docker/config.json`, gcloud's
`application_default_credentials.json`, Kubernetes Secret manifests, CI configs with inline tokens.

Worth knowing that this also fires constantly in *legitimate* operation — a Compose file naming
`./config.yaml`, an Ansible `include_vars`, a serverless `${file(...)}`. The "server mode never
touches disk" mental model is wrong in everyday use, not only under attack.

### Related, weaker evidence

`processCertContent` (`pkg/parser/yaml/parser.go:123`) reads PEM files off disk relative to the pushed
file. Verified at parser level only, **not** end-to-end. Narrower reach: `.pem` is not in the pushed
file set and it needs a rule reading a certificate attribute. Same structural fix applies.

## Trade-offs and decisions taken

**Config path filters silently stop applying to absolute paths.** `ignore-paths`/`only-paths` are
matched by `pathutil.MatchesPath` against relative, workspace-rooted patterns, so an absolute path
matches none of them except a leading-`**` one. Under `only-paths` that means *excluded*, not exempt —
and an unscanned file is indistinguishable from a clean one in the response.

Accepted deliberately, and documented in `validateFilePath` rather than left to be discovered. The
justification is that a file outside every workspace folder is not governed by that workspace's
config, and the extension only pushes absolute paths in exactly that situation. The real fix needs a
filter that stops matching an out-of-workspace file against a config it does not belong to, which is
more than this PR should carry. `TestAnalyze_ConfigIgnorePaths` pins the relative case only.

**Mixed absolute and relative paths in one request are allowed.** Not because we want it, but because
per-path validation makes it the default. The extension cannot produce such a request — a path's shape
is a property of its *directory*, and every file in a request comes from one directory. Rejecting the
mix would mean adding a request-level check with exactly the failure shape this PR exists to delete.
A test pins the behaviour as defined rather than accidental, and covers other API clients (IntelliJ,
future ones).

**No interim guard in the extension.** A guard in `toAnalyzeFile` was proposed, implemented, and
reverted in `20a26781d`. The scanner change ships before the extension ships this feature and the
binary tracks GitHub releases with no minimum-version gating, so there is no window where a
feature-enabled extension talks to a scanner that rejects absolute paths. **This depends on the
release ordering actually holding** — if the scanner change slips past the extension release, revisit.

**Out-of-workspace files get a best-effort analysis, and no extension change.** `missing_files`
escalation no-ops for them, because `resolveExtraPaths` returns `[]` when
`vscode.workspace.getWorkspaceFolder` finds no folder. Findings on the opened file still appear; what
is lost is enrichment of resources configured *through* a `module` block pointing outside the pushed
set. That is strictly better than today's whole-request 400. Widening it means widening a file-read
primitive (the scanner names a path, the extension reads it and sends the content back), which
deserves its own ticket.

## Kept as-is

- **`MemFS.Abs` still normalizes rather than absolutizing.** Relative paths stay relative to the
  request's own workspace, which is what keeps module and missing-file paths correct when one server
  process serves many IDE workspaces. Absolute paths stay absolute and are self-disambiguating. Only
  the comment changed.
- **`MemorySourceProvider.GetBasePaths` still returns `["."]`.** It is dead weight on the server path —
  `scan.Client.Scan` never consults it — so it was documented, not changed.
- **The `..` rejection**, unchanged. `../escape.tf` still 400s.
- **Helm resolver and parallel-parsing flags**, unchanged in behaviour; only relocated into
  `serverFlagEvaluator`.
- **The `MemFS.ReadDir` empty-segment fix is cheap correctness, not a reachability fix.** For an
  all-absolute request `dir == "."` is unreachable, since every directory the Terraform readers derive
  stays absolute; only a mixed request could reach it, and the extension cannot produce one. An entry
  named `""` is wrong however it is reached, and skipping empty segments is one line.

## Follow-ups (not in this PR)

1. **Thread `vfs.FS` through `file.Resolver`**, replacing `os.Stat`/`os.Open`. In server mode the memfs
   holds only pushed files, so an unpushed reference simply fails to resolve — the same degradation as
   a missing module, producing a `missing_files` entry the extension already ignores. CLI behaviour is
   unchanged since its `fsys` is the real disk. Same fix for `processCertContent`.
2. **A regression test asserting no disk reads in server mode** — a pushed document referencing an
   on-disk file must resolve to nothing. This is what keeps the invariant honest going forward.
3. **Revisit the CORS posture.** `Access-Control-Allow-Origin: *` with `Access-Control-Allow-Headers: *`
   on an unauthenticated localhost server that accepts caller-supplied Rego is a broad grant
   independent of the resolver bug. Because `/analyze` takes its ruleset from the request body, a
   caller controls both the input document and the rule that echoes it back. Tightening this blunts
   every variant at once. Entirely pre-existing.
4. **Make config path filters handle out-of-workspace files** rather than silently excluding them.

## Tests

Changed:

| Test | Change |
| --- | --- |
| `TestAnalyze_Validation/absolute_path` | 400 → 200, and the path swapped to a parseable `.tf`. This case goes through the real HTTP handler and runs a full scan, so the outcome for an extensionless path with a stub rule was incidental. |

Added:

- `TestValidateFilePath` — POSIX-absolute, Windows drive-qualified, and the `/c:/ws/main.tf` shape VS
  Code sends on Windows, plus the still-rejected shapes. This is where the new boundary is specified.
- An absolute-path twin of `TestAnalyze_ContentPush_TerraformFinding`, asserting the echoed `fileName`
  equals the pushed path. This is a cross-process contract the extension cannot assert from its side.
  The contract is equality after `Clean`/`ToSlash` normalization, **not** byte identity — a client
  sending a native Windows path (`C:\ws\main.tf`) gets `C:/ws/main.tf` back.
- Absolute-path missing-module escalation, asserting `missing_files` comes back absolute.
- A mixed absolute/relative request.
- `serverFlagEvaluator`'s pins, including `IacEnableLocalModuleEval: false`. **This is the test that
  makes the whole change defensible.**
- `MemFS.ReadDir` over absolute keys, covering the empty-segment case.

Unchanged but worth a reviewer's eye: `TestAnalyze_MissingModuleEscalation` and
`TestAnalyze_MissingFilesCWDIndependent` still pass on relative input, but their assertions now encode
"relative in, relative out" rather than a global invariant.

## Review guidance

The load-bearing change is `serverFlagEvaluator` and its test, not the deleted `if`. If you disagree
that pinning the flag is a sufficient replacement for the path-shape check, that is the thing to push
back on.

The second thing worth a hard look is the `only-paths` trade-off under "Trade-offs and decisions
taken" — it is the one behaviour change here that can make a file silently unscanned.

Verified locally on macOS: `go build ./...`, `go vet`, and `go test ./pkg/...` all pass.
`golangci-lint run -c .golangci.yml --timeout 20m` reports **no issues in any file this PR touches**.

A full-repo lint run does surface 51 pre-existing `goconst`/`govet` issues in files this PR does not
touch. The identical 51, with the same breakdown, appear at the merge base — they are an artifact of a
newer golangci-lint locally (v2.12.2) than the v2.4.0 CI pins, and CI will not see them.

**Not verified locally: Windows.** This change is entirely about path handling, and `filepath.IsAbs`
and `filepath.Clean` are OS-dependent — `TestValidateFilePath` covers drive-qualified shapes precisely
because of that. Everything above ran on macOS only, so CI's `windows-2022` unit-test job is the real
check on that axis and the most likely place for this to fail.

K9CODESEC-2171
K9CODESEC-4923