### PR TITLE
[K9CODESEC-4561] Reduce local module evaluation memory

### DIFF
--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -834,6 +834,50 @@ func (c *Inspector) TransformJsonencodeInPayload(ctx context.Context, value ast.
 	}
 }
 
+func (c *Inspector) interfaceToPayloadValue(
+	ctx context.Context,
+	value interface{},
+	objects map[uintptr]ast.Value,
+) (ast.Value, error) {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		pointer := reflect.ValueOf(v).Pointer()
+		if pointer != 0 {
+			if converted, ok := objects[pointer]; ok {
+				return converted, nil
+			}
+		}
+		object := ast.NewObject()
+		if pointer != 0 {
+			objects[pointer] = object
+		}
+		for key, raw := range v {
+			converted, err := c.interfaceToPayloadValue(ctx, raw, objects)
+			if err != nil {
+				return nil, err
+			}
+			object.Insert(ast.StringTerm(key), ast.NewTerm(converted))
+		}
+		return object, nil
+	case []interface{}:
+		terms := make([]*ast.Term, 0, len(v))
+		for _, raw := range v {
+			converted, err := c.interfaceToPayloadValue(ctx, raw, objects)
+			if err != nil {
+				return nil, err
+			}
+			terms = append(terms, ast.NewTerm(converted))
+		}
+		return ast.NewArray(terms...), nil
+	default:
+		converted, err := ast.InterfaceToValue(value)
+		if err != nil {
+			return nil, err
+		}
+		return c.TransformJsonencodeInPayload(ctx, converted), nil
+	}
+}
+
 // DecodeQueryResults decodes the results into []model.Vulnerability
 func (c *Inspector) DecodeQueryResults(
 	ctx context.Context,
@@ -1069,11 +1113,11 @@ func (c *Inspector) buildPlatformPayloads(
 	docsByPlatform, unknownDocs, allDocs := partitionDocsByPlatform(filesMap, combinedDocs, moduleDocs)
 
 	makePayload := func(ds []interface{}) (ast.Value, error) {
-		v, err := ast.InterfaceToValue(map[string]interface{}{"document": ds})
-		if err != nil {
-			return nil, err
-		}
-		return c.TransformJsonencodeInPayload(ctx, v), nil
+		return c.interfaceToPayloadValue(
+			ctx,
+			map[string]interface{}{"document": ds},
+			make(map[uintptr]ast.Value),
+		)
 	}
 
 	needFullPayload := false
@@ -1090,6 +1134,7 @@ func (c *Inspector) buildPlatformPayloads(
 	out := platformPayloads{
 		byPlatform: make(map[string]ast.Value, len(neededPlatforms)),
 	}
+	fullPayloadBuilt := false
 	for key := range neededPlatforms {
 		ds := docsByPlatform[key]
 		if len(unknownDocs) > 0 {
@@ -1103,9 +1148,16 @@ func (c *Inspector) buildPlatformPayloads(
 			return platformPayloads{}, err
 		}
 		out.byPlatform[key] = pv
+		if needFullPayload &&
+			len(neededPlatforms) == 1 &&
+			len(unknownDocs) == 0 &&
+			len(ds) == len(allDocs) {
+			out.full = pv
+			fullPayloadBuilt = true
+		}
 	}
 
-	if needFullPayload {
+	if needFullPayload && !fullPayloadBuilt {
 		pv, err := makePayload(allDocs)
 		if err != nil {
 			return platformPayloads{}, err

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -380,6 +380,60 @@ func Test_partitionDocsByPlatform(t *testing.T) {
 	require.Len(t, byPlatform["cloudformation"], 1)
 }
 
+func TestInterfaceToPayloadValueMatchesExistingTransformation(t *testing.T) {
+	shared := map[string]interface{}{"name": "example", "encoded": `jsonencode({foo = "bar"})`}
+	input := map[string]interface{}{
+		"document": []interface{}{
+			map[string]interface{}{
+				"id":       "one",
+				"resource": shared,
+				"_refs":    map[string]interface{}{"resource": shared},
+			},
+		},
+	}
+	inspector := &Inspector{}
+
+	raw, err := ast.InterfaceToValue(input)
+	require.NoError(t, err)
+	want := inspector.TransformJsonencodeInPayload(context.Background(), raw)
+	got, err := inspector.interfaceToPayloadValue(
+		context.Background(),
+		input,
+		make(map[uintptr]ast.Value),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, want.String(), got.String())
+}
+
+func TestBuildPlatformPayloadsReusesEquivalentFullPayload(t *testing.T) {
+	filesMap := map[string]*model.FileMetadata{
+		"terraform-id": {ID: "terraform-id", Platform: "terraform"},
+	}
+	documents := []model.Document{
+		{"id": "terraform-id", "resource": map[string]interface{}{"test": map[string]interface{}{}}},
+	}
+	queries := []model.QueryMetadata{
+		{Platform: "terraform"},
+		{Platform: "common"},
+	}
+
+	payloads, err := (&Inspector{}).buildPlatformPayloads(
+		context.Background(),
+		filesMap,
+		documents,
+		nil,
+		queries,
+	)
+
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		reflect.ValueOf(payloads.full).Pointer(),
+		reflect.ValueOf(payloads.byPlatform["terraform"]).Pointer(),
+	)
+}
+
 func TestEngine_selectPlatformPayload(t *testing.T) {
 	full := ast.String("FULL")
 	byPlatform := map[string]ast.Value{

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -213,7 +213,7 @@ func resolveModuleDocuments(
 	// Suppression and stripping are driven by actualCalledDirs (evaluation results).
 	staticCalledDirs := make(map[string]bool)
 	for dir := range dirsWithTf {
-		calledDirs := discoverCalledModuleDirs(evaluator, filesByDir[dir], repoPath, resolver, dir)
+		calledDirs := discoverCalledModuleDirs(ctx, evaluator, filesByDir[dir], repoPath, resolver, dir)
 		for _, called := range calledDirs {
 			staticCalledDirs[called] = true
 		}
@@ -464,6 +464,7 @@ func stripModuleCalls(doc model.Document, filePath, repoPath string, calledDirs 
 }
 
 func discoverCalledModuleDirs(
+	ctx context.Context,
 	evaluator *tfeval.Evaluator,
 	files []*model.FileMetadata,
 	repoPath string,
@@ -474,6 +475,10 @@ func discoverCalledModuleDirs(
 	if ok {
 		return calledDirs
 	}
+	contextLogger := logger.FromContext(ctx)
+	contextLogger.Debug().Str("dir", dir).Msg(
+		"module resolve: falling back to directory parse for called module discovery",
+	)
 	return evaluator.CalledModuleDirs(dir)
 }
 

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -213,7 +213,8 @@ func resolveModuleDocuments(
 	// Suppression and stripping are driven by actualCalledDirs (evaluation results).
 	staticCalledDirs := make(map[string]bool)
 	for dir := range dirsWithTf {
-		for _, called := range evaluator.CalledModuleDirs(dir) {
+		calledDirs := discoverCalledModuleDirs(evaluator, filesByDir[dir], repoPath, resolver, dir)
+		for _, called := range calledDirs {
 			staticCalledDirs[called] = true
 		}
 	}
@@ -244,6 +245,7 @@ func resolveModuleDocuments(
 		extra = append(extra, docs...)
 		syntheticFiles = append(syntheticFiles, syn...)
 	}
+	evaluator.ReleaseCaches()
 
 	// If every root evaluation failed, do not strip or suppress module bodies: that would
 	// remove coverage with no synthetic replacement.
@@ -307,6 +309,10 @@ func instantiatedDocs(
 			attrs:     tfeval.AttributesToDocument(r),
 		})
 	}
+	callContentKeys := make(map[string]string, len(cckRefs))
+	for cck, refs := range cckRefs {
+		callContentKeys[cck] = moduleCallRefsKey(refs)
+	}
 
 	// Pass 2: emit one doc per instance.
 	for i := range resources {
@@ -324,7 +330,7 @@ func instantiatedDocs(
 		docID := fm.ID + "\x00" + cck + "\x00" + r.Name
 
 		// Identical resolved attributes dedupe to one OPA doc; extras get cloned findings after OPA.
-		contentKey := moduleCallContentKey(r, cckRefs[cck], repoPath)
+		contentKey := moduleCallContentKey(r, callContentKeys[cck], repoPath)
 		if primaryDocID, dup := seen[contentKey]; dup {
 			extras[primaryDocID] = append(extras[primaryDocID], extraCallerInfo{callChain: cck, docID: docID})
 			continue
@@ -351,8 +357,7 @@ func instantiatedDocs(
 	return docs, synthetic
 }
 
-// moduleCallContentKey hashes the resource and every resolved resource in its module call.
-func moduleCallContentKey(self *tfeval.ResolvedResource, allInCall []moduleRefEntry, repoPath string) string {
+func moduleCallRefsKey(allInCall []moduleRefEntry) string {
 	type row struct{ typ, name, definedIn, defLine, attrKey string }
 	rows := make([]row, 0, len(allInCall))
 	for _, e := range allInCall {
@@ -373,14 +378,18 @@ func moduleCallContentKey(self *tfeval.ResolvedResource, allInCall []moduleRefEn
 		}
 		return false
 	})
-	parts := []string{
-		self.ModuleAddress, self.Type, self.Name,
-		absPath(self.DefinedIn, repoPath), strconv.Itoa(self.DefLine),
-	}
+	var parts []string
 	for _, r := range rows {
 		parts = append(parts, r.typ, r.name, r.definedIn, r.defLine, r.attrKey)
 	}
 	return strings.Join(parts, "\x00")
+}
+
+func moduleCallContentKey(self *tfeval.ResolvedResource, refsKey, repoPath string) string {
+	return strings.Join([]string{
+		self.ModuleAddress, self.Type, self.Name,
+		absPath(self.DefinedIn, repoPath), strconv.Itoa(self.DefLine), refsKey,
+	}, "\x00")
 }
 
 // buildRefsMap returns sibling resources in the same module call (for walk-based rules).
@@ -443,14 +452,7 @@ func stripModuleCalls(doc model.Document, filePath, repoPath string, calledDirs 
 			continue
 		}
 		version, _ := call["version"].(string)
-		cleanSource := tfeval.StripGetterPrefix(source)
-
-		var resolvedDir string
-		if tfmodules.LooksLikeLocalModuleSource(cleanSource) {
-			resolvedDir = filepath.Clean(filepath.Join(fileDir, cleanSource))
-		} else if resolver != nil {
-			resolvedDir, _ = resolver(source, version, filePath, name)
-		}
+		resolvedDir, _ := resolveModuleTargetDir(fileDir, source, version, filePath, name, resolver)
 
 		if resolvedDir != "" && calledDirs[resolvedDir] {
 			delete(modules, name)
@@ -459,6 +461,64 @@ func stripModuleCalls(doc model.Document, filePath, repoPath string, calledDirs 
 	if len(modules) == 0 {
 		delete(doc, "module")
 	}
+}
+
+func discoverCalledModuleDirs(
+	evaluator *tfeval.Evaluator,
+	files []*model.FileMetadata,
+	repoPath string,
+	resolver tfeval.RemoteResolver,
+	dir string,
+) []string {
+	calledDirs, ok := calledModuleDirsFromDocuments(files, repoPath, resolver)
+	if ok {
+		return calledDirs
+	}
+	return evaluator.CalledModuleDirs(dir)
+}
+
+func calledModuleDirsFromDocuments(
+	files []*model.FileMetadata,
+	repoPath string,
+	resolver tfeval.RemoteResolver,
+) ([]string, bool) {
+	var dirs []string
+	for _, file := range files {
+		if file == nil || len(file.Document) == 0 {
+			return nil, false
+		}
+		modules := docAsMap(file.Document["module"])
+		fileDir := filepath.Dir(absPath(file.FilePath, repoPath))
+		for name, callRaw := range modules {
+			call := docAsMap(callRaw)
+			source, _ := call["source"].(string)
+			if source == "" {
+				continue
+			}
+			version, _ := call["version"].(string)
+			if dir, ok := resolveModuleTargetDir(fileDir, source, version, file.FilePath, name, resolver); ok {
+				dirs = append(dirs, dir)
+			}
+		}
+	}
+	return dirs, true
+}
+
+func resolveModuleTargetDir(
+	callerDir, source, version, callerFile, moduleName string,
+	resolver tfeval.RemoteResolver,
+) (string, bool) {
+	cleanSource := tfeval.StripGetterPrefix(source)
+	if tfmodules.LooksLikeLocalModuleSource(cleanSource) {
+		if filepath.IsAbs(cleanSource) {
+			return filepath.Clean(cleanSource), true
+		}
+		return filepath.Clean(filepath.Join(callerDir, cleanSource)), true
+	}
+	if resolver == nil {
+		return "", false
+	}
+	return resolver(source, version, callerFile, moduleName)
 }
 
 // indexTerraformFiles builds lookup maps from a flat FileMetadatas slice.

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/tfeval"
 	"github.com/rs/zerolog"
 )
 
@@ -645,6 +646,92 @@ func TestInstantiatedModuleResourceCountIncludesDeduplicatedCallers(t *testing.T
 
 	if got := instantiatedModuleResourceCount(&res); got != 5 {
 		t.Fatalf("instantiatedModuleResourceCount() = %d, want 5", got)
+	}
+}
+
+func TestCalledModuleDirsFromDocuments_LocalModule(t *testing.T) {
+	root := t.TempDir()
+	modDir := filepath.Join(root, "modules", "bucket")
+	rootFile := filepath.Join(root, "stack", "main.tf")
+
+	dirs, ok := calledModuleDirsFromDocuments(model.FileMetadatas{
+		{
+			ID:       "root-id",
+			FilePath: rootFile,
+			Document: model.Document{
+				"module": map[string]interface{}{
+					"bucket": map[string]interface{}{
+						"source": "../modules/bucket",
+					},
+				},
+			},
+		},
+	}, root, nil)
+	if !ok {
+		t.Fatal("expected document-based discovery")
+	}
+	want := filepath.Clean(modDir)
+	if len(dirs) != 1 || dirs[0] != want {
+		t.Fatalf("dirs = %#v, want [%q]", dirs, want)
+	}
+}
+
+func TestDiscoverCalledModuleDirs_UsesParsedDocument(t *testing.T) {
+	root := t.TempDir()
+	modDir := filepath.Join(root, "modules", "bucket")
+	rootFile := filepath.Join(root, "stack", "main.tf")
+
+	evaluator := tfeval.New()
+	var logs bytes.Buffer
+	ctx := zerolog.New(&logs).WithContext(context.Background())
+
+	dirs := discoverCalledModuleDirs(ctx, evaluator, model.FileMetadatas{
+		{
+			ID:       "root-id",
+			FilePath: rootFile,
+			Document: model.Document{
+				"module": map[string]interface{}{
+					"bucket": map[string]interface{}{
+						"source": "../modules/bucket",
+					},
+				},
+			},
+		},
+	}, root, nil, filepath.Join(root, "stack"))
+
+	want := filepath.Clean(modDir)
+	if len(dirs) != 1 || dirs[0] != want {
+		t.Fatalf("dirs = %#v, want [%q]", dirs, want)
+	}
+	if strings.Contains(logs.String(), "falling back") {
+		t.Fatalf("did not expect fallback log, got %q", logs.String())
+	}
+}
+
+func TestDiscoverCalledModuleDirs_FallsBackWhenDocumentEmpty(t *testing.T) {
+	root := t.TempDir()
+	modDir := filepath.Join(root, "modules", "bucket")
+	writeFile(t, modDir, "main.tf", `resource "test" "x" {}`)
+	rootFile := writeFile(t, filepath.Join(root, "stack"), "main.tf", `
+module "bucket" {
+  source = "../modules/bucket"
+}
+`)
+
+	evaluator := tfeval.New()
+	var logs bytes.Buffer
+	ctx := zerolog.New(&logs).WithContext(context.Background())
+
+	dirs := discoverCalledModuleDirs(ctx, evaluator, model.FileMetadatas{
+		fileMeta("root-id", rootFile),
+	}, root, nil, filepath.Dir(rootFile))
+
+	want := filepath.Clean(modDir)
+	if len(dirs) != 1 || dirs[0] != want {
+		t.Fatalf("dirs = %#v, want [%q]", dirs, want)
+	}
+	if !strings.Contains(logs.String(), "falling back to directory parse") {
+		t.Fatalf("expected fallback debug log, got %q", logs.String())
 	}
 }
 

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -287,7 +287,11 @@ func fillModuleAttrs(
 			mod.SourceType, mod.RegistryScope = DetectModuleSourceType(resolved)
 			mod.IsLocal = LooksLikeLocalModuleSource(strings.TrimPrefix(resolved, "git::"))
 			if mod.IsLocal {
-				absPath := filepath.Join(baseDir, strings.TrimPrefix(resolved, "file://"))
+				sourcePath := strings.TrimPrefix(resolved, "file://")
+				absPath := filepath.Clean(sourcePath)
+				if !filepath.IsAbs(sourcePath) {
+					absPath = filepath.Join(baseDir, sourcePath)
+				}
 				var err error
 				mod.AbsSource, err = fsys.Abs(absPath)
 				if err != nil {

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -84,6 +84,28 @@ module "local_bucket" {
 	}
 }
 
+func TestParseTerraformModules_AbsoluteLocalModule(t *testing.T) {
+	rootDir := t.TempDir()
+	moduleDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte(`resource "test" "example" {}`), 0o600))
+	mainTF := `module "local" { source = "` + filepath.ToSlash(moduleDir) + `" }`
+	files := model.FileMetadatas{
+		&model.FileMetadata{
+			FilePath:          filepath.Join(rootDir, "main.tf"),
+			OriginalData:      mainTF,
+			LinesOriginalData: &[]string{mainTF},
+		},
+	}
+
+	modules, err := ParseTerraformModules(context.Background(), nil, files, 0)
+
+	require.NoError(t, err)
+	require.Len(t, modules, 1)
+	for _, module := range modules {
+		require.Equal(t, filepath.Clean(moduleDir), module.AbsSource)
+	}
+}
+
 // TestParseTerraformModules_CanceledContext guards the cancellation contract:
 // a canceled scan must surface ctx.Err() rather than silently return partial
 // module data. HCL parse workers skip individual failures, so without an

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -114,9 +114,9 @@ func (e *Evaluator) SetRemoteResolver(r RemoteResolver) {
 }
 
 func (e *Evaluator) ReleaseCaches() {
+	e.cache = make(map[evalCacheKey]*evalCacheEntry)
 	e.parseMu.Lock()
-	e.cache = nil
-	e.dirCache = nil
+	e.dirCache = make(map[string]dirParse)
 	e.parseMu.Unlock()
 }
 

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -113,6 +113,13 @@ func (e *Evaluator) SetRemoteResolver(r RemoteResolver) {
 	e.remoteResolver = r
 }
 
+func (e *Evaluator) ReleaseCaches() {
+	e.parseMu.Lock()
+	e.cache = nil
+	e.dirCache = nil
+	e.parseMu.Unlock()
+}
+
 // EvaluateModule evaluates the module rooted at dir with the given inputs and
 // returns all resources materialized by this module and its nested modules.
 // visitedChildDirs contains every child directory that was successfully evaluated

--- a/pkg/parser/terraform/tfeval/evaluator_test.go
+++ b/pkg/parser/terraform/tfeval/evaluator_test.go
@@ -1229,3 +1229,39 @@ resource "aws_s3_bucket" "this" {
 		t.Fatalf("versioning[0].enabled = %#v, want true", enabled)
 	}
 }
+
+func TestReleaseCachesAllowsReuse(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf": `
+variable "name" { type = string }
+resource "aws_s3_bucket" "this" {
+  bucket = var.name
+}
+`,
+	})
+
+	e := New()
+	resources1, _, _, err := e.EvaluateModule(context.Background(), dir, map[string]cty.Value{
+		"name": cty.StringVal("first"),
+	})
+	if err != nil {
+		t.Fatalf("first EvaluateModule: %v", err)
+	}
+	if len(resources1) != 1 {
+		t.Fatalf("first eval: got %d resources, want 1", len(resources1))
+	}
+
+	e.ReleaseCaches()
+
+	resources2, _, _, err := e.EvaluateModule(context.Background(), dir, map[string]cty.Value{
+		"name": cty.StringVal("second"),
+	})
+	if err != nil {
+		t.Fatalf("second EvaluateModule after ReleaseCaches: %v", err)
+	}
+	if len(resources2) != 1 {
+		t.Fatalf("second eval: got %d resources, want 1", len(resources2))
+	}
+	requireString(t, resources2[0].Attributes, "bucket", "second")
+}


### PR DESCRIPTION
## Motivation

Enabling local module evaluation on large repositories increased memory use enough to contribute to production OOMs. The scan still produced the same findings, but it kept more intermediate state in memory than necessary while resolving Terraform modules and building the OPA input.

This change reduces that overhead without changing scan results. It is a meaningful improvement on the local-module path, but a full multi-platform scan shows that most memory still comes from broader source preparation, so further investigation is still needed.

## Changes

**Local module resolution**

When local modules are instantiated, the scanner now avoids repeating expensive work that does not change the outcome. Module call discovery reuses already-parsed Terraform documents instead of re-parsing directories just to learn which modules are referenced. Reference data used for deduplicating synthetic module documents is computed once per module call chain rather than rebuilt for every resource. After module resolution finishes, evaluator caches are released so that memory can be reclaimed before Rego evaluation starts. Absolute local module paths are now resolved from the repository root instead of being incorrectly appended to the caller directory.

**Scan payload construction**

While converting scanned documents into OPA input, the scanner now preserves shared object structure instead of deep-copying the same maps and arrays many times. When a scan only needs one platform payload that is equivalent to the full payload, it reuses the same in-memory payload instead of building it twice.

## Benchmark example (full multi-platform scan)

Both runs scanned the same large monorepo with all supported platforms enabled and local module evaluation turned on. Findings were identical across both runs.

| Metric | Before | After | Delta |
| --- | --- | --- | --- |
| Peak RSS | 9.80 GB | 9.63 GB | -170 MB (-1.7%) |
| Live heap at query evaluation | 4.41 GB | 3.95 GB | -460 MB (-10%) |
| Scan duration | 4m 38s | 4m 18s | -20s |
| Scanned files | 29,711 | 29,711 | unchanged |
| Parsed files | 25,391 | 25,391 | unchanged |
| Module resources instantiated | 4,135 | 4,135 | unchanged |
| Findings | 10,462 | 10,462 | unchanged |

This confirms the optimization preserves correctness on a realistic full-repo workload. The smaller RSS improvement on a multi-platform scan also shows that most memory is still spent outside local module evaluation, mainly during source preparation across Helm, Kubernetes, YAML, and other platforms, but still a small win.

## Author Checklist

1. [x] I have reviewed my own PR.
2. [x] I have added or updated relevant unit tests where necessary.
3. [x] All changed-package tests pass.
4. [ ] I have tested my changes on staging, if applicable.
5. [x] No documentation changes are required.

## QA Instruction

1. Run `go test -mod=mod ./pkg/engine ./pkg/parser/terraform/tfeval ./pkg/parser/terraform/modules -count=1`.
2. Run `golangci-lint run -c .golangci.yml --timeout 20m`.
3. Scan a large repository with all platforms enabled and `--x-local-module-eval`, then confirm findings are unchanged and memory use is lower than before.

## Impact

This affects Terraform local module resolution and OPA payload construction. Other platform parsing behavior and rule evaluation logic are unchanged.

## Additional Notes

This is a safe first step toward re-enabling local module evaluation, but it does not fully solve large-repository memory pressure on its own. Follow-up work should focus on multi-platform source preparation and scan concurrency limits in production.

I submit this contribution under the Apache-2.0 license.