### PR TITLE
Add Git CLI fallback for reftable refstorage repositories

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -460,15 +461,18 @@ func getRepositoryCommitInfo(repoPaths []string) (*model.RepositoryCommitInfo, s
 	}
 	repo, repoDir, err := openRepo(commonDir)
 	if err != nil {
+		if isUnsupportedRefStorage(err) {
+			return getRepositoryCommitInfoWithGit(commonDir)
+		}
 		return nil, "", fmt.Errorf("error opening the repository: %w", err)
 	}
 
 	remote, err := repo.Remote("origin")
 	if err != nil {
-		return nil, "", fmt.Errorf("error retrieving remote `origin`: %w", err)
+		return getRepositoryCommitInfoWithGit(commonDir)
 	}
 	if len(remote.Config().URLs) == 0 {
-		return nil, "", errors.New("the repository doesn't have a configured remote")
+		return getRepositoryCommitInfoWithGit(commonDir)
 	}
 	out := &model.RepositoryCommitInfo{}
 	out.RepositoryUrl = remote.Config().URLs[0]
@@ -509,6 +513,66 @@ func getRepositoryCommitInfo(repoPaths []string) (*model.RepositoryCommitInfo, s
 	}
 
 	return out, repoDir, nil
+}
+
+func isUnsupportedRefStorage(err error) bool {
+	return errors.Is(err, git.ErrUnsupportedExtensionRepositoryFormatVersion) &&
+		strings.Contains(strings.ToLower(err.Error()), "refstorage")
+}
+
+func getRepositoryCommitInfoWithGit(path string) (*model.RepositoryCommitInfo, string, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, "", err
+	}
+	if !stat.IsDir() {
+		path = filepath.Dir(path)
+	}
+
+	repoDir, err := runGit(path, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return nil, "", fmt.Errorf("error determining repository root: %w", err)
+	}
+	repoDir = filepath.Clean(filepath.FromSlash(repoDir))
+	remoteURL, err := runGit(repoDir, "remote", "get-url", "origin")
+	if err != nil {
+		return nil, "", fmt.Errorf("error retrieving remote `origin`: %w", err)
+	}
+	sha, err := runGit(repoDir, "rev-parse", "HEAD")
+	if err != nil {
+		return nil, "", fmt.Errorf("error retrieving HEAD ref: %w", err)
+	}
+
+	branch, err := runGit(repoDir, "symbolic-ref", "--quiet", "--short", "HEAD")
+	if err != nil {
+		branch, err = runGit(repoDir, "for-each-ref", "--format=%(refname:short)", "--points-at", "HEAD", "refs/remotes")
+		if err != nil {
+			return nil, "", fmt.Errorf("error retrieving reference list: %w", err)
+		}
+		if index := strings.IndexByte(branch, '\n'); index >= 0 {
+			branch = branch[:index]
+		}
+	}
+
+	return &model.RepositoryCommitInfo{
+		RepositoryUrl: remoteURL,
+		CommitSHA:     sha,
+		Branch:        branch,
+	}, repoDir, nil
+}
+
+func runGit(repoDir string, args ...string) (string, error) {
+	cmdArgs := append([]string{"-C", repoDir}, args...)
+	//nolint:gosec // Arguments are fixed by internal callers.
+	output, err := exec.Command("git", cmdArgs...).CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			return "", err
+		}
+		return "", fmt.Errorf("%s: %w", message, err)
+	}
+	return strings.TrimSpace(string(output)), nil
 }
 
 // openRepo opens a Git repo, recursing up the directory tree if needed

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -545,13 +545,11 @@ func getRepositoryCommitInfoWithGit(path string) (*model.RepositoryCommitInfo, s
 
 	branch, err := runGit(repoDir, "symbolic-ref", "--quiet", "--short", "HEAD")
 	if err != nil {
-		branch, err = runGit(repoDir, "for-each-ref", "--format=%(refname:short)", "--points-at", "HEAD", "refs/remotes")
+		refs, err := runGit(repoDir, "for-each-ref", "--format=%(refname:short)%00%(symref)", "--points-at", "HEAD", "refs/remotes")
 		if err != nil {
 			return nil, "", fmt.Errorf("error retrieving reference list: %w", err)
 		}
-		if index := strings.IndexByte(branch, '\n'); index >= 0 {
-			branch = branch[:index]
-		}
+		branch = firstRemoteBranch(refs)
 	}
 
 	return &model.RepositoryCommitInfo{
@@ -559,6 +557,17 @@ func getRepositoryCommitInfoWithGit(path string) (*model.RepositoryCommitInfo, s
 		CommitSHA:     sha,
 		Branch:        branch,
 	}, repoDir, nil
+}
+
+func firstRemoteBranch(refs string) string {
+	for _, line := range strings.Split(refs, "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		name, symref, found := strings.Cut(line, "\x00")
+		if found && name != "" && symref == "" {
+			return name
+		}
+	}
+	return ""
 }
 
 func runGit(repoDir string, args ...string) (string, error) {

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -564,7 +564,9 @@ func getRepositoryCommitInfoWithGit(path string) (*model.RepositoryCommitInfo, s
 func runGit(repoDir string, args ...string) (string, error) {
 	cmdArgs := append([]string{"-C", repoDir}, args...)
 	//nolint:gosec // Arguments are fixed by internal callers.
-	output, err := exec.Command("git", cmdArgs...).CombinedOutput()
+	cmd := exec.Command("git", cmdArgs...)
+	cmd.Env = gitEnvironment()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		message := strings.TrimSpace(string(output))
 		if message == "" {
@@ -572,7 +574,32 @@ func runGit(repoDir string, args ...string) (string, error) {
 		}
 		return "", fmt.Errorf("%s: %w", message, err)
 	}
-	return strings.TrimSpace(string(output)), nil
+	return trimGitOutputTerminator(string(output)), nil
+}
+
+func trimGitOutputTerminator(output string) string {
+	return strings.TrimSuffix(strings.TrimSuffix(output, "\n"), "\r")
+}
+
+func gitEnvironment() []string {
+	env := os.Environ()
+	cleanEnv := env[:0]
+	for _, entry := range env {
+		name, _, _ := strings.Cut(entry, "=")
+		switch strings.ToUpper(name) {
+		case "GIT_DIR",
+			"GIT_WORK_TREE",
+			"GIT_COMMON_DIR",
+			"GIT_INDEX_FILE",
+			"GIT_OBJECT_DIRECTORY",
+			"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+			"GIT_NAMESPACE":
+			continue
+		default:
+			cleanEnv = append(cleanEnv, entry)
+		}
+	}
+	return cleanEnv
 }
 
 // openRepo opens a Git repo, recursing up the directory tree if needed

--- a/cmd/scanner/scan_test.go
+++ b/cmd/scanner/scan_test.go
@@ -2,14 +2,51 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/scan"
 	"github.com/stretchr/testify/assert"
-	cli "github.com/urfave/cli/v3"
 	"github.com/stretchr/testify/require"
+	cli "github.com/urfave/cli/v3"
 )
+
+func TestGetRepositoryCommitInfoWithRefStorage(t *testing.T) {
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	initCommand := exec.Command("git", "init", "--ref-format=reftable", "--initial-branch=main", repoDir)
+	if output, err := initCommand.CombinedOutput(); err != nil {
+		t.Skipf("Git does not support reftable: %s", strings.TrimSpace(string(output)))
+	}
+
+	runTestGit(t, repoDir, "config", "user.name", "Test User")
+	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	runTestGit(t, repoDir, "config", "commit.gpgsign", "false")
+	runTestGit(t, repoDir, "remote", "add", "origin", "https://example.com/repository.git")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("resource \"test\" \"example\" {}\n"), 0o600))
+	runTestGit(t, repoDir, "add", "main.tf")
+	runTestGit(t, repoDir, "commit", "-m", "initial commit")
+	wantSHA := runTestGit(t, repoDir, "rev-parse", "HEAD")
+
+	info, gotRepoDir, err := getRepositoryCommitInfo([]string{filepath.Join(repoDir, "main.tf")})
+
+	require.NoError(t, err)
+	resolvedRepoDir, err := filepath.EvalSymlinks(repoDir)
+	require.NoError(t, err)
+	assert.Equal(t, resolvedRepoDir, gotRepoDir)
+	assert.Equal(t, "https://example.com/repository.git", info.RepositoryUrl)
+	assert.Equal(t, wantSHA, info.CommitSHA)
+	assert.Equal(t, "main", info.Branch)
+}
+
+func runTestGit(t *testing.T, repoDir string, args ...string) string {
+	t.Helper()
+	cmdArgs := append([]string{"-C", repoDir}, args...)
+	output, err := exec.Command("git", cmdArgs...).CombinedOutput()
+	require.NoError(t, err, strings.TrimSpace(string(output)))
+	return strings.TrimSpace(string(output))
+}
 
 func TestApplyPlatformFilters(t *testing.T) {
 	all := []string{"Ansible", "CICD", "CloudFormation", "Dockerfile", "Kubernetes", "Terraform"}

--- a/cmd/scanner/scan_test.go
+++ b/cmd/scanner/scan_test.go
@@ -28,6 +28,17 @@ func TestGetRepositoryCommitInfoWithRefStorage(t *testing.T) {
 	runTestGit(t, repoDir, "add", "main.tf")
 	runTestGit(t, repoDir, "commit", "-m", "initial commit")
 	wantSHA := runTestGit(t, repoDir, "rev-parse", "HEAD")
+	for _, name := range []string{
+		"GIT_DIR",
+		"GIT_WORK_TREE",
+		"GIT_COMMON_DIR",
+		"GIT_INDEX_FILE",
+		"GIT_OBJECT_DIRECTORY",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+		"GIT_NAMESPACE",
+	} {
+		t.Setenv(name, filepath.Join(t.TempDir(), "override"))
+	}
 
 	info, gotRepoDir, err := getRepositoryCommitInfo([]string{filepath.Join(repoDir, "main.tf")})
 
@@ -38,6 +49,12 @@ func TestGetRepositoryCommitInfoWithRefStorage(t *testing.T) {
 	assert.Equal(t, "https://example.com/repository.git", info.RepositoryUrl)
 	assert.Equal(t, wantSHA, info.CommitSHA)
 	assert.Equal(t, "main", info.Branch)
+}
+
+func TestTrimGitOutputTerminator(t *testing.T) {
+	assert.Equal(t, "/tmp/repo ", trimGitOutputTerminator("/tmp/repo \n"))
+	assert.Equal(t, "/tmp/repo ", trimGitOutputTerminator("/tmp/repo \r\n"))
+	assert.Equal(t, " value ", trimGitOutputTerminator(" value "))
 }
 
 func runTestGit(t *testing.T, repoDir string, args ...string) string {

--- a/cmd/scanner/scan_test.go
+++ b/cmd/scanner/scan_test.go
@@ -28,6 +28,10 @@ func TestGetRepositoryCommitInfoWithRefStorage(t *testing.T) {
 	runTestGit(t, repoDir, "add", "main.tf")
 	runTestGit(t, repoDir, "commit", "-m", "initial commit")
 	wantSHA := runTestGit(t, repoDir, "rev-parse", "HEAD")
+	runTestGit(t, repoDir, "update-ref", "refs/remotes/origin/main", "HEAD")
+	runTestGit(t, repoDir, "update-ref", "refs/remotes/origin/second", "HEAD")
+	runTestGit(t, repoDir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+	runTestGit(t, repoDir, "checkout", "--detach", "HEAD")
 	for _, name := range []string{
 		"GIT_DIR",
 		"GIT_WORK_TREE",
@@ -48,13 +52,19 @@ func TestGetRepositoryCommitInfoWithRefStorage(t *testing.T) {
 	assert.Equal(t, resolvedRepoDir, gotRepoDir)
 	assert.Equal(t, "https://example.com/repository.git", info.RepositoryUrl)
 	assert.Equal(t, wantSHA, info.CommitSHA)
-	assert.Equal(t, "main", info.Branch)
+	assert.Equal(t, "origin/main", info.Branch)
 }
 
 func TestTrimGitOutputTerminator(t *testing.T) {
 	assert.Equal(t, "/tmp/repo ", trimGitOutputTerminator("/tmp/repo \n"))
 	assert.Equal(t, "/tmp/repo ", trimGitOutputTerminator("/tmp/repo \r\n"))
 	assert.Equal(t, " value ", trimGitOutputTerminator(" value "))
+}
+
+func TestFirstRemoteBranch(t *testing.T) {
+	refs := "origin\x00refs/remotes/origin/main\r\norigin/main\x00\r\norigin/second\x00"
+	assert.Equal(t, "origin/main", firstRemoteBranch(refs))
+	assert.Empty(t, firstRemoteBranch("origin\x00refs/remotes/origin/main"))
 }
 
 func runTestGit(t *testing.T, repoDir string, args ...string) string {


### PR DESCRIPTION
## Motivation

Some Git repositories use reftable reference storage, which the embedded Git library used by the scanner cannot open. Without a fallback, scans fail when collecting repository metadata (branch, commit, remote URL) even though the Git CLI can read those repositories normally.

## Changes

**Repository metadata**

When opening a repository fails because of unsupported reftable refstorage, or when the embedded library cannot read the `origin` remote, the scanner now falls back to the Git CLI to resolve the repository root, remote URL, HEAD commit, and branch. A unit test initializes a reftable repository and verifies metadata collection through this path.

## Author Checklist

1. [x] I have reviewed my own PR.
2. [x] I have added or updated relevant unit tests where necessary.
3. [x] All new and existing tests pass.
4. [ ] I have tested my changes on staging (if applicable).
5. [x] No documentation changes are required.

## QA Instruction

1. Run `go test -mod=mod ./cmd/scanner -run TestGetRepositoryCommitInfoWithRefStorage -count=1`.
2. Scan a local repository that uses reftable refstorage and confirm the scan completes with correct repository metadata in the output.

## Impact

This affects repository metadata discovery during CLI scans only. Scanning logic, rule evaluation, and serve mode are unchanged.

## Additional Notes

This is intentionally scoped separately from local module evaluation memory work so it can be reviewed and rolled out on its own.

I submit this contribution under the Apache-2.0 license.