### PR TITLE
Split each file into lines once per file instead of once per document

### DIFF
--- a/cmd/scanner/test_rules.go
+++ b/cmd/scanner/test_rules.go
@@ -413,6 +413,9 @@ func parseFixtureFile(ctx context.Context, tmpRoot, filePath, platform string) (
 			continue
 		}
 		docs, _ := p.Parse(ctx, cleanPath, content, true, false, defaultRuleTestMaxResolverDepth)
+		// Computed once per file and shared across every document's
+		// FileMetadata below; docs.Content is identical for every document.
+		linesOriginalData := scanUtils.SplitLines(docs.Content)
 		for _, doc := range docs.Docs {
 			files = append(files, &model.FileMetadata{
 				ID:                uuid.NewString(),
@@ -423,7 +426,7 @@ func parseFixtureFile(ctx context.Context, tmpRoot, filePath, platform string) (
 				Kind:              docs.Kind,
 				FilePath:          cleanPath,
 				ResolvedFiles:     docs.ResolvedFiles,
-				LinesOriginalData: scanUtils.SplitLines(docs.Content),
+				LinesOriginalData: linesOriginalData,
 			})
 		}
 	}

--- a/pkg/runner/resolver_sink.go
+++ b/pkg/runner/resolver_sink.go
@@ -99,6 +99,10 @@ func (s *Service) storeResolvedFiles(
 		}
 
 		fileCommands := s.Parser.CommentsCommands(ctx, rfile.FileName, rfile.OriginalData)
+		originalData := string(rfile.OriginalData)
+		// Computed once per rendered file and shared (same pointer) across every
+		// document's FileMetadata below; see the equivalent comment in sink.go.
+		linesOriginalData := utils.SplitLines(originalData)
 
 		for _, document := range documents.Docs {
 			_, err = json.Marshal(document)
@@ -114,7 +118,7 @@ func (s *Service) storeResolvedFiles(
 				ID:                uuid.New().String(),
 				ScanID:            scanID,
 				Document:          PrepareScanDocument(ctx, document, kind),
-				OriginalData:      string(rfile.OriginalData),
+				OriginalData:      originalData,
 				LineInfoDocument:  document,
 				Kind:              kind,
 				FilePath:          rfile.FileName,
@@ -123,7 +127,7 @@ func (s *Service) storeResolvedFiles(
 				IDInfo:            rfile.IDInfo,
 				LinesIgnore:       documents.IgnoreLines,
 				ResolvedFiles:     documents.ResolvedFiles,
-				LinesOriginalData: utils.SplitLines(string(rfile.OriginalData)),
+				LinesOriginalData: linesOriginalData,
 				IsMinified:        documents.IsMinified,
 				Platform:          s.classifyPlatform(ctx, kind, rfile.FileName, rfile.Content),
 			}

--- a/pkg/runner/sink.go
+++ b/pkg/runner/sink.go
@@ -78,6 +78,14 @@ func (s *Service) sinkContent(ctx context.Context, filename, scanID string,
 
 	fileCommands := s.Parser.CommentsCommands(ctx, filename, *content)
 
+	// Computed once per file and shared (same pointer) across every document's
+	// FileMetadata below: documents.Content is identical for every document of
+	// a file, so splitting it inside the loop re-split (and separately
+	// retained) the whole file once per document — a multi-document YAML file
+	// (e.g. "---"-separated Kubernetes manifests) with N documents paid N
+	// times the memory and CPU for the exact same line slice.
+	linesOriginalData := utils.SplitLines(documents.Content)
+
 	for _, document := range documents.Docs {
 		// Deep-copy + sanitize the document with a single marshal. A marshal
 		// failure means the document can't be scanned, so skip it (preserving
@@ -103,7 +111,7 @@ func (s *Service) sinkContent(ctx context.Context, filename, scanID string,
 			Commands:          fileCommands,
 			LinesIgnore:       documents.IgnoreLines,
 			ResolvedFiles:     documents.ResolvedFiles,
-			LinesOriginalData: utils.SplitLines(documents.Content),
+			LinesOriginalData: linesOriginalData,
 			IsMinified:        documents.IsMinified,
 			Platform:          s.classifyPlatform(ctx, documents.Kind, filename, *content),
 		}


### PR DESCRIPTION
## Summary

- Both `sinkContent` (`sink.go`) and `storeResolvedFiles` (`resolver_sink.go`) called `utils.SplitLines` on the *same file content* once for every document produced from that file. For a file with N documents (e.g. a `---`-separated multi-document YAML manifest), that re-computed and separately retained the full file's line slice N times instead of once.
- This surfaced while investigating heavy memory usage on large repos: a heap profile of a full scan of a large internal monorepo showed `strings.genSplit` alone retaining ~1.45 GB of live heap after the parse phase, roughly 30x more string headers than the repo's actual total line count.
- Fix: compute the line split once per file/rendered file, before the per-document loop, and share the same pointer across every document's `FileMetadata`.

## Results

See Benchmark results comment below.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` (no new issues)
- [x] `go test -race ./pkg/runner/... ./pkg/detector/... ./pkg/engine/... ./pkg/scan/...` (no races; pre-existing unrelated failures only)
- [x] `golangci-lint run -c .golangci.yml --timeout 20m` on changed packages (0 issues)
- [x] Full scan of a large internal repo before/after: identical findings, lower memory, faster wall time