### PR TITLE
[K9CODESEC-3923] Fetch and merge custom IaC ruleset during scans

### DIFF
--- a/cmd/scanner/fetch_bundle.go
+++ b/cmd/scanner/fetch_bundle.go
@@ -32,7 +32,7 @@ type bundleManifest struct {
 
 var fetchBundleAction = &cli.Command{
 	Name: "fetch-bundle",
-	Usage: "Fetches the default ruleset, Rego libraries, and merged remote " +
+	Usage: "Fetches the default and custom rulesets, Rego libraries, and merged remote " +
 		"configuration for a repository and writes them to local files, for " +
 		"later use with `scan --offline-bundle-path` in a network-isolated environment",
 	Flags: []cli.Flag{
@@ -78,10 +78,15 @@ func fetchBundle(ctx context.Context, c *cli.Command) error {
 		return errorWithExitCode(fmt.Errorf("error writing the configuration bundle: %w", err), constants.EngineErrorCode)
 	}
 
-	ruleset, err := client.GetDefaultRuleset(ctx)
+	defaultRuleset, err := client.GetDefaultRuleset(ctx)
 	if err != nil {
 		return errorWithExitCode(fmt.Errorf("error fetching the default ruleset: %w", err), constants.EngineErrorCode)
 	}
+	customRuleset, err := client.GetCustomRuleset(ctx)
+	if err != nil {
+		return errorWithExitCode(fmt.Errorf("error fetching the custom ruleset: %w", err), constants.EngineErrorCode)
+	}
+	ruleset := datadog.MergeRulesets(defaultRuleset, customRuleset)
 	rulesetBytes, err := json.Marshal(ruleset)
 	if err != nil {
 		return errorWithExitCode(fmt.Errorf("error marshaling the default ruleset: %w", err), constants.EngineErrorCode)

--- a/cmd/scanner/fetch_bundle_e2e_test.go
+++ b/cmd/scanner/fetch_bundle_e2e_test.go
@@ -88,6 +88,8 @@ func Test_E2EFetchBundleThenOfflineScan(t *testing.T) {
 			w.Header().Add("content-type", "application/json")
 			_, err = w.Write(body)
 			require.NoError(t, err)
+		case "/api/v2/static-analysis/iac/rulesets/custom-ruleset":
+			http.NotFound(w, r)
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
 			http.NotFound(w, r)

--- a/cmd/scanner/test_rules.go
+++ b/cmd/scanner/test_rules.go
@@ -100,10 +100,15 @@ var testRulesAction = &cli.Command{
 
 func runTestRules(ctx context.Context, c *cli.Command) error {
 	client := datadog.NewDatadogClient()
-	ruleset, err := client.GetDefaultRulesetWithTests(ctx)
+	defaultRuleset, err := client.GetDefaultRulesetWithTests(ctx)
 	if err != nil {
-		return fmt.Errorf("fetching rules with tests: %w", err)
+		return fmt.Errorf("fetching default rules with tests: %w", err)
 	}
+	customRuleset, err := client.GetCustomRulesetWithTests(ctx)
+	if err != nil {
+		return fmt.Errorf("fetching custom rules with tests: %w", err)
+	}
+	ruleset := datadog.MergeRulesets(defaultRuleset, customRuleset)
 
 	libSource, err := source.NewDatadogSource(client)
 	if err != nil {

--- a/pkg/config/reader_test.go
+++ b/pkg/config/reader_test.go
@@ -333,6 +333,14 @@ func (f *fakeDatadogClient) GetDefaultRulesetWithTests(ctx context.Context) (*da
 	panic("unimplemented")
 }
 
+func (f *fakeDatadogClient) GetCustomRuleset(_ context.Context) (*datadog.Ruleset, error) {
+	return &datadog.Ruleset{ID: datadog.CustomRulesetName, Name: datadog.CustomRulesetName}, nil
+}
+
+func (f *fakeDatadogClient) GetCustomRulesetWithTests(_ context.Context) (*datadog.Ruleset, error) {
+	panic("unimplemented")
+}
+
 func (f *fakeDatadogClient) GetRemoteConfig(_ context.Context, repoUrl string, localConfig []byte) ([]byte, error) {
 	assert.Equal(f.t, f.expectedRepoUrl, repoUrl)
 	assert.Equal(f.t, string(f.expectedSentConfig), string(localConfig))

--- a/pkg/datadog/client.go
+++ b/pkg/datadog/client.go
@@ -7,9 +7,15 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/DataDog/jsonapi"
+)
+
+const (
+	DefaultRulesetName = "default-ruleset"
+	CustomRulesetName  = "custom-ruleset"
 )
 
 type Client interface {
@@ -17,6 +23,13 @@ type Client interface {
 	GetDefaultRuleset(ctx context.Context) (*Ruleset, error)
 	// GetDefaultRulesetWithTests returns the default ruleset with per-rule test fixtures included.
 	GetDefaultRulesetWithTests(ctx context.Context) (*Ruleset, error)
+	// GetCustomRuleset returns the org's published custom IaC ruleset.
+	// When the org has no custom rules, the feature is disabled, or the caller
+	// lacks org-scoped auth, the backend returns 404 and this method returns an
+	// empty ruleset without error.
+	GetCustomRuleset(ctx context.Context) (*Ruleset, error)
+	// GetCustomRulesetWithTests returns the org's custom ruleset with test fixtures included.
+	GetCustomRulesetWithTests(ctx context.Context) (*Ruleset, error)
 	// GetRemoteConfig applies server-side changes to the local configuration.
 	GetRemoteConfig(ctx context.Context, repoUrl string, localConfig []byte) ([]byte, error)
 	// GetLibraries returns all Rego library modules from the backend, keyed by module name.
@@ -143,21 +156,50 @@ type datadogClient struct {
 
 // GetDefaultRuleset returns the content of the default ruleset.
 func (s *datadogClient) GetDefaultRuleset(ctx context.Context) (*Ruleset, error) {
-	return s.fetchDefaultRuleset(ctx, false)
+	return s.fetchRuleset(ctx, DefaultRulesetName, false)
 }
 
 // GetDefaultRulesetWithTests returns the default ruleset with per-rule test fixtures included.
 func (s *datadogClient) GetDefaultRulesetWithTests(ctx context.Context) (*Ruleset, error) {
-	return s.fetchDefaultRuleset(ctx, true)
+	return s.fetchRuleset(ctx, DefaultRulesetName, true)
 }
 
-func (s *datadogClient) fetchDefaultRuleset(ctx context.Context, includeTests bool) (*Ruleset, error) {
-	path := fmt.Sprintf("iac/rulesets/default-ruleset?include_tests=%t&include_testing_rules=true", includeTests)
+// GetCustomRuleset returns the org's published custom IaC ruleset.
+func (s *datadogClient) GetCustomRuleset(ctx context.Context) (*Ruleset, error) {
+	return s.fetchRuleset(ctx, CustomRulesetName, false)
+}
+
+// GetCustomRulesetWithTests returns the org's custom ruleset with test fixtures included.
+func (s *datadogClient) GetCustomRulesetWithTests(ctx context.Context) (*Ruleset, error) {
+	return s.fetchRuleset(ctx, CustomRulesetName, true)
+}
+
+// MergeRulesets appends custom rules onto a copy of the default ruleset.
+func MergeRulesets(defaultRuleset, customRuleset *Ruleset) *Ruleset {
+	if customRuleset == nil || len(customRuleset.Rules) == 0 {
+		return defaultRuleset
+	}
+	if defaultRuleset == nil {
+		return customRuleset
+	}
+	merged := *defaultRuleset
+	merged.Rules = append(slices.Clone(defaultRuleset.Rules), customRuleset.Rules...)
+	return &merged
+}
+
+func (s *datadogClient) fetchRuleset(ctx context.Context, rulesetName string, includeTests bool) (*Ruleset, error) {
+	path := fmt.Sprintf("iac/rulesets/%s?include_tests=%t&include_testing_rules=true", rulesetName, includeTests)
 	response, err := s.sendRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}
 	defer response.Body.Close() // nolint:errcheck
+	if response.StatusCode == http.StatusNotFound && rulesetName == CustomRulesetName {
+		return &Ruleset{
+			ID:   CustomRulesetName,
+			Name: CustomRulesetName,
+		}, nil
+	}
 	if response.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("the Datadog API returned status %d", response.StatusCode)
 	}

--- a/pkg/datadog/client_test.go
+++ b/pkg/datadog/client_test.go
@@ -11,6 +11,67 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetCustomRuleset_NotFoundReturnsEmpty(t *testing.T) {
+	clearDatadogEnv(t)
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v2/static-analysis/iac/rulesets/custom-ruleset", r.URL.Path)
+		http.NotFound(w, r)
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	client := NewDatadogClient(
+		WithHostname(server.Listener.Addr().String()),
+		WithHttpClient(server.Client()),
+		WithJwtToken("my-jwt-token"),
+	)
+	ruleset, err := client.GetCustomRuleset(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, CustomRulesetName, ruleset.ID)
+	assert.Empty(t, ruleset.Rules)
+}
+
+func TestGetCustomRuleset(t *testing.T) {
+	customRules := []*Rule{
+		{
+			ID:               "custom-dockerfile-untagged-from",
+			Name:             "custom-dockerfile-untagged-from",
+			ShortDescription: "Untagged FROM image",
+			Description:      "Dockerfile uses an untagged base image",
+			Platform:         "Dockerfile",
+			Type:             "rego",
+			RegoQuery:        []byte("package datadog"),
+			Severity:         "HIGH",
+			Category:         "Best Practices",
+			IsPublished:      true,
+		},
+	}
+
+	client := getDatadogClient(t, nil, customRules, "", nil)
+	ruleset, err := client.GetCustomRuleset(t.Context())
+	assert.NoError(t, err)
+	assert.Equal(t, customRules, ruleset.Rules)
+}
+
+func TestMergeRulesets(t *testing.T) {
+	defaultRule := &Rule{ID: "default-rule", Name: "default-rule", IsPublished: true}
+	customRule := &Rule{ID: "custom-rule", Name: "custom-rule", IsPublished: true}
+
+	merged := MergeRulesets(
+		&Ruleset{ID: DefaultRulesetName, Rules: []*Rule{defaultRule}},
+		&Ruleset{ID: CustomRulesetName, Rules: []*Rule{customRule}},
+	)
+	require.Len(t, merged.Rules, 2)
+	assert.Equal(t, "default-rule", merged.Rules[0].ID)
+	assert.Equal(t, "custom-rule", merged.Rules[1].ID)
+
+	assert.Equal(t,
+		&Ruleset{ID: DefaultRulesetName, Rules: []*Rule{defaultRule}},
+		MergeRulesets(&Ruleset{ID: DefaultRulesetName, Rules: []*Rule{defaultRule}}, &Ruleset{ID: CustomRulesetName}),
+	)
+}
+
 func TestGetDefaultRuleset(t *testing.T) {
 	rules := []*Rule{
 		{
@@ -47,7 +108,7 @@ func TestGetDefaultRuleset(t *testing.T) {
 		},
 	}
 
-	client := getDatadogClient(t, rules, "", nil)
+	client := getDatadogClient(t, rules, nil, "", nil)
 	ruleset, err := client.GetDefaultRuleset(t.Context())
 	assert.NoError(t, err)
 	assert.Equal(t, rules, ruleset.Rules)
@@ -56,7 +117,7 @@ func TestGetDefaultRuleset(t *testing.T) {
 func TestGetRemoteConfig(t *testing.T) {
 	repoUrl := "https://example.com/repo"
 	remoteConfig := "this is the configuration"
-	client := getDatadogClient(t, nil, repoUrl, []byte(remoteConfig))
+	client := getDatadogClient(t, nil, nil, repoUrl, []byte(remoteConfig))
 	actual, err := client.GetRemoteConfig(t.Context(), repoUrl, []byte{})
 	assert.NoError(t, err)
 	assert.Equal(t, remoteConfig, string(actual))
@@ -234,23 +295,36 @@ func TestGetRemoteConfig_HostnameWithHttpScheme(t *testing.T) {
 	assert.Equal(t, remoteConfig, string(actual))
 }
 
-func getDatadogClient(t *testing.T, rules []*Rule, repoUrl string, config []byte) Client {
+func getDatadogClient(t *testing.T, defaultRules, customRules []*Rule, repoUrl string, config []byte) Client {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "my-api-key", r.Header.Get("dd-api-key"))
 		assert.Equal(t, "my-app-key", r.Header.Get("dd-application-key"))
-		if r.URL.Path == "/api/v2/static-analysis/iac/rulesets/default-ruleset" {
+		switch r.URL.Path {
+		case "/api/v2/static-analysis/iac/rulesets/default-ruleset":
 			assert.Equal(t, http.MethodGet, r.Method)
 			ruleset := Ruleset{
-				ID:    "default-ruleset",
-				Name:  "default-ruleset",
-				Rules: rules,
+				ID:    DefaultRulesetName,
+				Name:  DefaultRulesetName,
+				Rules: defaultRules,
 			}
 			body, err := jsonapi.Marshal(ruleset)
 			require.NoError(t, err)
 			w.Header().Add("content-type", "application/json")
 			_, err = w.Write(body)
 			require.NoError(t, err)
-		} else if r.URL.Path == "/api/v2/static-analysis/config/client" {
+		case "/api/v2/static-analysis/iac/rulesets/custom-ruleset":
+			assert.Equal(t, http.MethodGet, r.Method)
+			ruleset := Ruleset{
+				ID:    CustomRulesetName,
+				Name:  CustomRulesetName,
+				Rules: customRules,
+			}
+			body, err := jsonapi.Marshal(ruleset)
+			require.NoError(t, err)
+			w.Header().Add("content-type", "application/json")
+			_, err = w.Write(body)
+			require.NoError(t, err)
+		case "/api/v2/static-analysis/config/client":
 			assert.Equal(t, http.MethodPost, r.Method)
 			defer r.Body.Close()
 			var request remoteConfigRequest
@@ -266,10 +340,9 @@ func getDatadogClient(t *testing.T, rules []*Rule, repoUrl string, config []byte
 			w.Header().Add("content-type", "application/json")
 			_, err = w.Write(body)
 			require.NoError(t, err)
-		} else {
+		default:
 			assert.Failf(t, "Unexpected request: %s %s", r.Method, r.URL)
 			http.NotFoundHandler().ServeHTTP(w, r)
-			return
 		}
 	}
 	server := httptest.NewTLSServer(http.HandlerFunc(handler))

--- a/pkg/datadog/local_file_client.go
+++ b/pkg/datadog/local_file_client.go
@@ -59,6 +59,14 @@ func (c *LocalFileClient) GetDefaultRulesetWithTests(_ context.Context) (*Rulese
 	return c.ruleset, nil
 }
 
+func (c *LocalFileClient) GetCustomRuleset(_ context.Context) (*Ruleset, error) {
+	return &Ruleset{ID: CustomRulesetName, Name: CustomRulesetName}, nil
+}
+
+func (c *LocalFileClient) GetCustomRulesetWithTests(_ context.Context) (*Ruleset, error) {
+	return &Ruleset{ID: CustomRulesetName, Name: CustomRulesetName}, nil
+}
+
 // GetRemoteConfig returns localConfig unchanged. The bundle's config.yaml
 // (written by `fetch-bundle`) already carries the fully-merged result, so
 // callers using LocalFileClient are expected to load that file directly with

--- a/pkg/engine/source/datadog.go
+++ b/pkg/engine/source/datadog.go
@@ -73,9 +73,13 @@ type DatadogSource struct {
 func (s *DatadogSource) GetQueries(ctx context.Context, querySelection *QueryInspectorParameters) ([]model.QueryMetadata, error) {
 	defaultRuleset, err := s.client.GetDefaultRuleset(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving rules from Datadog: %w", err)
+		return nil, fmt.Errorf("error retrieving default rules from Datadog: %w", err)
 	}
-	return s.filterRules(defaultRuleset, querySelection)
+	customRuleset, err := s.client.GetCustomRuleset(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving custom rules from Datadog: %w", err)
+	}
+	return s.filterRules(datadog.MergeRulesets(defaultRuleset, customRuleset), querySelection)
 }
 
 func (s *DatadogSource) loadLibraries(ctx context.Context) (map[string]RegoLibraries, error) {

--- a/pkg/engine/source/datadog_test.go
+++ b/pkg/engine/source/datadog_test.go
@@ -513,6 +513,46 @@ var queries = []model.QueryMetadata{
 	},
 }
 
+func TestGetQueriesMergesCustomRules(t *testing.T) {
+	source, err := NewDatadogSource(&fakeDatadogClient{
+		rules: []*datadog.Rule{
+			{
+				ID:               "default-rule",
+				Name:             "default-rule",
+				ShortDescription: "default",
+				Description:      "default",
+				Platform:         "Dockerfile",
+				Type:             "rego",
+				RegoQuery:        []byte("package datadog"),
+				Severity:         "HIGH",
+				Category:         "Best Practices",
+				IsPublished:      true,
+			},
+		},
+		customRules: []*datadog.Rule{
+			{
+				ID:               "custom-dockerfile-rule",
+				Name:             "custom-dockerfile-rule",
+				ShortDescription: "custom",
+				Description:      "custom",
+				Platform:         "Dockerfile",
+				Type:             "rego",
+				RegoQuery:        []byte("package datadog"),
+				Severity:         "HIGH",
+				Category:         "Best Practices",
+				IsPublished:      true,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	queries, err := source.GetQueries(t.Context(), &QueryInspectorParameters{})
+	require.NoError(t, err)
+	require.Len(t, queries, 2)
+	assert.Equal(t, "default-rule", queries[0].Metadata["id"])
+	assert.Equal(t, "custom-dockerfile-rule", queries[1].Metadata["id"])
+}
+
 func getDatadogSource(t *testing.T, rules []*datadog.Rule, options ...DatadogSourceOption) QueriesSource {
 	client := &fakeDatadogClient{rules: rules}
 	source, err := NewDatadogSource(client, options...)
@@ -593,8 +633,9 @@ func (s stubLibrarySource) GetQueryLibrary(_ context.Context, platform string) (
 }
 
 type fakeDatadogClient struct {
-	rules     []*datadog.Rule
-	libraries map[string]datadog.Library
+	rules       []*datadog.Rule
+	customRules []*datadog.Rule
+	libraries   map[string]datadog.Library
 }
 
 func (f fakeDatadogClient) GetDefaultRuleset(ctx context.Context) (*datadog.Ruleset, error) {
@@ -607,6 +648,21 @@ func (f fakeDatadogClient) GetDefaultRuleset(ctx context.Context) (*datadog.Rule
 }
 
 func (f fakeDatadogClient) GetDefaultRulesetWithTests(ctx context.Context) (*datadog.Ruleset, error) {
+	panic("unimplemented")
+}
+
+func (f fakeDatadogClient) GetCustomRuleset(_ context.Context) (*datadog.Ruleset, error) {
+	if len(f.customRules) == 0 {
+		return &datadog.Ruleset{ID: datadog.CustomRulesetName, Name: datadog.CustomRulesetName}, nil
+	}
+	return &datadog.Ruleset{
+		ID:    datadog.CustomRulesetName,
+		Name:  datadog.CustomRulesetName,
+		Rules: f.customRules,
+	}, nil
+}
+
+func (f fakeDatadogClient) GetCustomRulesetWithTests(_ context.Context) (*datadog.Ruleset, error) {
 	panic("unimplemented")
 }
 


### PR DESCRIPTION
## Motivation

Published org custom IaC rules are served by the backend at `iac/rulesets/custom-ruleset`, but the scanner only fetched `default-ruleset`. PR scans and `list-queries` therefore never loaded custom rules even when the org had published them.

Related Ticket: [K9CODESEC-3923](https://datadoghq.atlassian.net/browse/K9CODESEC-3923?atlOrigin=eyJpIjoiNjcwODg5MzEzMTVjNDQ2ZDgzZGY2ZWRkZWZlMmZjZDkiLCJwIjoiaiJ9)

## Changes

**Datadog client**

Added `GetCustomRuleset` / `GetCustomRulesetWithTests` on the API client. A 404 from `custom-ruleset` is treated as an empty ruleset (no custom rules, feature disabled, or caller without org-scoped auth). Added `MergeRulesets` to append custom rules onto the default ruleset.

**Query loading**

`DatadogSource.GetQueries`, `fetch-bundle`, and `test-rules` now fetch both rulesets and merge them before filtering or writing bundles. Offline bundles already store the merged result in `rules.json`; `LocalFileClient` returns an empty custom ruleset so double-merge does not occur.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [x] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/datadog/... ./pkg/engine/source/... ./cmd/scanner/...`
2. With org API/app keys or OBO JWT set, run `list-queries` and confirm custom rule IDs appear.
3. Scan a Dockerfile that should trigger a published custom rule and confirm a finding is emitted.

**Manual validation (US1 prod, this branch)**

I ran a local scan against the [iac_rules_configuration_jeff PR #113](https://github.com/DataDog/iac_rules_configuration_jeff/pull/113) fixture (`tests/dockerfile_untagged_from/Dockerfile`, untagged `FROM alpine`):

1. `list-queries` included the published custom rule `custom-dockerfile-chakib-testing-rule-dockerfile`.
2. `scan --type dockerfile --report-format simple-json` produced a finding for that custom rule on line 1 (severity MEDIUM).

## Blast Radius

Affects scan, `list-queries`, `fetch-bundle`, and `test-rules` when fetching rules from the Datadog backend. Orgs without custom rules are unchanged (404 → empty merge). Offline bundle scans are unchanged.

## Additional Notes

Requires org-scoped auth (OBO JWT in CI, or API + app keys locally) for custom rules to be returned by the backend.

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-3923]: https://datadoghq.atlassian.net/browse/K9CODESEC-3923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ