### PR TITLE
[K9CODESEC-4561] Lazy-load LineInfoDocument to reduce scan memory

### DIFF
--- a/cmd/scanner/test_rules.go
+++ b/cmd/scanner/test_rules.go
@@ -483,4 +483,5 @@ func (t *noopTracker) TrackQueryLoad(int)      {}
 func (t *noopTracker) TrackQueryExecuting(int) {}
 func (t *noopTracker) TrackQueryExecution(int) {}
 func (t *noopTracker) FailedDetectLine()       {}
+func (t *noopTracker) FailedLineInfoDocument() {}
 func (t *noopTracker) GetOutputLines() int     { return 0 }

--- a/internal/tracker/ci.go
+++ b/internal/tracker/ci.go
@@ -20,19 +20,20 @@ var (
 )
 
 type CITracker struct {
-	ExecutingQueries int
-	ExecutedQueries  int
-	FoundFiles       int
-	LoadedQueries    int
-	ParsedFiles      int
-	lines            int
-	FoundCountLines  int
-	ParsedCountLines int
-	IgnoreCountLines int
-	BagOfFilesParse  map[string]int
-	BagOfFilesFound  map[string]int
-	syncFileMutex    sync.Mutex
-	FoundResources   int
+	ExecutingQueries     int
+	ExecutedQueries      int
+	FoundFiles           int
+	LoadedQueries        int
+	ParsedFiles          int
+	lines                int
+	FoundCountLines      int
+	ParsedCountLines     int
+	IgnoreCountLines     int
+	BagOfFilesParse      map[string]int
+	BagOfFilesFound      map[string]int
+	syncFileMutex        sync.Mutex
+	FoundResources       int
+	LineInfoLoadFailures int
 }
 
 // NewTracker will create a new instance of a tracker with the number of lines to display in results output
@@ -106,6 +107,13 @@ func (c *CITracker) FailedDetectLine() {
 	trackerMu.Lock()
 	defer trackerMu.Unlock()
 	c.ExecutedQueries--
+}
+
+// FailedLineInfoDocument counts lazy line-info document load failures.
+func (c *CITracker) FailedLineInfoDocument() {
+	trackerMu.Lock()
+	defer trackerMu.Unlock()
+	c.LineInfoLoadFailures++
 }
 
 // TrackFileFoundCountLines - information about the lines of the scanned files

--- a/pkg/engine/loadquery_cache_test.go
+++ b/pkg/engine/loadquery_cache_test.go
@@ -25,6 +25,7 @@ func (cacheTracker) TrackQueryLoad(int)      {}
 func (cacheTracker) TrackQueryExecuting(int) {}
 func (cacheTracker) TrackQueryExecution(int) {}
 func (cacheTracker) FailedDetectLine()       {}
+func (cacheTracker) FailedLineInfoDocument() {}
 func (cacheTracker) GetOutputLines() int     { return 3 }
 
 func newCacheTestLoader(t *testing.T, platform string, queries []model.QueryMetadata) *QueryLoader {

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -80,7 +80,11 @@ func (c *Inspector) instantiateLocalModules(
 			// drop only those to avoid double-counting; keep the rest of the body
 			// (variable/output/data/locals) so those rules still fire.
 			delete(f.Document, "resource")
-			delete(f.LineInfoDocument, "resource")
+			if err := f.EnsureLineInfoDocument(ctx); err != nil {
+				contextLogger.Err(err).Msgf("failed to build line-info document for file %s", f.FilePath)
+			} else {
+				delete(f.LineInfoDocument, "resource")
+			}
 		}
 		// Only remove local module call-sites that were instantiated; remote/registry
 		// module blocks must remain so the corresponding Rego branches can still fire.
@@ -411,14 +415,20 @@ func buildRefsMap(self *tfeval.ResolvedResource, allInCall []moduleRefEntry) map
 
 // newInstanceFileMetadata clones fm for a synthetic doc (empty Document so Combine skips it).
 func newInstanceFileMetadata(fm *model.FileMetadata, id, callChain string) *model.FileMetadata {
-	clone := *fm
+	clone := fm.Clone()
 	clone.ID = id
 	clone.Document = model.Document{}
 	clone.ModuleCallChain = callChain
 	if fm.LineInfoDocument != nil {
+		// Already materialized: shallow-clone so later mutations on the
+		// parent (e.g. deleting a suppressed "resource" key) don't alias
+		// into this synthetic instance's copy.
 		clone.LineInfoDocument = maps.Clone(fm.LineInfoDocument)
+		clone.LineInfoLoader = nil
 	}
-	return &clone
+	// Otherwise not yet materialized: the clone keeps fm's LineInfoLoader
+	// (copied by Clone) and lazily reconstructs its own copy on demand.
+	return clone
 }
 
 // callChainKey is repo-relative outer caller + "|" + module address (no line numbers, to keep fingerprints stable).

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -415,7 +415,7 @@ func buildRefsMap(self *tfeval.ResolvedResource, allInCall []moduleRefEntry) map
 
 // newInstanceFileMetadata clones fm for a synthetic doc (empty Document so Combine skips it).
 func newInstanceFileMetadata(fm *model.FileMetadata, id, callChain string) *model.FileMetadata {
-	clone := fm.Clone()
+	clone := fm.ShallowCopy()
 	clone.ID = id
 	clone.Document = model.Document{}
 	clone.ModuleCallChain = callChain
@@ -424,10 +424,7 @@ func newInstanceFileMetadata(fm *model.FileMetadata, id, callChain string) *mode
 		// parent (e.g. deleting a suppressed "resource" key) don't alias
 		// into this synthetic instance's copy.
 		clone.LineInfoDocument = maps.Clone(fm.LineInfoDocument)
-		clone.LineInfoLoader = nil
 	}
-	// Otherwise not yet materialized: the clone keeps fm's LineInfoLoader
-	// (copied by Clone) and lazily reconstructs its own copy on demand.
 	return clone
 }
 

--- a/pkg/engine/tracker.go
+++ b/pkg/engine/tracker.go
@@ -9,11 +9,13 @@ package engine
 // TrackQueryLoad increments the number of loaded queries
 // TrackQueryExecution increments the number of queries executed
 // FailedDetectLine decrements the number of queries executed
+// FailedLineInfoDocument increments line-info lazy-load failures
 // GetOutputLines returns the number of lines to be displayed in results outputs
 type Tracker interface {
 	TrackQueryLoad(queryAggregation int)
 	TrackQueryExecuting(queryAggregation int)
 	TrackQueryExecution(queryAggregation int)
 	FailedDetectLine()
+	FailedLineInfoDocument()
 	GetOutputLines() int
 }

--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -107,6 +107,7 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 	// searchLine resolution) may need it, so materialize it once up front.
 	if err := file.EnsureLineInfoDocument(ctx); err != nil {
 		logWithFields.Err(err).Msg("failed to build line-info document for file")
+		tracker.FailedLineInfoDocument()
 	}
 
 	linesVulne := model.VulnerabilityLines{

--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -102,6 +102,13 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 		Str("queryName", qCtx.Query.Metadata.Query).
 		Logger()
 
+	// LineInfoDocument may be populated lazily (see EnsureLineInfoDocument);
+	// both branches below (searchKey resolution and calculeSearchLine's
+	// searchLine resolution) may need it, so materialize it once up front.
+	if err := file.EnsureLineInfoDocument(ctx); err != nil {
+		logWithFields.Err(err).Msg("failed to build line-info document for file")
+	}
+
 	linesVulne := model.VulnerabilityLines{
 		Line:                  -1,
 		VulnLines:             &[]model.CodeLine{},

--- a/pkg/model/line_info_lazy_test.go
+++ b/pkg/model/line_info_lazy_test.go
@@ -1,0 +1,79 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileMetadata_JSONMarshalSkipsLazyState(t *testing.T) {
+	fm := &FileMetadata{ID: "id", Document: Document{"k": "v"}}
+	fm.SetLineInfoLoader(func(context.Context, *FileMetadata) (map[string]interface{}, error) {
+		return nil, nil
+	})
+
+	b, err := json.Marshal(fm)
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"ID":"id"`)
+	require.NotContains(t, string(b), "LineInfoLoader")
+}
+
+func TestCombine_lineInfoFallbackOnEnsureFailure(t *testing.T) {
+	ctx := context.Background()
+	fm := &FileMetadata{
+		ID:       "id",
+		FilePath: "main.tf",
+		Document: Document{"resource": map[string]interface{}{}},
+	}
+	fm.SetLineInfoLoader(func(context.Context, *FileMetadata) (map[string]interface{}, error) {
+		return nil, errors.New("reparse failed")
+	})
+
+	out := FileMetadatas{fm}.Combine(ctx, true)
+	require.Len(t, out.Documents, 1)
+	require.Equal(t, "id", out.Documents[0]["id"])
+	require.Equal(t, "main.tf", out.Documents[0]["file"])
+	require.NotNil(t, out.Documents[0]["resource"])
+}
+
+func TestEnsureLineInfoDocument_concurrent(t *testing.T) {
+	ctx := context.Background()
+	var loads atomic.Int32
+	fm := &FileMetadata{FilePath: "main.tf"}
+	fm.SetLineInfoLoader(func(context.Context, *FileMetadata) (map[string]interface{}, error) {
+		loads.Add(1)
+		return Document{"_dd_lines": map[string]interface{}{}}, nil
+	})
+
+	const workers = 16
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			require.NoError(t, fm.EnsureLineInfoDocument(ctx))
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, int32(1), loads.Load())
+	require.NotNil(t, fm.LineInfoDocument)
+}
+
+func TestFileMetadata_ShallowCopyPreservesLazyLoader(t *testing.T) {
+	src := &FileMetadata{FilePath: "mod.tf"}
+	loader := func(context.Context, *FileMetadata) (map[string]interface{}, error) {
+		return Document{"x": 1}, nil
+	}
+	src.SetLineInfoLoader(loader)
+
+	clone := src.ShallowCopy()
+	require.NoError(t, clone.EnsureLineInfoDocument(context.Background()))
+	require.Nil(t, src.LineInfoDocument)
+	require.NoError(t, src.EnsureLineInfoDocument(context.Background()))
+	require.NotNil(t, src.LineInfoDocument)
+}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
@@ -136,10 +137,20 @@ type CommentsCommands map[string]string
 
 // FileMetadata is a representation of basic information and content of a file
 type FileMetadata struct {
-	ID                string `db:"id"`
-	ScanID            string `db:"scan_id"`
-	Document          Document
-	LineInfoDocument  map[string]interface{}
+	ID               string `db:"id"`
+	ScanID           string `db:"scan_id"`
+	Document         Document
+	LineInfoDocument map[string]interface{}
+	// LineInfoLoader, when set, lazily reconstructs LineInfoDocument (a
+	// second full copy of the parsed document tree, kept intact with
+	// _dd_lines markers purely to resolve a confirmed finding's source line)
+	// on first access via EnsureLineInfoDocument, instead of every file
+	// paying for it eagerly. Only a small fraction of scanned files ever
+	// have a finding, so most never need it. nil means LineInfoDocument is
+	// already populated (or intentionally left unset).
+	LineInfoLoader    func(ctx context.Context, f *FileMetadata) (map[string]interface{}, error)
+	lineInfoOnce      sync.Once
+	lineInfoErr       error
 	OriginalData      string   `db:"orig_data"`
 	Kind              FileKind `db:"kind"`
 	FilePath          string   `db:"file_path"`
@@ -156,6 +167,52 @@ type FileMetadata struct {
 	// "ansible", "kubernetes", "terraform"); "" when undetermined. Used by the
 	// engine to evaluate each query only against documents of its own platform.
 	Platform string
+}
+
+// Clone returns a shallow copy of f. FileMetadata carries a sync.Once (for
+// EnsureLineInfoDocument's memoization), so a plain `x := *f` struct-literal
+// copy would duplicate its current state (and trips go vet's copylocks
+// check); Clone instead copies field-by-field and gives the result its own,
+// independent, not-yet-fired memoization state.
+func (f *FileMetadata) Clone() *FileMetadata {
+	return &FileMetadata{
+		ID:                f.ID,
+		ScanID:            f.ScanID,
+		Document:          f.Document,
+		LineInfoDocument:  f.LineInfoDocument,
+		LineInfoLoader:    f.LineInfoLoader,
+		OriginalData:      f.OriginalData,
+		Kind:              f.Kind,
+		FilePath:          f.FilePath,
+		HelmID:            f.HelmID,
+		IDInfo:            f.IDInfo,
+		Commands:          f.Commands,
+		LinesIgnore:       f.LinesIgnore,
+		ResolvedFiles:     f.ResolvedFiles,
+		LinesOriginalData: f.LinesOriginalData,
+		IsMinified:        f.IsMinified,
+		ModuleCallChain:   f.ModuleCallChain,
+		Platform:          f.Platform,
+	}
+}
+
+// EnsureLineInfoDocument lazily materializes LineInfoDocument via
+// LineInfoLoader on first access, memoizing the result (or error) so repeat
+// calls are cheap. Safe for concurrent callers. No-op if LineInfoLoader is
+// nil, i.e. LineInfoDocument is already populated (or intentionally unset).
+func (f *FileMetadata) EnsureLineInfoDocument(ctx context.Context) error {
+	if f.LineInfoLoader == nil {
+		return nil
+	}
+	f.lineInfoOnce.Do(func() {
+		doc, err := f.LineInfoLoader(ctx, f)
+		if err != nil {
+			f.lineInfoErr = err
+			return
+		}
+		f.LineInfoDocument = doc
+	})
+	return f.lineInfoErr
 }
 
 // QueryMetadata is a representation of general information about a query
@@ -316,6 +373,10 @@ func (m FileMetadatas) Combine(ctx context.Context, lineInfo bool) Documents {
 			continue
 		}
 		if lineInfo {
+			if err := f.EnsureLineInfoDocument(ctx); err != nil {
+				contextLogger.Err(err).Msgf("failed to build line-info document for file %s", f.FilePath)
+				continue
+			}
 			f.LineInfoDocument["id"] = f.ID
 			f.LineInfoDocument["file"] = f.FilePath
 			documents.Documents = append(documents.Documents, f.LineInfoDocument)

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -135,25 +135,29 @@ type ExtractedPathObject struct {
 // CommentsCommands list of commands on a file that will be parsed
 type CommentsCommands map[string]string
 
+// lineInfoState holds lazy line-info state behind a pointer so FileMetadata
+// copies stay copylocks-clean (sync.Mutex must not be struct-copied).
+type lineInfoState struct {
+	mu     sync.Mutex
+	err    error
+	loader func(ctx context.Context, f *FileMetadata) (map[string]interface{}, error)
+}
+
 // FileMetadata is a representation of basic information and content of a file
 type FileMetadata struct {
 	ID               string `db:"id"`
 	ScanID           string `db:"scan_id"`
 	Document         Document
 	LineInfoDocument map[string]interface{}
-	// LineInfoLoader, when set, lazily reconstructs LineInfoDocument (a
-	// second full copy of the parsed document tree, kept intact with
-	// _dd_lines markers purely to resolve a confirmed finding's source line)
-	// on first access via EnsureLineInfoDocument, instead of every file
-	// paying for it eagerly. Only a small fraction of scanned files ever
-	// have a finding, so most never need it. nil means LineInfoDocument is
-	// already populated (or intentionally left unset).
-	LineInfoLoader    func(ctx context.Context, f *FileMetadata) (map[string]interface{}, error)
-	lineInfoOnce      sync.Once
-	lineInfoErr       error
-	OriginalData      string   `db:"orig_data"`
-	Kind              FileKind `db:"kind"`
-	FilePath          string   `db:"file_path"`
+	// lineInfo, when set, lazily reconstructs LineInfoDocument (a second full
+	// copy of the parsed document tree, kept intact with _dd_lines markers
+	// purely to resolve a confirmed finding's source line) on first access via
+	// EnsureLineInfoDocument. nil means LineInfoDocument is already populated
+	// (or intentionally left unset).
+	lineInfo          *lineInfoState `json:"-"`
+	OriginalData      string         `db:"orig_data"`
+	Kind              FileKind       `db:"kind"`
+	FilePath          string         `db:"file_path"`
 	HelmID            string
 	IDInfo            map[int]interface{}
 	Commands          CommentsCommands
@@ -169,50 +173,63 @@ type FileMetadata struct {
 	Platform string
 }
 
-// Clone returns a shallow copy of f. FileMetadata carries a sync.Once (for
-// EnsureLineInfoDocument's memoization), so a plain `x := *f` struct-literal
-// copy would duplicate its current state (and trips go vet's copylocks
-// check); Clone instead copies field-by-field and gives the result its own,
-// independent, not-yet-fired memoization state.
-func (f *FileMetadata) Clone() *FileMetadata {
-	return &FileMetadata{
-		ID:                f.ID,
-		ScanID:            f.ScanID,
-		Document:          f.Document,
-		LineInfoDocument:  f.LineInfoDocument,
-		LineInfoLoader:    f.LineInfoLoader,
-		OriginalData:      f.OriginalData,
-		Kind:              f.Kind,
-		FilePath:          f.FilePath,
-		HelmID:            f.HelmID,
-		IDInfo:            f.IDInfo,
-		Commands:          f.Commands,
-		LinesIgnore:       f.LinesIgnore,
-		ResolvedFiles:     f.ResolvedFiles,
-		LinesOriginalData: f.LinesOriginalData,
-		IsMinified:        f.IsMinified,
-		ModuleCallChain:   f.ModuleCallChain,
-		Platform:          f.Platform,
+// SetLineInfoLoader configures on-demand reconstruction of LineInfoDocument.
+func (f *FileMetadata) SetLineInfoLoader(
+	loader func(ctx context.Context, fm *FileMetadata) (map[string]interface{}, error),
+) {
+	if loader == nil {
+		f.lineInfo = nil
+		return
 	}
+	f.lineInfo = &lineInfoState{loader: loader}
 }
 
-// EnsureLineInfoDocument lazily materializes LineInfoDocument via
-// LineInfoLoader on first access, memoizing the result (or error) so repeat
-// calls are cheap. Safe for concurrent callers. No-op if LineInfoLoader is
-// nil, i.e. LineInfoDocument is already populated (or intentionally unset).
-func (f *FileMetadata) EnsureLineInfoDocument(ctx context.Context) error {
-	if f.LineInfoLoader == nil {
+// cloneLineInfoState returns an independent lazy state that shares loader.
+func cloneLineInfoState(src *lineInfoState) *lineInfoState {
+	if src == nil {
 		return nil
 	}
-	f.lineInfoOnce.Do(func() {
-		doc, err := f.LineInfoLoader(ctx, f)
-		if err != nil {
-			f.lineInfoErr = err
-			return
-		}
-		f.LineInfoDocument = doc
-	})
-	return f.lineInfoErr
+	return &lineInfoState{loader: src.loader}
+}
+
+// ShallowCopy returns a copy of f with independent lazy line-info memoization.
+func (f *FileMetadata) ShallowCopy() *FileMetadata {
+	clone := *f
+	if f.LineInfoDocument != nil {
+		clone.lineInfo = nil
+	} else {
+		clone.lineInfo = cloneLineInfoState(f.lineInfo)
+	}
+	return &clone
+}
+
+// EnsureLineInfoDocument lazily materializes LineInfoDocument on first access,
+// memoizing the result (or error) so repeat calls are cheap. Safe for
+// concurrent callers. No-op when line info is already populated or unset.
+func (f *FileMetadata) EnsureLineInfoDocument(ctx context.Context) error {
+	st := f.lineInfo
+	if st == nil {
+		return nil
+	}
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if f.LineInfoDocument != nil {
+		return nil
+	}
+	if st.err != nil {
+		return st.err
+	}
+	if st.loader == nil {
+		return nil
+	}
+	doc, err := st.loader(ctx, f)
+	if err != nil {
+		st.err = err
+		return err
+	}
+	f.LineInfoDocument = doc
+	st.loader = nil
+	return nil
 }
 
 // QueryMetadata is a representation of general information about a query
@@ -375,6 +392,9 @@ func (m FileMetadatas) Combine(ctx context.Context, lineInfo bool) Documents {
 		if lineInfo {
 			if err := f.EnsureLineInfoDocument(ctx); err != nil {
 				contextLogger.Err(err).Msgf("failed to build line-info document for file %s", f.FilePath)
+				f.Document["id"] = f.ID
+				f.Document["file"] = f.FilePath
+				documents.Documents = append(documents.Documents, f.Document)
 				continue
 			}
 			f.LineInfoDocument["id"] = f.ID

--- a/pkg/runner/line_info_loader_test.go
+++ b/pkg/runner/line_info_loader_test.go
@@ -1,0 +1,106 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser"
+	jsonParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/json"
+	terraformParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform"
+	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func buildTestParser(t *testing.T, ctx context.Context, add func(*parser.Builder) *parser.Builder) *parser.Parser {
+	t.Helper()
+	ps, err := add(parser.NewBuilder(ctx)).Build([]string{""}, []string{""})
+	require.NoError(t, err)
+	require.Len(t, ps, 1)
+	return ps[0]
+}
+
+func TestEnsureLineInfoDocument_matchesEagerParse(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.tf")
+	content := []byte(`resource "aws_s3_bucket" "logs" {
+  bucket = "my-logs"
+}
+`)
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+
+	p := buildTestParser(t, ctx, func(b *parser.Builder) *parser.Builder {
+		return b.Add(terraformParser.NewDefault())
+	})
+	parsed, err := p.Parse(ctx, path, content, false, false, 15)
+	require.NoError(t, err)
+	require.Len(t, parsed.Docs, 1)
+
+	file := &model.FileMetadata{
+		OriginalData:      parsed.Content,
+		Kind:              parsed.Kind,
+		FilePath:          path,
+		LinesOriginalData: utils.SplitLines(parsed.Content),
+	}
+	loader := newLineInfoLoader(p, path, 0, false, false, 15)
+	lazyDoc, err := loader(ctx, file)
+	require.NoError(t, err)
+
+	eagerJ, err := json.Marshal(parsed.Docs[0])
+	require.NoError(t, err)
+	lazyJ, err := json.Marshal(lazyDoc)
+	require.NoError(t, err)
+	require.JSONEq(t, string(eagerJ), string(lazyJ))
+
+	file.SetLineInfoLoader(loader)
+	require.NoError(t, file.EnsureLineInfoDocument(ctx))
+	require.True(t, reflect.DeepEqual(lazyDoc, file.LineInfoDocument))
+}
+
+func TestEnsureLineInfoDocument_minifiedTFPlanUsesOriginalData(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plan.json")
+	minified := []byte(`{"format_version":"1.0","planned_values":{"root_module":{"resources":[{"address":"alicloud_db_instance.example","type":"alicloud_db_instance","name":"example","values":{"address":"0.0.0.0/0"}}]}}}`)
+	require.NoError(t, os.WriteFile(path, minified, 0o600))
+
+	jp := &jsonParser.Parser{}
+	_, eagerFromMinified, _, _, err := jp.Parse(ctx, minified, path, false, 1)
+	require.NoError(t, err)
+
+	p := buildTestParser(t, ctx, func(b *parser.Builder) *parser.Builder {
+		return b.Add(jp)
+	})
+	parsed, err := p.Parse(ctx, path, minified, false, false, 1)
+	require.NoError(t, err)
+	require.NotEqual(t, string(minified), parsed.Content)
+
+	file := &model.FileMetadata{
+		OriginalData:      parsed.Content,
+		Kind:              model.KindTerraformPlan,
+		FilePath:          path,
+		LinesOriginalData: utils.SplitLines(parsed.Content),
+	}
+	loader := newLineInfoLoader(p, path, 0, false, false, 1)
+	lazyDoc, err := loader(ctx, file)
+	require.NoError(t, err)
+	require.False(t, reflect.DeepEqual(eagerFromMinified[0], lazyDoc),
+		"lazy reparse aligns _dd_lines with indented OriginalData, not the initial minified parse")
+
+	reparsed, err := p.Parse(ctx, path, []byte(parsed.Content), false, false, 1)
+	require.NoError(t, err)
+	lazyJ, err := json.Marshal(lazyDoc)
+	require.NoError(t, err)
+	reparsedJ, err := json.Marshal(reparsed.Docs[0])
+	require.NoError(t, err)
+	require.JSONEq(t, string(reparsedJ), string(lazyJ))
+
+	file.SetLineInfoLoader(loader)
+	require.NoError(t, file.EnsureLineInfoDocument(ctx))
+	require.True(t, reflect.DeepEqual(lazyDoc, file.LineInfoDocument))
+}

--- a/pkg/runner/resolver_sink.go
+++ b/pkg/runner/resolver_sink.go
@@ -115,10 +115,15 @@ func (s *Service) storeResolvedFiles(
 			}
 
 			file := model.FileMetadata{
-				ID:                uuid.New().String(),
-				ScanID:            scanID,
-				Document:          PrepareScanDocument(ctx, document, kind),
-				OriginalData:      originalData,
+				ID:           uuid.New().String(),
+				ScanID:       scanID,
+				Document:     PrepareScanDocument(ctx, document, kind),
+				OriginalData: originalData,
+				// Not lazily loaded here (unlike sink.go): OriginalData is the
+				// unrendered Helm/OpenAPI source, but parsing (and thus a
+				// reconstructed LineInfoDocument) needs rfile.Content, the
+				// resolved/rendered text. Keeping it eager avoids the risk of
+				// silently re-parsing the wrong content.
 				LineInfoDocument:  document,
 				Kind:              kind,
 				FilePath:          rfile.FileName,

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -297,6 +297,38 @@ func (s *Service) saveToFile(ctx context.Context, file *model.FileMetadata) {
 	}
 }
 
+// newLineInfoLoader builds a FileMetadata.LineInfoLoader that reconstructs a
+// file's line-info document (the raw parse output, with intact _dd_lines
+// markers, used only to resolve a confirmed finding's source line) by
+// re-parsing the file's own already-retained OriginalData on demand. This
+// avoids every scanned file having to hold a second full copy of its parsed
+// document tree for the whole scan just in case one of its findings needs a
+// line number - most files never have any finding at all.
+//
+// docIdx selects which of the re-parse's documents corresponds to this
+// FileMetadata, for multi-document files (e.g. "---"-separated YAML).
+func (s *Service) newLineInfoLoader(
+	filename string,
+	docIdx int,
+	openAPIResolveReferences bool,
+	isMinified bool,
+	maxResolverDepth int,
+) func(ctx context.Context, f *model.FileMetadata) (map[string]interface{}, error) {
+	return func(ctx context.Context, f *model.FileMetadata) (map[string]interface{}, error) {
+		reparsed, err := s.Parser.Parse(
+			ctx, filename, []byte(f.OriginalData), openAPIResolveReferences, isMinified, maxResolverDepth)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to reparse %s for line info", filename)
+		}
+		if docIdx >= len(reparsed.Docs) {
+			return nil, errors.Errorf(
+				"reparse of %s for line info produced %d documents, expected index %d",
+				filename, len(reparsed.Docs), docIdx)
+		}
+		return reparsed.Docs[docIdx], nil
+	}
+}
+
 // PrepareScanDocument removes _dd_lines from payload and parses json filters.
 // On a marshal failure it logs and returns the original body unchanged.
 func PrepareScanDocument(ctx context.Context, body map[string]interface{}, kind model.FileKind) map[string]interface{} {

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -297,17 +297,10 @@ func (s *Service) saveToFile(ctx context.Context, file *model.FileMetadata) {
 	}
 }
 
-// newLineInfoLoader builds a FileMetadata.LineInfoLoader that reconstructs a
-// file's line-info document (the raw parse output, with intact _dd_lines
-// markers, used only to resolve a confirmed finding's source line) by
-// re-parsing the file's own already-retained OriginalData on demand. This
-// avoids every scanned file having to hold a second full copy of its parsed
-// document tree for the whole scan just in case one of its findings needs a
-// line number - most files never have any finding at all.
-//
-// docIdx selects which of the re-parse's documents corresponds to this
-// FileMetadata, for multi-document files (e.g. "---"-separated YAML).
-func (s *Service) newLineInfoLoader(
+// newLineInfoLoader builds a lazy loader that reconstructs a file's line-info
+// document by re-parsing OriginalData on demand.
+func newLineInfoLoader(
+	p *parser.Parser,
 	filename string,
 	docIdx int,
 	openAPIResolveReferences bool,
@@ -315,7 +308,7 @@ func (s *Service) newLineInfoLoader(
 	maxResolverDepth int,
 ) func(ctx context.Context, f *model.FileMetadata) (map[string]interface{}, error) {
 	return func(ctx context.Context, f *model.FileMetadata) (map[string]interface{}, error) {
-		reparsed, err := s.Parser.Parse(
+		reparsed, err := p.Parse(
 			ctx, filename, []byte(f.OriginalData), openAPIResolveReferences, isMinified, maxResolverDepth)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to reparse %s for line info", filename)

--- a/pkg/runner/sink.go
+++ b/pkg/runner/sink.go
@@ -86,7 +86,7 @@ func (s *Service) sinkContent(ctx context.Context, filename, scanID string,
 	// times the memory and CPU for the exact same line slice.
 	linesOriginalData := utils.SplitLines(documents.Content)
 
-	for _, document := range documents.Docs {
+	for docIdx, document := range documents.Docs {
 		// Deep-copy + sanitize the document with a single marshal. A marshal
 		// failure means the document can't be scanned, so skip it (preserving
 		// the previous skip-on-unmarshalable-document behavior).
@@ -101,10 +101,11 @@ func (s *Service) sinkContent(ctx context.Context, filename, scanID string,
 		}
 
 		file := model.FileMetadata{
-			ID:                uuid.New().String(),
-			ScanID:            scanID,
-			Document:          preparedDocument,
-			LineInfoDocument:  document,
+			ID:       uuid.New().String(),
+			ScanID:   scanID,
+			Document: preparedDocument,
+			LineInfoLoader: s.newLineInfoLoader(
+				filename, docIdx, openAPIResolveReferences, c.IsMinified, maxResolverDepth),
 			OriginalData:      documents.Content,
 			Kind:              documents.Kind,
 			FilePath:          filename,

--- a/pkg/runner/sink.go
+++ b/pkg/runner/sink.go
@@ -101,11 +101,9 @@ func (s *Service) sinkContent(ctx context.Context, filename, scanID string,
 		}
 
 		file := model.FileMetadata{
-			ID:       uuid.New().String(),
-			ScanID:   scanID,
-			Document: preparedDocument,
-			LineInfoLoader: s.newLineInfoLoader(
-				filename, docIdx, openAPIResolveReferences, c.IsMinified, maxResolverDepth),
+			ID:                uuid.New().String(),
+			ScanID:            scanID,
+			Document:          preparedDocument,
 			OriginalData:      documents.Content,
 			Kind:              documents.Kind,
 			FilePath:          filename,
@@ -116,6 +114,8 @@ func (s *Service) sinkContent(ctx context.Context, filename, scanID string,
 			IsMinified:        documents.IsMinified,
 			Platform:          s.classifyPlatform(ctx, documents.Kind, filename, *content),
 		}
+		file.SetLineInfoLoader(newLineInfoLoader(
+			s.Parser, filename, docIdx, openAPIResolveReferences, c.IsMinified, maxResolverDepth))
 
 		s.saveToFile(ctx, &file)
 	}


### PR DESCRIPTION
## Motivation

Large scans retain a second full parsed document tree (`LineInfoDocument`, with `_dd_lines` markers) for every file even though only a small fraction of files ever produce a finding that needs line attribution. On a representative large repository scan this duplicate tree accounted for roughly half of peak heap (~6.5 GiB RSS), contributing to out-of-memory failures when other memory-heavy features (such as local Terraform module evaluation) are enabled.

Related Ticket: [K9CODESEC-4561](https://datadoghq.atlassian.net/browse/K9CODESEC-4561?atlOrigin=eyJpIjoiM2EyNDFmMzVlODllNDJjMmE2ZDgxODFkNjExMjg0OWUiLCJwIjoiaiJ9)

## Changes

**Scan pipeline**

During file ingestion, store a re-parse closure on `FileMetadata` instead of eagerly building `LineInfoDocument`. The tree is materialized on first access via `EnsureLineInfoDocument`, memoized with `sync.Once`, and only for files that actually need line resolution.

**Engine**

Call sites that read or mutate `LineInfoDocument` (vulnerability line building, module-instance cloning, suppression handling) now ensure the document is loaded first. `FileMetadata.Clone()` copies fields safely without duplicating `sync.Once` state.

**Resolver paths**

Helm and OpenAPI resolver ingestion still eagerly populate `LineInfoDocument` because rendered resolver content can differ from `OriginalData`, so on-demand re-parse would produce incorrect line maps.

## QA Instruction

See the benchmark that will be posted by DDCI below.

## Blast Radius

CLI and server scan paths that ingest parsed files through the main runner sink. Finding line numbers, suppressions, and SARIF output should be unchanged. Helm/OpenAPI resolver ingestion behavior is unchanged (still eager).

## Additional Notes

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-4561]: https://datadoghq.atlassian.net/browse/K9CODESEC-4561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ