### PR TITLE
Enable parallel file parsing by default

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -87,7 +87,7 @@ var scanAction = &cli.Command{
 			Name:   "x-parallelparsing",
 			Hidden: true,
 			Usage:  "(experimental, will be removed soon) parse files in parallel",
-			Value:  false,
+			Value:  true,
 		},
 		&cli.BoolFlag{
 			Name:   "x-local-module-eval",
@@ -163,17 +163,6 @@ var scanAction = &cli.Command{
 			Usage: "output report formats (valid: sarif, simple-json)",
 			Value: []string{"sarif"},
 		},
-
-		// NOTE: --x-parallelparsing flag disabled due to pre-existing race conditions
-		// in concurrent query workers (SetupLogs shared state write, docker detector
-		// shallow slice copy) that cause non-deterministic violation counts.
-		// See K9VULN-13746 for the follow-up to fix and re-enable.
-		// &cli.BoolFlag{
-		// 	Name:   "x-parallelparsing",
-		// 	Hidden: true,
-		// 	Usage:  "(experimental, will be removed soon) parse files in parallel",
-		// 	Value:  false,
-		// },
 	},
 	Action: runScan,
 }

--- a/cmd/scanner/serve.go
+++ b/cmd/scanner/serve.go
@@ -67,7 +67,7 @@ var serveAction = &cli.Command{
 			Name:   "x-parallelparsing",
 			Hidden: true,
 			Usage:  "(experimental, will be removed soon) parse pushed files in parallel across CPUs",
-			Value:  false,
+			Value:  true,
 		},
 	},
 	Action: serve,

--- a/pkg/featureflags/local_evaluator.go
+++ b/pkg/featureflags/local_evaluator.go
@@ -11,7 +11,7 @@ func NewLocalEvaluatorWithOverrides(overrides map[string]bool) *LocalEvaluator {
 		IacDisableKicsRule:               false,
 		IacEnableKicsPlatform:            true,
 		IacEnableKicsHelmResolver:        true,
-		IaCEnableKicsParallelFileParsing: false,
+		IaCEnableKicsParallelFileParsing: true,
 		IacEnableLocalModuleEval:         false,
 	}
 

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -298,8 +298,8 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 		MaxResolverDepth: 15,
 		// Helm rendering shells out to a chart on disk, which content-push mode
 		// has no way to materialize, so disable the resolver. Parallel file
-		// parsing fans the per-file parse across CPUs; off unless the server
-		// opts in via --x-parallelparsing.
+		// parsing fans the per-file parse across CPUs; enabled by default and
+		// can be disabled with --x-parallelparsing=false.
 		FlagEvaluator: featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
 			featureflags.IacEnableKicsHelmResolver:        false,
 			featureflags.IaCEnableKicsParallelFileParsing: s.cfg.ParallelParsing,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -96,8 +96,8 @@ type Config struct {
 	// cost of retained memory). Maps to the --use-rules-cache server flag.
 	UseRulesCache bool
 	// ParallelParsing fans the per-file parse across CPUs for pushed content.
-	// Measured ~26% faster wall-clock on a 950-file push; same CPU total. Maps
-	// to the experimental --x-parallelparsing server flag.
+	// Measured ~26% faster wall-clock on a 950-file push; same CPU total. Enabled
+	// by default via --x-parallelparsing; pass --x-parallelparsing=false to disable.
 	ParallelParsing bool
 	// WriteTimeout bounds how long writing a response may take, so a client that
 	// stops reading cannot hold a handler goroutine indefinitely. Zero applies


### PR DESCRIPTION
## Motivation

Parallel file parsing is fully rolled out in production iac-scanning, which passes `--x-parallelparsing` for every org scan. The scanner still defaulted to sequential parsing for direct CLI usage, custom scans, and the `serve` path unless callers opted in explicitly. Aligning the default removes that gap and matches production behavior.

## Changes

**Feature flags and CLI**

The local evaluator default for `IaCEnableKicsParallelFileParsing` is now `true`. The hidden `--x-parallelparsing` flag on `scan` and `serve` also defaults to `true`; pass `--x-parallelparsing=false` to opt out.

**Comments**

Removed stale notes that described parallel parsing as disabled due to race conditions, and updated server comments to reflect the new default.

## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/runner/... ./pkg/scanner/... ./pkg/server/... ./cmd/scanner/... -count=1`
2. Run a scan without flags and confirm files are parsed via the parallel path (e.g. faster wall-clock on large repos vs `--x-parallelparsing=false`).
3. On `serve`, POST to `/analyze` without `--x-parallelparsing=false` and confirm behavior matches.

## Blast Radius

This affects the Datadog IaC Scanner CLI (`scan`, `serve`), embedded scan clients using `NewLocalEvaluator()`, and any caller that relied on sequential parsing as the implicit default. Production iac-scanning already passes the flag explicitly, so its behavior is unchanged.

## Additional Notes

I submit this contribution under the Apache-2.0 license.