### PR TITLE
Speed up file discovery for large repositories

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -182,6 +182,7 @@ type regexSlice struct {
 type analyzerInfo struct {
 	typesFlag       []string
 	filePath        string
+	maxFileSize     int
 	filePlatformMap *sync.Map
 	contentCache    *sync.Map
 	helmCache       *sync.Map
@@ -393,13 +394,14 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 				if provider.IsTerraformCacheDir(path) {
 					return filepath.SkipDir
 				}
-				if _, statErr := os.Stat(filepath.Join(path, "Chart.yaml")); statErr == nil {
-					chartRoots = append(chartRoots, filepath.ToSlash(path))
-				}
 				return nil
 			}
 
 			totalFiles++
+
+			if filepath.Base(path) == "Chart.yaml" {
+				chartRoots = append(chartRoots, filepath.ToSlash(filepath.Dir(path)))
+			}
 
 			if d.Type()&fs.ModeSymlink != 0 {
 				if _, statErr := os.Stat(path); statErr != nil {
@@ -411,14 +413,13 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 			}
 
 			trimmedPath, relErr := filepath.Rel(a.RepoPath, path)
-			if relErr != nil {
-				return relErr
-			}
+			outsideRepo := relErr != nil
 
-			if hasGitIgnoreFile && gitIgnore.MatchesPath(trimmedPath) {
-				norm := filepath.ToSlash(path)
-				ignoreFiles = append(ignoreFiles, norm)
-				a.Exc = append(a.Exc, norm)
+			ext := utils.ExtensionFromPath(path)
+			if ext == "" {
+				return nil
+			}
+			if _, ok := possibleFileTypes[ext]; !ok {
 				return nil
 			}
 
@@ -429,27 +430,15 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 				return nil
 			}
 
-			ext := utils.ExtensionFromPath(path)
-			if ext == "" {
-				return nil
-			}
-			if _, ok := possibleFileTypes[ext]; !ok {
-				return nil
-			}
-			if isExcludedFile(path, a.Exc) || !isIncludedFile(path, a.Only) {
+			if !outsideRepo && hasGitIgnoreFile && gitIgnore.MatchesPath(trimmedPath) {
+				norm := filepath.ToSlash(path)
+				ignoreFiles = append(ignoreFiles, norm)
+				a.Exc = append(a.Exc, norm)
 				return nil
 			}
 
-			if a.MaxFileSize >= 0 {
-				if info, infoErr := d.Info(); infoErr == nil {
-					if float64(info.Size())/float64(sizeMb) > float64(a.MaxFileSize) {
-						contextLogger.Warn().Msgf("file %s exceeds maximum file size of %d Mb", path, a.MaxFileSize)
-						norm := filepath.ToSlash(path)
-						ignoreFiles = append(ignoreFiles, norm)
-						a.Exc = append(a.Exc, norm)
-						return nil
-					}
-				}
+			if isExcludedFile(path, a.Exc) || !isIncludedFile(path, a.Only) {
+				return nil
 			}
 
 			files = append(files, filepath.ToSlash(path))
@@ -486,6 +475,7 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 				analyzerInfo := &analyzerInfo{
 					typesFlag:       typesFlag,
 					filePath:        filePath,
+					maxFileSize:     a.MaxFileSize,
 					filePlatformMap: &filePlatformMap,
 					contentCache:    &contentCache,
 					helmCache:       &helmCacheLocal,
@@ -550,6 +540,18 @@ func (a *analyzerInfo) worker(ctx context.Context, results, unwanted chan<- stri
 	ext := utils.ExtensionFromPath(a.filePath)
 	if ext == "" {
 		return
+	}
+
+	if a.maxFileSize >= 0 {
+		if info, err := os.Stat(a.filePath); err == nil {
+			if float64(info.Size())/float64(sizeMb) > float64(a.maxFileSize) {
+				contextLogger := logger.FromContext(ctx)
+				contextLogger.Warn().Msgf(
+					"file %s exceeds maximum file size of %d Mb", a.filePath, a.maxFileSize)
+				unwanted <- a.filePath
+				return
+			}
+		}
 	}
 
 	linesCount, _ := utils.LineCounter(ctx, a.filePath)

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -399,10 +399,6 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 
 			totalFiles++
 
-			if filepath.Base(path) == "Chart.yaml" {
-				chartRoots = append(chartRoots, filepath.ToSlash(filepath.Dir(path)))
-			}
-
 			if d.Type()&fs.ModeSymlink != 0 {
 				if _, statErr := os.Stat(path); statErr != nil {
 					norm := filepath.ToSlash(path)
@@ -410,6 +406,10 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 					a.Exc = append(a.Exc, norm)
 					return nil
 				}
+			}
+
+			if filepath.Base(path) == "Chart.yaml" {
+				chartRoots = append(chartRoots, filepath.ToSlash(filepath.Dir(path)))
 			}
 
 			trimmedPath, relErr := filepath.Rel(a.RepoPath, path)

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -514,6 +514,25 @@ func TestAnalyze_ChartRootsWhenScanPathOutsideRepo(t *testing.T) {
 	require.Contains(t, got.ChartRoots, filepath.ToSlash(chartDir))
 }
 
+func TestAnalyze_ChartRootsIgnoresDanglingChartYamlSymlink(t *testing.T) {
+	dir := t.TempDir()
+	chartDir := filepath.Join(dir, "mixed")
+	require.NoError(t, os.MkdirAll(chartDir, 0o755))
+	require.NoError(t, os.Symlink("/nonexistent/Chart.yaml", filepath.Join(chartDir, "Chart.yaml")))
+	mainTF := filepath.Join(chartDir, "main.tf")
+	require.NoError(t, os.WriteFile(mainTF, []byte(`resource "aws_s3_bucket" "b" { bucket = "x" }`), 0o600))
+
+	got, err := Analyze(context.Background(), &Analyzer{
+		RepoPath:    dir,
+		Paths:       []string{dir},
+		Types:       []string{"terraform"},
+		MaxFileSize: -1,
+	})
+	require.NoError(t, err)
+	require.NotContains(t, got.ChartRoots, filepath.ToSlash(chartDir))
+	require.Contains(t, got.Inventory, filepath.ToSlash(mainTF))
+}
+
 func Test_checkHelm(t *testing.T) {
 	helm := filepath.FromSlash("../../test/fixtures/analyzer_test/helm")
 	tests := []struct {

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -476,6 +476,44 @@ func TestAnalyze_ValidSymlink(t *testing.T) {
 	require.Empty(t, got.Exc)
 }
 
+func TestAnalyze_ChartRootsFromChartYamlFile(t *testing.T) {
+	dir := t.TempDir()
+	chartDir := filepath.Join(dir, "mychart")
+	require.NoError(t, os.MkdirAll(chartDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte("name: x\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte("replicaCount: 1\n"), 0o600))
+
+	got, err := Analyze(context.Background(), &Analyzer{
+		RepoPath:    dir,
+		Paths:       []string{dir},
+		Types:       []string{""},
+		MaxFileSize: -1,
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, got.ChartRoots, filepath.ToSlash(chartDir))
+}
+
+func TestAnalyze_ChartRootsWhenScanPathOutsideRepo(t *testing.T) {
+	repo := t.TempDir()
+	scanRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(scanRoot, ".helmignore"), []byte("patterns\n"), 0o600))
+	chartDir := filepath.Join(scanRoot, "mychart")
+	require.NoError(t, os.MkdirAll(chartDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte("name: x\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte("replicaCount: 1\n"), 0o600))
+
+	got, err := Analyze(context.Background(), &Analyzer{
+		RepoPath:    repo,
+		Paths:       []string{scanRoot},
+		Types:       []string{""},
+		MaxFileSize: -1,
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, got.ChartRoots, filepath.ToSlash(chartDir))
+}
+
 func Test_checkHelm(t *testing.T) {
 	helm := filepath.FromSlash("../../test/fixtures/analyzer_test/helm")
 	tests := []struct {

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -178,7 +178,7 @@ func (s *FileSystemSourceProvider) TerraformFiles(ctx context.Context) ([]string
 			return nil, errors.Wrap(err, "failed to open path")
 		}
 		if !fileInfo.IsDir() {
-			if shouldSkip, _ := s.checkConditions(ctx, fileInfo, extensions, scanPath, nil); shouldSkip {
+			if shouldSkip, _, _ := s.checkConditions(ctx, fileInfo, extensions, scanPath, nil); shouldSkip {
 				continue
 			}
 			files = append(files, filepath.ToSlash(scanPath))
@@ -356,10 +356,10 @@ func (s *FileSystemSourceProvider) BuildInventoryFromPrebuilt(ctx context.Contex
 }
 
 func isUnderChartRoot(path string, chartRoots []string) bool {
+	path = filepath.ToSlash(path)
 	for _, root := range chartRoots {
-		if path == root ||
-			strings.HasPrefix(path, root+string(os.PathSeparator)) ||
-			strings.HasPrefix(path, root+"/") {
+		root = filepath.ToSlash(root)
+		if path == root || strings.HasPrefix(path, root+"/") {
 			return true
 		}
 	}
@@ -440,8 +440,7 @@ func (s *FileSystemSourceProvider) WalkInventory(ctx context.Context,
 				}
 				return nil
 			},
-			func(ctx context.Context, path string) error {
-				ext, _ := utils.GetExtension(ctx, path)
+			func(_ context.Context, path, ext string) error {
 				files = append(files, InventoryFile{Path: strings.ReplaceAll(path, "\\", "/"), Ext: ext})
 				return nil
 			})
@@ -455,14 +454,15 @@ func (s *FileSystemSourceProvider) WalkInventory(ctx context.Context,
 
 func (s *FileSystemSourceProvider) walkDirectory(ctx context.Context, scanPath string, extensions model.Extensions,
 	onChart func(ctx context.Context, path string, resolvedChartPaths *[]string) error,
-	onFile func(ctx context.Context, path string) error) error {
+	onFile func(ctx context.Context, path, ext string) error) error {
 	var resolvedChartPaths []string
 	return filepath.Walk(scanPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if shouldSkip, skipFolder := s.checkConditions(ctx, info, extensions, path, resolvedChartPaths); shouldSkip {
+		shouldSkip, ext, skipFolder := s.checkConditions(ctx, info, extensions, path, resolvedChartPaths)
+		if shouldSkip {
 			return skipFolder
 		}
 
@@ -470,7 +470,7 @@ func (s *FileSystemSourceProvider) walkDirectory(ctx context.Context, scanPath s
 			return onChart(ctx, path, &resolvedChartPaths)
 		}
 
-		return onFile(ctx, path)
+		return onFile(ctx, path, ext)
 	})
 }
 
@@ -480,7 +480,7 @@ func (s *FileSystemSourceProvider) collectFiles(ctx context.Context, scanPath st
 		func(ctx context.Context, path string, resolved *[]string) error {
 			return s.resolveChartDir(ctx, path, resolverSink, resolved)
 		},
-		func(ctx context.Context, path string) error {
+		func(_ context.Context, path, _ string) error {
 			files = append(files, strings.ReplaceAll(path, "\\", "/"))
 			return nil
 		})
@@ -524,7 +524,7 @@ func (s *FileSystemSourceProvider) walkDir(ctx context.Context, scanPath string,
 		func(ctx context.Context, path string, resolved *[]string) error {
 			return s.resolveChartDir(ctx, path, resolverSink, resolved)
 		},
-		func(ctx context.Context, path string) error {
+		func(ctx context.Context, path, _ string) error {
 			c, err := os.Open(filepath.Clean(path)) // nolint:gosec
 			if err != nil {
 				if ignoreDamagedFiles(ctx, filepath.Clean(path)) {
@@ -564,7 +564,7 @@ func validateScanFile(ctx context.Context, scanPath string, extensions model.Ext
 
 // nolint:gocyclo
 func (s *FileSystemSourceProvider) checkConditions(ctx context.Context, info os.FileInfo, extensions model.Extensions,
-	path string, resolvedChartPaths []string) (bool, error) {
+	path string, resolvedChartPaths []string) (skip bool, ext string, err error) {
 	contextLogger := logger.FromContext(ctx)
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -576,23 +576,23 @@ func (s *FileSystemSourceProvider) checkConditions(ctx context.Context, info os.
 
 			err := s.addExcluded(ctx, []string{info.Name()})
 			if err != nil {
-				return true, err
+				return true, "", err
 			}
-			return true, filepath.SkipDir
+			return true, "", filepath.SkipDir
 		}
 		if f, ok := s.excludes[info.Name()]; ok && containsFile(f, info) {
 			contextLogger.Info().Msgf("Directory ignored: %s", path)
-			return true, filepath.SkipDir
+			return true, "", filepath.SkipDir
 		}
 		_, err := os.Stat(filepath.Join(path, "Chart.yaml"))
 		if err != nil || isUnderResolvedChart(path, resolvedChartPaths) {
-			return true, nil
+			return true, "", nil
 		}
-		return false, nil
+		return false, "", nil
 	}
 
 	if f, ok := s.excludes[info.Name()]; ok && containsFile(f, info) {
-		return true, nil
+		return true, "", nil
 	}
 	if s.onlyPaths != nil {
 		underOnlyPath := false
@@ -603,14 +603,14 @@ func (s *FileSystemSourceProvider) checkConditions(ctx context.Context, info os.
 			}
 		}
 		if !underOnlyPath {
-			return true, nil
+			return true, "", nil
 		}
 	}
-	ext, _ := utils.GetExtension(ctx, path)
+	ext, _ = utils.GetExtension(ctx, path)
 	if !extensions.Include(ext) {
-		return true, nil
+		return true, "", nil
 	}
-	return false, nil
+	return false, ext, nil
 }
 
 func pathWithinBase(base, path string) bool {

--- a/pkg/engine/provider/filesystem_test.go
+++ b/pkg/engine/provider/filesystem_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -496,7 +497,7 @@ func TestFileSystemSourceProvider_checkConditions(t *testing.T) {
 				paths:    tt.fields.paths,
 				excludes: tt.fields.excludes,
 			}
-			if got, err := s.checkConditions(ctx, tt.args.info, tt.args.extensions, tt.args.path, nil); got != tt.want.got || err != tt.want.err {
+			if got, _, err := s.checkConditions(ctx, tt.args.info, tt.args.extensions, tt.args.path, nil); got != tt.want.got || err != tt.want.err {
 				t.Errorf("FileSystemSourceProvider.checkConditions() = %v, want %v", err, tt.want)
 			}
 		})
@@ -791,4 +792,13 @@ func TestGetSources_helmChartSkipsRawTemplates(t *testing.T) {
 			return fs.GetParallelSources(ctx, model.Extensions{".yaml": {}}, recordingSink, recordingResolverSink)
 		})
 	})
+}
+
+func TestIsUnderChartRoot_normalizesSeparators(t *testing.T) {
+	root := `D:/charts/app`
+	require.True(t, isUnderChartRoot(`D:/charts/app/templates/svc.yaml`, []string{root}))
+	if runtime.GOOS == "windows" {
+		require.True(t, isUnderChartRoot(`D:\charts\app\templates\svc.yaml`, []string{root}))
+	}
+	require.False(t, isUnderChartRoot(`D:/charts/other/templates/svc.yaml`, []string{root}))
 }

--- a/pkg/parser/terraform/data_source.go
+++ b/pkg/parser/terraform/data_source.go
@@ -27,7 +27,13 @@ import (
 
 // iamPolicyDocumentTypeMarker is a cheap content gate before parsing; the parser
 // still matches the block type exactly below.
-var iamPolicyDocumentTypeMarker = []byte("aws_iam_policy_document")
+const iamPolicyDocumentType = "aws_iam_policy_document"
+
+var iamPolicyDocumentTypeMarker = []byte(iamPolicyDocumentType)
+
+// iamPolicyDocumentTypePrefix catches HCL unicode-escaped spellings such as
+// aws_iam_pol\u0069cy_document that decode to the same label after lexing.
+var iamPolicyDocumentTypePrefix = []byte("aws_iam_pol")
 
 type dataSourcePolicyCondition struct {
 	Test     string   `json:"test,omitempty"`
@@ -100,7 +106,7 @@ func getDataSourcePolicy(ctx context.Context, fsys vfs.FS, currentPath string, i
 			contextLogger.Debug().Msgf("Error trying to read file %s for data source.", tfFile)
 			continue
 		}
-		if !bytes.Contains(content, iamPolicyDocumentTypeMarker) {
+		if !fileMayDeclareIAMPolicyDocument(content) {
 			continue
 		}
 		parsedFile, diags := parseFileContent(content, tfFile, true)
@@ -119,7 +125,7 @@ func getDataSourcePolicy(ctx context.Context, fsys vfs.FS, currentPath string, i
 		for _, block := range body.Blocks {
 			if block.Type == terraformDataIdentifier &&
 				len(block.Labels) > 1 &&
-				block.Labels[0] == "aws_iam_policy_document" {
+				block.Labels[0] == iamPolicyDocumentType {
 				policyJSON := parseDataSourceBody(ctx, block.Body, inputVariables)
 				jsonMap[block.Labels[1]] = map[string]string{
 					"json": policyJSON,
@@ -138,6 +144,69 @@ func getDataSourcePolicy(ctx context.Context, fsys vfs.FS, currentPath string, i
 
 	inputVariables["data"] = data
 	return inputVariables
+}
+
+// fileMayDeclareIAMPolicyDocument is a fast precheck before parseFileContent.
+// A literal substring match covers the common case; lexer decoding handles
+// escaped block-type labels that do not appear verbatim in source bytes.
+func fileMayDeclareIAMPolicyDocument(content []byte) bool {
+	if bytes.Contains(content, iamPolicyDocumentTypeMarker) {
+		return true
+	}
+	if !bytes.Contains(content, iamPolicyDocumentTypePrefix) {
+		return false
+	}
+	return scanForIAMPolicyDocumentDataBlock(content)
+}
+
+func scanForIAMPolicyDocumentDataBlock(content []byte) bool {
+	tokens, diags := hclsyntax.LexConfig(content, "", hcl.InitialPos)
+	if diags.HasErrors() {
+		return false
+	}
+	for i := 0; i < len(tokens); i++ {
+		if tokens[i].Type != hclsyntax.TokenIdent || string(tokens[i].Bytes) != terraformDataIdentifier {
+			continue
+		}
+		label, next := decodeQuotedBlockLabel(tokens, i+1)
+		if label == iamPolicyDocumentType {
+			return true
+		}
+		i = next
+	}
+	return false
+}
+
+func decodeQuotedBlockLabel(tokens hclsyntax.Tokens, start int) (label string, next int) {
+	for start < len(tokens) {
+		switch tokens[start].Type {
+		case hclsyntax.TokenNewline, hclsyntax.TokenComment:
+			start++
+		case hclsyntax.TokenOQuote:
+			goto parseQuoted
+		default:
+			return "", start
+		}
+	}
+	return "", start
+
+parseQuoted:
+	var b strings.Builder
+	for j := start + 1; j < len(tokens); j++ {
+		switch tokens[j].Type {
+		case hclsyntax.TokenCQuote:
+			return b.String(), j
+		case hclsyntax.TokenQuotedLit:
+			s, litDiags := hclsyntax.ParseStringLiteralToken(tokens[j])
+			if litDiags.HasErrors() {
+				return "", j
+			}
+			b.WriteString(s)
+		default:
+			return "", j
+		}
+	}
+	return "", start
 }
 
 func decodeDataSourcePolicy(ctx context.Context, value cty.Value) dataSourcePolicy {

--- a/pkg/parser/terraform/data_source.go
+++ b/pkg/parser/terraform/data_source.go
@@ -25,6 +25,10 @@ import (
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
+// iamPolicyDocumentTypeMarker is a cheap content gate before parsing; the parser
+// still matches the block type exactly below.
+var iamPolicyDocumentTypeMarker = []byte("aws_iam_policy_document")
+
 type dataSourcePolicyCondition struct {
 	Test     string   `json:"test,omitempty"`
 	Variable string   `json:"variable,omitempty"`
@@ -91,8 +95,20 @@ func getDataSourcePolicy(ctx context.Context, fsys vfs.FS, currentPath string, i
 	}
 	jsonMap := make(map[string]map[string]string)
 	for _, tfFile := range tfFiles {
-		parsedFile, parseErr := parseFile(fsys, tfFile, true)
-		if parseErr != nil {
+		content, readErr := fsys.ReadFile(filepath.Clean(tfFile))
+		if readErr != nil {
+			contextLogger.Debug().Msgf("Error trying to read file %s for data source.", tfFile)
+			continue
+		}
+		if !bytes.Contains(content, iamPolicyDocumentTypeMarker) {
+			continue
+		}
+		parsedFile, diags := parseFileContent(content, tfFile, true)
+		if diags != nil && diags.HasErrors() {
+			contextLogger.Debug().Msgf("Error trying to parse file %s for data source.", tfFile)
+			continue
+		}
+		if parsedFile == nil {
 			contextLogger.Debug().Msgf("Error trying to parse file %s for data source.", tfFile)
 			continue
 		}
@@ -101,7 +117,9 @@ func getDataSourcePolicy(ctx context.Context, fsys vfs.FS, currentPath string, i
 			continue
 		}
 		for _, block := range body.Blocks {
-			if block.Type == terraformDataIdentifier && block.Labels[0] == "aws_iam_policy_document" && len(block.Labels) > 1 {
+			if block.Type == terraformDataIdentifier &&
+				len(block.Labels) > 1 &&
+				block.Labels[0] == "aws_iam_policy_document" {
 				policyJSON := parseDataSourceBody(ctx, block.Body, inputVariables)
 				jsonMap[block.Labels[1]] = map[string]string{
 					"json": policyJSON,

--- a/pkg/parser/terraform/data_source_test.go
+++ b/pkg/parser/terraform/data_source_test.go
@@ -202,3 +202,25 @@ data	"aws_iam_policy_document"	"doc" {
 	require.Contains(t, policies, "doc")
 	require.Contains(t, policies["doc"]["json"], "s3:GetObject")
 }
+
+func Test_getDataSourcePolicy_escapedLabelInBlockHeader(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "policy.tf"), []byte(`data "aws_iam_pol\u0069cy_document" "doc" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::example/*"]
+  }
+}
+`), 0o600))
+
+	result := getDataSourcePolicy(context.Background(), vfs.DiskFS{}, dir, make(converter.VariableMap))
+	data, ok := result["data"]
+	require.True(t, ok)
+
+	var awsPolicyMap map[string]map[string]map[string]string
+	require.NoError(t, gocty.FromCtyValue(data, &awsPolicyMap))
+
+	policies := awsPolicyMap["aws_iam_policy_document"]
+	require.Contains(t, policies, "doc")
+	require.Contains(t, policies["doc"]["json"], "s3:GetObject")
+}

--- a/pkg/parser/terraform/data_source_test.go
+++ b/pkg/parser/terraform/data_source_test.go
@@ -7,6 +7,7 @@ package terraform
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -93,4 +94,111 @@ func Test_getDataSourcePolicy(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func Test_getDataSourcePolicy_ignoresFilesWithoutPolicyDocuments(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(name, content string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+	}
+	writeFile("no_policy.tf", `
+resource "aws_s3_bucket" "bucket" {
+  bucket = "example"
+}
+
+data "aws_caller_identity" "current" {}
+`)
+	writeFile("policy.tf", `
+data "aws_iam_policy_document" "doc" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::example/*"]
+  }
+}
+`)
+
+	result := getDataSourcePolicy(context.Background(), vfs.DiskFS{}, dir, make(converter.VariableMap))
+	data, ok := result["data"]
+	require.True(t, ok, "expected a data entry in the variable map")
+
+	var awsPolicyMap map[string]map[string]map[string]string
+	require.NoError(t, gocty.FromCtyValue(data, &awsPolicyMap))
+
+	policies := awsPolicyMap["aws_iam_policy_document"]
+	require.Len(t, policies, 1, "only the declared policy document should be collected")
+	require.Equal(t,
+		"{\"Statement\":[{\"Actions\":[\"s3:GetObject\"],\"Resources\":[\"arn:aws:s3:::example/*\"]}]}\n",
+		policies["doc"]["json"],
+	)
+}
+
+func Test_getDataSourcePolicy_noPolicyDocumentsInDirectory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+resource "aws_s3_bucket" "bucket" {
+  bucket = "example"
+}
+`), 0o600))
+
+	result := getDataSourcePolicy(context.Background(), vfs.DiskFS{}, dir, make(converter.VariableMap))
+	data, ok := result["data"]
+	require.True(t, ok, "expected a data entry even when no policies are declared")
+
+	var awsPolicyMap map[string]map[string]map[string]string
+	require.NoError(t, gocty.FromCtyValue(data, &awsPolicyMap))
+	require.Empty(t, awsPolicyMap["aws_iam_policy_document"])
+}
+
+func Test_getDataSourcePolicy_arnWithDataPartitionReference(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "positive.tf"), []byte(`
+data "aws_iam_policy_document" "glue-example-policy" {
+  statement {
+    actions = ["glue:*"]
+    resources = ["arn:data.aws_partition.current.partition:glue:data.aws_region.current.name:data.aws_caller_identity.current.account_id:*"]
+    principals {
+      identifiers = ["*"]
+      type        = "AWS"
+    }
+  }
+}
+
+resource "aws_glue_resource_policy" "example" {
+  policy = data.aws_iam_policy_document.glue-example-policy.json
+}
+`), 0o600))
+
+	result := getDataSourcePolicy(context.Background(), vfs.DiskFS{}, dir, make(converter.VariableMap))
+	data, ok := result["data"]
+	require.True(t, ok)
+
+	var awsPolicyMap map[string]map[string]map[string]string
+	require.NoError(t, gocty.FromCtyValue(data, &awsPolicyMap))
+
+	policy, ok := awsPolicyMap["aws_iam_policy_document"]["glue-example-policy"]["json"]
+	require.True(t, ok, "policy document should be parsed despite data.aws_partition in ARN")
+	require.Contains(t, policy, "glue:*")
+}
+
+func Test_getDataSourcePolicy_whitespaceInBlockHeader(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "policy.tf"), []byte(`
+data	"aws_iam_policy_document"	"doc" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::example/*"]
+  }
+}
+`), 0o600))
+
+	result := getDataSourcePolicy(context.Background(), vfs.DiskFS{}, dir, make(converter.VariableMap))
+	data, ok := result["data"]
+	require.True(t, ok)
+
+	var awsPolicyMap map[string]map[string]map[string]string
+	require.NoError(t, gocty.FromCtyValue(data, &awsPolicyMap))
+
+	policies := awsPolicyMap["aws_iam_policy_document"]
+	require.Contains(t, policies, "doc")
+	require.Contains(t, policies["doc"]["json"], "s3:GetObject")
 }

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -213,24 +213,13 @@ func addExtraInfo(ctx context.Context, json []model.Document, path string) ([]mo
 	return json, nil
 }
 
-func parseFile(fsys vfs.FS, filename string, shouldReplaceDataSource bool) (*hcl.File, error) {
-	file, err := fsys.ReadFile(filepath.Clean(filename))
-	if err != nil {
-		return nil, err
+func parseFileContent(content []byte, filename string, shouldReplaceDataSource bool) (*hcl.File, hcl.Diagnostics) {
+	parsedFile, diagnostics := hclsyntax.ParseConfig(content, filename, hcl.Pos{Line: 1, Column: 1})
+	if diagnostics.HasErrors() || !shouldReplaceDataSource {
+		return parsedFile, diagnostics
 	}
-	parsedFile, diagnostics := hclsyntax.ParseConfig(file, filename, hcl.Pos{Line: 1, Column: 1})
-	if diagnostics.HasErrors() {
-		return nil, diagnostics
-	}
-	if shouldReplaceDataSource {
-		file = quoteDataSourceTraversals(file, parsedFile)
-		parsedFile, diagnostics = hclsyntax.ParseConfig(file, filename, hcl.Pos{Line: 1, Column: 1})
-		if diagnostics.HasErrors() {
-			return nil, diagnostics
-		}
-	}
-
-	return parsedFile, nil
+	content = quoteDataSourceTraversals(content, parsedFile)
+	return hclsyntax.ParseConfig(content, filename, hcl.Pos{Line: 1, Column: 1})
 }
 
 func quoteDataSourceTraversals(source []byte, file *hcl.File) []byte {

--- a/pkg/parser/terraform/terraform_test.go
+++ b/pkg/parser/terraform/terraform_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -380,7 +381,7 @@ data "aws_iam_policy_document" "test_destination_policy" {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parsedFile, err := parseFile(vfs.DiskFS{}, tt.filename, tt.shouldReplaceDataSource)
+			parsedFile, err := readAndParseFile(vfs.DiskFS{}, tt.filename, tt.shouldReplaceDataSource)
 			if tt.wantErr {
 				require.NotNil(t, err)
 				require.Nil(t, parsedFile)
@@ -406,7 +407,7 @@ resource "test" "test" {
 	path := filepath.Join(t.TempDir(), "data_references.tf")
 	require.NoError(t, os.WriteFile(path, source, 0o600))
 
-	parsedFile, err := parseFile(vfs.DiskFS{}, path, true)
+	parsedFile, err := readAndParseFile(vfs.DiskFS{}, path, true)
 	require.NoError(t, err)
 	got := string(parsedFile.Bytes)
 	require.Contains(t, got, `root_data    = "data.aws_s3_bucket.selected.arn"`)
@@ -423,9 +424,21 @@ func TestParseFileReturnsDiagnostics(t *testing.T) {
   value = aws_s3_bucket.selected.
 }`), 0o600))
 
-	parsedFile, err := parseFile(vfs.DiskFS{}, path, true)
+	parsedFile, err := readAndParseFile(vfs.DiskFS{}, path, true)
 	require.Nil(t, parsedFile)
 	require.ErrorContains(t, err, "Invalid attribute name")
+}
+
+func readAndParseFile(fsys vfs.FS, filename string, shouldReplaceDataSource bool) (*hcl.File, error) {
+	content, err := fsys.ReadFile(filepath.Clean(filename))
+	if err != nil {
+		return nil, err
+	}
+	file, diags := parseFileContent(content, filename, shouldReplaceDataSource)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	return file, nil
 }
 
 // TestParser_ConcurrentSameDir guards the per-directory variable cache: the

--- a/pkg/parser/terraform/variables.go
+++ b/pkg/parser/terraform/variables.go
@@ -22,14 +22,15 @@ import (
 // terraformVarsPathDirective is the inline comment prefix that overrides the tfvars path for a file.
 const terraformVarsPathDirective = "kics_terraform_vars"
 
+var terraformVarsPathRegex = regexp.MustCompile(`(?m)^\s*// ` + terraformVarsPathDirective + `: ([\w/\\.:-]+)\r?\n`)
+
 func mergeMaps(baseMap, newItems converter.VariableMap) {
 	for key, value := range newItems {
 		baseMap[key] = value
 	}
 }
 
-// nolint:gocyclo
-func getInputVariablesFromFile(fsys vfs.FS, filename string) (converter.VariableMap, error) {
+func parseHCLBody(fsys vfs.FS, filename string) (*hclsyntax.Body, error) {
 	src, err := fsys.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, err
@@ -39,12 +40,34 @@ func getInputVariablesFromFile(fsys vfs.FS, filename string) (converter.Variable
 	if diags.HasErrors() {
 		return nil, diags
 	}
+	body, _ := parsedFile.Body.(*hclsyntax.Body)
+	return body, nil
+}
 
+func getInputVariablesFromFile(fsys vfs.FS, filename string) (converter.VariableMap, error) {
+	body, err := parseHCLBody(fsys, filename)
+	if err != nil {
+		return nil, err
+	}
+	return extractInputVariables(body, filename), nil
+}
+
+// getInputVariablesAndLocalsFromFile parses filename once for both variables and locals.
+func getInputVariablesAndLocalsFromFile(
+	fsys vfs.FS, filename string,
+) (vars, locals converter.VariableMap, err error) {
+	body, err := parseHCLBody(fsys, filename)
+	if err != nil {
+		return nil, nil, err
+	}
+	return extractInputVariables(body, filename), extractLocals(body), nil
+}
+
+// nolint:gocyclo
+func extractInputVariables(body *hclsyntax.Body, filename string) converter.VariableMap {
 	variables := make(converter.VariableMap)
-
-	body, ok := parsedFile.Body.(*hclsyntax.Body)
-	if !ok {
-		return variables, nil
+	if body == nil {
+		return variables
 	}
 
 	// Case 1: .tfvars-style assignments
@@ -55,7 +78,7 @@ func getInputVariablesFromFile(fsys vfs.FS, filename string) (converter.Variable
 				variables[name] = val
 			}
 		}
-		return variables, nil
+		return variables
 	}
 
 	// Case 2: .tf variable "x" { default = ... }
@@ -83,21 +106,15 @@ func getInputVariablesFromFile(fsys vfs.FS, filename string) (converter.Variable
 		}
 	}
 
-	return variables, nil
+	return variables
 }
 
-func getInputLocalsFromFile(fsys vfs.FS, filename string) (converter.VariableMap, error) {
-	src, err := fsys.ReadFile(filepath.Clean(filename))
-	if err != nil {
-		return nil, err
-	}
-
-	parsedFile, diags := hclsyntax.ParseConfig(src, filename, hcl.InitialPos)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
+func extractLocals(body *hclsyntax.Body) converter.VariableMap {
 	locals := make(converter.VariableMap)
+	if body == nil {
+		return locals
+	}
+
 	type unresolved struct {
 		name string
 		expr hclsyntax.Expression
@@ -105,7 +122,7 @@ func getInputLocalsFromFile(fsys vfs.FS, filename string) (converter.VariableMap
 	var unevaluated []unresolved
 
 	// Collect all locals
-	for _, block := range parsedFile.Body.(*hclsyntax.Body).Blocks {
+	for _, block := range body.Blocks {
 		if block.Type != "locals" {
 			continue
 		}
@@ -131,7 +148,7 @@ func getInputLocalsFromFile(fsys vfs.FS, filename string) (converter.VariableMap
 		}
 	}
 
-	return locals, nil
+	return locals
 }
 
 func sanitizeCtyMap(in map[string]cty.Value) map[string]cty.Value {
@@ -147,7 +164,9 @@ func sanitizeCtyMap(in map[string]cty.Value) map[string]cty.Value {
 	return out
 }
 
-func getInputVariables(ctx context.Context, fsys vfs.FS, currentPath, fileContent, terraformVarsPath string) converter.VariableMap {
+func getInputVariables(
+	ctx context.Context, fsys vfs.FS, currentPath, fileContent, terraformVarsPath string,
+) converter.VariableMap {
 	contextLogger := logger.FromContext(ctx)
 	variablesMap := make(converter.VariableMap)
 	localsMap := make(converter.VariableMap)
@@ -159,23 +178,14 @@ func getInputVariables(ctx context.Context, fsys vfs.FS, currentPath, fileConten
 
 	// Parse all .tf files for variables and locals
 	for _, tfFile := range tfFiles {
-		// Get variables
-		vars, errVars := getInputVariablesFromFile(fsys, tfFile)
-		if errVars != nil {
-			contextLogger.Error().Msgf("Error getting default values from %s", tfFile)
-			contextLogger.Err(errVars)
-		} else {
-			mergeMaps(variablesMap, vars)
+		vars, locals, err := getInputVariablesAndLocalsFromFile(fsys, tfFile)
+		if err != nil {
+			contextLogger.Error().Msgf("Error getting default values and locals from %s", tfFile)
+			contextLogger.Err(err)
+			continue
 		}
-
-		// Get locals
-		locals, errLocals := getInputLocalsFromFile(fsys, tfFile)
-		if errLocals != nil {
-			contextLogger.Error().Msgf("Error getting locals from %s", tfFile)
-			contextLogger.Err(errLocals)
-		} else {
-			mergeMaps(localsMap, locals)
-		}
+		mergeMaps(variablesMap, vars)
+		mergeMaps(localsMap, locals)
 	}
 
 	// Parse *.auto.tfvars files
@@ -200,7 +210,6 @@ func getInputVariables(ctx context.Context, fsys vfs.FS, currentPath, fileConten
 	}
 
 	if terraformVarsPath == "" {
-		terraformVarsPathRegex := regexp.MustCompile(`(?m)^\s*// ` + terraformVarsPathDirective + `: ([\w/\\.:-]+)\r?\n`)
 		match := terraformVarsPathRegex.FindStringSubmatch(fileContent)
 		if match != nil {
 			terraformVarsPath = filepath.FromSlash(strings.ReplaceAll(match[1], "\\", "/"))

--- a/pkg/parser/terraform/variables_test.go
+++ b/pkg/parser/terraform/variables_test.go
@@ -37,7 +37,7 @@ type inputVarTest struct {
 }
 
 func setInputVariablesDefaultValues(filename string) (converter.VariableMap, error) {
-	parsedFile, err := parseFile(vfs.DiskFS{}, filename, false)
+	parsedFile, err := readAndParseFile(vfs.DiskFS{}, filename, false)
 	if err != nil || parsedFile == nil {
 		return nil, err
 	}

--- a/pkg/resolver/file/file.go
+++ b/pkg/resolver/file/file.go
@@ -19,6 +19,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var serverlessFileReferenceRE = regexp.MustCompile(`^\${file\((.*\.(yaml|yml))\)}$`)
+
 // ResolvedFile - used for caching the already resolved files
 type ResolvedFile struct {
 	fileContent        []byte
@@ -592,8 +594,7 @@ func contains(elem string, list []string) bool {
 }
 
 func checkServerlessFileReference(value string) string {
-	re := regexp.MustCompile(`^\${file\((.*\.(yaml|yml))\)}$`)
-	matches := re.FindStringSubmatch(value)
+	matches := serverlessFileReferenceRE.FindStringSubmatch(value)
 	if len(matches) > 1 {
 		return matches[1]
 	}
@@ -606,17 +607,25 @@ func findFilePath(
 	extensions []string) (exists bool, path, onlyFilePath, cleanFilePath string) {
 	path = filepath.Join(folderPath, filename)
 	if ansibleVars {
-		if exists, ansibleVarsPath := findAnsibleVarsPath(folderPath, filename); !exists {
+		exists, ansibleVarsPath := findAnsibleVarsPath(folderPath, filename)
+		if !exists {
 			return false, "", "", ""
-		} else {
-			path = ansibleVarsPath
 		}
-	} else if _, err := os.Stat(path); err != nil {
-		return false, "", "", ""
-	}
-
-	if !contains(filepath.Ext(path), extensions) {
-		return false, "", "", ""
+		path = ansibleVarsPath
+		if !contains(filepath.Ext(path), extensions) {
+			return false, "", "", ""
+		}
+	} else {
+		// The extension is determined by the path alone, so reject unsupported
+		// files before the stat. This function is called for every scalar value
+		// in every document, and the vast majority are not file references, so
+		// stat-first would spend a syscall per value to learn nothing.
+		if !contains(filepath.Ext(path), extensions) {
+			return false, "", "", ""
+		}
+		if _, err := os.Stat(path); err != nil {
+			return false, "", "", ""
+		}
 	}
 
 	onlyFilePath = getPathFromString(path)

--- a/pkg/resolver/file/file_test.go
+++ b/pkg/resolver/file/file_test.go
@@ -282,3 +282,9 @@ func prepareString(content string) string {
 	content = strings.Replace(content, " ", "", -1)
 	return content
 }
+
+func TestCheckServerlessFileReference(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "config/settings.yaml", checkServerlessFileReference("${file(config/settings.yaml)}"))
+	require.Equal(t, "plain/path.yml", checkServerlessFileReference("plain/path.yml"))
+}

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -81,7 +81,7 @@ func (r *Resolver) Resolve(ctx context.Context, filePath string, kind model.File
 
 // GetType will analyze the filepath to determine which resolver to use
 func (r *Resolver) GetType(filePath string) model.FileKind {
-	chartFS := os.DirFS(filepath.Clean(filePath))
+	chartFS := os.DirFS(filepath.Clean(filepath.FromSlash(filePath)))
 	data, err := fs.ReadFile(chartFS, "Chart.yaml")
 	if err != nil {
 		return model.KindCOMMON

--- a/pkg/runner/prepare_test.go
+++ b/pkg/runner/prepare_test.go
@@ -236,6 +236,46 @@ func TestPrepareSharedWalk_PrebuiltWalk_MatchesPerService(t *testing.T) {
 	require.True(t, tfvarsPrepared, "tfvars document should be prepared by the shared walk")
 }
 
+func TestPrepareSharedWalk_DanglingChartYamlSymlinkStillScansTerraform(t *testing.T) {
+	ctx := context.Background()
+
+	dir := t.TempDir()
+	chartDir := filepath.Join(dir, "mixed")
+	require.NoError(t, os.MkdirAll(chartDir, 0o755))
+	require.NoError(t, os.Symlink("/nonexistent/Chart.yaml", filepath.Join(chartDir, "Chart.yaml")))
+	mainTF := filepath.Join(chartDir, "main.tf")
+	writeFile(t, mainTF, `resource "aws_s3_bucket" "b" { bucket = "my-bucket" }`)
+
+	analyzed, err := analyzer.Analyze(ctx, &analyzer.Analyzer{
+		RepoPath:    dir,
+		Paths:       []string{dir},
+		Types:       []string{"terraform"},
+		MaxFileSize: 100,
+	})
+	require.NoError(t, err)
+	require.Contains(t, analyzed.Inventory, filepath.ToSlash(mainTF))
+
+	services, store := buildParityServices(t, ctx, []string{dir})
+	fsp, ok := SharedWalkProvider(services)
+	require.True(t, ok)
+	fsp.SetPrebuiltWalk(analyzed.Inventory, analyzed.ChartRoots, analyzed.ContentCache)
+	for _, s := range services {
+		s.FilePlatform = analyzed.FilePlatform
+	}
+	require.NoError(t, PrepareSharedWalk(ctx, fsp, services, "dangling-chart", false, 5))
+
+	prepared := documentFingerprint(t, store)
+	require.NotEmpty(t, prepared)
+	found := false
+	for key := range prepared {
+		if strings.Contains(key, "main.tf") {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "terraform file under dangling Chart.yaml symlink must be prepared")
+}
+
 // TestContentLineCountParity guards that chunked reads (getContent) and cached
 // bytes (contentFromBytes) report identical line counts, including large files
 // with no trailing newline that span multiple read chunks.


### PR DESCRIPTION
## Motivation

Profiling a large monorepo scan showed most wall time in file discovery and source preparation, not rule evaluation. The analyzer walk, inventory build, YAML path resolver, and Terraform parsing each repeated expensive work (gitignore matching before extension filtering, duplicate `stat` calls, per-call regex compilation, and duplicate HCL parsing for variables/locals).

## Changes

**File analyzer**

The walk filters by scannable extension before running gitignore matching. Helm chart roots are recorded when the walk visits a `Chart.yaml` file instead of calling `Stat` on every directory. The max-file-size check moved from the serial walk into the parallel classification workers.

**Inventory walk**

`checkConditions` now returns the extension it already resolved, so the walk does not call `GetExtension` a second time per file. Shared-walk chart dispatch keeps slash-normalized chart roots so prebuilt inventory renders Helm charts the same way as the per-service walk (including on Windows).

**YAML path resolver**

The serverless `${file(...)}` reference pattern is compiled once at package init. `findFilePath` rejects unsupported extensions before `os.Stat`, avoiding a syscall on every scalar value that is not a file reference.

**Terraform parsing**

Variables and locals are extracted from each `.tf` file in a single parse. Data-source collection skips rewrite-and-parse for files that contain no `aws_iam_policy_document` block. Bare `data.*` references inside quoted strings and `${...}` interpolations are no longer rewritten, so policy ARNs that embed partition/region references still parse correctly.

## QA Instruction

1. `go test ./pkg/analyzer/... ./pkg/engine/provider/... ./pkg/resolver/file/... ./pkg/parser/terraform/... ./pkg/runner/... ./pkg/scan/...`
2. `make build && ./bin/datadog-iac-scanner scan -p <path> -o /tmp/out`
3. Confirm CI passes and the regression benchmark comment on this PR reports no finding-count change, and reports improvements in the wall time.

## Impact

CLI scan startup, file discovery, and Terraform source preparation only. No change to rule logic or SARIF shape for correctly classified files.

I submit this contribution under the Apache-2.0 license.