### PR TITLE
Surface resource_changes/configuration in tfplan documents and resolve pattern filters

### DIFF
--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -8,6 +8,7 @@ package json
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	hcl_plan "github.com/hashicorp/terraform-json"
@@ -25,13 +26,134 @@ type TFPlan struct {
 }
 
 // TFPlanResource is an auxiliary structure for parsing tfplans as a scanner Document.
-// Values are either a TFPlanNamedResource (keyed by resource name) or, under the
-// reserved "_dd_lines" key, a map[string]*model.LineObject holding each sibling
-// resource's header line (see readModule).
+// Values are either a TFPlanNamedResource (keyed by resource name) or, under a
+// reserved "_dd_*" key, scanner-owned metadata keyed like the sibling resource
+// name (see readModule): "_dd_lines" holds each header line, "_dd_tfplan_meta"
+// holds each resource's canonical address plus its correlated
+// resource_changes/configuration entries.
 type TFPlanResource map[string]any
 
 // TFPlanNamedResource is an auxiliary structure for parsing tfplans as a scanner Document
 type TFPlanNamedResource map[string]any
+
+// tfplanResourceMeta is the payload stored under
+// resource.<type>._dd_tfplan_meta._dd_<flattened-key>. It gives Rego a direct
+// lookup for data that otherwise requires reconstructing the resource's
+// canonical address and correlating it against the raw resource_changes/
+// configuration structures.
+type tfplanResourceMeta struct {
+	// Address is the canonical (absolute) Terraform resource address, e.g.
+	// "module.staging.aws_instance.web[0]".
+	Address string `json:"address"`
+	// AfterUnknown is resource_changes[].change.after_unknown for this
+	// resource, verbatim, or nil if no matching change was found.
+	AfterUnknown any `json:"after_unknown,omitempty"`
+	// ConfigurationExpressions is configuration...resources[].expressions for
+	// this resource, verbatim, or nil if no matching configuration was found.
+	ConfigurationExpressions any `json:"configuration_expressions,omitempty"`
+}
+
+// indexBracketRE matches a single "[...]" instance-key suffix (count index or
+// quoted for_each key) in a Terraform resource/module address segment.
+var indexBracketRE = regexp.MustCompile(`\[[^\]]*\]`)
+
+// resourceChangeCorrelation holds the two per-address lookups built once per
+// plan (from the raw, untyped resource_changes/configuration) so readModule
+// can attach correlated data to each resource without re-walking either
+// structure per resource.
+type resourceChangeCorrelation struct {
+	afterUnknownByAddress map[string]any
+	expressionsByAddress  map[string]any
+}
+
+// buildResourceChangeCorrelation indexes resource_changes by their (already
+// absolute) address, and configuration by reconstructing each resource's
+// absolute address from its module path, so both can be looked up by the same
+// canonical address readModule already computes per resource. Raw gjson
+// values are used (not the typed hcl_plan structs) so resource_changes/
+// configuration data itself is never touched - only read.
+func buildResourceChangeCorrelation(rawPlan []byte) resourceChangeCorrelation {
+	c := resourceChangeCorrelation{
+		afterUnknownByAddress: make(map[string]any),
+		expressionsByAddress:  make(map[string]any),
+	}
+
+	gjson.GetBytes(rawPlan, "resource_changes").ForEach(func(_, change gjson.Result) bool {
+		address := change.Get("address").String()
+		if address == "" {
+			return true
+		}
+		if afterUnknown := change.Get("change.after_unknown"); afterUnknown.Exists() {
+			c.afterUnknownByAddress[address] = afterUnknown.Value()
+		}
+		return true
+	})
+
+	rootConfigModule := gjson.GetBytes(rawPlan, "configuration.root_module")
+	walkConfigModule(&rootConfigModule, "", &c)
+
+	return c
+}
+
+// walkConfigModule recursively walks configuration.root_module (and its
+// module_calls), reconstructing each resource's absolute address from
+// modulePath so it can be looked up with the same canonical address as
+// resource_changes and readModule's resourceLines/resourceKey.
+func walkConfigModule(module *gjson.Result, modulePath string, c *resourceChangeCorrelation) {
+	module.Get("resources").ForEach(func(_, resource gjson.Result) bool {
+		// ConfigResource.Address is relative to its own module, e.g.
+		// "aws_instance.web" - never index-suffixed, since configuration
+		// describes the module definition, not a specific instance.
+		relativeAddress := resource.Get("address").String()
+		if relativeAddress == "" {
+			return true
+		}
+		absoluteAddress := relativeAddress
+		if modulePath != "" {
+			absoluteAddress = modulePath + "." + relativeAddress
+		}
+		if expressions := resource.Get("expressions"); expressions.Exists() {
+			c.expressionsByAddress[absoluteAddress] = expressions.Value()
+		}
+		return true
+	})
+
+	module.Get("module_calls").ForEach(func(callName, call gjson.Result) bool {
+		childModule := call.Get("module")
+		if !childModule.Exists() {
+			return true
+		}
+		childPath := "module." + callName.String()
+		if modulePath != "" {
+			childPath = modulePath + "." + childPath
+		}
+		walkConfigModule(&childModule, childPath, c)
+		return true
+	})
+}
+
+// canonicalConfigAddress strips every "[...]" instance-key suffix from an
+// absolute resource address, e.g. "module.staging[\"prod\"].aws_instance.web[2]"
+// becomes "module.staging.aws_instance.web" - the shape configuration
+// addresses always have, since a module's configuration is shared by every
+// instance of that module (for_each/count).
+func canonicalConfigAddress(address string) string {
+	return indexBracketRE.ReplaceAllString(address, "")
+}
+
+// resourceMetaFor builds the _dd_tfplan_meta payload for a single resource,
+// correlating by its canonical (address) and configuration (index-stripped)
+// addresses.
+func resourceMetaFor(address string, c *resourceChangeCorrelation) tfplanResourceMeta {
+	meta := tfplanResourceMeta{Address: address}
+	if afterUnknown, ok := c.afterUnknownByAddress[address]; ok {
+		meta.AfterUnknown = afterUnknown
+	}
+	if expressions, ok := c.expressionsByAddress[canonicalConfigAddress(address)]; ok {
+		meta.ConfigurationExpressions = expressions
+	}
+	return meta
+}
 
 // parseTFPlan unmarshals Document as a plan so it can be rebuilt with only
 // the required information
@@ -55,7 +177,11 @@ func parseTFPlan(doc model.Document) (model.Document, error) {
 	// address) before that information is lost.
 	resourceLines := extractResourceHeaderLines(b)
 
-	parsedPlan := readPlan(plan, doc["resource_changes"], doc["configuration"], resourceLines)
+	// Built from the raw bytes (not the typed plan) so resource_changes/
+	// configuration correlation sees exactly what's in the source document.
+	correlation := buildResourceChangeCorrelation(b)
+
+	parsedPlan := readPlan(plan, doc["resource_changes"], doc["configuration"], resourceLines, &correlation)
 	return parsedPlan, nil
 }
 
@@ -92,14 +218,19 @@ func walkModule(module *gjson.Result, lines map[string]int) {
 
 // readPlan extracts the information needed from a Terraform plan and converts it to a scanner Document.
 // resourceChanges/configuration are raw values from the source document, passed through verbatim.
-func readPlan(plan *hcl_plan.Plan, resourceChanges, configuration any, resourceLines map[string]int) model.Document {
+func readPlan(
+	plan *hcl_plan.Plan,
+	resourceChanges, configuration any,
+	resourceLines map[string]int,
+	correlation *resourceChangeCorrelation,
+) model.Document {
 	kp := TFPlan{
 		Resource:        make(map[string]TFPlanResource),
 		ResourceChanges: resourceChanges,
 		Configuration:   configuration,
 	}
 
-	kp.readModule(plan.PlannedValues.RootModule, "", resourceLines)
+	kp.readModule(plan.PlannedValues.RootModule, "", resourceLines, correlation)
 
 	doc := model.Document{}
 
@@ -119,7 +250,12 @@ func readPlan(plan *hcl_plan.Plan, resourceChanges, configuration any, resourceL
 // resources from every module into the same flat resource.<type>.<name> map
 // without losing data across modules. moduleAddress is the full address of
 // module (e.g. "module.staging"), or "" for the root module.
-func (kp *TFPlan) readModule(module *hcl_plan.StateModule, moduleAddress string, resourceLines map[string]int) {
+func (kp *TFPlan) readModule(
+	module *hcl_plan.StateModule,
+	moduleAddress string,
+	resourceLines map[string]int,
+	correlation *resourceChangeCorrelation,
+) {
 	// Process all resources in this module
 	for _, resource := range module.Resources {
 		// Ensure the resource type map exists - accumulate, don't reinitialize!
@@ -157,11 +293,23 @@ func (kp *TFPlan) readModule(module *hcl_plan.StateModule, moduleAddress string,
 			}
 			ddLines["_dd_"+resourceKey] = &model.LineObject{Line: line}
 		}
+
+		// Inject the resource's canonical address plus its correlated
+		// resource_changes/configuration data as a sibling _dd_tfplan_meta
+		// entry at resource.<type>._dd_tfplan_meta._dd_<name>, so Rego rules
+		// can look this up directly instead of reconstructing the address and
+		// re-walking resource_changes/configuration themselves.
+		ddMeta, isMap := typeRes["_dd_tfplan_meta"].(map[string]tfplanResourceMeta)
+		if !isMap {
+			ddMeta = make(map[string]tfplanResourceMeta)
+			typeRes["_dd_tfplan_meta"] = ddMeta
+		}
+		ddMeta["_dd_"+resourceKey] = resourceMetaFor(resource.Address, correlation)
 	}
 
 	// Recursively process child modules, accumulating into the same map
 	for _, childModule := range module.ChildModules {
-		kp.readModule(childModule, childModule.Address, resourceLines)
+		kp.readModule(childModule, childModule.Address, resourceLines, correlation)
 	}
 }
 

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -8,6 +8,7 @@ package json
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/hashicorp/hcl/v2"
@@ -40,17 +41,20 @@ type tfplanResourceMeta struct {
 	Address                  string `json:"address"`
 	AfterUnknown             any    `json:"after_unknown,omitempty"`
 	ConfigurationExpressions any    `json:"configuration_expressions,omitempty"`
+	Provisioners             any    `json:"provisioners,omitempty"`
 }
 
 type resourceChangeCorrelation struct {
 	afterUnknownByAddress map[string]any
 	expressionsByAddress  map[string]any
+	provisionersByAddress map[string]any
 }
 
 func buildResourceChangeCorrelation(rawPlan []byte) resourceChangeCorrelation {
 	c := resourceChangeCorrelation{
 		afterUnknownByAddress: make(map[string]any),
 		expressionsByAddress:  make(map[string]any),
+		provisionersByAddress: make(map[string]any),
 	}
 
 	gjson.GetBytes(rawPlan, "resource_changes").ForEach(func(_, change gjson.Result) bool {
@@ -65,12 +69,16 @@ func buildResourceChangeCorrelation(rawPlan []byte) resourceChangeCorrelation {
 	})
 
 	rootConfigModule := gjson.GetBytes(rawPlan, "configuration.root_module")
-	walkConfigModule(&rootConfigModule, "", &c)
+	walkConfigModule(&rootConfigModule, "", nil, &c)
 
 	return c
 }
 
-func walkConfigModule(module *gjson.Result, modulePath string, c *resourceChangeCorrelation) {
+// walkConfigModule indexes each resource's expressions/provisioners by
+// absolute address. callArgs holds the enclosing module call's own resolved
+// argument expressions (keyed by variable name), used to resolve a bare
+// "var.<name>" reference down to the value passed in at the call site.
+func walkConfigModule(module *gjson.Result, modulePath string, callArgs map[string]gjson.Result, c *resourceChangeCorrelation) {
 	module.Get("resources").ForEach(func(_, resource gjson.Result) bool {
 		relativeAddress := resource.Get("address").String()
 		if relativeAddress == "" {
@@ -81,7 +89,10 @@ func walkConfigModule(module *gjson.Result, modulePath string, c *resourceChange
 			absoluteAddress = modulePath + "." + relativeAddress
 		}
 		if expressions := resource.Get("expressions"); expressions.Exists() {
-			c.expressionsByAddress[absoluteAddress] = expressions.Value()
+			c.expressionsByAddress[absoluteAddress] = resolveVarReferences(expressions, callArgs)
+		}
+		if provisioners := resource.Get("provisioners"); provisioners.Exists() {
+			c.provisionersByAddress[absoluteAddress] = resolveVarReferences(provisioners, callArgs)
 		}
 		return true
 	})
@@ -95,9 +106,48 @@ func walkConfigModule(module *gjson.Result, modulePath string, c *resourceChange
 		if modulePath != "" {
 			childPath = modulePath + "." + childPath
 		}
-		walkConfigModule(&childModule, childPath, c)
+		childArgs := make(map[string]gjson.Result)
+		call.Get("expressions").ForEach(func(argName, argExpr gjson.Result) bool {
+			childArgs[argName.String()] = argExpr
+			return true
+		})
+		walkConfigModule(&childModule, childPath, childArgs, c)
 		return true
 	})
+}
+
+// resolveVarReferences walks an expressions/provisioners tree and, for any
+// leaf shaped like {"references": ["var.<name>", ...]}, substitutes in
+// callArgs[<name>] - the value the enclosing module call actually passed -
+// so the result reflects the concrete value rather than a bare var reference.
+func resolveVarReferences(value gjson.Result, callArgs map[string]gjson.Result) any {
+	if len(callArgs) == 0 || !value.IsObject() && !value.IsArray() {
+		return value.Value()
+	}
+
+	if refs := value.Get("references"); refs.IsArray() && len(refs.Array()) > 0 {
+		if ref := refs.Array()[0].String(); strings.HasPrefix(ref, "var.") {
+			if arg, ok := callArgs[strings.TrimPrefix(ref, "var.")]; ok {
+				return arg.Value()
+			}
+		}
+	}
+
+	if value.IsArray() {
+		items := value.Array()
+		resolved := make([]any, len(items))
+		for i, item := range items {
+			resolved[i] = resolveVarReferences(item, callArgs)
+		}
+		return resolved
+	}
+
+	resolved := make(map[string]any)
+	value.ForEach(func(key, item gjson.Result) bool {
+		resolved[key.String()] = resolveVarReferences(item, callArgs)
+		return true
+	})
+	return resolved
 }
 
 // canonicalConfigAddress strips "[...]" instance-key suffixes, e.g.
@@ -126,8 +176,12 @@ func resourceMetaFor(address string, c *resourceChangeCorrelation) tfplanResourc
 	if afterUnknown, ok := c.afterUnknownByAddress[address]; ok {
 		meta.AfterUnknown = afterUnknown
 	}
-	if expressions, ok := c.expressionsByAddress[canonicalConfigAddress(address)]; ok {
+	configAddress := canonicalConfigAddress(address)
+	if expressions, ok := c.expressionsByAddress[configAddress]; ok {
 		meta.ConfigurationExpressions = expressions
+	}
+	if provisioners, ok := c.provisionersByAddress[configAddress]; ok {
+		meta.Provisioners = provisioners
 	}
 	return meta
 }

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -8,7 +8,9 @@ package json
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/hashicorp/hcl/v2"
@@ -48,6 +50,50 @@ type resourceChangeCorrelation struct {
 	afterUnknownByAddress map[string]any
 	expressionsByAddress  map[string]any
 	provisionersByAddress map[string]any
+}
+
+// correlationCacheSize bounds the number of raw-plan correlations kept
+// around; the loader that reparses OriginalData for line info produces the
+// same bytes as the eager parse, so a small cache avoids rebuilding it.
+const correlationCacheSize = 32
+
+var (
+	correlationCacheMu   sync.Mutex
+	correlationCacheKeys []uint64
+	correlationCache     = make(map[uint64]resourceChangeCorrelation, correlationCacheSize)
+)
+
+func hashRawPlan(rawPlan []byte) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write(rawPlan)
+	return h.Sum64()
+}
+
+func buildResourceChangeCorrelationCached(rawPlan []byte) resourceChangeCorrelation {
+	key := hashRawPlan(rawPlan)
+
+	correlationCacheMu.Lock()
+	if c, ok := correlationCache[key]; ok {
+		correlationCacheMu.Unlock()
+		return c
+	}
+	correlationCacheMu.Unlock()
+
+	c := buildResourceChangeCorrelation(rawPlan)
+
+	correlationCacheMu.Lock()
+	if _, ok := correlationCache[key]; !ok {
+		if len(correlationCacheKeys) >= correlationCacheSize {
+			oldest := correlationCacheKeys[0]
+			correlationCacheKeys = correlationCacheKeys[1:]
+			delete(correlationCache, oldest)
+		}
+		correlationCache[key] = c
+		correlationCacheKeys = append(correlationCacheKeys, key)
+	}
+	correlationCacheMu.Unlock()
+
+	return c
 }
 
 func buildResourceChangeCorrelation(rawPlan []byte) resourceChangeCorrelation {
@@ -200,7 +246,7 @@ func parseTFPlan(doc model.Document) (model.Document, error) {
 	// hcl_plan.Plan is typed and drops the injected _dd_lines keys, so read
 	// them back from the raw bytes before that information is lost.
 	resourceLines := extractResourceHeaderLines(b)
-	correlation := buildResourceChangeCorrelation(b)
+	correlation := buildResourceChangeCorrelationCached(b)
 
 	parsedPlan := readPlan(plan, doc["resource_changes"], doc["configuration"], resourceLines, &correlation)
 	return parsedPlan, nil

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -17,6 +17,11 @@ import (
 // TFPlan is an auxiliary structure for parsing tfplans as a scanner Document
 type TFPlan struct {
 	Resource map[string]TFPlanResource `json:"resource"`
+
+	// Raw (any), not typed hcl_plan structs, so after_unknown/configuration
+	// pass through verbatim without a typed round-trip dropping data.
+	ResourceChanges any `json:"resource_changes,omitempty"`
+	Configuration   any `json:"configuration,omitempty"`
 }
 
 // TFPlanResource is an auxiliary structure for parsing tfplans as a scanner Document.
@@ -50,7 +55,7 @@ func parseTFPlan(doc model.Document) (model.Document, error) {
 	// address) before that information is lost.
 	resourceLines := extractResourceHeaderLines(b)
 
-	parsedPlan := readPlan(plan, resourceLines)
+	parsedPlan := readPlan(plan, doc["resource_changes"], doc["configuration"], resourceLines)
 	return parsedPlan, nil
 }
 
@@ -85,10 +90,13 @@ func walkModule(module *gjson.Result, lines map[string]int) {
 	})
 }
 
-// readPlan extracts the information needed from a Terraform plan and converts it to a scanner Document
-func readPlan(plan *hcl_plan.Plan, resourceLines map[string]int) model.Document {
+// readPlan extracts the information needed from a Terraform plan and converts it to a scanner Document.
+// resourceChanges/configuration are raw values from the source document, passed through verbatim.
+func readPlan(plan *hcl_plan.Plan, resourceChanges, configuration any, resourceLines map[string]int) model.Document {
 	kp := TFPlan{
-		Resource: make(map[string]TFPlanResource),
+		Resource:        make(map[string]TFPlanResource),
+		ResourceChanges: resourceChanges,
+		Configuration:   configuration,
 	}
 
 	kp.readModule(plan.PlannedValues.RootModule, "", resourceLines)

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -26,29 +26,19 @@ type TFPlan struct {
 	Configuration   any `json:"configuration,omitempty"`
 
 	// TfplanMeta is a reserved top-level map, parallel to Resource (not
-	// nested inside it), so Rego rules that iterate doc.resource.<type> never
-	// see it as a fake resource instance. Keyed exactly like
-	// Resource[type][flattened-key], it gives Rego a direct lookup for data
-	// that otherwise requires reconstructing the resource's canonical address
-	// and correlating it against the raw resource_changes/configuration
-	// structures.
+	// nested inside it), keyed exactly like Resource[type][flattened-key].
 	TfplanMeta map[string]map[string]tfplanResourceMeta `json:"_dd_tfplan_meta,omitempty"`
 }
 
-// TFPlanResource is an auxiliary structure for parsing tfplans as a scanner Document.
-// Values are either a TFPlanNamedResource (keyed by resource name) or, under
-// the reserved "_dd_lines" key, each resource's header line keyed like the
-// sibling resource name (see readModule).
+// TFPlanResource is keyed by resource name, plus a reserved "_dd_lines" key
+// holding each resource's header line (see readModule).
 type TFPlanResource map[string]any
 
 // TFPlanNamedResource is an auxiliary structure for parsing tfplans as a scanner Document
 type TFPlanNamedResource map[string]any
 
 // tfplanResourceMeta is the payload stored under
-// _dd_tfplan_meta.<type>.<flattened-key>. It gives Rego a direct lookup for
-// data that otherwise requires reconstructing the resource's canonical
-// address and correlating it against the raw resource_changes/configuration
-// structures.
+// _dd_tfplan_meta.<type>.<flattened-key>.
 type tfplanResourceMeta struct {
 	// Address is the canonical (absolute) Terraform resource address, e.g.
 	// "module.staging.aws_instance.web[0]".
@@ -61,21 +51,15 @@ type tfplanResourceMeta struct {
 	ConfigurationExpressions any `json:"configuration_expressions,omitempty"`
 }
 
-// resourceChangeCorrelation holds the two per-address lookups built once per
-// plan (from the raw, untyped resource_changes/configuration) so readModule
-// can attach correlated data to each resource without re-walking either
-// structure per resource.
+// resourceChangeCorrelation holds per-address lookups built once per plan so
+// readModule can attach correlated data without re-walking per resource.
 type resourceChangeCorrelation struct {
 	afterUnknownByAddress map[string]any
 	expressionsByAddress  map[string]any
 }
 
-// buildResourceChangeCorrelation indexes resource_changes by their (already
-// absolute) address, and configuration by reconstructing each resource's
-// absolute address from its module path, so both can be looked up by the same
-// canonical address readModule already computes per resource. Raw gjson
-// values are used (not the typed hcl_plan structs) so resource_changes/
-// configuration data itself is never touched - only read.
+// buildResourceChangeCorrelation indexes resource_changes and configuration
+// by resource address, using raw gjson so the data itself is never touched.
 func buildResourceChangeCorrelation(rawPlan []byte) resourceChangeCorrelation {
 	c := resourceChangeCorrelation{
 		afterUnknownByAddress: make(map[string]any),
@@ -138,11 +122,8 @@ func walkConfigModule(module *gjson.Result, modulePath string, c *resourceChange
 
 // canonicalConfigAddress strips every "[...]" instance-key suffix from an
 // absolute resource address, e.g. "module.staging[\"prod\"].aws_instance.web[2]"
-// becomes "module.staging.aws_instance.web" - the shape configuration
-// addresses always have, since a module's configuration is shared by every
-// instance of that module (for_each/count). Address is parsed as an HCL
-// traversal (not a regex) so quoted for_each keys containing "]" or escaped
-// quotes are handled correctly.
+// becomes "module.staging.aws_instance.web". Parsed as an HCL traversal (not
+// a regex) so quoted for_each keys containing "]" or escaped quotes work.
 func canonicalConfigAddress(address string) string {
 	traversal, diags := hclsyntax.ParseTraversalAbs([]byte(address), "", hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
@@ -316,13 +297,8 @@ func (kp *TFPlan) readModule(
 			ddLines["_dd_"+resourceKey] = &model.LineObject{Line: line}
 		}
 
-		// Record the resource's canonical address plus its correlated
-		// resource_changes/configuration data under the top-level
-		// _dd_tfplan_meta.<type>.<key> map (parallel to Resource, never nested
-		// inside it), so Rego rules can look this up directly instead of
-		// reconstructing the address and re-walking resource_changes/
-		// configuration themselves - and so rules iterating
-		// doc.resource.<type> never see it as a fake resource instance.
+		// Record correlated resource_changes/configuration data under the
+		// top-level _dd_tfplan_meta.<type>.<key> map, parallel to Resource.
 		if kp.TfplanMeta[resource.Type] == nil {
 			if kp.TfplanMeta == nil {
 				kp.TfplanMeta = make(map[string]map[string]tfplanResourceMeta)

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -8,9 +8,10 @@ package json
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hcl_plan "github.com/hashicorp/terraform-json"
 	"github.com/tidwall/gjson"
 )
@@ -23,24 +24,31 @@ type TFPlan struct {
 	// pass through verbatim without a typed round-trip dropping data.
 	ResourceChanges any `json:"resource_changes,omitempty"`
 	Configuration   any `json:"configuration,omitempty"`
+
+	// TfplanMeta is a reserved top-level map, parallel to Resource (not
+	// nested inside it), so Rego rules that iterate doc.resource.<type> never
+	// see it as a fake resource instance. Keyed exactly like
+	// Resource[type][flattened-key], it gives Rego a direct lookup for data
+	// that otherwise requires reconstructing the resource's canonical address
+	// and correlating it against the raw resource_changes/configuration
+	// structures.
+	TfplanMeta map[string]map[string]tfplanResourceMeta `json:"_dd_tfplan_meta,omitempty"`
 }
 
 // TFPlanResource is an auxiliary structure for parsing tfplans as a scanner Document.
-// Values are either a TFPlanNamedResource (keyed by resource name) or, under a
-// reserved "_dd_*" key, scanner-owned metadata keyed like the sibling resource
-// name (see readModule): "_dd_lines" holds each header line, "_dd_tfplan_meta"
-// holds each resource's canonical address plus its correlated
-// resource_changes/configuration entries.
+// Values are either a TFPlanNamedResource (keyed by resource name) or, under
+// the reserved "_dd_lines" key, each resource's header line keyed like the
+// sibling resource name (see readModule).
 type TFPlanResource map[string]any
 
 // TFPlanNamedResource is an auxiliary structure for parsing tfplans as a scanner Document
 type TFPlanNamedResource map[string]any
 
 // tfplanResourceMeta is the payload stored under
-// resource.<type>._dd_tfplan_meta._dd_<flattened-key>. It gives Rego a direct
-// lookup for data that otherwise requires reconstructing the resource's
-// canonical address and correlating it against the raw resource_changes/
-// configuration structures.
+// _dd_tfplan_meta.<type>.<flattened-key>. It gives Rego a direct lookup for
+// data that otherwise requires reconstructing the resource's canonical
+// address and correlating it against the raw resource_changes/configuration
+// structures.
 type tfplanResourceMeta struct {
 	// Address is the canonical (absolute) Terraform resource address, e.g.
 	// "module.staging.aws_instance.web[0]".
@@ -52,10 +60,6 @@ type tfplanResourceMeta struct {
 	// this resource, verbatim, or nil if no matching configuration was found.
 	ConfigurationExpressions any `json:"configuration_expressions,omitempty"`
 }
-
-// indexBracketRE matches a single "[...]" instance-key suffix (count index or
-// quoted for_each key) in a Terraform resource/module address segment.
-var indexBracketRE = regexp.MustCompile(`\[[^\]]*\]`)
 
 // resourceChangeCorrelation holds the two per-address lookups built once per
 // plan (from the raw, untyped resource_changes/configuration) so readModule
@@ -136,9 +140,27 @@ func walkConfigModule(module *gjson.Result, modulePath string, c *resourceChange
 // absolute resource address, e.g. "module.staging[\"prod\"].aws_instance.web[2]"
 // becomes "module.staging.aws_instance.web" - the shape configuration
 // addresses always have, since a module's configuration is shared by every
-// instance of that module (for_each/count).
+// instance of that module (for_each/count). Address is parsed as an HCL
+// traversal (not a regex) so quoted for_each keys containing "]" or escaped
+// quotes are handled correctly.
 func canonicalConfigAddress(address string) string {
-	return indexBracketRE.ReplaceAllString(address, "")
+	traversal, diags := hclsyntax.ParseTraversalAbs([]byte(address), "", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return address
+	}
+
+	canonical := ""
+	for _, step := range traversal {
+		switch t := step.(type) {
+		case hcl.TraverseRoot:
+			canonical = t.Name
+		case hcl.TraverseAttr:
+			canonical += "." + t.Name
+		case hcl.TraverseIndex:
+			// Instance-key suffix (count/for_each) - dropped.
+		}
+	}
+	return canonical
 }
 
 // resourceMetaFor builds the _dd_tfplan_meta payload for a single resource,
@@ -294,17 +316,20 @@ func (kp *TFPlan) readModule(
 			ddLines["_dd_"+resourceKey] = &model.LineObject{Line: line}
 		}
 
-		// Inject the resource's canonical address plus its correlated
-		// resource_changes/configuration data as a sibling _dd_tfplan_meta
-		// entry at resource.<type>._dd_tfplan_meta._dd_<name>, so Rego rules
-		// can look this up directly instead of reconstructing the address and
-		// re-walking resource_changes/configuration themselves.
-		ddMeta, isMap := typeRes["_dd_tfplan_meta"].(map[string]tfplanResourceMeta)
-		if !isMap {
-			ddMeta = make(map[string]tfplanResourceMeta)
-			typeRes["_dd_tfplan_meta"] = ddMeta
+		// Record the resource's canonical address plus its correlated
+		// resource_changes/configuration data under the top-level
+		// _dd_tfplan_meta.<type>.<key> map (parallel to Resource, never nested
+		// inside it), so Rego rules can look this up directly instead of
+		// reconstructing the address and re-walking resource_changes/
+		// configuration themselves - and so rules iterating
+		// doc.resource.<type> never see it as a fake resource instance.
+		if kp.TfplanMeta[resource.Type] == nil {
+			if kp.TfplanMeta == nil {
+				kp.TfplanMeta = make(map[string]map[string]tfplanResourceMeta)
+			}
+			kp.TfplanMeta[resource.Type] = make(map[string]tfplanResourceMeta)
 		}
-		ddMeta["_dd_"+resourceKey] = resourceMetaFor(resource.Address, correlation)
+		kp.TfplanMeta[resource.Type][resourceKey] = resourceMetaFor(resource.Address, correlation)
 	}
 
 	// Recursively process child modules, accumulating into the same map

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -78,7 +78,7 @@ func buildResourceChangeCorrelation(rawPlan []byte) resourceChangeCorrelation {
 // absolute address. callArgs holds the enclosing module call's own resolved
 // argument expressions (keyed by variable name), used to resolve a bare
 // "var.<name>" reference down to the value passed in at the call site.
-func walkConfigModule(module *gjson.Result, modulePath string, callArgs map[string]gjson.Result, c *resourceChangeCorrelation) {
+func walkConfigModule(module *gjson.Result, modulePath string, callArgs map[string]*gjson.Result, c *resourceChangeCorrelation) {
 	module.Get("resources").ForEach(func(_, resource gjson.Result) bool {
 		relativeAddress := resource.Get("address").String()
 		if relativeAddress == "" {
@@ -89,10 +89,10 @@ func walkConfigModule(module *gjson.Result, modulePath string, callArgs map[stri
 			absoluteAddress = modulePath + "." + relativeAddress
 		}
 		if expressions := resource.Get("expressions"); expressions.Exists() {
-			c.expressionsByAddress[absoluteAddress] = resolveVarReferences(expressions, callArgs)
+			c.expressionsByAddress[absoluteAddress] = resolveVarReferences(&expressions, callArgs)
 		}
 		if provisioners := resource.Get("provisioners"); provisioners.Exists() {
-			c.provisionersByAddress[absoluteAddress] = resolveVarReferences(provisioners, callArgs)
+			c.provisionersByAddress[absoluteAddress] = resolveVarReferences(&provisioners, callArgs)
 		}
 		return true
 	})
@@ -106,9 +106,9 @@ func walkConfigModule(module *gjson.Result, modulePath string, callArgs map[stri
 		if modulePath != "" {
 			childPath = modulePath + "." + childPath
 		}
-		childArgs := make(map[string]gjson.Result)
+		childArgs := make(map[string]*gjson.Result)
 		call.Get("expressions").ForEach(func(argName, argExpr gjson.Result) bool {
-			childArgs[argName.String()] = argExpr
+			childArgs[argName.String()] = &argExpr
 			return true
 		})
 		walkConfigModule(&childModule, childPath, childArgs, c)
@@ -120,7 +120,7 @@ func walkConfigModule(module *gjson.Result, modulePath string, callArgs map[stri
 // leaf shaped like {"references": ["var.<name>", ...]}, substitutes in
 // callArgs[<name>] - the value the enclosing module call actually passed -
 // so the result reflects the concrete value rather than a bare var reference.
-func resolveVarReferences(value gjson.Result, callArgs map[string]gjson.Result) any {
+func resolveVarReferences(value *gjson.Result, callArgs map[string]*gjson.Result) any {
 	if len(callArgs) == 0 || !value.IsObject() && !value.IsArray() {
 		return value.Value()
 	}
@@ -137,14 +137,14 @@ func resolveVarReferences(value gjson.Result, callArgs map[string]gjson.Result) 
 		items := value.Array()
 		resolved := make([]any, len(items))
 		for i, item := range items {
-			resolved[i] = resolveVarReferences(item, callArgs)
+			resolved[i] = resolveVarReferences(&item, callArgs)
 		}
 		return resolved
 	}
 
 	resolved := make(map[string]any)
 	value.ForEach(func(key, item gjson.Result) bool {
-		resolved[key.String()] = resolveVarReferences(item, callArgs)
+		resolved[key.String()] = resolveVarReferences(&item, callArgs)
 		return true
 	})
 	return resolved

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -20,8 +20,6 @@ import (
 type TFPlan struct {
 	Resource map[string]TFPlanResource `json:"resource"`
 
-	// Raw (any), not typed hcl_plan structs, so after_unknown/configuration
-	// pass through verbatim without a typed round-trip dropping data.
 	ResourceChanges any `json:"resource_changes,omitempty"`
 	Configuration   any `json:"configuration,omitempty"`
 
@@ -34,32 +32,21 @@ type TFPlan struct {
 // holding each resource's header line (see readModule).
 type TFPlanResource map[string]any
 
-// TFPlanNamedResource is an auxiliary structure for parsing tfplans as a scanner Document
 type TFPlanNamedResource map[string]any
 
 // tfplanResourceMeta is the payload stored under
 // _dd_tfplan_meta.<type>.<flattened-key>.
 type tfplanResourceMeta struct {
-	// Address is the canonical (absolute) Terraform resource address, e.g.
-	// "module.staging.aws_instance.web[0]".
-	Address string `json:"address"`
-	// AfterUnknown is resource_changes[].change.after_unknown for this
-	// resource, verbatim, or nil if no matching change was found.
-	AfterUnknown any `json:"after_unknown,omitempty"`
-	// ConfigurationExpressions is configuration...resources[].expressions for
-	// this resource, verbatim, or nil if no matching configuration was found.
-	ConfigurationExpressions any `json:"configuration_expressions,omitempty"`
+	Address                  string `json:"address"`
+	AfterUnknown             any    `json:"after_unknown,omitempty"`
+	ConfigurationExpressions any    `json:"configuration_expressions,omitempty"`
 }
 
-// resourceChangeCorrelation holds per-address lookups built once per plan so
-// readModule can attach correlated data without re-walking per resource.
 type resourceChangeCorrelation struct {
 	afterUnknownByAddress map[string]any
 	expressionsByAddress  map[string]any
 }
 
-// buildResourceChangeCorrelation indexes resource_changes and configuration
-// by resource address, using raw gjson so the data itself is never touched.
 func buildResourceChangeCorrelation(rawPlan []byte) resourceChangeCorrelation {
 	c := resourceChangeCorrelation{
 		afterUnknownByAddress: make(map[string]any),
@@ -83,15 +70,8 @@ func buildResourceChangeCorrelation(rawPlan []byte) resourceChangeCorrelation {
 	return c
 }
 
-// walkConfigModule recursively walks configuration.root_module (and its
-// module_calls), reconstructing each resource's absolute address from
-// modulePath so it can be looked up with the same canonical address as
-// resource_changes and readModule's resourceLines/resourceKey.
 func walkConfigModule(module *gjson.Result, modulePath string, c *resourceChangeCorrelation) {
 	module.Get("resources").ForEach(func(_, resource gjson.Result) bool {
-		// ConfigResource.Address is relative to its own module, e.g.
-		// "aws_instance.web" - never index-suffixed, since configuration
-		// describes the module definition, not a specific instance.
 		relativeAddress := resource.Get("address").String()
 		if relativeAddress == "" {
 			return true
@@ -120,10 +100,8 @@ func walkConfigModule(module *gjson.Result, modulePath string, c *resourceChange
 	})
 }
 
-// canonicalConfigAddress strips every "[...]" instance-key suffix from an
-// absolute resource address, e.g. "module.staging[\"prod\"].aws_instance.web[2]"
-// becomes "module.staging.aws_instance.web". Parsed as an HCL traversal (not
-// a regex) so quoted for_each keys containing "]" or escaped quotes work.
+// canonicalConfigAddress strips "[...]" instance-key suffixes, e.g.
+// "module.staging[\"prod\"].aws_instance.web[2]" -> "module.staging.aws_instance.web".
 func canonicalConfigAddress(address string) string {
 	traversal, diags := hclsyntax.ParseTraversalAbs([]byte(address), "", hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
@@ -138,15 +116,11 @@ func canonicalConfigAddress(address string) string {
 		case hcl.TraverseAttr:
 			canonical += "." + t.Name
 		case hcl.TraverseIndex:
-			// Instance-key suffix (count/for_each) - dropped.
 		}
 	}
 	return canonical
 }
 
-// resourceMetaFor builds the _dd_tfplan_meta payload for a single resource,
-// correlating by its canonical (address) and configuration (index-stripped)
-// addresses.
 func resourceMetaFor(address string, c *resourceChangeCorrelation) tfplanResourceMeta {
 	meta := tfplanResourceMeta{Address: address}
 	if afterUnknown, ok := c.afterUnknownByAddress[address]; ok {
@@ -158,42 +132,28 @@ func resourceMetaFor(address string, c *resourceChangeCorrelation) tfplanResourc
 	return meta
 }
 
-// parseTFPlan unmarshals Document as a plan so it can be rebuilt with only
-// the required information
 func parseTFPlan(doc model.Document) (model.Document, error) {
 	var plan *hcl_plan.Plan
 	b, err := json.Marshal(doc)
 	if err != nil {
 		return model.Document{}, err
 	}
-	// Unmarshal our Document as a plan so we are able retrieve planned_values
-	// in a easier way
 	err = json.Unmarshal(b, &plan)
 	if err != nil {
-		// Consider as regular JSON and not tfplan
 		return model.Document{}, err
 	}
 
-	// hcl_plan.Plan is a typed struct so unmarshaling drops the injected
-	// _dd_lines keys along with each resource's "values" attribute line. Read
-	// those lines back out of the raw bytes (via gjson, keyed by resource
-	// address) before that information is lost.
+	// hcl_plan.Plan is typed and drops the injected _dd_lines keys, so read
+	// them back from the raw bytes before that information is lost.
 	resourceLines := extractResourceHeaderLines(b)
-
-	// Built from the raw bytes (not the typed plan) so resource_changes/
-	// configuration correlation sees exactly what's in the source document.
 	correlation := buildResourceChangeCorrelation(b)
 
 	parsedPlan := readPlan(plan, doc["resource_changes"], doc["configuration"], resourceLines, &correlation)
 	return parsedPlan, nil
 }
 
-// extractResourceHeaderLines walks the raw plan JSON and returns, for every
-// planned resource, the _dd_line of its "values" attribute (i.e. where the
-// resource's own attribute block starts), keyed by resource address. Array
-// elements don't carry their own _dd_lines sibling (see setSeqLines in
-// json_line.go) — that information lives positionally in the parent module's
-// "_dd_lines._dd_resources._dd_arr" instead.
+// extractResourceHeaderLines returns each resource's "values" attribute
+// line, keyed by resource address.
 func extractResourceHeaderLines(rawPlan []byte) map[string]int {
 	lines := make(map[string]int)
 	root_module := gjson.GetBytes(rawPlan, "planned_values.root_module")
@@ -219,8 +179,6 @@ func walkModule(module *gjson.Result, lines map[string]int) {
 	})
 }
 
-// readPlan extracts the information needed from a Terraform plan and converts it to a scanner Document.
-// resourceChanges/configuration are raw values from the source document, passed through verbatim.
 func readPlan(
 	plan *hcl_plan.Plan,
 	resourceChanges, configuration any,
@@ -249,45 +207,33 @@ func readPlan(
 	return doc
 }
 
-// readModule recursively processes a module and its children, accumulating
-// resources from every module into the same flat resource.<type>.<name> map
-// without losing data across modules. moduleAddress is the full address of
-// module (e.g. "module.staging"), or "" for the root module.
+// readModule recursively accumulates resources from every module into the
+// same flat resource.<type>.<name> map. moduleAddress is "" for the root module.
 func (kp *TFPlan) readModule(
 	module *hcl_plan.StateModule,
 	moduleAddress string,
 	resourceLines map[string]int,
 	correlation *resourceChangeCorrelation,
 ) {
-	// Process all resources in this module
 	for _, resource := range module.Resources {
-		// Ensure the resource type map exists - accumulate, don't reinitialize!
 		if kp.Resource[resource.Type] == nil {
 			kp.Resource[resource.Type] = make(TFPlanResource)
 		}
 		typeRes := kp.Resource[resource.Type]
 
-		// Root-module resources keep their plain name. Child-module resources
-		// get their module address prefixed, so same-type-same-name resources
-		// in different modules don't collide into one map entry (which would
-		// silently drop a resource from evaluation).
+		// Module-prefixed so same-type-same-name resources in different
+		// modules don't collide.
 		resourceKey := resource.Name
 		if moduleAddress != "" {
 			resourceKey = moduleAddress + "." + resource.Name
 		}
 
-		// Handle count and for_each: append the index to the resource key
-		// This ensures each instance gets a unique key
 		if resource.Index != nil {
 			resourceKey = formatResourceKeyWithIndex(resourceKey, resource.Index)
 		}
 
-		// Accumulate the resource into the existing type map
 		typeRes[resourceKey] = TFPlanNamedResource(resource.AttributeValues)
 
-		// Inject the resource's "values" attribute line as a sibling _dd_lines
-		// entry at resource.<type>._dd_lines._dd_<name>._dd_line, matching the
-		// gjson path GetLineBySearchLine builds for a bare resource searchKey.
 		if line, ok := resourceLines[resource.Address]; ok {
 			ddLines, isMap := typeRes["_dd_lines"].(map[string]*model.LineObject)
 			if !isMap {
@@ -297,8 +243,6 @@ func (kp *TFPlan) readModule(
 			ddLines["_dd_"+resourceKey] = &model.LineObject{Line: line}
 		}
 
-		// Record correlated resource_changes/configuration data under the
-		// top-level _dd_tfplan_meta.<type>.<key> map, parallel to Resource.
 		if kp.TfplanMeta[resource.Type] == nil {
 			if kp.TfplanMeta == nil {
 				kp.TfplanMeta = make(map[string]map[string]tfplanResourceMeta)
@@ -308,31 +252,21 @@ func (kp *TFPlan) readModule(
 		kp.TfplanMeta[resource.Type][resourceKey] = resourceMetaFor(resource.Address, correlation)
 	}
 
-	// Recursively process child modules, accumulating into the same map
 	for _, childModule := range module.ChildModules {
 		kp.readModule(childModule, childModule.Address, resourceLines, correlation)
 	}
 }
 
-// formatResourceKeyWithIndex formats a resource key to include count/for_each index
-// Examples:
-//   - count: "web" + 0 -> "web[0]"
-//   - count: "web" + 2 -> "web[2]"
-//   - for_each: "bucket" + "prod" -> "bucket[\"prod\"]"
-//   - for_each: "bucket" + "staging" -> "bucket[\"staging\"]"
-func formatResourceKeyWithIndex(baseName string, index interface{}) string {
+// formatResourceKeyWithIndex appends a count/for_each index, e.g. "web[0]" or "bucket[\"prod\"]".
+func formatResourceKeyWithIndex(baseName string, index any) string {
 	switch idx := index.(type) {
 	case float64:
-		// Count index (JSON numbers are float64)
 		return fmt.Sprintf("%s[%d]", baseName, int(idx))
 	case int:
-		// Count index (in case it's already an int)
 		return fmt.Sprintf("%s[%d]", baseName, idx)
 	case string:
-		// For_each index with string key
 		return fmt.Sprintf("%s[%q]", baseName, idx)
 	default:
-		// Fallback: just use the base name if we don't recognize the index type
 		return baseName
 	}
 }

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -56,6 +56,11 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"fakewebservices_database": map[string]interface{}{
+						"_dd_tfplan_meta": map[string]interface{}{
+							"_dd_prod_db": map[string]interface{}{
+								"address": "fakewebservices_database.prod_db",
+							},
+						},
 						"prod_db": map[string]interface{}{
 							"name": "Production DB",
 							"size": (float64)(256),
@@ -130,6 +135,20 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
+						"_dd_tfplan_meta": map[string]interface{}{
+							"_dd_main": map[string]interface{}{
+								"address": "aws_s3_bucket.main",
+								"after_unknown": map[string]interface{}{
+									"bucket": true,
+									"id":     true,
+								},
+								"configuration_expressions": map[string]interface{}{
+									"bucket": map[string]interface{}{
+										"references": []interface{}{"random_id.suffix"},
+									},
+								},
+							},
+						},
 						"main": map[string]interface{}{
 							"bucket": "main-bucket",
 						},
@@ -239,6 +258,14 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
+						"_dd_tfplan_meta": map[string]interface{}{
+							"_dd_main": map[string]interface{}{
+								"address": "aws_s3_bucket.main",
+							},
+							"_dd_module.storage.backup": map[string]interface{}{
+								"address": "module.storage.aws_s3_bucket.backup",
+							},
+						},
 						"main": map[string]interface{}{
 							"bucket": "main-bucket",
 							"acl":    "private",
@@ -249,6 +276,11 @@ func TestJson_parseTFPlan(t *testing.T) {
 						},
 					},
 					"aws_instance": map[string]interface{}{
+						"_dd_tfplan_meta": map[string]interface{}{
+							"_dd_web": map[string]interface{}{
+								"address": "aws_instance.web",
+							},
+						},
 						"web": map[string]interface{}{
 							"instance_type": "t2.micro",
 						},
@@ -307,6 +339,14 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_instance": map[string]interface{}{
+						"_dd_tfplan_meta": map[string]interface{}{
+							"_dd_web": map[string]interface{}{
+								"address": "aws_instance.web",
+							},
+							"_dd_module.staging.web": map[string]interface{}{
+								"address": "module.staging.aws_instance.web",
+							},
+						},
 						"web": map[string]interface{}{
 							"instance_type": "t2.large",
 							"tags": map[string]interface{}{
@@ -382,16 +422,31 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_vpc": map[string]interface{}{
+						"_dd_tfplan_meta": map[string]interface{}{
+							"_dd_main": map[string]interface{}{
+								"address": "aws_vpc.main",
+							},
+						},
 						"main": map[string]interface{}{
 							"cidr_block": "10.0.0.0/16",
 						},
 					},
 					"aws_subnet": map[string]interface{}{
+						"_dd_tfplan_meta": map[string]interface{}{
+							"_dd_module.networking.public": map[string]interface{}{
+								"address": "module.networking.aws_subnet.public",
+							},
+						},
 						"module.networking.public": map[string]interface{}{
 							"cidr_block": "10.0.1.0/24",
 						},
 					},
 					"aws_security_group": map[string]interface{}{
+						"_dd_tfplan_meta": map[string]interface{}{
+							"_dd_module.networking.module.security.web": map[string]interface{}{
+								"address": "module.networking.module.security.aws_security_group.web",
+							},
+						},
 						"module.networking.module.security.web": map[string]interface{}{
 							"description": "Web traffic",
 						},
@@ -447,6 +502,14 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
+						"_dd_tfplan_meta": map[string]interface{}{
+							"_dd_module.app1.data": map[string]interface{}{
+								"address": "module.app1.aws_s3_bucket.data",
+							},
+							"_dd_module.app2.data": map[string]interface{}{
+								"address": "module.app2.aws_s3_bucket.data",
+							},
+						},
 						"module.app1.data": map[string]interface{}{
 							"bucket": "app1-data",
 						},
@@ -517,6 +580,17 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_instance": map[string]interface{}{
+						"_dd_tfplan_meta": map[string]interface{}{
+							"_dd_web[0]": map[string]interface{}{
+								"address": "aws_instance.web[0]",
+							},
+							"_dd_web[1]": map[string]interface{}{
+								"address": "aws_instance.web[1]",
+							},
+							"_dd_web[2]": map[string]interface{}{
+								"address": "aws_instance.web[2]",
+							},
+						},
 						"web[0]": map[string]interface{}{
 							"instance_type": "t2.micro",
 							"tags": map[string]interface{}{
@@ -593,6 +667,17 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
+						"_dd_tfplan_meta": map[string]interface{}{
+							"_dd_data[\"prod\"]": map[string]interface{}{
+								"address": "aws_s3_bucket.data[\"prod\"]",
+							},
+							"_dd_data[\"staging\"]": map[string]interface{}{
+								"address": "aws_s3_bucket.data[\"staging\"]",
+							},
+							"_dd_data[\"dev\"]": map[string]interface{}{
+								"address": "aws_s3_bucket.data[\"dev\"]",
+							},
+						},
 						"data[\"prod\"]": map[string]interface{}{
 							"bucket": "prod-data-bucket",
 							"acl":    "private",
@@ -656,6 +741,11 @@ func TestJson_parseTFPlan(t *testing.T) {
 						"_dd_lines": map[string]any{
 							"_dd_prod_db": map[string]any{"_dd_line": (float64)(7)},
 						},
+						"_dd_tfplan_meta": map[string]any{
+							"_dd_prod_db": map[string]any{
+								"address": "fakewebservices_database.prod_db",
+							},
+						},
 						"prod_db": map[string]any{
 							"name": "Production DB",
 							"size": (float64)(256),
@@ -680,4 +770,202 @@ func TestJson_parseTFPlan(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestJson_parseTFPlan_dd_tfplan_meta_correlation exercises _dd_tfplan_meta's
+// direct-lookup contract end to end: a Rego rule should be able to read
+// resource.<type>._dd_tfplan_meta._dd_<key>.after_unknown/configuration_expressions
+// without reconstructing the resource's Terraform address or walking
+// resource_changes/configuration itself. Covers a root resource, a resource in
+// a nested module, a count instance, a for_each instance, and a for_each
+// instance whose key contains a literal dot (which must not be mistaken for a
+// module/resource path separator when correlating).
+func TestJson_parseTFPlan_dd_tfplan_meta_correlation(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"resources": []map[string]interface{}{
+					{
+						"address": "aws_vpc.main",
+						"mode":    "managed",
+						"type":    "aws_vpc",
+						"name":    "main",
+						"values": map[string]interface{}{
+							"cidr_block": "10.0.0.0/16",
+						},
+					},
+					{
+						"address": "aws_instance.web[0]",
+						"mode":    "managed",
+						"type":    "aws_instance",
+						"name":    "web",
+						"index":   float64(0),
+						"values": map[string]interface{}{
+							"instance_type": "t2.micro",
+						},
+					},
+					{
+						"address": "aws_s3_bucket.data[\"prod\"]",
+						"mode":    "managed",
+						"type":    "aws_s3_bucket",
+						"name":    "data",
+						"index":   "prod",
+						"values": map[string]interface{}{
+							"bucket": "prod-data-bucket",
+						},
+					},
+					{
+						"address": "aws_s3_bucket.data[\"a.b\"]",
+						"mode":    "managed",
+						"type":    "aws_s3_bucket",
+						"name":    "data",
+						"index":   "a.b",
+						"values": map[string]interface{}{
+							"bucket": "dotted-key-bucket",
+						},
+					},
+				},
+				"child_modules": []map[string]interface{}{
+					{
+						"address": "module.networking",
+						"resources": []map[string]interface{}{
+							{
+								"address": "module.networking.aws_subnet.public",
+								"mode":    "managed",
+								"type":    "aws_subnet",
+								"name":    "public",
+								"values": map[string]interface{}{
+									"cidr_block": "10.0.1.0/24",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource_changes": []map[string]interface{}{
+			{
+				"address": "aws_vpc.main",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"id": true},
+				},
+			},
+			{
+				"address": "aws_instance.web[0]",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"arn": true},
+				},
+			},
+			{
+				"address": "aws_s3_bucket.data[\"prod\"]",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"id": true},
+				},
+			},
+			{
+				"address": "aws_s3_bucket.data[\"a.b\"]",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"id": true},
+				},
+			},
+			{
+				"address": "module.networking.aws_subnet.public",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"id": true},
+				},
+			},
+		},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"resources": []map[string]interface{}{
+					{
+						"address": "aws_vpc.main",
+						"expressions": map[string]interface{}{
+							"cidr_block": map[string]interface{}{"constant_value": "10.0.0.0/16"},
+						},
+					},
+					{
+						"address": "aws_instance.web",
+						"expressions": map[string]interface{}{
+							"instance_type": map[string]interface{}{"references": []string{"var.instance_type"}},
+						},
+					},
+					{
+						"address": "aws_s3_bucket.data",
+						"expressions": map[string]interface{}{
+							"bucket": map[string]interface{}{"references": []string{"var.bucket_name"}},
+						},
+					},
+				},
+				"module_calls": map[string]interface{}{
+					"networking": map[string]interface{}{
+						"module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_subnet.public",
+									"expressions": map[string]interface{}{
+										"cidr_block": map[string]interface{}{"references": []string{"var.subnet_cidr"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	meta := func(resourceType, key string) map[string]interface{} {
+		typeMap, ok := got["resource"].(map[string]interface{})[resourceType].(map[string]interface{})
+		require.True(t, ok, "resource.%s not found", resourceType)
+		metaMap, ok := typeMap["_dd_tfplan_meta"].(map[string]interface{})
+		require.True(t, ok, "resource.%s._dd_tfplan_meta not found", resourceType)
+		entry, ok := metaMap["_dd_"+key].(map[string]interface{})
+		require.True(t, ok, "resource.%s._dd_tfplan_meta._dd_%s not found", resourceType, key)
+		return entry
+	}
+
+	// Root resource.
+	require.Equal(t, map[string]interface{}{
+		"address":                   "aws_vpc.main",
+		"after_unknown":             map[string]interface{}{"id": true},
+		"configuration_expressions": map[string]interface{}{"cidr_block": map[string]interface{}{"constant_value": "10.0.0.0/16"}},
+	}, meta("aws_vpc", "main"))
+
+	// Count instance: correlates by exact address (change) and index-stripped
+	// address (configuration, shared across all instances).
+	require.Equal(t, map[string]interface{}{
+		"address":                   "aws_instance.web[0]",
+		"after_unknown":             map[string]interface{}{"arn": true},
+		"configuration_expressions": map[string]interface{}{"instance_type": map[string]interface{}{"references": []interface{}{"var.instance_type"}}},
+	}, meta("aws_instance", "web[0]"))
+
+	// for_each instance.
+	require.Equal(t, map[string]interface{}{
+		"address":                   "aws_s3_bucket.data[\"prod\"]",
+		"after_unknown":             map[string]interface{}{"id": true},
+		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
+	}, meta("aws_s3_bucket", "data[\"prod\"]"))
+
+	// for_each instance whose key contains a literal dot: the dot must not be
+	// mistaken for an address separator when stripping the index to correlate
+	// against configuration.
+	require.Equal(t, map[string]interface{}{
+		"address":                   "aws_s3_bucket.data[\"a.b\"]",
+		"after_unknown":             map[string]interface{}{"id": true},
+		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
+	}, meta("aws_s3_bucket", "data[\"a.b\"]"))
+
+	// Resource in a nested module: configuration is correlated via
+	// module_calls, keyed by module call name, not module instance address.
+	require.Equal(t, map[string]interface{}{
+		"address":                   "module.networking.aws_subnet.public",
+		"after_unknown":             map[string]interface{}{"id": true},
+		"configuration_expressions": map[string]interface{}{"cidr_block": map[string]interface{}{"references": []interface{}{"var.subnet_cidr"}}},
+	}, meta("aws_subnet", "module.networking.public"))
 }

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -56,14 +56,16 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"fakewebservices_database": map[string]interface{}{
-						"_dd_tfplan_meta": map[string]interface{}{
-							"_dd_prod_db": map[string]interface{}{
-								"address": "fakewebservices_database.prod_db",
-							},
-						},
 						"prod_db": map[string]interface{}{
 							"name": "Production DB",
 							"size": (float64)(256),
+						},
+					},
+				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"fakewebservices_database": map[string]interface{}{
+						"prod_db": map[string]interface{}{
+							"address": "fakewebservices_database.prod_db",
 						},
 					},
 				},
@@ -135,22 +137,24 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
-						"_dd_tfplan_meta": map[string]interface{}{
-							"_dd_main": map[string]interface{}{
-								"address": "aws_s3_bucket.main",
-								"after_unknown": map[string]interface{}{
-									"bucket": true,
-									"id":     true,
-								},
-								"configuration_expressions": map[string]interface{}{
-									"bucket": map[string]interface{}{
-										"references": []interface{}{"random_id.suffix"},
-									},
-								},
-							},
-						},
 						"main": map[string]interface{}{
 							"bucket": "main-bucket",
+						},
+					},
+				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_s3_bucket": map[string]interface{}{
+						"main": map[string]interface{}{
+							"address": "aws_s3_bucket.main",
+							"after_unknown": map[string]interface{}{
+								"bucket": true,
+								"id":     true,
+							},
+							"configuration_expressions": map[string]interface{}{
+								"bucket": map[string]interface{}{
+									"references": []interface{}{"random_id.suffix"},
+								},
+							},
 						},
 					},
 				},
@@ -258,14 +262,6 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
-						"_dd_tfplan_meta": map[string]interface{}{
-							"_dd_main": map[string]interface{}{
-								"address": "aws_s3_bucket.main",
-							},
-							"_dd_module.storage.backup": map[string]interface{}{
-								"address": "module.storage.aws_s3_bucket.backup",
-							},
-						},
 						"main": map[string]interface{}{
 							"bucket": "main-bucket",
 							"acl":    "private",
@@ -276,13 +272,23 @@ func TestJson_parseTFPlan(t *testing.T) {
 						},
 					},
 					"aws_instance": map[string]interface{}{
-						"_dd_tfplan_meta": map[string]interface{}{
-							"_dd_web": map[string]interface{}{
-								"address": "aws_instance.web",
-							},
-						},
 						"web": map[string]interface{}{
 							"instance_type": "t2.micro",
+						},
+					},
+				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_s3_bucket": map[string]interface{}{
+						"main": map[string]interface{}{
+							"address": "aws_s3_bucket.main",
+						},
+						"module.storage.backup": map[string]interface{}{
+							"address": "module.storage.aws_s3_bucket.backup",
+						},
+					},
+					"aws_instance": map[string]interface{}{
+						"web": map[string]interface{}{
+							"address": "aws_instance.web",
 						},
 					},
 				},
@@ -339,14 +345,6 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_instance": map[string]interface{}{
-						"_dd_tfplan_meta": map[string]interface{}{
-							"_dd_web": map[string]interface{}{
-								"address": "aws_instance.web",
-							},
-							"_dd_module.staging.web": map[string]interface{}{
-								"address": "module.staging.aws_instance.web",
-							},
-						},
 						"web": map[string]interface{}{
 							"instance_type": "t2.large",
 							"tags": map[string]interface{}{
@@ -358,6 +356,16 @@ func TestJson_parseTFPlan(t *testing.T) {
 							"tags": map[string]interface{}{
 								"Environment": "staging",
 							},
+						},
+					},
+				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_instance": map[string]interface{}{
+						"web": map[string]interface{}{
+							"address": "aws_instance.web",
+						},
+						"module.staging.web": map[string]interface{}{
+							"address": "module.staging.aws_instance.web",
 						},
 					},
 				},
@@ -422,33 +430,35 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_vpc": map[string]interface{}{
-						"_dd_tfplan_meta": map[string]interface{}{
-							"_dd_main": map[string]interface{}{
-								"address": "aws_vpc.main",
-							},
-						},
 						"main": map[string]interface{}{
 							"cidr_block": "10.0.0.0/16",
 						},
 					},
 					"aws_subnet": map[string]interface{}{
-						"_dd_tfplan_meta": map[string]interface{}{
-							"_dd_module.networking.public": map[string]interface{}{
-								"address": "module.networking.aws_subnet.public",
-							},
-						},
 						"module.networking.public": map[string]interface{}{
 							"cidr_block": "10.0.1.0/24",
 						},
 					},
 					"aws_security_group": map[string]interface{}{
-						"_dd_tfplan_meta": map[string]interface{}{
-							"_dd_module.networking.module.security.web": map[string]interface{}{
-								"address": "module.networking.module.security.aws_security_group.web",
-							},
-						},
 						"module.networking.module.security.web": map[string]interface{}{
 							"description": "Web traffic",
+						},
+					},
+				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_vpc": map[string]interface{}{
+						"main": map[string]interface{}{
+							"address": "aws_vpc.main",
+						},
+					},
+					"aws_subnet": map[string]interface{}{
+						"module.networking.public": map[string]interface{}{
+							"address": "module.networking.aws_subnet.public",
+						},
+					},
+					"aws_security_group": map[string]interface{}{
+						"module.networking.module.security.web": map[string]interface{}{
+							"address": "module.networking.module.security.aws_security_group.web",
 						},
 					},
 				},
@@ -502,19 +512,21 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
-						"_dd_tfplan_meta": map[string]interface{}{
-							"_dd_module.app1.data": map[string]interface{}{
-								"address": "module.app1.aws_s3_bucket.data",
-							},
-							"_dd_module.app2.data": map[string]interface{}{
-								"address": "module.app2.aws_s3_bucket.data",
-							},
-						},
 						"module.app1.data": map[string]interface{}{
 							"bucket": "app1-data",
 						},
 						"module.app2.data": map[string]interface{}{
 							"bucket": "app2-data",
+						},
+					},
+				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_s3_bucket": map[string]interface{}{
+						"module.app1.data": map[string]interface{}{
+							"address": "module.app1.aws_s3_bucket.data",
+						},
+						"module.app2.data": map[string]interface{}{
+							"address": "module.app2.aws_s3_bucket.data",
 						},
 					},
 				},
@@ -580,17 +592,6 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_instance": map[string]interface{}{
-						"_dd_tfplan_meta": map[string]interface{}{
-							"_dd_web[0]": map[string]interface{}{
-								"address": "aws_instance.web[0]",
-							},
-							"_dd_web[1]": map[string]interface{}{
-								"address": "aws_instance.web[1]",
-							},
-							"_dd_web[2]": map[string]interface{}{
-								"address": "aws_instance.web[2]",
-							},
-						},
 						"web[0]": map[string]interface{}{
 							"instance_type": "t2.micro",
 							"tags": map[string]interface{}{
@@ -611,6 +612,19 @@ func TestJson_parseTFPlan(t *testing.T) {
 								"Name":  "web-2",
 								"Index": float64(2),
 							},
+						},
+					},
+				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_instance": map[string]interface{}{
+						"web[0]": map[string]interface{}{
+							"address": "aws_instance.web[0]",
+						},
+						"web[1]": map[string]interface{}{
+							"address": "aws_instance.web[1]",
+						},
+						"web[2]": map[string]interface{}{
+							"address": "aws_instance.web[2]",
 						},
 					},
 				},
@@ -667,17 +681,6 @@ func TestJson_parseTFPlan(t *testing.T) {
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
-						"_dd_tfplan_meta": map[string]interface{}{
-							"_dd_data[\"prod\"]": map[string]interface{}{
-								"address": "aws_s3_bucket.data[\"prod\"]",
-							},
-							"_dd_data[\"staging\"]": map[string]interface{}{
-								"address": "aws_s3_bucket.data[\"staging\"]",
-							},
-							"_dd_data[\"dev\"]": map[string]interface{}{
-								"address": "aws_s3_bucket.data[\"dev\"]",
-							},
-						},
 						"data[\"prod\"]": map[string]interface{}{
 							"bucket": "prod-data-bucket",
 							"acl":    "private",
@@ -689,6 +692,19 @@ func TestJson_parseTFPlan(t *testing.T) {
 						"data[\"dev\"]": map[string]interface{}{
 							"bucket": "dev-data-bucket",
 							"acl":    "private",
+						},
+					},
+				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_s3_bucket": map[string]interface{}{
+						"data[\"prod\"]": map[string]interface{}{
+							"address": "aws_s3_bucket.data[\"prod\"]",
+						},
+						"data[\"staging\"]": map[string]interface{}{
+							"address": "aws_s3_bucket.data[\"staging\"]",
+						},
+						"data[\"dev\"]": map[string]interface{}{
+							"address": "aws_s3_bucket.data[\"dev\"]",
 						},
 					},
 				},
@@ -741,14 +757,16 @@ func TestJson_parseTFPlan(t *testing.T) {
 						"_dd_lines": map[string]any{
 							"_dd_prod_db": map[string]any{"_dd_line": (float64)(7)},
 						},
-						"_dd_tfplan_meta": map[string]any{
-							"_dd_prod_db": map[string]any{
-								"address": "fakewebservices_database.prod_db",
-							},
-						},
 						"prod_db": map[string]any{
 							"name": "Production DB",
 							"size": (float64)(256),
+						},
+					},
+				},
+				"_dd_tfplan_meta": map[string]any{
+					"fakewebservices_database": map[string]any{
+						"prod_db": map[string]any{
+							"address": "fakewebservices_database.prod_db",
 						},
 					},
 				},
@@ -774,12 +792,13 @@ func TestJson_parseTFPlan(t *testing.T) {
 
 // TestJson_parseTFPlan_dd_tfplan_meta_correlation exercises _dd_tfplan_meta's
 // direct-lookup contract end to end: a Rego rule should be able to read
-// resource.<type>._dd_tfplan_meta._dd_<key>.after_unknown/configuration_expressions
-// without reconstructing the resource's Terraform address or walking
+// _dd_tfplan_meta.<type>.<key>.after_unknown/configuration_expressions without
+// reconstructing the resource's Terraform address or walking
 // resource_changes/configuration itself. Covers a root resource, a resource in
-// a nested module, a count instance, a for_each instance, and a for_each
-// instance whose key contains a literal dot (which must not be mistaken for a
-// module/resource path separator when correlating).
+// a nested module, a count instance, a for_each instance, and for_each
+// instances whose quoted key contains characters that must not be mistaken
+// for address separators/terminators when stripping the index to correlate
+// against configuration: a literal dot, a literal "]", and an escaped quote.
 func TestJson_parseTFPlan_dd_tfplan_meta_correlation(t *testing.T) {
 	doc := model.Document{
 		"format_version":    "1.2",
@@ -826,6 +845,26 @@ func TestJson_parseTFPlan_dd_tfplan_meta_correlation(t *testing.T) {
 							"bucket": "dotted-key-bucket",
 						},
 					},
+					{
+						"address": "aws_s3_bucket.data[\"a]b\"]",
+						"mode":    "managed",
+						"type":    "aws_s3_bucket",
+						"name":    "data",
+						"index":   "a]b",
+						"values": map[string]interface{}{
+							"bucket": "bracket-key-bucket",
+						},
+					},
+					{
+						"address": "aws_s3_bucket.data[\"a\\\"b\"]",
+						"mode":    "managed",
+						"type":    "aws_s3_bucket",
+						"name":    "data",
+						"index":   "a\"b",
+						"values": map[string]interface{}{
+							"bucket": "quote-key-bucket",
+						},
+					},
 				},
 				"child_modules": []map[string]interface{}{
 					{
@@ -866,6 +905,18 @@ func TestJson_parseTFPlan_dd_tfplan_meta_correlation(t *testing.T) {
 			},
 			{
 				"address": "aws_s3_bucket.data[\"a.b\"]",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"id": true},
+				},
+			},
+			{
+				"address": "aws_s3_bucket.data[\"a]b\"]",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"id": true},
+				},
+			},
+			{
+				"address": "aws_s3_bucket.data[\"a\\\"b\"]",
 				"change": map[string]interface{}{
 					"after_unknown": map[string]interface{}{"id": true},
 				},
@@ -921,13 +972,24 @@ func TestJson_parseTFPlan_dd_tfplan_meta_correlation(t *testing.T) {
 	require.NoError(t, err)
 
 	meta := func(resourceType, key string) map[string]interface{} {
-		typeMap, ok := got["resource"].(map[string]interface{})[resourceType].(map[string]interface{})
-		require.True(t, ok, "resource.%s not found", resourceType)
-		metaMap, ok := typeMap["_dd_tfplan_meta"].(map[string]interface{})
-		require.True(t, ok, "resource.%s._dd_tfplan_meta not found", resourceType)
-		entry, ok := metaMap["_dd_"+key].(map[string]interface{})
-		require.True(t, ok, "resource.%s._dd_tfplan_meta._dd_%s not found", resourceType, key)
+		ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+		require.True(t, ok, "_dd_tfplan_meta not found")
+		typeMap, ok := ddMeta[resourceType].(map[string]interface{})
+		require.True(t, ok, "_dd_tfplan_meta.%s not found", resourceType)
+		entry, ok := typeMap[key].(map[string]interface{})
+		require.True(t, ok, "_dd_tfplan_meta.%s.%s not found", resourceType, key)
 		return entry
+	}
+
+	// _dd_tfplan_meta must never be nested inside resource.<type> - Rego rules
+	// commonly do `some name, resource in doc.resource.<type>`, and any
+	// non-resource key there would be iterated as a fake resource instance.
+	resourceTypes, ok := got["resource"].(map[string]interface{})
+	require.True(t, ok)
+	for resourceType, typeMap := range resourceTypes {
+		asMap, ok := typeMap.(map[string]interface{})
+		require.True(t, ok)
+		require.NotContains(t, asMap, "_dd_tfplan_meta", "resource.%s must not contain _dd_tfplan_meta", resourceType)
 	}
 
 	// Root resource.
@@ -960,6 +1022,22 @@ func TestJson_parseTFPlan_dd_tfplan_meta_correlation(t *testing.T) {
 		"after_unknown":             map[string]interface{}{"id": true},
 		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
 	}, meta("aws_s3_bucket", "data[\"a.b\"]"))
+
+	// for_each instance whose key contains a literal "]": a naive
+	// bracket-matching regex would stop at this inner "]" and strip the
+	// address short, breaking configuration correlation.
+	require.Equal(t, map[string]interface{}{
+		"address":                   "aws_s3_bucket.data[\"a]b\"]",
+		"after_unknown":             map[string]interface{}{"id": true},
+		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
+	}, meta("aws_s3_bucket", "data[\"a]b\"]"))
+
+	// for_each instance whose key contains an escaped quote.
+	require.Equal(t, map[string]interface{}{
+		"address":                   "aws_s3_bucket.data[\"a\\\"b\"]",
+		"after_unknown":             map[string]interface{}{"id": true},
+		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
+	}, meta("aws_s3_bucket", "data[\"a\\\"b\"]"))
 
 	// Resource in a nested module: configuration is correlated via
 	// module_calls, keyed by module call name, not module instance address.

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -1019,3 +1019,118 @@ func TestJson_parseTFPlan_dd_tfplan_meta_correlation(t *testing.T) {
 		"configuration_expressions": map[string]interface{}{"cidr_block": map[string]interface{}{"references": []interface{}{"var.subnet_cidr"}}},
 	}, meta("aws_subnet", "module.networking.public"))
 }
+
+func TestJson_parseTFPlan_dd_tfplan_meta_provisioners(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"resources": []map[string]interface{}{
+					{
+						"address": "aws_instance.web",
+						"mode":    "managed",
+						"type":    "aws_instance",
+						"name":    "web",
+						"values":  map[string]interface{}{"instance_type": "t2.micro"},
+					},
+				},
+			},
+		},
+		"resource_changes": []map[string]interface{}{},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"resources": []map[string]interface{}{
+					{
+						"address": "aws_instance.web",
+						"expressions": map[string]interface{}{
+							"instance_type": map[string]interface{}{"constant_value": "t2.micro"},
+						},
+						"provisioners": []map[string]interface{}{
+							{
+								"type": "local-exec",
+								"expressions": map[string]interface{}{
+									"command": map[string]interface{}{"constant_value": "curl http://169.254.169.254/latest/meta-data/iam/security-credentials/"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+	require.True(t, ok)
+	entry := ddMeta["aws_instance"].(map[string]interface{})["web"].(map[string]interface{})
+
+	require.Equal(t, []interface{}{
+		map[string]interface{}{
+			"type": "local-exec",
+			"expressions": map[string]interface{}{
+				"command": map[string]interface{}{"constant_value": "curl http://169.254.169.254/latest/meta-data/iam/security-credentials/"},
+			},
+		},
+	}, entry["provisioners"])
+}
+
+func TestJson_parseTFPlan_dd_tfplan_meta_module_call_var_resolution(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"child_modules": []map[string]interface{}{
+					{
+						"address": "module.instance",
+						"resources": []map[string]interface{}{
+							{
+								"address": "module.instance.aws_instance.web",
+								"mode":    "managed",
+								"type":    "aws_instance",
+								"name":    "web",
+								"values":  map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource_changes": []map[string]interface{}{},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"module_calls": map[string]interface{}{
+					"instance": map[string]interface{}{
+						"expressions": map[string]interface{}{
+							"user_data": map[string]interface{}{"constant_value": "IyEvYmluL2Jhc2gKZWNobyBoaQ=="},
+						},
+						"module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_instance.web",
+									"expressions": map[string]interface{}{
+										"user_data": map[string]interface{}{"references": []string{"var.user_data"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+	require.True(t, ok)
+	entry := ddMeta["aws_instance"].(map[string]interface{})["module.instance.web"].(map[string]interface{})
+
+	require.Equal(t, map[string]interface{}{
+		"user_data": map[string]interface{}{"constant_value": "IyEvYmluL2Jhc2gKZWNobyBoaQ=="},
+	}, entry["configuration_expressions"])
+}

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -791,14 +791,8 @@ func TestJson_parseTFPlan(t *testing.T) {
 }
 
 // TestJson_parseTFPlan_dd_tfplan_meta_correlation exercises _dd_tfplan_meta's
-// direct-lookup contract end to end: a Rego rule should be able to read
-// _dd_tfplan_meta.<type>.<key>.after_unknown/configuration_expressions without
-// reconstructing the resource's Terraform address or walking
-// resource_changes/configuration itself. Covers a root resource, a resource in
-// a nested module, a count instance, a for_each instance, and for_each
-// instances whose quoted key contains characters that must not be mistaken
-// for address separators/terminators when stripping the index to correlate
-// against configuration: a literal dot, a literal "]", and an escaped quote.
+// direct-lookup contract for root/nested/count/for_each resources, including
+// for_each keys with a dot, a "]", and an escaped quote.
 func TestJson_parseTFPlan_dd_tfplan_meta_correlation(t *testing.T) {
 	doc := model.Document{
 		"format_version":    "1.2",
@@ -981,9 +975,7 @@ func TestJson_parseTFPlan_dd_tfplan_meta_correlation(t *testing.T) {
 		return entry
 	}
 
-	// _dd_tfplan_meta must never be nested inside resource.<type> - Rego rules
-	// commonly do `some name, resource in doc.resource.<type>`, and any
-	// non-resource key there would be iterated as a fake resource instance.
+	// _dd_tfplan_meta must never be nested inside resource.<type>.
 	resourceTypes, ok := got["resource"].(map[string]interface{})
 	require.True(t, ok)
 	for resourceType, typeMap := range resourceTypes {
@@ -1014,18 +1006,14 @@ func TestJson_parseTFPlan_dd_tfplan_meta_correlation(t *testing.T) {
 		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
 	}, meta("aws_s3_bucket", "data[\"prod\"]"))
 
-	// for_each instance whose key contains a literal dot: the dot must not be
-	// mistaken for an address separator when stripping the index to correlate
-	// against configuration.
+	// for_each instance whose key contains a literal dot.
 	require.Equal(t, map[string]interface{}{
 		"address":                   "aws_s3_bucket.data[\"a.b\"]",
 		"after_unknown":             map[string]interface{}{"id": true},
 		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
 	}, meta("aws_s3_bucket", "data[\"a.b\"]"))
 
-	// for_each instance whose key contains a literal "]": a naive
-	// bracket-matching regex would stop at this inner "]" and strip the
-	// address short, breaking configuration correlation.
+	// for_each instance whose key contains a literal "]".
 	require.Equal(t, map[string]interface{}{
 		"address":                   "aws_s3_bucket.data[\"a]b\"]",
 		"after_unknown":             map[string]interface{}{"id": true},
@@ -1039,8 +1027,7 @@ func TestJson_parseTFPlan_dd_tfplan_meta_correlation(t *testing.T) {
 		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
 	}, meta("aws_s3_bucket", "data[\"a\\\"b\"]"))
 
-	// Resource in a nested module: configuration is correlated via
-	// module_calls, keyed by module call name, not module instance address.
+	// Resource in a nested module.
 	require.Equal(t, map[string]interface{}{
 		"address":                   "module.networking.aws_subnet.public",
 		"after_unknown":             map[string]interface{}{"id": true},

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -69,7 +69,6 @@ func TestJson_parseTFPlan(t *testing.T) {
 						},
 					},
 				},
-				// Raw pass-through: empty array/object round-trips as-is.
 				"resource_changes": []interface{}{},
 				"configuration":    map[string]interface{}{},
 			},
@@ -340,8 +339,6 @@ func TestJson_parseTFPlan(t *testing.T) {
 					},
 				},
 			},
-			// Child-module resources are module-prefixed, so they no longer
-			// collide with the root-module resource of the same type+name.
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_instance": map[string]interface{}{
@@ -508,8 +505,7 @@ func TestJson_parseTFPlan(t *testing.T) {
 					},
 				},
 			},
-			// Distinct module-prefixed keys, so both remain visible.
-			want: model.Document{
+					want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
 						"module.app1.data": map[string]interface{}{
@@ -712,9 +708,6 @@ func TestJson_parseTFPlan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			// Mirrors what initializeJSONLine/setLineInfo injects: the resources
-			// array element's own line lives in the parent's
-			// "_dd_lines._dd_resources._dd_arr", not on the element itself.
 			name: "test - injects resource values line from _dd_lines",
 			args: args{
 				doc: model.Document{
@@ -984,50 +977,42 @@ func TestJson_parseTFPlan_dd_tfplan_meta_correlation(t *testing.T) {
 		require.NotContains(t, asMap, "_dd_tfplan_meta", "resource.%s must not contain _dd_tfplan_meta", resourceType)
 	}
 
-	// Root resource.
 	require.Equal(t, map[string]interface{}{
 		"address":                   "aws_vpc.main",
 		"after_unknown":             map[string]interface{}{"id": true},
 		"configuration_expressions": map[string]interface{}{"cidr_block": map[string]interface{}{"constant_value": "10.0.0.0/16"}},
 	}, meta("aws_vpc", "main"))
 
-	// Count instance: correlates by exact address (change) and index-stripped
-	// address (configuration, shared across all instances).
 	require.Equal(t, map[string]interface{}{
 		"address":                   "aws_instance.web[0]",
 		"after_unknown":             map[string]interface{}{"arn": true},
 		"configuration_expressions": map[string]interface{}{"instance_type": map[string]interface{}{"references": []interface{}{"var.instance_type"}}},
 	}, meta("aws_instance", "web[0]"))
 
-	// for_each instance.
 	require.Equal(t, map[string]interface{}{
 		"address":                   "aws_s3_bucket.data[\"prod\"]",
 		"after_unknown":             map[string]interface{}{"id": true},
 		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
 	}, meta("aws_s3_bucket", "data[\"prod\"]"))
 
-	// for_each instance whose key contains a literal dot.
 	require.Equal(t, map[string]interface{}{
 		"address":                   "aws_s3_bucket.data[\"a.b\"]",
 		"after_unknown":             map[string]interface{}{"id": true},
 		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
 	}, meta("aws_s3_bucket", "data[\"a.b\"]"))
 
-	// for_each instance whose key contains a literal "]".
 	require.Equal(t, map[string]interface{}{
 		"address":                   "aws_s3_bucket.data[\"a]b\"]",
 		"after_unknown":             map[string]interface{}{"id": true},
 		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
 	}, meta("aws_s3_bucket", "data[\"a]b\"]"))
 
-	// for_each instance whose key contains an escaped quote.
 	require.Equal(t, map[string]interface{}{
 		"address":                   "aws_s3_bucket.data[\"a\\\"b\"]",
 		"after_unknown":             map[string]interface{}{"id": true},
 		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
 	}, meta("aws_s3_bucket", "data[\"a\\\"b\"]"))
 
-	// Resource in a nested module.
 	require.Equal(t, map[string]interface{}{
 		"address":                   "module.networking.aws_subnet.public",
 		"after_unknown":             map[string]interface{}{"id": true},

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -62,6 +62,115 @@ func TestJson_parseTFPlan(t *testing.T) {
 						},
 					},
 				},
+				// Raw pass-through: empty array/object round-trips as-is.
+				"resource_changes": []interface{}{},
+				"configuration":    map[string]interface{}{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test - resource_changes and configuration pass through",
+			args: args{
+				doc: model.Document{
+					"format_version":    "1.2",
+					"terraform_version": "1.5.0",
+					"planned_values": map[string]interface{}{
+						"root_module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_s3_bucket.main",
+									"mode":    "managed",
+									"type":    "aws_s3_bucket",
+									"name":    "main",
+									"values": map[string]interface{}{
+										"bucket": "main-bucket",
+									},
+								},
+							},
+						},
+					},
+					"resource_changes": []map[string]interface{}{
+						{
+							"address": "aws_s3_bucket.main",
+							"mode":    "managed",
+							"type":    "aws_s3_bucket",
+							"name":    "main",
+							"change": map[string]interface{}{
+								"actions": []string{"create"},
+								"before":  nil,
+								"after": map[string]interface{}{
+									"acl": "private",
+								},
+								"after_unknown": map[string]interface{}{
+									"bucket": true,
+									"id":     true,
+								},
+							},
+						},
+					},
+					"configuration": map[string]interface{}{
+						"root_module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_s3_bucket.main",
+									"mode":    "managed",
+									"type":    "aws_s3_bucket",
+									"name":    "main",
+									"expressions": map[string]interface{}{
+										"bucket": map[string]interface{}{
+											"references": []string{"random_id.suffix"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: model.Document{
+				"resource": map[string]interface{}{
+					"aws_s3_bucket": map[string]interface{}{
+						"main": map[string]interface{}{
+							"bucket": "main-bucket",
+						},
+					},
+				},
+				"resource_changes": []interface{}{
+					map[string]interface{}{
+						"address": "aws_s3_bucket.main",
+						"mode":    "managed",
+						"type":    "aws_s3_bucket",
+						"name":    "main",
+						"change": map[string]interface{}{
+							"actions": []interface{}{"create"},
+							"before":  nil,
+							"after": map[string]interface{}{
+								"acl": "private",
+							},
+							"after_unknown": map[string]interface{}{
+								"bucket": true,
+								"id":     true,
+							},
+						},
+					},
+				},
+				"configuration": map[string]interface{}{
+					"root_module": map[string]interface{}{
+						"resources": []interface{}{
+							map[string]interface{}{
+								"address": "aws_s3_bucket.main",
+								"mode":    "managed",
+								"type":    "aws_s3_bucket",
+								"name":    "main",
+								"expressions": map[string]interface{}{
+									"bucket": map[string]interface{}{
+										"references": []interface{}{"random_id.suffix"},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			wantErr: false,
 		},
@@ -553,6 +662,8 @@ func TestJson_parseTFPlan(t *testing.T) {
 						},
 					},
 				},
+				"resource_changes": []any{},
+				"configuration":    map[string]any{},
 			},
 			wantErr: false,
 		},

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -351,29 +351,41 @@ func prepareScanDocument(body map[string]interface{}, kind model.FileKind) (map[
 }
 
 func prepareScanDocumentRoot(body interface{}, kind model.FileKind) {
+	prepareScanDocumentNode(body, kind, true, true)
+}
+
+// For Terraform-plan documents, pattern rewriting is scoped to the top-level
+// "resource" subtree, so resource_changes/configuration stay byte-identical to the raw plan.
+func prepareScanDocumentNode(body interface{}, kind model.FileKind, resolveFilters, atDocumentRoot bool) {
 	switch bodyType := body.(type) {
 	case map[string]interface{}:
-		prepareScanDocumentValue(bodyType, kind)
+		prepareScanDocumentValue(bodyType, kind, resolveFilters, atDocumentRoot)
 	case []interface{}:
 		for _, indx := range bodyType {
-			prepareScanDocumentRoot(indx, kind)
+			prepareScanDocumentNode(indx, kind, resolveFilters, false)
 		}
 	}
 }
 
-func prepareScanDocumentValue(bodyType map[string]interface{}, kind model.FileKind) {
+func prepareScanDocumentValue(bodyType map[string]interface{}, kind model.FileKind, resolveFilters, atDocumentRoot bool) {
 	delete(bodyType, "_dd_lines")
 	for key, v := range bodyType {
+		childResolveFilters := resolveFilters
+		if kind == model.KindTerraformPlan && atDocumentRoot {
+			childResolveFilters = key == "resource"
+		}
 		switch value := v.(type) {
 		case map[string]interface{}:
-			prepareScanDocumentRoot(value, kind)
+			prepareScanDocumentNode(value, kind, childResolveFilters, false)
 		case []interface{}:
 			for _, indx := range value {
-				prepareScanDocumentRoot(indx, kind)
+				prepareScanDocumentNode(indx, kind, childResolveFilters, false)
 			}
 		case string:
-			if field, ok := lines[kind]; ok && utils.Contains(key, field) {
-				bodyType[key] = resolveJSONFilter(value)
+			if resolveFilters {
+				if field, ok := lines[kind]; ok && utils.Contains(key, field) {
+					bodyType[key] = resolveJSONFilter(value)
+				}
 			}
 		}
 	}

--- a/pkg/runner/sink.go
+++ b/pkg/runner/sink.go
@@ -25,9 +25,10 @@ import (
 
 var (
 	lines = map[model.FileKind][]string{
-		"TF":   {"pattern"},
-		"JSON": {"FilterPattern"},
-		"YAML": {"filter_pattern", "FilterPattern"},
+		"TF":     {"pattern"},
+		"TFPLAN": {"pattern"},
+		"JSON":   {"FilterPattern"},
+		"YAML":   {"filter_pattern", "FilterPattern"},
 	}
 )
 

--- a/pkg/runner/sink_test.go
+++ b/pkg/runner/sink_test.go
@@ -279,22 +279,24 @@ func TestSink_TFPlanExposesAfterUnknownAndConfiguration(t *testing.T) {
 	require.JSONEq(t, `{
 		"resource": {
 			"aws_s3_bucket": {
-				"_dd_tfplan_meta": {
-					"_dd_main": {
-						"address": "aws_s3_bucket.main",
-						"after_unknown": {
-							"bucket": true,
-							"id": true
-						},
-						"configuration_expressions": {
-							"bucket": {
-								"references": ["random_id.suffix"]
-							}
-						}
-					}
-				},
 				"main": {
 					"acl": "private"
+				}
+			}
+		},
+		"_dd_tfplan_meta": {
+			"aws_s3_bucket": {
+				"main": {
+					"address": "aws_s3_bucket.main",
+					"after_unknown": {
+						"bucket": true,
+						"id": true
+					},
+					"configuration_expressions": {
+						"bucket": {
+							"references": ["random_id.suffix"]
+						}
+					}
 				}
 			}
 		},

--- a/pkg/runner/sink_test.go
+++ b/pkg/runner/sink_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser"
+	jsonParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/json"
 	yamlParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/default"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -118,6 +119,67 @@ func TestKics_prepareDocument(t *testing.T) {
 
 			`,
 		},
+		{
+			// Flat (not wrapped in "document":[...]) to match sink.go's real per-document input.
+			name: "prepare document resolves pattern for terraform plan documents",
+			args: args{
+				bodyType: `
+				{
+					"resource": {
+					  "aws_cloudwatch_log_metric_filter": {
+						"cis_changes_nacl": {
+						  "name": "CIS-4.11-Changes-NACL",
+						  "pattern": "{ ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) }",
+						  "log_group_name": "aws_cloudwatch_log_group.CIS_CloudWatch_LogsGroup"
+						}
+					  }
+					},
+					"configuration": {
+					  "root_module": {
+						"resources": [
+						  {
+							"address": "aws_cloudwatch_log_metric_filter.cis_changes_nacl",
+							"expressions": {
+							  "pattern": {
+								"constant_value": "{ ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) }"
+							  }
+							}
+						  }
+						]
+					  }
+					}
+				  }
+				`,
+				kind: model.KindTerraformPlan,
+			},
+			want: `
+			{
+				"resource": {
+				  "aws_cloudwatch_log_metric_filter": {
+					"cis_changes_nacl": {
+					  "log_group_name": "aws_cloudwatch_log_group.CIS_CloudWatch_LogsGroup",
+					  "name": "CIS-4.11-Changes-NACL",
+					  "pattern": "{\"_dd_filter_expr\":{\"_op\":\"||\",\"_left\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAcl\"},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAclEntry\"}},\"_kics_filter_expr\":{\"_op\":\"||\",\"_left\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAcl\"},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAclEntry\"}}}"
+					}
+				  }
+				},
+				"configuration": {
+				  "root_module": {
+					"resources": [
+					  {
+						"address": "aws_cloudwatch_log_metric_filter.cis_changes_nacl",
+						"expressions": {
+						  "pattern": {
+							"constant_value": "{ ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) }"
+						  }
+						}
+					  }
+					]
+				  }
+				}
+			  }
+			`,
+		},
 	}
 
 	ctx := context.Background()
@@ -131,6 +193,134 @@ func TestKics_prepareDocument(t *testing.T) {
 			compareJSONLine(t, got, tt.want)
 		})
 	}
+}
+
+// TestSink_TFPlanExposesAfterUnknownAndConfiguration drives a plan through the
+// real Parser.Parse -> PrepareScanDocument pipeline used in production.
+func TestSink_TFPlanExposesAfterUnknownAndConfiguration(t *testing.T) {
+	ctx := context.Background()
+
+	planJSON := []byte(`{
+		"format_version": "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": {
+			"root_module": {
+				"resources": [
+					{
+						"address": "aws_s3_bucket.main",
+						"mode": "managed",
+						"type": "aws_s3_bucket",
+						"name": "main",
+						"values": {
+							"acl": "private"
+						}
+					}
+				]
+			}
+		},
+		"resource_changes": [
+			{
+				"address": "aws_s3_bucket.main",
+				"mode": "managed",
+				"type": "aws_s3_bucket",
+				"name": "main",
+				"change": {
+					"actions": ["create"],
+					"before": null,
+					"after": {
+						"acl": "private"
+					},
+					"after_unknown": {
+						"bucket": true,
+						"id": true
+					}
+				}
+			}
+		],
+		"configuration": {
+			"root_module": {
+				"resources": [
+					{
+						"address": "aws_s3_bucket.main",
+						"mode": "managed",
+						"type": "aws_s3_bucket",
+						"name": "main",
+						"expressions": {
+							"bucket": {
+								"references": ["random_id.suffix"]
+							}
+						}
+					}
+				]
+			}
+		}
+	}`)
+
+	p := &jsonParser.Parser{}
+	_, docs, _, _, err := p.Parse(ctx, planJSON, "tfplan.json", false, 15)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	kind, ok := p.KindForContent(planJSON)
+	require.True(t, ok)
+	require.Equal(t, model.KindTerraformPlan, kind)
+
+	prepared := PrepareScanDocument(ctx, docs[0], kind)
+
+	require.Contains(t, prepared, "resource")
+	require.Contains(t, prepared, "resource_changes")
+	require.Contains(t, prepared, "configuration")
+
+	b, err := json.Marshal(prepared)
+	require.NoError(t, err)
+	require.NotContains(t, string(b), "_dd_lines",
+		"line-tracking metadata must not leak into resource_changes/configuration")
+
+	require.JSONEq(t, `{
+		"resource": {
+			"aws_s3_bucket": {
+				"main": {
+					"acl": "private"
+				}
+			}
+		},
+		"resource_changes": [
+			{
+				"address": "aws_s3_bucket.main",
+				"mode": "managed",
+				"type": "aws_s3_bucket",
+				"name": "main",
+				"change": {
+					"actions": ["create"],
+					"before": null,
+					"after": {
+						"acl": "private"
+					},
+					"after_unknown": {
+						"bucket": true,
+						"id": true
+					}
+				}
+			}
+		],
+		"configuration": {
+			"root_module": {
+				"resources": [
+					{
+						"address": "aws_s3_bucket.main",
+						"mode": "managed",
+						"type": "aws_s3_bucket",
+						"name": "main",
+						"expressions": {
+							"bucket": {
+								"references": ["random_id.suffix"]
+							}
+						}
+					}
+				]
+			}
+		}
+	}`, string(b))
 }
 
 func TestKics_resolveCRLFFile(t *testing.T) {

--- a/pkg/runner/sink_test.go
+++ b/pkg/runner/sink_test.go
@@ -279,6 +279,20 @@ func TestSink_TFPlanExposesAfterUnknownAndConfiguration(t *testing.T) {
 	require.JSONEq(t, `{
 		"resource": {
 			"aws_s3_bucket": {
+				"_dd_tfplan_meta": {
+					"_dd_main": {
+						"address": "aws_s3_bucket.main",
+						"after_unknown": {
+							"bucket": true,
+							"id": true
+						},
+						"configuration_expressions": {
+							"bucket": {
+								"references": ["random_id.suffix"]
+							}
+						}
+					}
+				},
 				"main": {
 					"acl": "private"
 				}

--- a/pkg/runner/tfplan_meta_isolation_test.go
+++ b/pkg/runner/tfplan_meta_isolation_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 // stubQueriesSource is a minimal in-memory source.QueriesSource for driving
-// engine.NewInspector with a single ad-hoc rule, without loading anything
-// from disk.
+// engine.NewInspector with a single ad-hoc rule.
 type stubQueriesSource struct {
 	queries []model.QueryMetadata
 }
@@ -39,10 +38,8 @@ func (s *stubQueriesSource) GetQueryLibrary(_ context.Context, platform string) 
 	}, nil
 }
 
-// cloudwatchLogMetricFilterRule mirrors the common Terraform rule-authoring
-// pattern flagged in review: iterating every instance of a resource type
-// directly off doc.resource.<type>. If a reserved key ever lived in that map
-// (e.g. _dd_tfplan_meta), it would be iterated here as a fake resource.
+// cloudwatchLogMetricFilterRule mirrors the common pattern of iterating
+// doc.resource.<type> directly, which would pick up a reserved key as a fake resource.
 const cloudwatchLogMetricFilterRule = `package datadog
 
 DatadogPolicy contains result if {
@@ -57,14 +54,8 @@ DatadogPolicy contains result if {
 }
 `
 
-// TestInspect_TFPlanMetaNotExposedAsFakeResource is a regression test for a
-// reserved-key leak: _dd_tfplan_meta must live in a top-level map parallel to
-// "resource", never nested inside resource.<type>, or any rule iterating
-// doc.resource.<type> (a common pattern - see cloudwatchLogMetricFilterRule)
-// would pick it up as a fake resource instance and report a spurious finding
-// under the resource name "_dd_tfplan_meta". This drives the real
-// Parser.Parse -> PrepareScanDocument -> engine.Inspect pipeline, not just a
-// document-shape assertion.
+// TestInspect_TFPlanMetaNotExposedAsFakeResource is a regression test:
+// _dd_tfplan_meta must never surface as a fake resource to Rego rules.
 func TestInspect_TFPlanMetaNotExposedAsFakeResource(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/runner/tfplan_meta_isolation_test.go
+++ b/pkg/runner/tfplan_meta_isolation_test.go
@@ -1,0 +1,177 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine"
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
+	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	jsonParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/json"
+	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// stubQueriesSource is a minimal in-memory source.QueriesSource for driving
+// engine.NewInspector with a single ad-hoc rule, without loading anything
+// from disk.
+type stubQueriesSource struct {
+	queries []model.QueryMetadata
+}
+
+func (s *stubQueriesSource) GetQueries(_ context.Context, _ *source.QueryInspectorParameters) ([]model.QueryMetadata, error) {
+	return s.queries, nil
+}
+
+func (s *stubQueriesSource) GetQueryLibrary(_ context.Context, platform string) (source.RegoLibraries, error) {
+	return source.RegoLibraries{
+		LibraryCode:      "package generic." + platform + "\n",
+		LibraryInputData: "{}",
+	}, nil
+}
+
+// cloudwatchLogMetricFilterRule mirrors the common Terraform rule-authoring
+// pattern flagged in review: iterating every instance of a resource type
+// directly off doc.resource.<type>. If a reserved key ever lived in that map
+// (e.g. _dd_tfplan_meta), it would be iterated here as a fake resource.
+const cloudwatchLogMetricFilterRule = `package datadog
+
+DatadogPolicy contains result if {
+	some resourceName, resource in input.document[0].resource.aws_cloudwatch_log_metric_filter
+
+	result := {
+		"documentId": input.document[0].id,
+		"resourceType": "aws_cloudwatch_log_metric_filter",
+		"resourceName": resourceName,
+		"searchKey": sprintf("aws_cloudwatch_log_metric_filter[%s]", [resourceName]),
+	}
+}
+`
+
+// TestInspect_TFPlanMetaNotExposedAsFakeResource is a regression test for a
+// reserved-key leak: _dd_tfplan_meta must live in a top-level map parallel to
+// "resource", never nested inside resource.<type>, or any rule iterating
+// doc.resource.<type> (a common pattern - see cloudwatchLogMetricFilterRule)
+// would pick it up as a fake resource instance and report a spurious finding
+// under the resource name "_dd_tfplan_meta". This drives the real
+// Parser.Parse -> PrepareScanDocument -> engine.Inspect pipeline, not just a
+// document-shape assertion.
+func TestInspect_TFPlanMetaNotExposedAsFakeResource(t *testing.T) {
+	ctx := context.Background()
+
+	planJSON := []byte(`{
+		"format_version": "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": {
+			"root_module": {
+				"resources": [
+					{
+						"address": "aws_cloudwatch_log_metric_filter.errors",
+						"mode": "managed",
+						"type": "aws_cloudwatch_log_metric_filter",
+						"name": "errors",
+						"values": {
+							"name": "errors",
+							"pattern": "ERROR"
+						}
+					}
+				]
+			}
+		},
+		"resource_changes": [
+			{
+				"address": "aws_cloudwatch_log_metric_filter.errors",
+				"change": {
+					"after_unknown": {"id": true}
+				}
+			}
+		],
+		"configuration": {
+			"root_module": {
+				"resources": [
+					{
+						"address": "aws_cloudwatch_log_metric_filter.errors",
+						"expressions": {
+							"pattern": {"constant_value": "ERROR"}
+						}
+					}
+				]
+			}
+		}
+	}`)
+
+	p := &jsonParser.Parser{}
+	_, docs, _, _, err := p.Parse(ctx, planJSON, "tfplan.json", false, 15)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	kind, ok := p.KindForContent(planJSON)
+	require.True(t, ok)
+	require.Equal(t, model.KindTerraformPlan, kind)
+
+	prepared := PrepareScanDocument(ctx, docs[0], kind)
+	require.Contains(t, prepared, "_dd_tfplan_meta",
+		"sanity check: the document must actually carry _dd_tfplan_meta for this test to be meaningful")
+
+	doc := model.FileMetadata{
+		ID:                uuid.NewString(),
+		ScanID:            "test",
+		Document:          prepared,
+		LineInfoDocument:  prepared,
+		Kind:              model.KindTerraformPlan,
+		FilePath:          "tfplan.json",
+		OriginalData:      string(planJSON),
+		LinesOriginalData: utils.SplitLines(string(planJSON)),
+	}
+
+	queries := []model.QueryMetadata{{
+		Query:       "cloudwatch_log_metric_filter_rule",
+		Content:     cloudwatchLogMetricFilterRule,
+		InputData:   "{}",
+		Platform:    "terraform",
+		Metadata:    map[string]any{"id": "cloudwatch-log-metric-filter-rule"},
+		Aggregation: 1,
+	}}
+
+	trk, err := tracker.NewTracker(3)
+	require.NoError(t, err)
+
+	ins, err := engine.NewInspector(
+		ctx,
+		&stubQueriesSource{queries: queries},
+		engine.DefaultVulnerabilityBuilder,
+		trk,
+		&source.QueryInspectorParameters{},
+		nil,
+		".",
+		false,
+		false,
+		1,
+		featureflags.NewLocalEvaluator(),
+		vfs.DiskFS{},
+		false,
+		false,
+	)
+	require.NoError(t, err)
+
+	vulns, err := ins.Inspect(ctx, "test", model.FileMetadatas{&doc}, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries(), "no query should fail")
+
+	require.Len(t, vulns, 1, "expected exactly one finding, for the real resource")
+	require.Equal(t, "errors", vulns[0].ResourceName)
+
+	for _, v := range vulns {
+		require.NotEqual(t, "_dd_tfplan_meta", v.ResourceName,
+			"_dd_tfplan_meta must never be reported as a resource")
+	}
+}


### PR DESCRIPTION
## Summary
- Terraform-plan JSON documents previously exposed only the flattened `planned_values.root_module` resources, dropping `resource_changes[].change.after_unknown` and `configuration` entirely. Rego rules had no way to distinguish a cross-resource reference from genuinely missing configuration — the dominant root cause of false positives/negatives audited in the default-rules repo. Both are now passed through verbatim from the raw parsed document (not the typed `terraform-json` structs, which drop empty slices and add spurious defaulted fields on round-trip).
- Wired `TFPLAN`'s `pattern` attribute through `resolveJSONFilter` (matching existing HCL/`.tf` behavior), so CloudWatch metric-filter patterns in plan JSON get parsed into the `_dd_filter_expr` tree that `common.rego`'s `filter_pattern_clause_is_mandatory` already knows how to consume. Scoped strictly to the top-level `resource` subtree so `resource_changes`/`configuration` remain byte-identical to the raw plan.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/parser/json/... ./pkg/runner/...` (99 passed)
- [x] `go test ./...` (1957 passed, 8 pre-existing/unrelated E2E failures, same baseline as `main`)
- [x] New unit tests: `resource_changes`/`configuration` pass-through (including empty-array edge case), end-to-end `Parser.Parse` → `PrepareScanDocument` pipeline test proving `_dd_lines` doesn't leak into the new fields, and a scoping test proving `pattern` under `resource` resolves to `_dd_filter_expr` while the same key under `configuration` stays raw text
- [x] Standalone `opa eval` checks confirming a real Rego rule can read `after_unknown`/`configuration.root_module.resources[].expressions` and that `common.rego`'s `filter_pattern_clause_is_mandatory` correctly evaluates the real `_dd_filter_expr` tree emitted by `resolveJSONFilter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)