### PR TITLE
Speed up file discovery by fixing gitignore matching and redundant line counting

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -703,7 +703,6 @@ core,github.com/rubenv/sql-migrate,MIT,Copyright (C) 2014-2021 by Ruben Vermeers
 core,github.com/rubenv/sql-migrate/sqlparse,MIT,Copyright (C) 2012-2014 by Liam Staskawicz | Copyright (C) 2014-2017 by Ruben Vermeersch <ruben@rocketeer.be> | Copyright (C) 2014-2021 by Ruben Vermeersch <ruben@rocketeer.be>
 core,github.com/russross/blackfriday/v2,BSD-2-Clause,Copyright © 2011 Russ Ross
 core,github.com/ruudk/golang-pdf417,MIT,Copyright (c) 2018 Ruud Kamphuis
-core,github.com/sabhiram/go-gitignore,MIT,Copyright (c) 2015 Shaba Abhiram
 core,github.com/sagikazarmark/locafero,MIT,Copyright (c) 2023 Márk Sági-Kazár <mark.sagikazar@gmail.com>
 core,github.com/sagikazarmark/locafero/internal/queue,MIT,Copyright (c) 2023 Márk Sági-Kazár <mark.sagikazar@gmail.com>
 core,github.com/samber/lo,MIT,Copyright (c) 2022-2025 Samuel Berthe | Copyright © 2022 [Samuel Berthe](https://github.com/samber)

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/relex/aini v1.6.0
 	github.com/rmuir/tree-sitter-ghactions v0.2.5
 	github.com/rs/zerolog v1.34.0
-	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/sosedoff/ansible-vault-go v0.2.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tdewolff/minify/v2 v2.24.9

--- a/go.sum
+++ b/go.sum
@@ -527,8 +527,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245 h1:K1Xf3bKttbF+koVGaX5xngRIZ5bVjbmPnaxE/dR08uY=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
-github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
-github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/sagikazarmark/locafero v0.12.0 h1:/NQhBAkUb4+fH1jivKHWusDYFjMOOKU88eegjfxfHb4=
 github.com/sagikazarmark/locafero v0.12.0/go.mod h1:sZh36u/YSZ918v0Io+U9ogLYQJ9tLLBmM4eneO6WwsI=
 github.com/samber/lo v1.52.0 h1:Rvi+3BFHES3A8meP33VPAxiBZX/Aws5RxrschYGjomw=

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -25,8 +25,6 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/pkg/errors"
-
-	yamlParser "gopkg.in/yaml.v3"
 )
 
 // move the openApi regex to public to be used on file.go
@@ -855,6 +853,9 @@ func checkYamlPlatform(ctx context.Context, content []byte, path string) string 
 	if isInsideAnsibleTemplatesDir(path) {
 		return ""
 	}
+	if checkForAnsibleByPaths(path) {
+		return ansible
+	}
 
 	contextLogger := logger.FromContext(ctx)
 
@@ -864,48 +865,23 @@ func checkYamlPlatform(ctx context.Context, content []byte, path string) string 
 		return ""
 	}
 
-	// Parse as Node to manually call Datadog's version of UnmarshalYAML with context
-	var node yamlParser.Node
-	if err := yamlParser.Unmarshal(content, &node); err != nil {
+	if !yamlRootHasAnyKey(content, yamlPlatformRootKeys...) {
+		return ""
+	}
+
+	root, err := yamlDocumentRoot(content)
+	if err != nil {
 		contextLogger.Warn().Msgf("failed to parse yaml file (%s): %s", path, err)
 		return ""
 	}
-
-	// Get the yaml content in node
-	contentNode := &node
-	if node.Kind == yamlParser.DocumentNode && len(node.Content) > 0 {
-		contentNode = node.Content[0]
-	}
-
-	// A scalar root means the document is empty/null (e.g. a comment-only vars file).
-	// No platform can be detected; skip silently.
-	if contentNode.Kind == yamlParser.ScalarNode {
+	if root == nil {
 		return ""
 	}
 
-	var yamlContent model.Document
-	if err := yamlContent.UnmarshalYAML(ctx, contentNode, nil); err != nil {
-		contextLogger.Warn().Msgf("failed to unmarshal yaml file (%s): %s", path, err)
-		return ""
+	if yamlMapKeyNode(root, listKeywordsGoogleDeployment[0]) != nil {
+		return gdm
 	}
-
-	// check if it is google deployment manager platform
-	for _, keyword := range listKeywordsGoogleDeployment {
-		if _, ok := yamlContent[keyword]; ok {
-			return gdm
-		}
-	}
-
-	// check if the file contains some keywords related with Ansible
-	if checkForAnsible(yamlContent) {
-		return ansible
-	}
-	// check if the file contains some keywords related with Ansible Host
-	if checkForAnsibleHost(yamlContent) {
-		return ansible
-	}
-	// add for yaml files contained at paths (group_vars, host_vars) related with ansible
-	if checkForAnsibleByPaths(path) {
+	if ansibleFromYAMLNode(root) {
 		return ansible
 	}
 	return ""
@@ -936,41 +912,6 @@ func isInsideAnsibleTemplatesDir(path string) bool {
 		}
 	}
 	return false
-}
-
-func checkForAnsible(yamlContent model.Document) bool {
-	isAnsible := false
-	if play := yamlContent[playBooks]; play != nil {
-		if listOfPlayBooks, ok := play.([]interface{}); ok {
-			for _, value := range listOfPlayBooks {
-				castingValue, ok := value.(map[string]interface{})
-				if ok {
-					for _, keyword := range listKeywordsAnsible {
-						if _, ok := castingValue[keyword]; ok {
-							isAnsible = true
-						}
-					}
-				}
-			}
-		}
-	}
-	return isAnsible
-}
-
-func checkForAnsibleHost(yamlContent model.Document) bool {
-	isAnsible := false
-	for _, ansibleDefault := range ansibleHost {
-		if hosts := yamlContent[ansibleDefault]; hosts != nil {
-			if listHosts, ok := hosts.(map[string]interface{}); ok {
-				for _, value := range listKeywordsAnsibleHots {
-					if host := listHosts[value]; host != nil {
-						isAnsible = true
-					}
-				}
-			}
-		}
-	}
-	return isAnsible
 }
 
 // computeValues computes expected Lines of Code to be scanned from locCount channel

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -883,9 +883,6 @@ func checkYamlPlatform(ctx context.Context, content []byte, path string) string 
 	if isInsideAnsibleTemplatesDir(path) {
 		return ""
 	}
-	if checkForAnsibleByPaths(path) {
-		return ansible
-	}
 
 	contextLogger := logger.FromContext(ctx)
 
@@ -893,6 +890,9 @@ func checkYamlPlatform(ctx context.Context, content []byte, path string) string 
 
 	if utils.IsAnsibleVaultEncrypted(content) {
 		return ""
+	}
+	if checkForAnsibleByPaths(path) {
+		return ansible
 	}
 
 	if !yamlRootHasAnyKey(content, yamlPlatformRootKeys...) {

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -539,7 +540,7 @@ func (a *analyzerInfo) worker(ctx context.Context, results, unwanted chan<- stri
 		return
 	}
 
-	if a.maxFileSize >= 0 {
+	if a.maxFileSize >= 0 && !isContentClassifiedExt(ext) {
 		if info, err := os.Stat(a.filePath); err == nil {
 			if float64(info.Size())/float64(sizeMb) > float64(a.maxFileSize) {
 				contextLogger := logger.FromContext(ctx)
@@ -551,7 +552,11 @@ func (a *analyzerInfo) worker(ctx context.Context, results, unwanted chan<- stri
 		}
 	}
 
-	content, ok := a.readClassifyContent(ctx, ext)
+	content, ok, tooLarge := a.readClassifyContent(ctx, ext)
+	if tooLarge {
+		unwanted <- a.filePath
+		return
+	}
 	if !ok {
 		return
 	}
@@ -590,17 +595,40 @@ func isContentClassifiedExt(ext string) bool {
 	return ext == yaml || ext == yml || ext == json || ext == sh
 }
 
-func (a *analyzerInfo) readClassifyContent(ctx context.Context, ext string) ([]byte, bool) {
+func (a *analyzerInfo) readClassifyContent(ctx context.Context, ext string) (content []byte, ok, tooLarge bool) {
 	if !isContentClassifiedExt(ext) {
-		return nil, true
+		return nil, true, false
 	}
-	content, err := os.ReadFile(a.filePath)
+	file, err := os.Open(filepath.Clean(a.filePath))
 	if err != nil {
 		contextLogger := logger.FromContext(ctx)
 		contextLogger.Error().Msgf("failed to analyze file: %s", err)
-		return nil, false
+		return nil, false, false
 	}
-	return content, true
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			contextLogger := logger.FromContext(ctx)
+			contextLogger.Err(closeErr).Msgf("failed to close '%s'", a.filePath)
+		}
+	}()
+
+	if a.maxFileSize >= 0 {
+		info, statErr := file.Stat()
+		if statErr == nil && float64(info.Size())/float64(sizeMb) > float64(a.maxFileSize) {
+			contextLogger := logger.FromContext(ctx)
+			contextLogger.Warn().Msgf(
+				"file %s exceeds maximum file size of %d Mb", a.filePath, a.maxFileSize)
+			return nil, false, true
+		}
+	}
+
+	readContent, err := io.ReadAll(file)
+	if err != nil {
+		contextLogger := logger.FromContext(ctx)
+		contextLogger.Error().Msgf("failed to analyze file: %s", err)
+		return nil, false, false
+	}
+	return readContent, true, false
 }
 
 func (a *analyzerInfo) persistWorkerState(content []byte, platform string) {

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -25,7 +25,6 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/pkg/errors"
-	ignore "github.com/sabhiram/go-gitignore"
 
 	yamlParser "gopkg.in/yaml.v3"
 )
@@ -1085,13 +1084,13 @@ func isConfigFile(path string, suffixes []string) bool {
 
 // shouldConsiderGitIgnoreFile verifies if the scan should exclude the files according to the .gitignore file
 func shouldConsiderGitIgnoreFile(ctx context.Context, path, gitIgnore string, excludeGitIgnoreFile bool) (hasGitIgnoreFileRes bool,
-	gitIgnoreRes *ignore.GitIgnore) {
+	gitIgnoreRes *gitIgnoreMatcher) {
 	contextLogger := logger.FromContext(ctx)
 	gitIgnorePath := filepath.ToSlash(filepath.Join(path, gitIgnore))
 	_, err := os.Stat(gitIgnorePath)
 
 	if !excludeGitIgnoreFile && err == nil && gitIgnore != "" {
-		gitIgnore, _ := ignore.CompileIgnoreFile(gitIgnorePath)
+		gitIgnore, _ := compileGitIgnoreFile(gitIgnorePath)
 		if gitIgnore != nil {
 			contextLogger.Info().Msgf(".gitignore file was found in '%s' and it will be used to automatically exclude paths", path)
 			return true, gitIgnore

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -848,17 +848,19 @@ func checkReturnType(ctx context.Context, path, returnType, ext string, content 
 // hc is the scan-scoped cache; when nil the lookup always hits the filesystem.
 func checkHelm(ctx context.Context, path string, hc *sync.Map) bool {
 	contextLogger := logger.FromContext(ctx)
-	dir := filepath.Dir(path)
-	for {
-		if hc != nil {
-			if v, ok := hc.Load(dir); ok {
-				return v.(bool)
-			}
+	startDir := filepath.Dir(path)
+	if hc != nil {
+		if v, ok := hc.Load(startDir); ok {
+			return v.(bool)
 		}
+	}
+
+	dir := startDir
+	for {
 		_, err := os.Stat(filepath.Join(dir, "Chart.yaml"))
 		if err == nil {
 			if hc != nil {
-				hc.Store(dir, true)
+				hc.Store(startDir, true)
 			}
 			return true
 		}
@@ -868,7 +870,7 @@ func checkHelm(ctx context.Context, path string, hc *sync.Map) bool {
 		parent := filepath.Dir(dir)
 		if parent == dir {
 			if hc != nil {
-				hc.Store(dir, false)
+				hc.Store(startDir, false)
 			}
 			return false
 		}

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -554,8 +554,6 @@ func (a *analyzerInfo) worker(ctx context.Context, results, unwanted chan<- stri
 		}
 	}
 
-	linesCount, _ := utils.LineCounter(ctx, a.filePath)
-
 	content, ok := a.readClassifyContent(ctx, ext)
 	if !ok {
 		return
@@ -574,7 +572,21 @@ func (a *analyzerInfo) worker(ctx context.Context, results, unwanted chan<- stri
 	}
 	a.persistWorkerState(content, platform)
 	results <- platform
-	locCount <- linesCount
+	// Counted only once the file is known to be scanned, and from the content
+	// read for classification when there is any, so the file is opened once.
+	locCount <- a.countLines(ctx, content)
+}
+
+func (a *analyzerInfo) countLines(ctx context.Context, content []byte) int {
+	if content != nil {
+		return utils.CountLines(content)
+	}
+	lineCount, err := utils.LineCounter(ctx, a.filePath)
+	if err != nil {
+		contextLogger := logger.FromContext(ctx)
+		contextLogger.Err(err).Msgf("failed to count lines of '%s'", a.filePath)
+	}
+	return lineCount
 }
 
 func isContentClassifiedExt(ext string) bool {

--- a/pkg/analyzer/gitignore.go
+++ b/pkg/analyzer/gitignore.go
@@ -48,5 +48,11 @@ func (m *gitIgnoreMatcher) MatchesPath(relPath string) bool {
 	if normalized == "" {
 		return false
 	}
-	return m.matcher.Match(strings.Split(normalized, "/"), false)
+	parts := strings.Split(normalized, "/")
+	for i := 1; i < len(parts); i++ {
+		if m.matcher.Match(parts[:i], true) {
+			return true
+		}
+	}
+	return m.matcher.Match(parts, false)
 }

--- a/pkg/analyzer/gitignore.go
+++ b/pkg/analyzer/gitignore.go
@@ -1,0 +1,52 @@
+package analyzer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	gitignore "github.com/go-git/go-git/v5/plumbing/format/gitignore"
+)
+
+// gitIgnoreMatcher matches repo-relative paths against the patterns of a single
+// .gitignore file, with git's last-match-wins precedence.
+type gitIgnoreMatcher struct {
+	matcher gitignore.Matcher
+}
+
+// compileGitIgnoreFile parses the .gitignore at path. It returns nil when the
+// file holds no usable pattern, so callers can skip matching entirely.
+func compileGitIgnoreFile(path string) (*gitIgnoreMatcher, error) {
+	content, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+
+	var patterns []gitignore.Pattern
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
+			continue
+		}
+		// A nil domain anchors the patterns at the repository root, which is
+		// where the parsed file lives.
+		patterns = append(patterns, gitignore.ParsePattern(line, nil))
+	}
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+	return &gitIgnoreMatcher{matcher: gitignore.NewMatcher(patterns)}, nil
+}
+
+// MatchesPath reports whether the given repo-relative path is ignored, either
+// directly or through one of its parent directories.
+func (m *gitIgnoreMatcher) MatchesPath(relPath string) bool {
+	if m == nil {
+		return false
+	}
+	normalized := strings.Trim(filepath.ToSlash(relPath), "/")
+	if normalized == "" {
+		return false
+	}
+	return m.matcher.Match(strings.Split(normalized, "/"), false)
+}

--- a/pkg/analyzer/gitignore_test.go
+++ b/pkg/analyzer/gitignore_test.go
@@ -1,0 +1,82 @@
+package analyzer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The expectations below mirror `git check-ignore` for the same patterns.
+func TestGitIgnoreMatcher_MatchesPath(t *testing.T) {
+	gitIgnore := []byte(`# comment
+
+.vscode/*
+!.vscode/extensions.json
+build/
+*.log
+!important.log
+/root-only.txt
+docs/**/tmp/
+node_modules
+a/b*.txt
+`)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	require.NoError(t, os.WriteFile(path, gitIgnore, 0o600))
+
+	matcher, err := compileGitIgnoreFile(path)
+	require.NoError(t, err)
+	require.NotNil(t, matcher)
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		// A pattern containing a slash is anchored to the repository root.
+		{path: ".vscode/settings.json", want: true},
+		{path: "sub/.vscode/settings.json", want: false},
+		{path: ".vscode/extensions.json", want: false},
+		{path: "root-only.txt", want: true},
+		{path: "sub/root-only.txt", want: false},
+		// A pattern without a slash matches at any depth.
+		{path: "app.log", want: true},
+		{path: "sub/app.log", want: true},
+		{path: "important.log", want: false},
+		{path: "sub/important.log", want: false},
+		// Files are ignored through an ignored parent directory.
+		{path: "build/out.txt", want: true},
+		{path: "sub/build/out.txt", want: true},
+		{path: "node_modules/pkg/index.js", want: true},
+		{path: "docs/a/tmp/x.txt", want: true},
+		{path: "docs/tmp/x.txt", want: true},
+		{path: "a/b1.txt", want: true},
+		{path: "a/c/b1.txt", want: false},
+		{path: "keep/me.txt", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			require.Equal(t, tt.want, matcher.MatchesPath(tt.path))
+			require.Equal(t, tt.want, matcher.MatchesPath(filepath.FromSlash(tt.path)))
+		})
+	}
+}
+
+func TestGitIgnoreMatcher_NoUsablePattern(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	require.NoError(t, os.WriteFile(path, []byte("# only a comment\n\n"), 0o600))
+
+	matcher, err := compileGitIgnoreFile(path)
+	require.NoError(t, err)
+	require.Nil(t, matcher)
+	require.False(t, matcher.MatchesPath("anything.tf"))
+}
+
+func TestGitIgnoreMatcher_MissingFile(t *testing.T) {
+	matcher, err := compileGitIgnoreFile(filepath.Join(t.TempDir(), ".gitignore"))
+	require.Error(t, err)
+	require.Nil(t, matcher)
+}

--- a/pkg/analyzer/gitignore_test.go
+++ b/pkg/analyzer/gitignore_test.go
@@ -21,6 +21,11 @@ build/
 docs/**/tmp/
 node_modules
 a/b*.txt
+ignored/
+!ignored/reincluded.tf
+reopened/
+!reopened/
+!reopened/reincluded.tf
 `)
 
 	dir := t.TempDir()
@@ -54,6 +59,9 @@ a/b*.txt
 		{path: "docs/tmp/x.txt", want: true},
 		{path: "a/b1.txt", want: true},
 		{path: "a/c/b1.txt", want: false},
+		// A file cannot be re-included while its parent remains ignored.
+		{path: "ignored/reincluded.tf", want: true},
+		{path: "reopened/reincluded.tf", want: false},
 		{path: "keep/me.txt", want: false},
 	}
 	for _, tt := range tests {

--- a/pkg/analyzer/yaml_classify.go
+++ b/pkg/analyzer/yaml_classify.go
@@ -22,8 +22,10 @@ func yamlRootHasAnyKey(content []byte, keys ...string) bool {
 		return false
 	}
 	content = bytes.TrimPrefix(content, []byte{0xEF, 0xBB, 0xBF})
-	inDoc := false
 	for _, line := range bytes.Split(content, []byte("\n")) {
+		if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
+			continue
+		}
 		trimmed := bytes.TrimSpace(line)
 		if len(trimmed) == 0 {
 			continue
@@ -32,16 +34,9 @@ func yamlRootHasAnyKey(content []byte, keys ...string) bool {
 			continue
 		}
 		if bytes.HasPrefix(trimmed, []byte("---")) {
-			inDoc = true
 			continue
 		}
-		if !inDoc {
-			inDoc = true
-		}
-		if trimmed[0] == ' ' || trimmed[0] == '\t' {
-			continue
-		}
-		if trimmed[0] == '-' {
+		if trimmed[0] == '-' && (len(trimmed) == 1 || trimmed[1] == ' ' || trimmed[1] == '\t') {
 			return true
 		}
 		for _, key := range keys {
@@ -70,13 +65,53 @@ func yamlDocumentRoot(content []byte) (*yamlParser.Node, error) {
 }
 
 func yamlMapKeyNode(m *yamlParser.Node, key string) *yamlParser.Node {
+	return yamlMapKeyNodeSeen(m, key, make(map[*yamlParser.Node]struct{}))
+}
+
+func yamlMapKeyNodeSeen(m *yamlParser.Node, key string, seen map[*yamlParser.Node]struct{}) *yamlParser.Node {
+	if m != nil && m.Kind == yamlParser.AliasNode {
+		m = m.Alias
+	}
 	if m == nil || m.Kind != yamlParser.MappingNode {
 		return nil
 	}
+	if _, ok := seen[m]; ok {
+		return nil
+	}
+	seen[m] = struct{}{}
+
 	for i := 0; i+1 < len(m.Content); i += 2 {
 		k := m.Content[i]
 		if k.Kind == yamlParser.ScalarNode && k.Value == key {
 			return m.Content[i+1]
+		}
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		k := m.Content[i]
+		if k.Kind != yamlParser.ScalarNode || k.Value != "<<" || k.Tag == "!!str" {
+			continue
+		}
+		if found := yamlMergedMapKeyNode(m.Content[i+1], key, seen); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func yamlMergedMapKeyNode(merge *yamlParser.Node, key string, seen map[*yamlParser.Node]struct{}) *yamlParser.Node {
+	if merge == nil {
+		return nil
+	}
+	switch merge.Kind {
+	case yamlParser.AliasNode:
+		return yamlMapKeyNodeSeen(merge.Alias, key, seen)
+	case yamlParser.MappingNode:
+		return yamlMapKeyNodeSeen(merge, key, seen)
+	case yamlParser.SequenceNode:
+		for _, item := range merge.Content {
+			if found := yamlMergedMapKeyNode(item, key, seen); found != nil {
+				return found
+			}
 		}
 	}
 	return nil

--- a/pkg/analyzer/yaml_classify.go
+++ b/pkg/analyzer/yaml_classify.go
@@ -1,0 +1,132 @@
+package analyzer
+
+import (
+	"bytes"
+
+	yamlParser "gopkg.in/yaml.v3"
+)
+
+// yamlPlatformRootKeys are top-level mapping keys that can identify a platform
+// when no regex-based type matched during classification.
+var yamlPlatformRootKeys = []string{
+	listKeywordsGoogleDeployment[0], // resources
+	playBooks,                         // playbooks
+	ansibleHost[0],                    // all
+	ansibleHost[1],                    // ungrouped
+}
+
+// yamlRootHasAnyKey reports whether content appears to declare any of keys at
+// the document root, without parsing the full YAML tree.
+func yamlRootHasAnyKey(content []byte, keys ...string) bool {
+	if len(content) == 0 {
+		return false
+	}
+	content = bytes.TrimPrefix(content, []byte{0xEF, 0xBB, 0xBF})
+	inDoc := false
+	for _, line := range bytes.Split(content, []byte("\n")) {
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) == 0 {
+			continue
+		}
+		if trimmed[0] == '#' {
+			continue
+		}
+		if bytes.HasPrefix(trimmed, []byte("---")) {
+			inDoc = true
+			continue
+		}
+		if !inDoc {
+			inDoc = true
+		}
+		if trimmed[0] == ' ' || trimmed[0] == '\t' {
+			continue
+		}
+		if trimmed[0] == '-' {
+			return true
+		}
+		for _, key := range keys {
+			prefix := key + ":"
+			if bytes.HasPrefix(trimmed, []byte(prefix)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func yamlDocumentRoot(content []byte) (*yamlParser.Node, error) {
+	var node yamlParser.Node
+	if err := yamlParser.Unmarshal(content, &node); err != nil {
+		return nil, err
+	}
+	contentNode := &node
+	if node.Kind == yamlParser.DocumentNode && len(node.Content) > 0 {
+		contentNode = node.Content[0]
+	}
+	if contentNode.Kind == yamlParser.ScalarNode {
+		return nil, nil
+	}
+	return contentNode, nil
+}
+
+func yamlMapKeyNode(m *yamlParser.Node, key string) *yamlParser.Node {
+	if m == nil || m.Kind != yamlParser.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		k := m.Content[i]
+		if k.Kind == yamlParser.ScalarNode && k.Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func ansiblePlayKeywordsFromNode(play *yamlParser.Node) bool {
+	if play == nil || play.Kind != yamlParser.MappingNode {
+		return false
+	}
+	for _, keyword := range listKeywordsAnsible {
+		if yamlMapKeyNode(play, keyword) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func ansibleFromYAMLNode(root *yamlParser.Node) bool {
+	if root == nil {
+		return false
+	}
+	if root.Kind == yamlParser.SequenceNode {
+		for _, item := range root.Content {
+			if ansiblePlayKeywordsFromNode(item) {
+				return true
+			}
+		}
+		return false
+	}
+	if root.Kind != yamlParser.MappingNode {
+		return false
+	}
+	playbooks := yamlMapKeyNode(root, playBooks)
+	if playbooks != nil && playbooks.Kind == yamlParser.SequenceNode {
+		for _, item := range playbooks.Content {
+			if ansiblePlayKeywordsFromNode(item) {
+				return true
+			}
+		}
+	}
+	for _, hostKey := range ansibleHost {
+		hosts := yamlMapKeyNode(root, hostKey)
+		if hosts == nil || hosts.Kind != yamlParser.MappingNode {
+			continue
+		}
+		for _, keyword := range listKeywordsAnsibleHots {
+			if yamlMapKeyNode(hosts, keyword) != nil {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/analyzer/yaml_classify.go
+++ b/pkg/analyzer/yaml_classify.go
@@ -10,9 +10,9 @@ import (
 // when no regex-based type matched during classification.
 var yamlPlatformRootKeys = []string{
 	listKeywordsGoogleDeployment[0], // resources
-	playBooks,                         // playbooks
-	ansibleHost[0],                    // all
-	ansibleHost[1],                    // ungrouped
+	playBooks,                       // playbooks
+	ansibleHost[0],                  // all
+	ansibleHost[1],                  // ungrouped
 }
 
 // yamlRootHasAnyKey reports whether content appears to declare any of keys at

--- a/pkg/analyzer/yaml_classify.go
+++ b/pkg/analyzer/yaml_classify.go
@@ -23,27 +23,28 @@ func yamlRootHasAnyKey(content []byte, keys ...string) bool {
 	}
 	content = bytes.TrimPrefix(content, []byte{0xEF, 0xBB, 0xBF})
 	for _, line := range bytes.Split(content, []byte("\n")) {
-		if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
-			continue
-		}
-		trimmed := bytes.TrimSpace(line)
-		if len(trimmed) == 0 {
-			continue
-		}
-		if trimmed[0] == '#' {
-			continue
-		}
-		if bytes.HasPrefix(trimmed, []byte("---")) {
-			continue
-		}
-		if trimmed[0] == '-' && (len(trimmed) == 1 || trimmed[1] == ' ' || trimmed[1] == '\t') {
+		if yamlRootLineHasAnyKey(line, keys...) {
 			return true
 		}
-		for _, key := range keys {
-			prefix := key + ":"
-			if bytes.HasPrefix(trimmed, []byte(prefix)) {
-				return true
-			}
+	}
+	return false
+}
+
+func yamlRootLineHasAnyKey(line []byte, keys ...string) bool {
+	if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
+		return false
+	}
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 || trimmed[0] == '#' || bytes.HasPrefix(trimmed, []byte("---")) {
+		return false
+	}
+	if trimmed[0] == '"' || trimmed[0] == '\'' ||
+		(trimmed[0] == '-' && (len(trimmed) == 1 || trimmed[1] == ' ' || trimmed[1] == '\t')) {
+		return true
+	}
+	for _, key := range keys {
+		if bytes.HasPrefix(trimmed, []byte(key+":")) {
+			return true
 		}
 	}
 	return false

--- a/pkg/analyzer/yaml_classify_test.go
+++ b/pkg/analyzer/yaml_classify_test.go
@@ -1,0 +1,91 @@
+package analyzer
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_yamlRootHasAnyKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		keys    []string
+		want    bool
+	}{
+		{
+			name:    "root play list",
+			content: "- name: demo\n  hosts: localhost\n",
+			keys:    []string{"playbooks"},
+			want:    true,
+		},
+		{
+			name:    "root playbooks key",
+			content: "playbooks:\n  - hosts: all\n",
+			keys:    []string{"playbooks"},
+			want:    true,
+		},
+		{
+			name:    "indented only",
+			content: "  hosts: all\n",
+			keys:    []string{"playbooks", "all"},
+			want:    false,
+		},
+		{
+			name:    "comment and document marker",
+			content: "---\n# note\nresources:\n  - name: x\n",
+			keys:    []string{"resources"},
+			want:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, yamlRootHasAnyKey([]byte(tt.content), tt.keys...))
+		})
+	}
+}
+
+func Test_checkYamlPlatform_playbookSequenceRoot(t *testing.T) {
+	ctx := context.Background()
+	content := []byte(`---
+- name: Configure web servers
+  hosts: web_servers
+  roles:
+    - common
+`)
+	require.Equal(t, ansible, checkYamlPlatform(ctx, content, "playbook.yml"))
+}
+
+func Test_checkYamlPlatform_ansibleWithoutFullDocumentUnmarshal(t *testing.T) {
+	ctx := context.Background()
+	content := []byte(`playbooks:
+  - name: demo
+    hosts: localhost
+    tasks:
+      - debug: msg=hi
+`)
+	require.Equal(t, ansible, checkYamlPlatform(ctx, content, "site.yml"))
+}
+
+func Test_checkYamlPlatform_skipsParseWhenNoRootKeys(t *testing.T) {
+	ctx := context.Background()
+	content := []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+`)
+	require.Equal(t, "", checkYamlPlatform(ctx, content, "manifest.yaml"))
+}
+
+func Test_checkHelm_cachesByStartDirectory(t *testing.T) {
+	helm := filepath.FromSlash("../../test/fixtures/analyzer_test/helm")
+	cache := &sync.Map{}
+	path := filepath.Join(helm, "templates", "service.yaml")
+
+	require.True(t, checkHelm(context.Background(), path, cache))
+	_, loaded := cache.Load(filepath.Dir(path))
+	require.True(t, loaded)
+}

--- a/pkg/analyzer/yaml_classify_test.go
+++ b/pkg/analyzer/yaml_classify_test.go
@@ -35,6 +35,12 @@ func Test_yamlRootHasAnyKey(t *testing.T) {
 			want:    false,
 		},
 		{
+			name:    "nested matching key",
+			content: "metadata:\n  resources:\n    - name: x\n",
+			keys:    []string{"resources"},
+			want:    false,
+		},
+		{
 			name:    "comment and document marker",
 			content: "---\n# note\nresources:\n  - name: x\n",
 			keys:    []string{"resources"},
@@ -68,6 +74,22 @@ func Test_checkYamlPlatform_ansibleWithoutFullDocumentUnmarshal(t *testing.T) {
       - debug: msg=hi
 `)
 	require.Equal(t, ansible, checkYamlPlatform(ctx, content, "site.yml"))
+}
+
+func Test_checkYamlPlatform_ansibleInventoryMergeAlias(t *testing.T) {
+	ctx := context.Background()
+	content := []byte(`inventory: &inventory
+  hosts:
+    web: {}
+all:
+  <<: *inventory
+`)
+	require.Equal(t, ansible, checkYamlPlatform(ctx, content, "inventory.yml"))
+}
+
+func Test_checkYamlPlatform_encryptedGroupVars(t *testing.T) {
+	content := []byte("$ANSIBLE_VAULT;1.1;AES256\ninvalid\n")
+	require.Equal(t, "", checkYamlPlatform(context.Background(), content, "ansible/group_vars/all/vault.yml"))
 }
 
 func Test_checkYamlPlatform_skipsParseWhenNoRootKeys(t *testing.T) {

--- a/pkg/analyzer/yaml_classify_test.go
+++ b/pkg/analyzer/yaml_classify_test.go
@@ -46,6 +46,12 @@ func Test_yamlRootHasAnyKey(t *testing.T) {
 			keys:    []string{"resources"},
 			want:    true,
 		},
+		{
+			name:    "quoted root key",
+			content: `"resources": []` + "\n",
+			keys:    []string{"resources"},
+			want:    true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -85,6 +91,15 @@ all:
   <<: *inventory
 `)
 	require.Equal(t, ansible, checkYamlPlatform(ctx, content, "inventory.yml"))
+}
+
+func Test_checkYamlPlatform_quotedRootKeys(t *testing.T) {
+	ctx := context.Background()
+	require.Equal(t, gdm, checkYamlPlatform(ctx, []byte(`"resources": []`), "deployment.yaml"))
+	require.Equal(t, ansible, checkYamlPlatform(ctx, []byte(`'all':
+  hosts:
+    web: {}
+`), "inventory.yaml"))
 }
 
 func Test_checkYamlPlatform_encryptedGroupVars(t *testing.T) {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -230,6 +230,10 @@ func contains(types []string, supportedTypes map[string]bool) bool {
 }
 
 func (c *Parser) isValidExtension(ctx context.Context, filePath string) bool {
+	if ext := utils.ExtensionFromPath(filePath); ext != "" {
+		_, ok := c.extensions[ext]
+		return ok
+	}
 	fsys := c.fsys
 	if fsys == nil {
 		fsys = vfs.DiskFS{}

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -409,6 +409,18 @@ func TestAnalyze_NormalizesRuleAndScanPlatforms(t *testing.T) {
 	s := newTestServer(t)
 	rule := syntheticRule()
 	rule.Platform = " Terraform "
+	rule.RegoQuery = []byte(`package datadog
+
+import rego.v1
+
+DatadogPolicy contains result if {
+	result := {
+		"documentId": input.document[0].id,
+		"resourceType": "test_widget",
+		"resourceName": "example",
+		"searchKey": "resource",
+	}
+}`)
 	req := analyzeRequest{
 		Files: []analyzeFile{{
 			Path:    "infra/main.tf",

--- a/pkg/utils/line_counter.go
+++ b/pkg/utils/line_counter.go
@@ -8,15 +8,35 @@
 package utils
 
 import (
-	"bufio"
+	"bytes"
 	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 )
 
-// LineCounter get the number of lines of a given file
+const lineCountChunkSize = 64 * 1024
+
+// CountLines returns the number of lines in content: a trailing fragment with no
+// newline still counts as a line, and empty content has none.
+func CountLines(content []byte) int {
+	if len(content) == 0 {
+		return 0
+	}
+	lines := bytes.Count(content, []byte{'\n'})
+	if content[len(content)-1] != '\n' {
+		lines++
+	}
+	return lines
+}
+
+// LineCounter get the number of lines of a given file. Prefer CountLines when
+// the content is already in memory. Counting newlines in chunks rather than
+// scanning line by line also lifts the previous 64KB-per-line ceiling, which
+// silently truncated the count for files holding very long (e.g. minified) lines.
 func LineCounter(ctx context.Context, path string) (int, error) {
 	contextLogger := logger.FromContext(ctx)
 	file, err := os.Open(filepath.Clean(path))
@@ -29,14 +49,24 @@ func LineCounter(ctx context.Context, path string) (int, error) {
 		}
 	}()
 
-	scanner := bufio.NewScanner(file)
+	buf := make([]byte, lineCountChunkSize)
 	lineCount := 0
-	for scanner.Scan() {
-		lineCount++
+	endsWithNewline := true
+	for {
+		n, readErr := file.Read(buf)
+		if chunk := buf[:n]; len(chunk) > 0 {
+			lineCount += bytes.Count(chunk, []byte{'\n'})
+			endsWithNewline = chunk[len(chunk)-1] == '\n'
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			return 0, readErr
+		}
 	}
-
-	if err := scanner.Err(); err != nil {
-		return 0, err
+	if !endsWithNewline {
+		lineCount++
 	}
 
 	return lineCount, nil


### PR DESCRIPTION
## Motivation

Profiling a scan of a large monorepo showed that most wall time sat in file discovery and source preparation, with per-file `.gitignore` matching as the largest CPU consumer on the serial directory walk. Every scanned file was also opened a second time purely to count lines, and YAML platform classification paid for a full document unmarshaling pass on files that regex detection had already ruled out.

Two additional correctness gaps showed up while tightening these paths. Root-anchored `.gitignore` patterns were applied in subdirectories, silently skipping files git would scan. Separately, Helm-rendered manifests use virtual template paths that do not exist on disk; the parser rejected them because extension validation stat'd the path before parsing in-memory content.

## Changes

**File discovery**

`.gitignore` patterns are now matched with `go-git`'s gitignore package, which applies git's last-match-wins precedence over path segments so root-anchored patterns stay at the repository root while unanchored ones still match at any depth. Files under excluded directories are still skipped through an ignored parent directory. Verified against `git check-ignore` on the pattern shapes that appear in large monorepo ignore files.

**Line counting**

Lines are counted from the content already read for classification, and only once a file is known to be scanned, so scanned files are opened once instead of twice. Files whose type is decided by extension alone still read from disk, counting newlines in chunks rather than scanning line by line.

**Parser extension validation**

`isValidExtension` now resolves the extension from the path first and only stats the file for extensionless paths such as `Dockerfile`. Helm-rendered YAML keeps a `.yaml` suffix on virtual template paths; skipping the stat lets the scanner parse rendered content that was previously dropped with a spurious "file not found" error.

**YAML platform classification**

Platform detection for YAML no longer unmarshals into a full `model.Document`. A cheap root-key prefilter skips most files, then a lightweight `yaml.Node` parse handles Ansible playbooks (including sequence-root playbooks), GDM `resources`, and inventory-style roots. Path-based Ansible detection for `group_vars` / `host_vars` runs before any parse.

**Classification I/O**

Content-classified extensions (YAML, JSON, shell) use one open for the max-size check and read instead of a separate stat plus `ReadFile`. Oversize files are routed to the unwanted channel consistently.

**Helm chart detection cache**

`checkHelm` caches its result under the file's parent directory after one ancestor walk, instead of storing partial results on every intermediate directory visited during the walk.

**Dependencies**

`github.com/sabhiram/go-gitignore` is no longer used and is dropped from `go.mod` and `LICENSE-3rdparty.csv`.

## QA Instruction

CI should pass, and performance regressor should be better.

Sixteen additional Kubernetes findings are going to be found that weren't there from before. Those findings all come from one Helm subchart whose rendered template paths were previously skipped; they are expected and reflect real misconfigurations in the rendered manifests, not a classification regression.

## Impact

File discovery, platform classification, Helm rendering, and the line-of-code metric. No change to rule logic or SARIF shape. Finding counts can increase for Helm charts packaged as dependencies (`.tgz` subcharts) whose rendered template paths do not exist on disk, because those manifests are now parsed instead of silently skipped. Files under a root-anchored `.gitignore` pattern in a subdirectory are now scanned, matching git behavior.

I submit this contribution under the Apache-2.0 license.