### PR TITLE
Fix Terraform data reference preprocessing

### DIFF
--- a/pkg/parser/terraform/data_source.go
+++ b/pkg/parser/terraform/data_source.go
@@ -101,7 +101,7 @@ func getDataSourcePolicy(ctx context.Context, fsys vfs.FS, currentPath string, i
 			continue
 		}
 		for _, block := range body.Blocks {
-			if block.Type == "data" && block.Labels[0] == "aws_iam_policy_document" && len(block.Labels) > 1 {
+			if block.Type == terraformDataIdentifier && block.Labels[0] == "aws_iam_policy_document" && len(block.Labels) > 1 {
 				policyJSON := parseDataSourceBody(ctx, block.Body, inputVariables)
 				jsonMap[block.Labels[1]] = map[string]string{
 					"json": policyJSON,

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -8,7 +8,8 @@ package terraform
 import (
 	"context"
 	"path/filepath"
-	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -26,8 +27,11 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
-// RetriesDefaultValue is default number of times a parser will retry to execute
-const RetriesDefaultValue = 50
+const (
+	// RetriesDefaultValue is default number of times a parser will retry to execute
+	RetriesDefaultValue     = 50
+	terraformDataIdentifier = "data"
+)
 
 // Converter returns content json, error line, error
 type Converter func(ctx context.Context, file *hcl.File, inputVariables converter.VariableMap) (model.Document, error)
@@ -214,13 +218,48 @@ func parseFile(fsys vfs.FS, filename string, shouldReplaceDataSource bool) (*hcl
 	if err != nil {
 		return nil, err
 	}
-	if shouldReplaceDataSource {
-		replaceDataIdentifiers := regexp.MustCompile(`(data\.[A-Za-z0-9._-]+)`)
-		file = []byte(replaceDataIdentifiers.ReplaceAllString(string(file), "\"$1\""))
+	parsedFile, diagnostics := hclsyntax.ParseConfig(file, filename, hcl.Pos{Line: 1, Column: 1})
+	if diagnostics.HasErrors() {
+		return nil, diagnostics
 	}
-	parsedFile, _ := hclsyntax.ParseConfig(file, filename, hcl.Pos{Line: 1, Column: 1})
+	if shouldReplaceDataSource {
+		file = quoteDataSourceTraversals(file, parsedFile)
+		parsedFile, diagnostics = hclsyntax.ParseConfig(file, filename, hcl.Pos{Line: 1, Column: 1})
+		if diagnostics.HasErrors() {
+			return nil, diagnostics
+		}
+	}
 
 	return parsedFile, nil
+}
+
+func quoteDataSourceTraversals(source []byte, file *hcl.File) []byte {
+	type sourceRange struct {
+		start int
+		end   int
+	}
+	var ranges []sourceRange
+	_ = hclsyntax.VisitAll(file.Body.(*hclsyntax.Body), func(node hclsyntax.Node) hcl.Diagnostics {
+		expr, ok := node.(*hclsyntax.ScopeTraversalExpr)
+		if !ok || expr.Traversal.RootName() != terraformDataIdentifier {
+			return nil
+		}
+		exprRange := expr.Range()
+		ranges = append(ranges, sourceRange{start: exprRange.Start.Byte, end: exprRange.End.Byte})
+		return nil
+	})
+	sort.Slice(ranges, func(i, j int) bool {
+		return ranges[i].start > ranges[j].start
+	})
+	for _, sourceRange := range ranges {
+		quoted := strconv.Quote(string(source[sourceRange.start:sourceRange.end]))
+		updated := make([]byte, 0, len(source)+len(quoted))
+		updated = append(updated, source[:sourceRange.start]...)
+		updated = append(updated, quoted...)
+		updated = append(updated, source[sourceRange.end:]...)
+		source = updated
+	}
+	return source
 }
 
 // Parse execute parser for the content in a file

--- a/pkg/parser/terraform/terraform_test.go
+++ b/pkg/parser/terraform/terraform_test.go
@@ -392,6 +392,42 @@ data "aws_iam_policy_document" "test_destination_policy" {
 	}
 }
 
+func TestParseFileReplacesOnlyRootDataTraversals(t *testing.T) {
+	source := []byte(`
+resource "test" "test" {
+  root_data    = data.aws_s3_bucket.selected.arn
+  nested_var   = var.data.resource_arn
+  nested_local = local.data.resource_arn
+  nested_each  = each.value.data.resource_arn
+  literal      = "data.aws_s3_bucket.selected.arn"
+  template     = "arn:${data.aws_partition.current.partition}:s3:::example"
+}
+`)
+	path := filepath.Join(t.TempDir(), "data_references.tf")
+	require.NoError(t, os.WriteFile(path, source, 0o600))
+
+	parsedFile, err := parseFile(vfs.DiskFS{}, path, true)
+	require.NoError(t, err)
+	got := string(parsedFile.Bytes)
+	require.Contains(t, got, `root_data    = "data.aws_s3_bucket.selected.arn"`)
+	require.Contains(t, got, `nested_var   = var.data.resource_arn`)
+	require.Contains(t, got, `nested_local = local.data.resource_arn`)
+	require.Contains(t, got, `nested_each  = each.value.data.resource_arn`)
+	require.Contains(t, got, `literal      = "data.aws_s3_bucket.selected.arn"`)
+	require.Contains(t, got, `template     = "arn:${"data.aws_partition.current.partition"}:s3:::example"`)
+}
+
+func TestParseFileReturnsDiagnostics(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "invalid.tf")
+	require.NoError(t, os.WriteFile(path, []byte(`resource "test" "test" {
+  value = aws_s3_bucket.selected.
+}`), 0o600))
+
+	parsedFile, err := parseFile(vfs.DiskFS{}, path, true)
+	require.Nil(t, parsedFile)
+	require.ErrorContains(t, err, "Invalid attribute name")
+}
+
 // TestParser_ConcurrentSameDir guards the per-directory variable cache: the
 // converter adds per-file keys to the variable map during evaluation, so the
 // cached map must never be shared across the files parsed concurrently in the


### PR DESCRIPTION
## Motivation

Terraform policy preprocessing treated any `data.*` substring as a root data-source traversal. Valid nested attributes such as `var.data.resource_arn` were consequently rewritten into invalid HCL and omitted from policy analysis.

## Changes

**Terraform preprocessing**

Parse source HCL before rewriting and quote only syntax-tree traversals rooted at Terraform's `data` namespace. Return parser diagnostics instead of passing invalid placeholder expressions into policy conversion.

**Regression coverage**

Cover root data-source references, nested `.data` attributes, literal text, templates, and malformed expressions.

## Author Checklist

1. [x] I have reviewed my own PR.
2. [x] I have added or updated relevant unit tests where necessary.
3. [x] Relevant tests and lint checks pass.
4. [x] Staging testing is not applicable.
5. [x] Documentation updates are not required.

## QA Instruction

1. Run `go test ./pkg/parser/terraform -count=1`.
2. Run `golangci-lint run -c .golangci.yml --timeout 20m`.
3. Confirm root `data.*` traversals are quoted while `var.data.*`, `local.data.*`, and `each.value.data.*` remain valid.

## Blast Radius

This change only affects Terraform data-source preprocessing used when resolving IAM policy documents.

## Additional Notes

The full test suite was attempted from an isolated worktree. Path-sensitive tests unrelated to this change require the checkout directory to be named exactly `datadog-iac-scanner`; the affected parser package and repository lint checks pass.

I submit this contribution under the Apache-2.0 license.