### PR TITLE
Speed up file discovery by fixing gitignore matching and redundant line counting

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -703,7 +703,6 @@ core,github.com/rubenv/sql-migrate,MIT,Copyright (C) 2014-2021 by Ruben Vermeers
 core,github.com/rubenv/sql-migrate/sqlparse,MIT,Copyright (C) 2012-2014 by Liam Staskawicz | Copyright (C) 2014-2017 by Ruben Vermeersch <ruben@rocketeer.be> | Copyright (C) 2014-2021 by Ruben Vermeersch <ruben@rocketeer.be>
 core,github.com/russross/blackfriday/v2,BSD-2-Clause,Copyright © 2011 Russ Ross
 core,github.com/ruudk/golang-pdf417,MIT,Copyright (c) 2018 Ruud Kamphuis
-core,github.com/sabhiram/go-gitignore,MIT,Copyright (c) 2015 Shaba Abhiram
 core,github.com/sagikazarmark/locafero,MIT,Copyright (c) 2023 Márk Sági-Kazár <mark.sagikazar@gmail.com>
 core,github.com/sagikazarmark/locafero/internal/queue,MIT,Copyright (c) 2023 Márk Sági-Kazár <mark.sagikazar@gmail.com>
 core,github.com/samber/lo,MIT,Copyright (c) 2022-2025 Samuel Berthe | Copyright © 2022 [Samuel Berthe](https://github.com/samber)

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/relex/aini v1.6.0
 	github.com/rmuir/tree-sitter-ghactions v0.2.5
 	github.com/rs/zerolog v1.34.0
-	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/sosedoff/ansible-vault-go v0.2.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tdewolff/minify/v2 v2.24.9

--- a/go.sum
+++ b/go.sum
@@ -527,8 +527,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245 h1:K1Xf3bKttbF+koVGaX5xngRIZ5bVjbmPnaxE/dR08uY=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
-github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
-github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/sagikazarmark/locafero v0.12.0 h1:/NQhBAkUb4+fH1jivKHWusDYFjMOOKU88eegjfxfHb4=
 github.com/sagikazarmark/locafero v0.12.0/go.mod h1:sZh36u/YSZ918v0Io+U9ogLYQJ9tLLBmM4eneO6WwsI=
 github.com/samber/lo v1.52.0 h1:Rvi+3BFHES3A8meP33VPAxiBZX/Aws5RxrschYGjomw=

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -871,32 +871,49 @@ func checkReturnType(ctx context.Context, path, returnType, ext string, content 
 // hc is the scan-scoped cache; when nil the lookup always hits the filesystem.
 func checkHelm(ctx context.Context, path string, hc *sync.Map) bool {
 	contextLogger := logger.FromContext(ctx)
-	dir := filepath.Dir(path)
+	startDir := filepath.Dir(path)
+	if hc != nil {
+		if v, ok := hc.Load(startDir); ok {
+			return v.(bool)
+		}
+	}
+
+	// Every directory walked before the answer is known shares that answer, so
+	// all of them are memoized. This keeps the total number of Chart.yaml probes
+	// proportional to the number of directories in the repository rather than to
+	// directories times their depth, and lets sibling subtrees reuse the walk.
+	walked := []string{startDir}
+	dir := startDir
 	for {
-		if hc != nil {
+		if hc != nil && dir != startDir {
 			if v, ok := hc.Load(dir); ok {
-				return v.(bool)
+				return storeHelmResults(hc, walked, v.(bool))
 			}
 		}
 		_, err := os.Stat(filepath.Join(dir, "Chart.yaml"))
 		if err == nil {
-			if hc != nil {
-				hc.Store(dir, true)
-			}
-			return true
+			return storeHelmResults(hc, walked, true)
 		}
 		if !errors.Is(err, os.ErrNotExist) {
 			contextLogger.Error().Msgf("failed to check helm: %s", err)
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			if hc != nil {
-				hc.Store(dir, false)
-			}
-			return false
+			return storeHelmResults(hc, walked, false)
 		}
 		dir = parent
+		walked = append(walked, dir)
 	}
+}
+
+func storeHelmResults(hc *sync.Map, dirs []string, result bool) bool {
+	if hc == nil {
+		return result
+	}
+	for _, dir := range dirs {
+		hc.Store(dir, result)
+	}
+	return result
 }
 
 func checkYamlPlatform(ctx context.Context, content []byte, path string) string {

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -556,7 +556,7 @@ func (a *analyzerInfo) worker(ctx context.Context, results, unwanted chan<- stri
 		return
 	}
 
-	if a.maxFileSize >= 0 {
+	if a.maxFileSize >= 0 && !isContentClassifiedExt(ext) {
 		if info, err := os.Stat(a.filePath); err == nil {
 			if float64(info.Size())/float64(sizeMb) > float64(a.maxFileSize) {
 				contextLogger := logger.FromContext(ctx)
@@ -568,7 +568,11 @@ func (a *analyzerInfo) worker(ctx context.Context, results, unwanted chan<- stri
 		}
 	}
 
-	content, ok := a.readClassifyContent(ctx, ext)
+	content, ok, tooLarge := a.readClassifyContent(ctx, ext)
+	if tooLarge {
+		unwanted <- a.filePath
+		return
+	}
 	if !ok {
 		return
 	}
@@ -607,17 +611,47 @@ func isContentClassifiedExt(ext string) bool {
 	return ext == yaml || ext == yml || ext == json || ext == sh
 }
 
-func (a *analyzerInfo) readClassifyContent(ctx context.Context, ext string) ([]byte, bool) {
+func (a *analyzerInfo) readClassifyContent(ctx context.Context, ext string) (content []byte, ok, tooLarge bool) {
 	if !isContentClassifiedExt(ext) {
-		return nil, true
+		return nil, true, false
 	}
-	content, err := os.ReadFile(a.filePath)
+	file, err := os.Open(filepath.Clean(a.filePath))
 	if err != nil {
 		contextLogger := logger.FromContext(ctx)
 		contextLogger.Error().Msgf("failed to analyze file: %s", err)
-		return nil, false
+		return nil, false, false
 	}
-	return content, true
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			contextLogger := logger.FromContext(ctx)
+			contextLogger.Err(closeErr).Msgf("failed to close '%s'", a.filePath)
+		}
+	}()
+
+	size := int64(-1)
+	if info, statErr := file.Stat(); statErr == nil {
+		size = info.Size()
+		if a.maxFileSize >= 0 && float64(size)/float64(sizeMb) > float64(a.maxFileSize) {
+			contextLogger := logger.FromContext(ctx)
+			contextLogger.Warn().Msgf(
+				"file %s exceeds maximum file size of %d Mb", a.filePath, a.maxFileSize)
+			return nil, false, true
+		}
+	}
+
+	// Sizing the buffer from the stat already taken above reads the file in one
+	// pass. io.ReadAll would start at 512 bytes and repeatedly double, so every
+	// classified file would cost a handful of allocations and copies instead.
+	var buf bytes.Buffer
+	if size > 0 && int64(int(size)) == size {
+		buf.Grow(int(size) + bytes.MinRead)
+	}
+	if _, err := buf.ReadFrom(file); err != nil {
+		contextLogger := logger.FromContext(ctx)
+		contextLogger.Error().Msgf("failed to analyze file: %s", err)
+		return nil, false, false
+	}
+	return buf.Bytes(), true, false
 }
 
 func (a *analyzerInfo) persistWorkerState(content []byte, platform string) {

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -931,11 +931,9 @@ func checkYamlPlatform(ctx context.Context, content []byte, path string) string 
 	if utils.IsAnsibleVaultEncrypted(content) {
 		return ""
 	}
-	if checkForAnsibleByPaths(path) {
-		return ansible
-	}
 
-	if !yamlRootHasAnyKey(content, yamlPlatformRootKeys...) {
+	ansibleVarsPath := checkForAnsibleByPaths(path)
+	if !ansibleVarsPath && !yamlRootHasAnyKey(content, yamlPlatformRootKeys...) {
 		return ""
 	}
 
@@ -945,6 +943,12 @@ func checkYamlPlatform(ctx context.Context, content []byte, path string) string 
 		return ""
 	}
 	if root == nil {
+		return ""
+	}
+	if ansibleVarsPath {
+		if yamlRootIsMapping(root) {
+			return ansible
+		}
 		return ""
 	}
 

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -25,8 +25,6 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/pkg/errors"
-
-	yamlParser "gopkg.in/yaml.v3"
 )
 
 // move the openApi regex to public to be used on file.go
@@ -877,52 +875,32 @@ func checkYamlPlatform(ctx context.Context, content []byte, path string) string 
 
 	content = utils.DecryptAnsibleVault(ctx, content, utils.GetVaultPassword())
 
+	// A still-encrypted file has no readable content to classify, so it stays
+	// unclassified even when it sits in a path that otherwise implies Ansible.
 	if utils.IsAnsibleVaultEncrypted(content) {
 		return ""
 	}
+	if checkForAnsibleByPaths(path) {
+		return ansible
+	}
 
-	// Parse as Node to manually call Datadog's version of UnmarshalYAML with context
-	var node yamlParser.Node
-	if err := yamlParser.Unmarshal(content, &node); err != nil {
+	if !yamlRootHasAnyKey(content, yamlPlatformRootKeys...) {
+		return ""
+	}
+
+	root, err := yamlDocumentRoot(content)
+	if err != nil {
 		contextLogger.Warn().Msgf("failed to parse yaml file (%s): %s", path, err)
 		return ""
 	}
-
-	// Get the yaml content in node
-	contentNode := &node
-	if node.Kind == yamlParser.DocumentNode && len(node.Content) > 0 {
-		contentNode = node.Content[0]
-	}
-
-	// A scalar root means the document is empty/null (e.g. a comment-only vars file).
-	// No platform can be detected; skip silently.
-	if contentNode.Kind == yamlParser.ScalarNode {
+	if root == nil {
 		return ""
 	}
 
-	var yamlContent model.Document
-	if err := yamlContent.UnmarshalYAML(ctx, contentNode, nil); err != nil {
-		contextLogger.Warn().Msgf("failed to unmarshal yaml file (%s): %s", path, err)
-		return ""
+	if yamlMapKeyNode(root, listKeywordsGoogleDeployment[0]) != nil {
+		return gdm
 	}
-
-	// check if it is google deployment manager platform
-	for _, keyword := range listKeywordsGoogleDeployment {
-		if _, ok := yamlContent[keyword]; ok {
-			return gdm
-		}
-	}
-
-	// check if the file contains some keywords related with Ansible
-	if checkForAnsible(yamlContent) {
-		return ansible
-	}
-	// check if the file contains some keywords related with Ansible Host
-	if checkForAnsibleHost(yamlContent) {
-		return ansible
-	}
-	// add for yaml files contained at paths (group_vars, host_vars) related with ansible
-	if checkForAnsibleByPaths(path) {
+	if ansibleFromYAMLNode(root) {
 		return ansible
 	}
 	return ""
@@ -953,41 +931,6 @@ func isInsideAnsibleTemplatesDir(path string) bool {
 		}
 	}
 	return false
-}
-
-func checkForAnsible(yamlContent model.Document) bool {
-	isAnsible := false
-	if play := yamlContent[playBooks]; play != nil {
-		if listOfPlayBooks, ok := play.([]interface{}); ok {
-			for _, value := range listOfPlayBooks {
-				castingValue, ok := value.(map[string]interface{})
-				if ok {
-					for _, keyword := range listKeywordsAnsible {
-						if _, ok := castingValue[keyword]; ok {
-							isAnsible = true
-						}
-					}
-				}
-			}
-		}
-	}
-	return isAnsible
-}
-
-func checkForAnsibleHost(yamlContent model.Document) bool {
-	isAnsible := false
-	for _, ansibleDefault := range ansibleHost {
-		if hosts := yamlContent[ansibleDefault]; hosts != nil {
-			if listHosts, ok := hosts.(map[string]interface{}); ok {
-				for _, value := range listKeywordsAnsibleHots {
-					if host := listHosts[value]; host != nil {
-						isAnsible = true
-					}
-				}
-			}
-		}
-	}
-	return isAnsible
 }
 
 // computeValues computes expected Lines of Code to be scanned from locCount channel

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -380,6 +380,7 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 			return returnAnalyzedPaths, errors.Wrap(statErr, "failed to analyze path")
 		}
 		singleFilePath := !pathInfo.IsDir()
+		walkRootDirChecked := false
 		if err := filepath.WalkDir(path, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				return err
@@ -397,6 +398,19 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 			if d.IsDir() {
 				if provider.IsTerraformCacheDir(path) {
 					return filepath.SkipDir
+				}
+				// When the walk root starts below an ignored ancestor, git never
+				// enters that ancestor so MatchesDir on the root basename is not
+				// enough. One parent check per WalkDir root preserves pruning
+				// without re-testing every file or directory in the tree.
+				if insideRepo && hasGitIgnoreFile && !walkRootDirChecked {
+					walkRootDirChecked = true
+					if gitIgnore.MatchesParentDir(trimmedPath) {
+						norm := filepath.ToSlash(path)
+						ignoreFiles = append(ignoreFiles, norm)
+						a.Exc = append(a.Exc, norm)
+						return filepath.SkipDir
+					}
 				}
 				// Pruning the subtree is cheaper than testing every file below
 				// it, and it is what makes an ignored directory final: git

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -25,7 +25,6 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/pkg/errors"
-	ignore "github.com/sabhiram/go-gitignore"
 
 	yamlParser "gopkg.in/yaml.v3"
 )
@@ -378,9 +377,11 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 	}
 	// get all the files inside the given paths
 	for _, path := range a.Paths {
-		if _, err := os.Stat(path); err != nil {
-			return returnAnalyzedPaths, errors.Wrap(err, "failed to analyze path")
+		pathInfo, statErr := os.Stat(path)
+		if statErr != nil {
+			return returnAnalyzedPaths, errors.Wrap(statErr, "failed to analyze path")
 		}
+		singleFilePath := !pathInfo.IsDir()
 		if err := filepath.WalkDir(path, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				return err
@@ -390,8 +391,24 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 				return filepath.SkipDir
 			}
 
+			trimmedPath, relErr := filepath.Rel(a.RepoPath, path)
+			insideRepo := relErr == nil &&
+				trimmedPath != ".." &&
+				!strings.HasPrefix(trimmedPath, ".."+string(os.PathSeparator))
+
 			if d.IsDir() {
 				if provider.IsTerraformCacheDir(path) {
+					return filepath.SkipDir
+				}
+				// Pruning the subtree is cheaper than testing every file below
+				// it, and it is what makes an ignored directory final: git
+				// cannot re-include a file whose parent is excluded, so the
+				// files under it must never be considered at all. The directory
+				// itself is recorded as excluded so downstream walks skip it too.
+				if insideRepo && hasGitIgnoreFile && gitIgnore.MatchesDir(trimmedPath) {
+					norm := filepath.ToSlash(path)
+					ignoreFiles = append(ignoreFiles, norm)
+					a.Exc = append(a.Exc, norm)
 					return filepath.SkipDir
 				}
 				return nil
@@ -412,9 +429,6 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 				chartRoots = append(chartRoots, filepath.ToSlash(filepath.Dir(path)))
 			}
 
-			trimmedPath, relErr := filepath.Rel(a.RepoPath, path)
-			outsideRepo := relErr != nil
-
 			ext := utils.ExtensionFromPath(path)
 			if ext == "" {
 				return nil
@@ -430,7 +444,9 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 				return nil
 			}
 
-			if !outsideRepo && hasGitIgnoreFile && gitIgnore.MatchesPath(trimmedPath) {
+			if insideRepo && hasGitIgnoreFile &&
+				(gitIgnore.MatchesPath(trimmedPath) ||
+					(singleFilePath && gitIgnore.MatchesParentDir(trimmedPath))) {
 				norm := filepath.ToSlash(path)
 				ignoreFiles = append(ignoreFiles, norm)
 				a.Exc = append(a.Exc, norm)
@@ -1085,13 +1101,13 @@ func isConfigFile(path string, suffixes []string) bool {
 
 // shouldConsiderGitIgnoreFile verifies if the scan should exclude the files according to the .gitignore file
 func shouldConsiderGitIgnoreFile(ctx context.Context, path, gitIgnore string, excludeGitIgnoreFile bool) (hasGitIgnoreFileRes bool,
-	gitIgnoreRes *ignore.GitIgnore) {
+	gitIgnoreRes *gitIgnoreMatcher) {
 	contextLogger := logger.FromContext(ctx)
 	gitIgnorePath := filepath.ToSlash(filepath.Join(path, gitIgnore))
 	_, err := os.Stat(gitIgnorePath)
 
 	if !excludeGitIgnoreFile && err == nil && gitIgnore != "" {
-		gitIgnore, _ := ignore.CompileIgnoreFile(gitIgnorePath)
+		gitIgnore, _ := compileGitIgnoreFile(gitIgnorePath)
 		if gitIgnore != nil {
 			contextLogger.Info().Msgf(".gitignore file was found in '%s' and it will be used to automatically exclude paths", path)
 			return true, gitIgnore

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -554,8 +554,6 @@ func (a *analyzerInfo) worker(ctx context.Context, results, unwanted chan<- stri
 		}
 	}
 
-	linesCount, _ := utils.LineCounter(ctx, a.filePath)
-
 	content, ok := a.readClassifyContent(ctx, ext)
 	if !ok {
 		return
@@ -574,7 +572,21 @@ func (a *analyzerInfo) worker(ctx context.Context, results, unwanted chan<- stri
 	}
 	a.persistWorkerState(content, platform)
 	results <- platform
-	locCount <- linesCount
+	// Counted only once the file is known to be scanned, and from the content
+	// read for classification when there is any, so the file is opened once.
+	locCount <- a.countLines(ctx, content)
+}
+
+func (a *analyzerInfo) countLines(ctx context.Context, content []byte) int {
+	if content != nil {
+		return utils.CountLines(content)
+	}
+	lineCount, err := utils.LineCounter(ctx, a.filePath)
+	if err != nil {
+		contextLogger := logger.FromContext(ctx)
+		contextLogger.Err(err).Msgf("failed to count lines of '%s'", a.filePath)
+	}
+	return lineCount
 }
 
 func isContentClassifiedExt(ext string) bool {

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -476,6 +476,52 @@ func TestAnalyze_ValidSymlink(t *testing.T) {
 	require.Empty(t, got.Exc)
 }
 
+// An ignored directory is pruned rather than expanded into its files, so the
+// subtree is never walked and only the directory is reported as excluded.
+func TestAnalyze_PrunesGitIgnoredDirectory(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("resource \"aws_s3_bucket\" \"b\" {}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("vendor/\n!vendor/keep.tf\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), body, 0o600))
+	vendorDir := filepath.Join(dir, "vendor", "nested")
+	require.NoError(t, os.MkdirAll(vendorDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "vendor", "keep.tf"), body, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(vendorDir, "deep.tf"), body, 0o600))
+
+	got, err := Analyze(context.Background(), &Analyzer{
+		RepoPath:          dir,
+		Paths:             []string{dir},
+		Types:             []string{""},
+		GitIgnoreFileName: ".gitignore",
+		MaxFileSize:       -1,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{filepath.ToSlash(filepath.Join(dir, "vendor"))}, got.Exc)
+	require.Equal(t, []string{filepath.ToSlash(filepath.Join(dir, "main.tf"))}, got.Inventory)
+}
+
+func TestAnalyze_DoesNotApplyGitIgnoreOutsideRepo(t *testing.T) {
+	repo := t.TempDir()
+	scanRoot := t.TempDir()
+	vendorDir := filepath.Join(scanRoot, "vendor")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".gitignore"), []byte("vendor/\n"), 0o600))
+	require.NoError(t, os.MkdirAll(vendorDir, 0o755))
+	externalFile := filepath.Join(vendorDir, "main.tf")
+	require.NoError(t, os.WriteFile(externalFile, []byte("resource \"aws_s3_bucket\" \"b\" {}\n"), 0o600))
+
+	got, err := Analyze(context.Background(), &Analyzer{
+		RepoPath:          repo,
+		Paths:             []string{scanRoot},
+		Types:             []string{""},
+		GitIgnoreFileName: ".gitignore",
+		MaxFileSize:       -1,
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, got.Inventory, filepath.ToSlash(externalFile))
+}
+
 func TestAnalyze_ChartRootsFromChartYamlFile(t *testing.T) {
 	dir := t.TempDir()
 	chartDir := filepath.Join(dir, "mychart")

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -474,6 +475,50 @@ func TestAnalyze_ValidSymlink(t *testing.T) {
 	require.Equal(t, []string{terraform}, got.Types)
 	require.Contains(t, got.Inventory, filepath.ToSlash(link))
 	require.Empty(t, got.Exc)
+}
+
+func Test_checkHelm_memoizesEveryWalkedDirectory(t *testing.T) {
+	dir := t.TempDir()
+	chart := filepath.Join(dir, "mychart")
+	templates := filepath.Join(chart, "templates")
+	require.NoError(t, os.MkdirAll(templates, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(chart, "Chart.yaml"), []byte("name: x\n"), 0o600))
+
+	cache := &sync.Map{}
+	require.True(t, checkHelm(context.Background(), filepath.Join(templates, "service.yaml"), cache))
+
+	// The chart root is reached by walking up from the file, so both it and the
+	// directories passed on the way share the answer.
+	for _, d := range []string{templates, chart} {
+		v, ok := cache.Load(d)
+		require.True(t, ok, d)
+		require.True(t, v.(bool), d)
+	}
+}
+
+// A negative answer is memoized for the whole chain too, so a sibling subtree
+// stops at the first cached ancestor instead of walking to the root again.
+func Test_checkHelm_memoizesNegativeResultForAncestors(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "a", "b")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	sibling := filepath.Join(dir, "a", "c")
+	require.NoError(t, os.MkdirAll(sibling, 0o755))
+
+	cache := &sync.Map{}
+	ctx := context.Background()
+	require.False(t, checkHelm(ctx, filepath.Join(nested, "svc.yaml"), cache))
+
+	for _, d := range []string{nested, filepath.Join(dir, "a"), dir} {
+		v, ok := cache.Load(d)
+		require.True(t, ok, d)
+		require.False(t, v.(bool), d)
+	}
+
+	require.False(t, checkHelm(ctx, filepath.Join(sibling, "svc.yaml"), cache))
+	v, ok := cache.Load(sibling)
+	require.True(t, ok)
+	require.False(t, v.(bool))
 }
 
 // An ignored directory is pruned rather than expanded into its files, so the

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -567,6 +567,27 @@ func TestAnalyze_DoesNotApplyGitIgnoreOutsideRepo(t *testing.T) {
 	require.Contains(t, got.Inventory, filepath.ToSlash(externalFile))
 }
 
+func TestAnalyze_SkipsWalkRootBelowGitIgnoredDirectory(t *testing.T) {
+	repo := t.TempDir()
+	build := filepath.Join(repo, "build", "nested")
+	require.NoError(t, os.MkdirAll(build, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".gitignore"), []byte("build/\n"), 0o600))
+	nestedFile := filepath.Join(build, "main.tf")
+	require.NoError(t, os.WriteFile(nestedFile, []byte("resource \"aws_s3_bucket\" \"b\" {}\n"), 0o600))
+
+	got, err := Analyze(context.Background(), &Analyzer{
+		RepoPath:          repo,
+		Paths:             []string{build},
+		Types:             []string{""},
+		GitIgnoreFileName: ".gitignore",
+		MaxFileSize:       -1,
+	})
+	require.NoError(t, err)
+	require.Contains(t, got.Exc, filepath.ToSlash(build))
+	require.NotContains(t, got.Inventory, filepath.ToSlash(nestedFile))
+	require.NotContains(t, got.Types, terraform)
+}
+
 func TestAnalyze_ChartRootsFromChartYamlFile(t *testing.T) {
 	dir := t.TempDir()
 	chartDir := filepath.Join(dir, "mychart")

--- a/pkg/analyzer/gitignore.go
+++ b/pkg/analyzer/gitignore.go
@@ -1,0 +1,110 @@
+package analyzer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	gitignore "github.com/go-git/go-git/v5/plumbing/format/gitignore"
+)
+
+// gitIgnoreMatcher matches repo-relative paths against the patterns of a single
+// .gitignore file, with git's last-match-wins precedence.
+type gitIgnoreMatcher struct {
+	matcher    gitignore.Matcher
+	dirMatcher gitignore.Matcher
+}
+
+// compileGitIgnoreFile parses the .gitignore at path. It returns nil when the
+// file holds no usable pattern, so callers can skip matching entirely.
+func compileGitIgnoreFile(path string) (*gitIgnoreMatcher, error) {
+	content, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+
+	var filePatterns, dirPatterns []gitignore.Pattern
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
+			continue
+		}
+		// A nil domain anchors the patterns at the repository root, which is
+		// where the parsed file lives.
+		if !isDirectoryOnlyPattern(line) {
+			filePatterns = append(filePatterns, gitignore.ParsePattern(line, nil))
+		}
+		dirPatterns = append(dirPatterns, gitignore.ParsePattern(directoryPattern(line), nil))
+	}
+	if len(dirPatterns) == 0 {
+		return nil, nil
+	}
+	return &gitIgnoreMatcher{
+		matcher:    gitignore.NewMatcher(filePatterns),
+		dirMatcher: gitignore.NewMatcher(dirPatterns),
+	}, nil
+}
+
+func isDirectoryOnlyPattern(pattern string) bool {
+	if !strings.HasSuffix(pattern, `\ `) {
+		pattern = strings.TrimRight(pattern, " ")
+	}
+	return strings.HasSuffix(pattern, "/")
+}
+
+func directoryPattern(pattern string) string {
+	// Git's trailing /** matches a directory's contents, not the directory itself.
+	if strings.HasSuffix(pattern, "/**") {
+		return strings.TrimSuffix(pattern, "**") + "*"
+	}
+	return pattern
+}
+
+// MatchesPath reports whether the given repo-relative file path is ignored by a
+// pattern naming the file itself.
+//
+// Exclusions inherited from a parent directory are not reported here. Callers
+// walk directories through MatchesDir and stop descending when it matches,
+// which mirrors git never entering an ignored directory and keeps matching at
+// one pass over the patterns per path instead of one per path component.
+func (m *gitIgnoreMatcher) MatchesPath(relPath string) bool {
+	if m == nil {
+		return false
+	}
+	return m.matches(m.matcher, relPath, false)
+}
+
+// MatchesDir reports whether the given repo-relative directory is ignored.
+//
+// Callers must stop descending when this returns true. Pruning is what enforces
+// git's rule that a file cannot be re-included once one of its parent
+// directories is excluded: a negated pattern deeper in the tree would otherwise
+// win the last-match-wins precedence and resurrect the file.
+func (m *gitIgnoreMatcher) MatchesDir(relPath string) bool {
+	if m == nil {
+		return false
+	}
+	return m.matches(m.dirMatcher, relPath, true)
+}
+
+func (m *gitIgnoreMatcher) MatchesParentDir(relPath string) bool {
+	if m == nil {
+		return false
+	}
+	normalized := strings.Trim(filepath.ToSlash(relPath), "/")
+	parts := strings.Split(normalized, "/")
+	for i := 1; i < len(parts); i++ {
+		if m.dirMatcher.Match(parts[:i], true) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *gitIgnoreMatcher) matches(matcher gitignore.Matcher, relPath string, isDir bool) bool {
+	normalized := strings.Trim(filepath.ToSlash(relPath), "/")
+	if normalized == "" || normalized == "." {
+		return false
+	}
+	return matcher.Match(strings.Split(normalized, "/"), isDir)
+}

--- a/pkg/analyzer/gitignore.go
+++ b/pkg/analyzer/gitignore.go
@@ -63,8 +63,10 @@ func compileGitIgnorePattern(pattern string) gitIgnorePattern {
 		}
 	}
 
-	// A trailing /** requires at least one path component below its parent.
-	if strings.HasSuffix(body, "/**") {
+	// These recursive suffixes require at least one component below the parent.
+	if strings.HasSuffix(body, "/**/*") {
+		body = strings.TrimSuffix(body, "/**/*") + "/*/**"
+	} else if strings.HasSuffix(body, "/**") {
 		body = strings.TrimSuffix(body, "/**") + "/*/**"
 	}
 	const pathEnd = "\x00"

--- a/pkg/analyzer/gitignore.go
+++ b/pkg/analyzer/gitignore.go
@@ -11,8 +11,13 @@ import (
 // gitIgnoreMatcher matches repo-relative paths against the patterns of a single
 // .gitignore file, with git's last-match-wins precedence.
 type gitIgnoreMatcher struct {
-	matcher    gitignore.Matcher
-	dirMatcher gitignore.Matcher
+	patterns []gitIgnorePattern
+}
+
+type gitIgnorePattern struct {
+	pattern       gitignore.Pattern
+	exactPath     bool
+	directoryOnly bool
 }
 
 // compileGitIgnoreFile parses the .gitignore at path. It returns nil when the
@@ -23,41 +28,51 @@ func compileGitIgnoreFile(path string) (*gitIgnoreMatcher, error) {
 		return nil, err
 	}
 
-	var filePatterns, dirPatterns []gitignore.Pattern
+	var patterns []gitIgnorePattern
 	for _, line := range strings.Split(string(content), "\n") {
 		line = strings.TrimSuffix(line, "\r")
 		if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
 			continue
 		}
-		// A nil domain anchors the patterns at the repository root, which is
-		// where the parsed file lives.
-		if !isDirectoryOnlyPattern(line) {
-			filePatterns = append(filePatterns, gitignore.ParsePattern(line, nil))
-		}
-		dirPatterns = append(dirPatterns, gitignore.ParsePattern(directoryPattern(line), nil))
+		patterns = append(patterns, compileGitIgnorePattern(line))
 	}
-	if len(dirPatterns) == 0 {
+	if len(patterns) == 0 {
 		return nil, nil
 	}
-	return &gitIgnoreMatcher{
-		matcher:    gitignore.NewMatcher(filePatterns),
-		dirMatcher: gitignore.NewMatcher(dirPatterns),
-	}, nil
+	return &gitIgnoreMatcher{patterns: patterns}, nil
 }
 
-func isDirectoryOnlyPattern(pattern string) bool {
+func compileGitIgnorePattern(pattern string) gitIgnorePattern {
 	if !strings.HasSuffix(pattern, `\ `) {
 		pattern = strings.TrimRight(pattern, " ")
 	}
-	return strings.HasSuffix(pattern, "/")
-}
 
-func directoryPattern(pattern string) string {
-	// Git's trailing /** matches a directory's contents, not the directory itself.
-	if strings.HasSuffix(pattern, "/**") {
-		return strings.TrimSuffix(pattern, "**") + "*"
+	inclusion := ""
+	body := pattern
+	if strings.HasPrefix(body, "!") {
+		inclusion = "!"
+		body = body[1:]
 	}
-	return pattern
+	directoryOnly := strings.HasSuffix(body, "/")
+	body = strings.TrimSuffix(body, "/")
+	exactPath := strings.Contains(body, "/")
+	if !exactPath {
+		return gitIgnorePattern{
+			pattern:       gitignore.ParsePattern(pattern, nil),
+			directoryOnly: directoryOnly,
+		}
+	}
+
+	// A trailing /** requires at least one path component below its parent.
+	if strings.HasSuffix(body, "/**") {
+		body = strings.TrimSuffix(body, "/**") + "/*/**"
+	}
+	const pathEnd = "\x00"
+	return gitIgnorePattern{
+		pattern:       gitignore.ParsePattern(inclusion+body+"/"+pathEnd, nil),
+		exactPath:     true,
+		directoryOnly: directoryOnly,
+	}
 }
 
 // MatchesPath reports whether the given repo-relative file path is ignored by a
@@ -68,10 +83,7 @@ func directoryPattern(pattern string) string {
 // which mirrors git never entering an ignored directory and keeps matching at
 // one pass over the patterns per path instead of one per path component.
 func (m *gitIgnoreMatcher) MatchesPath(relPath string) bool {
-	if m == nil {
-		return false
-	}
-	return m.matches(m.matcher, relPath, false)
+	return m.matches(relPath, false)
 }
 
 // MatchesDir reports whether the given repo-relative directory is ignored.
@@ -81,10 +93,7 @@ func (m *gitIgnoreMatcher) MatchesPath(relPath string) bool {
 // directories is excluded: a negated pattern deeper in the tree would otherwise
 // win the last-match-wins precedence and resurrect the file.
 func (m *gitIgnoreMatcher) MatchesDir(relPath string) bool {
-	if m == nil {
-		return false
-	}
-	return m.matches(m.dirMatcher, relPath, true)
+	return m.matches(relPath, true)
 }
 
 func (m *gitIgnoreMatcher) MatchesParentDir(relPath string) bool {
@@ -94,17 +103,43 @@ func (m *gitIgnoreMatcher) MatchesParentDir(relPath string) bool {
 	normalized := strings.Trim(filepath.ToSlash(relPath), "/")
 	parts := strings.Split(normalized, "/")
 	for i := 1; i < len(parts); i++ {
-		if m.dirMatcher.Match(parts[:i], true) {
+		if m.matchParts(parts[:i], true) {
 			return true
 		}
 	}
 	return false
 }
 
-func (m *gitIgnoreMatcher) matches(matcher gitignore.Matcher, relPath string, isDir bool) bool {
+func (m *gitIgnoreMatcher) matches(relPath string, isDir bool) bool {
+	if m == nil {
+		return false
+	}
 	normalized := strings.Trim(filepath.ToSlash(relPath), "/")
 	if normalized == "" || normalized == "." {
 		return false
 	}
-	return matcher.Match(strings.Split(normalized, "/"), isDir)
+	return m.matchParts(strings.Split(normalized, "/"), isDir)
+}
+
+func (m *gitIgnoreMatcher) matchParts(parts []string, isDir bool) bool {
+	const pathEnd = "\x00"
+	exactParts := make([]string, len(parts)+1)
+	copy(exactParts, parts)
+	exactParts[len(parts)] = pathEnd
+	basename := parts[len(parts)-1:]
+
+	for i := len(m.patterns) - 1; i >= 0; i-- {
+		pattern := m.patterns[i]
+		if pattern.directoryOnly && !isDir {
+			continue
+		}
+		matchPath := basename
+		if pattern.exactPath {
+			matchPath = exactParts
+		}
+		if result := pattern.pattern.Match(matchPath, isDir); result > gitignore.NoMatch {
+			return result == gitignore.Exclude
+		}
+	}
+	return false
 }

--- a/pkg/analyzer/gitignore_test.go
+++ b/pkg/analyzer/gitignore_test.go
@@ -145,6 +145,20 @@ func TestGitIgnoreMatcher_ExplicitFileChecksIgnoredParents(t *testing.T) {
 	require.True(t, matcher.MatchesParentDir("build/main.tf"))
 }
 
+func TestGitIgnoreMatcher_ReincludedWildcardDirectoryKeepsDescendants(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	require.NoError(t, os.WriteFile(path, []byte("foo/*\n!foo/bar/\n"), 0o600))
+
+	matcher, err := compileGitIgnoreFile(path)
+	require.NoError(t, err)
+	require.NotNil(t, matcher)
+
+	require.True(t, ignoredDuringWalk(matcher, "foo/other.tf"))
+	require.False(t, matcher.MatchesDir("foo/bar"))
+	require.False(t, ignoredDuringWalk(matcher, "foo/bar/main.tf"))
+}
+
 func TestGitIgnoreMatcher_NoUsablePattern(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".gitignore")

--- a/pkg/analyzer/gitignore_test.go
+++ b/pkg/analyzer/gitignore_test.go
@@ -1,0 +1,163 @@
+package analyzer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ignoredDuringWalk reproduces how file discovery applies the matcher: each
+// directory is tested on the way down and its subtree is pruned when ignored,
+// then the file itself is tested. Exclusion inherited from a parent comes from
+// the pruning, so it can only be observed through the walk.
+func ignoredDuringWalk(m *gitIgnoreMatcher, relPath string) bool {
+	relPath = filepath.ToSlash(relPath)
+	parts := strings.Split(relPath, "/")
+	for i := 1; i < len(parts); i++ {
+		if m.MatchesDir(strings.Join(parts[:i], "/")) {
+			return true
+		}
+	}
+	return m.MatchesPath(relPath)
+}
+
+// The expectations below mirror `git check-ignore` for the same patterns.
+func TestGitIgnoreMatcher_MatchesPath(t *testing.T) {
+	gitIgnore := []byte(`# comment
+
+.vscode/*
+!.vscode/extensions.json
+build/
+*.log
+!important.log
+/root-only.txt
+docs/**/tmp/
+node_modules
+a/b*.txt
+ignored/
+!ignored/reincluded.tf
+reopened/
+!reopened/
+!reopened/reincluded.tf
+abc/**
+!abc/def/
+!abc/def/keep.tf
+`)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	require.NoError(t, os.WriteFile(path, gitIgnore, 0o600))
+
+	matcher, err := compileGitIgnoreFile(path)
+	require.NoError(t, err)
+	require.NotNil(t, matcher)
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		// A pattern containing a slash is anchored to the repository root.
+		{path: ".vscode/settings.json", want: true},
+		{path: "sub/.vscode/settings.json", want: false},
+		{path: ".vscode/extensions.json", want: false},
+		{path: "root-only.txt", want: true},
+		{path: "sub/root-only.txt", want: false},
+		// A pattern without a slash matches at any depth.
+		{path: "app.log", want: true},
+		{path: "sub/app.log", want: true},
+		{path: "important.log", want: false},
+		{path: "sub/important.log", want: false},
+		// Files are ignored through an ignored parent directory.
+		{path: "build/out.txt", want: true},
+		{path: "sub/build/out.txt", want: true},
+		{path: "node_modules/pkg/index.js", want: true},
+		{path: "docs/a/tmp/x.txt", want: true},
+		{path: "docs/tmp/x.txt", want: true},
+		{path: "a/b1.txt", want: true},
+		{path: "a/c/b1.txt", want: false},
+		// A file cannot be re-included while its parent remains ignored.
+		{path: "ignored/reincluded.tf", want: true},
+		{path: "reopened/reincluded.tf", want: false},
+		// A trailing /** ignores contents, not the parent directory.
+		{path: "abc/other.tf", want: true},
+		{path: "abc/def/drop.tf", want: true},
+		{path: "abc/def/keep.tf", want: false},
+		{path: "keep/me.txt", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			require.Equal(t, tt.want, ignoredDuringWalk(matcher, tt.path))
+			require.Equal(t, tt.want, ignoredDuringWalk(matcher, filepath.FromSlash(tt.path)))
+		})
+	}
+}
+
+// A negated pattern deeper in the tree wins last-match-wins precedence when the
+// file is tested on its own, so honoring git requires pruning the directory
+// rather than asking MatchesPath about inherited exclusions.
+func TestGitIgnoreMatcher_ReincludeUnderIgnoredParentNeedsPruning(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	require.NoError(t, os.WriteFile(path, []byte("ignored/\n!ignored/keep.tf\n"), 0o600))
+
+	matcher, err := compileGitIgnoreFile(path)
+	require.NoError(t, err)
+	require.NotNil(t, matcher)
+
+	require.False(t, matcher.MatchesPath("ignored/keep.tf"))
+	require.True(t, matcher.MatchesDir("ignored"))
+	require.True(t, ignoredDuringWalk(matcher, "ignored/keep.tf"))
+
+	// The walk root resolves to an empty or dot-relative path and is never ignored.
+	require.False(t, matcher.MatchesDir(""))
+	require.False(t, matcher.MatchesDir("."))
+}
+
+func TestGitIgnoreMatcher_TrailingGlobstarDoesNotIgnoreParent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	require.NoError(t, os.WriteFile(path, []byte("abc/**\n!abc/def/\n!abc/def/keep.tf\n"), 0o600))
+
+	matcher, err := compileGitIgnoreFile(path)
+	require.NoError(t, err)
+	require.NotNil(t, matcher)
+
+	require.False(t, matcher.MatchesDir("abc"))
+	require.False(t, matcher.MatchesDir("abc/def"))
+	require.True(t, ignoredDuringWalk(matcher, "abc/other.tf"))
+	require.True(t, ignoredDuringWalk(matcher, "abc/def/drop.tf"))
+	require.False(t, ignoredDuringWalk(matcher, "abc/def/keep.tf"))
+}
+
+func TestGitIgnoreMatcher_ExplicitFileChecksIgnoredParents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	require.NoError(t, os.WriteFile(path, []byte("build/\n"), 0o600))
+
+	matcher, err := compileGitIgnoreFile(path)
+	require.NoError(t, err)
+	require.NotNil(t, matcher)
+
+	require.False(t, matcher.MatchesPath("build/main.tf"))
+	require.True(t, matcher.MatchesParentDir("build/main.tf"))
+}
+
+func TestGitIgnoreMatcher_NoUsablePattern(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	require.NoError(t, os.WriteFile(path, []byte("# only a comment\n\n"), 0o600))
+
+	matcher, err := compileGitIgnoreFile(path)
+	require.NoError(t, err)
+	require.Nil(t, matcher)
+	require.False(t, matcher.MatchesPath("anything.tf"))
+}
+
+func TestGitIgnoreMatcher_MissingFile(t *testing.T) {
+	matcher, err := compileGitIgnoreFile(filepath.Join(t.TempDir(), ".gitignore"))
+	require.Error(t, err)
+	require.Nil(t, matcher)
+}

--- a/pkg/analyzer/gitignore_test.go
+++ b/pkg/analyzer/gitignore_test.go
@@ -132,6 +132,22 @@ func TestGitIgnoreMatcher_TrailingGlobstarDoesNotIgnoreParent(t *testing.T) {
 	require.False(t, ignoredDuringWalk(matcher, "abc/def/keep.tf"))
 }
 
+func TestGitIgnoreMatcher_RecursiveWildcardAfterReincludedDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	require.NoError(t, os.WriteFile(path, []byte("foo/**/*\n!foo/bar/\n!foo/bar/keep.tf\n"), 0o600))
+
+	matcher, err := compileGitIgnoreFile(path)
+	require.NoError(t, err)
+	require.NotNil(t, matcher)
+
+	require.False(t, matcher.MatchesDir("foo"))
+	require.False(t, matcher.MatchesDir("foo/bar"))
+	require.True(t, ignoredDuringWalk(matcher, "foo/bar/a.tf"))
+	require.True(t, ignoredDuringWalk(matcher, "foo/bar/nested/a.tf"))
+	require.False(t, ignoredDuringWalk(matcher, "foo/bar/keep.tf"))
+}
+
 func TestGitIgnoreMatcher_ExplicitFileChecksIgnoredParents(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".gitignore")

--- a/pkg/analyzer/yaml_classify.go
+++ b/pkg/analyzer/yaml_classify.go
@@ -128,6 +128,13 @@ func yamlRootIsMapping(root *yamlParser.Node) bool {
 	return root != nil && root.Kind == yamlParser.MappingNode
 }
 
+func yamlResolveAlias(n *yamlParser.Node) *yamlParser.Node {
+	for n != nil && n.Kind == yamlParser.AliasNode {
+		n = n.Alias
+	}
+	return n
+}
+
 func yamlMapKeyNode(m *yamlParser.Node, key string) *yamlParser.Node {
 	return yamlMapKeyNodeSeen(m, key, nil)
 }
@@ -189,6 +196,7 @@ func yamlMergedMapKeyNode(merge *yamlParser.Node, key string, seen map[*yamlPars
 }
 
 func ansiblePlayKeywordsFromNode(play *yamlParser.Node) bool {
+	play = yamlResolveAlias(play)
 	if play == nil || play.Kind != yamlParser.MappingNode {
 		return false
 	}
@@ -215,7 +223,7 @@ func ansibleFromYAMLNode(root *yamlParser.Node) bool {
 	if root.Kind != yamlParser.MappingNode {
 		return false
 	}
-	playbooks := yamlMapKeyNode(root, playBooks)
+	playbooks := yamlResolveAlias(yamlMapKeyNode(root, playBooks))
 	if playbooks != nil && playbooks.Kind == yamlParser.SequenceNode {
 		for _, item := range playbooks.Content {
 			if ansiblePlayKeywordsFromNode(item) {

--- a/pkg/analyzer/yaml_classify.go
+++ b/pkg/analyzer/yaml_classify.go
@@ -1,0 +1,230 @@
+package analyzer
+
+import (
+	"bytes"
+
+	yamlParser "gopkg.in/yaml.v3"
+)
+
+// yamlPlatformRootKeys are top-level mapping keys that can identify a platform
+// when no regex-based type matched during classification.
+var yamlPlatformRootKeys = []string{
+	listKeywordsGoogleDeployment[0], // resources
+	playBooks,                       // playbooks
+	ansibleHost[0],                  // all
+	ansibleHost[1],                  // ungrouped
+}
+
+// yamlRootHasAnyKey reports whether content appears to declare any of keys at
+// the document root, without parsing the full YAML tree.
+func yamlRootHasAnyKey(content []byte, keys ...string) bool {
+	if len(content) == 0 {
+		return false
+	}
+	content = bytes.TrimPrefix(content, []byte{0xEF, 0xBB, 0xBF})
+	for _, line := range bytes.Split(content, []byte("\n")) {
+		if yamlRootLineHasAnyKey(line, keys...) {
+			return true
+		}
+	}
+	return false
+}
+
+func yamlRootLineHasAnyKey(line []byte, keys ...string) bool {
+	trimmed := yamlRootLineContent(line)
+	if len(trimmed) == 0 {
+		return false
+	}
+	// A root-level sequence is the shape of an Ansible playbook, where the
+	// keywords live on the plays rather than on the document root.
+	if trimmed[0] == '-' && (len(trimmed) == 1 || trimmed[1] == ' ' || trimmed[1] == '\t') {
+		return true
+	}
+	if trimmed[0] == '{' || trimmed[0] == '[' {
+		return true
+	}
+	if quote := trimmed[0]; quote == '"' || quote == '\'' {
+		return quotedRootKeyIsAny(trimmed, quote, keys...)
+	}
+	return plainRootKeyIsAny(trimmed, keys...) || plainRootKeyIsAny(trimmed, "<<")
+}
+
+func yamlRootLineContent(line []byte) []byte {
+	if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
+		return nil
+	}
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 || trimmed[0] == '#' {
+		return nil
+	}
+	if bytes.HasPrefix(trimmed, []byte("---")) {
+		trimmed = bytes.TrimSpace(trimmed[3:])
+		if len(trimmed) == 0 || trimmed[0] == '#' {
+			return nil
+		}
+	}
+	return trimmed
+}
+
+func plainRootKeyIsAny(trimmed []byte, keys ...string) bool {
+	for _, key := range keys {
+		if !bytes.HasPrefix(trimmed, []byte(key)) {
+			continue
+		}
+		afterKey := bytes.TrimLeft(trimmed[len(key):], " \t")
+		if len(afterKey) > 0 && afterKey[0] == ':' {
+			return true
+		}
+	}
+	return false
+}
+
+// quotedRootKeyIsAny reports whether a quoted root key equals one of keys.
+// Only the plain form is decoded; an unterminated or escaped quote makes the
+// key ambiguous, so those lines are reported as a possible match and left for
+// the parser to resolve.
+func quotedRootKeyIsAny(trimmed []byte, quote byte, keys ...string) bool {
+	rest := trimmed[1:]
+	end := bytes.IndexByte(rest, quote)
+	if end < 0 {
+		return true
+	}
+	if quote == '"' && bytes.IndexByte(rest[:end], '\\') >= 0 {
+		return true
+	}
+	// Without a colon the line is a scalar rather than a mapping key.
+	if after := bytes.TrimLeft(rest[end+1:], " \t"); len(after) == 0 || after[0] != ':' {
+		return false
+	}
+	name := rest[:end]
+	for _, key := range keys {
+		if string(name) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func yamlDocumentRoot(content []byte) (*yamlParser.Node, error) {
+	var node yamlParser.Node
+	if err := yamlParser.Unmarshal(content, &node); err != nil {
+		return nil, err
+	}
+	contentNode := &node
+	if node.Kind == yamlParser.DocumentNode && len(node.Content) > 0 {
+		contentNode = node.Content[0]
+	}
+	if contentNode.Kind == yamlParser.ScalarNode {
+		return nil, nil
+	}
+	return contentNode, nil
+}
+
+func yamlMapKeyNode(m *yamlParser.Node, key string) *yamlParser.Node {
+	return yamlMapKeyNodeSeen(m, key, nil)
+}
+
+// yamlMapKeyNodeSeen looks key up in m, following merge keys into the mappings
+// they pull in. seen guards against alias cycles and may be nil; it is only
+// allocated once a merge key is actually found, since the overwhelmingly common
+// case is a mapping with none and this runs for every keyword of every play.
+func yamlMapKeyNodeSeen(m *yamlParser.Node, key string, seen map[*yamlParser.Node]struct{}) *yamlParser.Node {
+	if m != nil && m.Kind == yamlParser.AliasNode {
+		m = m.Alias
+	}
+	if m == nil || m.Kind != yamlParser.MappingNode {
+		return nil
+	}
+	if _, ok := seen[m]; ok {
+		return nil
+	}
+
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		k := m.Content[i]
+		if k.Kind == yamlParser.ScalarNode && k.Value == key {
+			return m.Content[i+1]
+		}
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		k := m.Content[i]
+		if k.Kind != yamlParser.ScalarNode || k.Value != "<<" || k.Tag == "!!str" {
+			continue
+		}
+		if seen == nil {
+			seen = make(map[*yamlParser.Node]struct{})
+		}
+		seen[m] = struct{}{}
+		if found := yamlMergedMapKeyNode(m.Content[i+1], key, seen); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func yamlMergedMapKeyNode(merge *yamlParser.Node, key string, seen map[*yamlParser.Node]struct{}) *yamlParser.Node {
+	if merge == nil {
+		return nil
+	}
+	switch merge.Kind {
+	case yamlParser.AliasNode:
+		return yamlMapKeyNodeSeen(merge.Alias, key, seen)
+	case yamlParser.MappingNode:
+		return yamlMapKeyNodeSeen(merge, key, seen)
+	case yamlParser.SequenceNode:
+		for _, item := range merge.Content {
+			if found := yamlMergedMapKeyNode(item, key, seen); found != nil {
+				return found
+			}
+		}
+	}
+	return nil
+}
+
+func ansiblePlayKeywordsFromNode(play *yamlParser.Node) bool {
+	if play == nil || play.Kind != yamlParser.MappingNode {
+		return false
+	}
+	for _, keyword := range listKeywordsAnsible {
+		if yamlMapKeyNode(play, keyword) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func ansibleFromYAMLNode(root *yamlParser.Node) bool {
+	if root == nil {
+		return false
+	}
+	if root.Kind == yamlParser.SequenceNode {
+		for _, item := range root.Content {
+			if ansiblePlayKeywordsFromNode(item) {
+				return true
+			}
+		}
+		return false
+	}
+	if root.Kind != yamlParser.MappingNode {
+		return false
+	}
+	playbooks := yamlMapKeyNode(root, playBooks)
+	if playbooks != nil && playbooks.Kind == yamlParser.SequenceNode {
+		for _, item := range playbooks.Content {
+			if ansiblePlayKeywordsFromNode(item) {
+				return true
+			}
+		}
+	}
+	for _, hostKey := range ansibleHost {
+		hosts := yamlMapKeyNode(root, hostKey)
+		if hosts == nil || hosts.Kind != yamlParser.MappingNode {
+			continue
+		}
+		for _, keyword := range listKeywordsAnsibleHots {
+			if yamlMapKeyNode(hosts, keyword) != nil {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/analyzer/yaml_classify.go
+++ b/pkg/analyzer/yaml_classify.go
@@ -22,19 +22,23 @@ func yamlRootHasAnyKey(content []byte, keys ...string) bool {
 		return false
 	}
 	content = bytes.TrimPrefix(content, []byte{0xEF, 0xBB, 0xBF})
+	rootIndent, matchIndent := -1, -1
 	for _, line := range bytes.Split(content, []byte("\n")) {
-		if yamlRootLineHasAnyKey(line, keys...) {
-			return true
+		indent, trimmed := yamlLineContent(line)
+		if len(trimmed) == 0 {
+			continue
+		}
+		if rootIndent < 0 || indent < rootIndent {
+			rootIndent = indent
+		}
+		if yamlRootContentHasAnyKey(trimmed, keys...) && (matchIndent < 0 || indent < matchIndent) {
+			matchIndent = indent
 		}
 	}
-	return false
+	return matchIndent >= 0 && matchIndent == rootIndent
 }
 
-func yamlRootLineHasAnyKey(line []byte, keys ...string) bool {
-	trimmed := yamlRootLineContent(line)
-	if len(trimmed) == 0 {
-		return false
-	}
+func yamlRootContentHasAnyKey(trimmed []byte, keys ...string) bool {
 	// A root-level sequence is the shape of an Ansible playbook, where the
 	// keywords live on the plays rather than on the document root.
 	if trimmed[0] == '-' && (len(trimmed) == 1 || trimmed[1] == ' ' || trimmed[1] == '\t') {
@@ -49,21 +53,21 @@ func yamlRootLineHasAnyKey(line []byte, keys ...string) bool {
 	return plainRootKeyIsAny(trimmed, keys...) || plainRootKeyIsAny(trimmed, "<<")
 }
 
-func yamlRootLineContent(line []byte) []byte {
-	if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
-		return nil
+func yamlLineContent(line []byte) (indent int, content []byte) {
+	for indent < len(line) && (line[indent] == ' ' || line[indent] == '\t') {
+		indent++
 	}
 	trimmed := bytes.TrimSpace(line)
 	if len(trimmed) == 0 || trimmed[0] == '#' {
-		return nil
+		return 0, nil
 	}
 	if bytes.HasPrefix(trimmed, []byte("---")) {
 		trimmed = bytes.TrimSpace(trimmed[3:])
 		if len(trimmed) == 0 || trimmed[0] == '#' {
-			return nil
+			return 0, nil
 		}
 	}
-	return trimmed
+	return indent, trimmed
 }
 
 func plainRootKeyIsAny(trimmed []byte, keys ...string) bool {
@@ -118,6 +122,10 @@ func yamlDocumentRoot(content []byte) (*yamlParser.Node, error) {
 		return nil, nil
 	}
 	return contentNode, nil
+}
+
+func yamlRootIsMapping(root *yamlParser.Node) bool {
+	return root != nil && root.Kind == yamlParser.MappingNode
 }
 
 func yamlMapKeyNode(m *yamlParser.Node, key string) *yamlParser.Node {

--- a/pkg/analyzer/yaml_classify.go
+++ b/pkg/analyzer/yaml_classify.go
@@ -232,7 +232,7 @@ func ansibleFromYAMLNode(root *yamlParser.Node) bool {
 		}
 	}
 	for _, hostKey := range ansibleHost {
-		hosts := yamlMapKeyNode(root, hostKey)
+		hosts := yamlResolveAlias(yamlMapKeyNode(root, hostKey))
 		if hosts == nil || hosts.Kind != yamlParser.MappingNode {
 			continue
 		}

--- a/pkg/analyzer/yaml_classify_test.go
+++ b/pkg/analyzer/yaml_classify_test.go
@@ -163,6 +163,15 @@ all:
 	require.Equal(t, ansible, checkYamlPlatform(ctx, content, "inventory.yml"))
 }
 
+func Test_checkYamlPlatform_aliasBackedPlaybooks(t *testing.T) {
+	ctx := context.Background()
+	content := []byte(`plays: &plays
+  - hosts: all
+playbooks: *plays
+`)
+	require.Equal(t, ansible, checkYamlPlatform(ctx, content, "playbook.yaml"))
+}
+
 func Test_checkYamlPlatform_quotedRootKeys(t *testing.T) {
 	ctx := context.Background()
 	require.Equal(t, gdm, checkYamlPlatform(ctx, []byte(`"resources": []`), "deployment.yaml"))

--- a/pkg/analyzer/yaml_classify_test.go
+++ b/pkg/analyzer/yaml_classify_test.go
@@ -1,0 +1,202 @@
+package analyzer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_yamlRootHasAnyKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		keys    []string
+		want    bool
+	}{
+		{
+			name:    "root play list",
+			content: "- name: demo\n  hosts: localhost\n",
+			keys:    []string{"playbooks"},
+			want:    true,
+		},
+		{
+			name:    "root playbooks key",
+			content: "playbooks:\n  - hosts: all\n",
+			keys:    []string{"playbooks"},
+			want:    true,
+		},
+		{
+			name:    "plain root key padded before colon",
+			content: "resources : []\n",
+			keys:    []string{"resources"},
+			want:    true,
+		},
+		{
+			name:    "plain root key with tab before colon",
+			content: "all\t:\n  hosts: {}\n",
+			keys:    []string{"all"},
+			want:    true,
+		},
+		{
+			name:    "plain root key prefix does not match",
+			content: "resourcesExtra: []\n",
+			keys:    []string{"resources"},
+			want:    false,
+		},
+		{
+			name:    "indented only",
+			content: "  hosts: all\n",
+			keys:    []string{"playbooks", "all"},
+			want:    false,
+		},
+		{
+			name:    "nested matching key",
+			content: "metadata:\n  resources:\n    - name: x\n",
+			keys:    []string{"resources"},
+			want:    false,
+		},
+		{
+			name:    "comment and document marker",
+			content: "---\n# note\nresources:\n  - name: x\n",
+			keys:    []string{"resources"},
+			want:    true,
+		},
+		{
+			name:    "flow mapping root",
+			content: "{resources: []}\n",
+			keys:    []string{"resources"},
+			want:    true,
+		},
+		{
+			name:    "flow sequence root",
+			content: "[{hosts: all}]\n",
+			keys:    []string{"playbooks"},
+			want:    true,
+		},
+		{
+			name:    "flow root after document marker",
+			content: "--- {resources: []}\n",
+			keys:    []string{"resources"},
+			want:    true,
+		},
+		{
+			name:    "root merge key",
+			content: "defaults: &defaults\n  resources: []\n<<: *defaults\n",
+			keys:    []string{"resources"},
+			want:    true,
+		},
+		{
+			name:    "quoted root key",
+			content: `"resources": []` + "\n",
+			keys:    []string{"resources"},
+			want:    true,
+		},
+		{
+			name:    "single quoted root key",
+			content: "'all':\n  hosts: {}\n",
+			keys:    []string{"all"},
+			want:    true,
+		},
+		{
+			name:    "quoted root key padded before colon",
+			content: `"resources" : []` + "\n",
+			keys:    []string{"resources"},
+			want:    true,
+		},
+		{
+			name:    "quoted root key that does not match",
+			content: `"metadata": {}` + "\n",
+			keys:    []string{"resources"},
+			want:    false,
+		},
+		{
+			name:    "quoted root scalar is not a key",
+			content: `"resources"` + "\n",
+			keys:    []string{"resources"},
+			want:    false,
+		},
+		{
+			name:    "escaped quote is left for the parser",
+			content: `"res\"ources": []` + "\n",
+			keys:    []string{"resources"},
+			want:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, yamlRootHasAnyKey([]byte(tt.content), tt.keys...))
+		})
+	}
+}
+
+func Test_checkYamlPlatform_playbookSequenceRoot(t *testing.T) {
+	ctx := context.Background()
+	content := []byte(`---
+- name: Configure web servers
+  hosts: web_servers
+  roles:
+    - common
+`)
+	require.Equal(t, ansible, checkYamlPlatform(ctx, content, "playbook.yml"))
+}
+
+func Test_checkYamlPlatform_ansibleWithoutFullDocumentUnmarshal(t *testing.T) {
+	ctx := context.Background()
+	content := []byte(`playbooks:
+  - name: demo
+    hosts: localhost
+    tasks:
+      - debug: msg=hi
+`)
+	require.Equal(t, ansible, checkYamlPlatform(ctx, content, "site.yml"))
+}
+
+func Test_checkYamlPlatform_ansibleInventoryMergeAlias(t *testing.T) {
+	ctx := context.Background()
+	content := []byte(`inventory: &inventory
+  hosts:
+    web: {}
+all:
+  <<: *inventory
+`)
+	require.Equal(t, ansible, checkYamlPlatform(ctx, content, "inventory.yml"))
+}
+
+func Test_checkYamlPlatform_quotedRootKeys(t *testing.T) {
+	ctx := context.Background()
+	require.Equal(t, gdm, checkYamlPlatform(ctx, []byte(`"resources": []`), "deployment.yaml"))
+	require.Equal(t, ansible, checkYamlPlatform(ctx, []byte(`'all':
+  hosts:
+    web: {}
+`), "inventory.yaml"))
+}
+
+func Test_checkYamlPlatform_flowStyleRoots(t *testing.T) {
+	ctx := context.Background()
+	require.Equal(t, gdm, checkYamlPlatform(ctx, []byte(`{resources: []}`), "deployment.yaml"))
+	require.Equal(t, ansible, checkYamlPlatform(ctx, []byte(`[{hosts: all}]`), "playbook.yaml"))
+}
+
+func Test_checkYamlPlatform_rootMerge(t *testing.T) {
+	content := []byte(`defaults: &defaults
+  resources: []
+<<: *defaults
+`)
+	require.Equal(t, gdm, checkYamlPlatform(context.Background(), content, "deployment.yaml"))
+}
+
+func Test_checkYamlPlatform_encryptedGroupVars(t *testing.T) {
+	content := []byte("$ANSIBLE_VAULT;1.1;AES256\ninvalid\n")
+	require.Equal(t, "", checkYamlPlatform(context.Background(), content, "ansible/group_vars/all/vault.yml"))
+}
+
+func Test_checkYamlPlatform_skipsParseWhenNoRootKeys(t *testing.T) {
+	ctx := context.Background()
+	content := []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+`)
+	require.Equal(t, "", checkYamlPlatform(ctx, content, "manifest.yaml"))
+}

--- a/pkg/analyzer/yaml_classify_test.go
+++ b/pkg/analyzer/yaml_classify_test.go
@@ -163,6 +163,16 @@ all:
 	require.Equal(t, ansible, checkYamlPlatform(ctx, content, "inventory.yml"))
 }
 
+func Test_checkYamlPlatform_aliasBackedInventory(t *testing.T) {
+	ctx := context.Background()
+	content := []byte(`inventory: &inventory
+  hosts:
+    web: {}
+all: *inventory
+`)
+	require.Equal(t, ansible, checkYamlPlatform(ctx, content, "inventory.yml"))
+}
+
 func Test_checkYamlPlatform_aliasBackedPlaybooks(t *testing.T) {
 	ctx := context.Background()
 	content := []byte(`plays: &plays

--- a/pkg/analyzer/yaml_classify_test.go
+++ b/pkg/analyzer/yaml_classify_test.go
@@ -45,10 +45,10 @@ func Test_yamlRootHasAnyKey(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "indented only",
-			content: "  hosts: all\n",
-			keys:    []string{"playbooks", "all"},
-			want:    false,
+			name:    "indented root",
+			content: "  resources: []\n",
+			keys:    []string{"resources"},
+			want:    true,
 		},
 		{
 			name:    "nested matching key",
@@ -186,9 +186,42 @@ func Test_checkYamlPlatform_rootMerge(t *testing.T) {
 	require.Equal(t, gdm, checkYamlPlatform(context.Background(), content, "deployment.yaml"))
 }
 
+func Test_checkYamlPlatform_indentedRoots(t *testing.T) {
+	ctx := context.Background()
+	require.Equal(t, gdm, checkYamlPlatform(ctx, []byte(`  resources: []`), "deployment.yaml"))
+	require.Equal(t, ansible, checkYamlPlatform(ctx, []byte(`  playbooks:
+    - hosts: all
+`), "playbook.yaml"))
+}
+
 func Test_checkYamlPlatform_encryptedGroupVars(t *testing.T) {
 	content := []byte("$ANSIBLE_VAULT;1.1;AES256\ninvalid\n")
 	require.Equal(t, "", checkYamlPlatform(context.Background(), content, "ansible/group_vars/all/vault.yml"))
+}
+
+func Test_checkYamlPlatform_pathVarsRequireMappingRoot(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "mapping", content: "region: us-east-1\n", want: ansible},
+		{name: "empty", content: "", want: ""},
+		{name: "comment only", content: "---\n# vars\n", want: ""},
+		{name: "scalar", content: "value\n", want: ""},
+		{name: "sequence", content: "- value\n", want: ""},
+		{name: "malformed", content: "key: [\n", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkYamlPlatform(
+				context.Background(),
+				[]byte(tt.content),
+				"ansible/group_vars/all/main.yml",
+			)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func Test_checkYamlPlatform_skipsParseWhenNoRootKeys(t *testing.T) {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -230,6 +230,10 @@ func contains(types []string, supportedTypes map[string]bool) bool {
 }
 
 func (c *Parser) isValidExtension(ctx context.Context, filePath string) bool {
+	if ext := utils.ExtensionFromPath(filePath); ext != "" {
+		_, ok := c.extensions[ext]
+		return ok
+	}
 	fsys := c.fsys
 	if fsys == nil {
 		fsys = vfs.DiskFS{}

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -409,6 +409,18 @@ func TestAnalyze_NormalizesRuleAndScanPlatforms(t *testing.T) {
 	s := newTestServer(t)
 	rule := syntheticRule()
 	rule.Platform = " Terraform "
+	rule.RegoQuery = []byte(`package datadog
+
+import rego.v1
+
+DatadogPolicy contains result if {
+	result := {
+		"documentId": input.document[0].id,
+		"resourceType": "test_widget",
+		"resourceName": "example",
+		"searchKey": "resource",
+	}
+}`)
 	req := analyzeRequest{
 		Files: []analyzeFile{{
 			Path:    "infra/main.tf",

--- a/pkg/utils/line_counter.go
+++ b/pkg/utils/line_counter.go
@@ -8,15 +8,35 @@
 package utils
 
 import (
-	"bufio"
+	"bytes"
 	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 )
 
-// LineCounter get the number of lines of a given file
+const lineCountChunkSize = 64 * 1024
+
+// CountLines returns the number of lines in content: a trailing fragment with no
+// newline still counts as a line, and empty content has none.
+func CountLines(content []byte) int {
+	if len(content) == 0 {
+		return 0
+	}
+	lines := bytes.Count(content, []byte{'\n'})
+	if content[len(content)-1] != '\n' {
+		lines++
+	}
+	return lines
+}
+
+// LineCounter get the number of lines of a given file. Prefer CountLines when
+// the content is already in memory. Counting newlines in chunks rather than
+// scanning line by line also lifts the previous 64KB-per-line ceiling, which
+// silently truncated the count for files holding very long (e.g. minified) lines.
 func LineCounter(ctx context.Context, path string) (int, error) {
 	contextLogger := logger.FromContext(ctx)
 	file, err := os.Open(filepath.Clean(path))
@@ -29,14 +49,24 @@ func LineCounter(ctx context.Context, path string) (int, error) {
 		}
 	}()
 
-	scanner := bufio.NewScanner(file)
+	buf := make([]byte, lineCountChunkSize)
 	lineCount := 0
-	for scanner.Scan() {
-		lineCount++
+	endsWithNewline := true
+	for {
+		n, readErr := file.Read(buf)
+		if chunk := buf[:n]; len(chunk) > 0 {
+			lineCount += bytes.Count(chunk, []byte{'\n'})
+			endsWithNewline = chunk[len(chunk)-1] == '\n'
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			return 0, readErr
+		}
 	}
-
-	if err := scanner.Err(); err != nil {
-		return 0, err
+	if !endsWithNewline {
+		lineCount++
 	}
 
 	return lineCount, nil


### PR DESCRIPTION
## Motivation

Profiling a large monorepo scan showed most wall time in file discovery and source preparation. Per-file `.gitignore` matching dominated the serial directory walk, scanned files were opened twice (classify + line count), and YAML platform classification unmarshaled full documents for files regex detection had already ruled out.

Two correctness gaps showed up while tightening these paths: root-anchored `.gitignore` patterns were applied in subdirectories, and Helm-rendered virtual template paths failed extension validation because the parser stat'd paths that do not exist on disk.

An intermediate revision reintroduced a large regression by checking every path component against the full pattern list on every file. This branch replaces that with directory pruning during the walk.

## Changes

**File discovery**

`.gitignore` patterns use `go-git`'s matcher with git's last-match-wins precedence. Ignored directories are matched once on the way down and pruned with `SkipDir`, which is both faster than per-file matching and correct: git cannot re-include a file whose parent directory is excluded. File-targeting patterns (e.g. `*.log`) are still tested on each file.

**Line counting**

Lines are counted from content already read for classification, only once a file is known to be scanned.

**Parser extension validation**

`isValidExtension` resolves the extension from the path first and only stats extensionless paths. Helm-rendered YAML on virtual template paths is no longer dropped with a spurious "file not found" error.

**YAML platform classification**

A lexical root-key prefilter skips most YAML files; survivors are parsed as `yaml.Node`. Handles sequence-root Ansible playbooks, merge-key/alias inventory, quoted root keys (decoded and compared, not assumed), vault-encrypted `group_vars`/`host_vars` (stay unclassified), and indentation checked before trimming.

**Classification I/O**

Content-classified extensions use one open for the max-size check and read; the buffer is pre-sized from the stat result instead of growing through `io.ReadAll`.

**Helm chart detection cache**

Every directory visited while walking up to `Chart.yaml` is memoized, not just the file's parent directory.

**Dependencies**

`github.com/sabhiram/go-gitignore` is removed from `go.mod` and `LICENSE-3rdparty.csv`.

## QA Instruction

CI should pass.

Sixteen additional Kubernetes findings are expected: one Helm subchart whose rendered template paths were previously skipped. Those reflect real misconfigurations in rendered manifests, not a classification regression. This is visible on Regression Detector.

## Impact

File discovery, platform classification, Helm rendering, and the line-of-code metric. No change to rule logic or SARIF shape. Finding counts can increase for Helm dependency subcharts whose rendered paths do not exist on disk. Files under a root-anchored `.gitignore` pattern in a subdirectory are now scanned, matching git behavior.

I submit this contribution under the Apache-2.0 license.