### PR TITLE
Group instantiated module documents per call and file to fix quadratic memory and scan time

### DIFF
--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -36,6 +36,9 @@ type moduleResolutionResult struct {
 	calledDirs     map[string]bool
 	extras         map[string][]extraCallerInfo
 	ok             bool
+	// resourceCount is how many module resources were instantiated. Documents
+	// hold many resources each, so it cannot be derived from the document count.
+	resourceCount int
 }
 
 // instantiateLocalModules evaluates local modules and injects resolved resource
@@ -62,11 +65,12 @@ func (c *Inspector) instantiateLocalModules(
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Info().
 		Int("module_resources_instantiated", totalCallers).
+		Int("module_documents_instantiated", len(res.docs)).
 		Msgf(
-			"Instantiated %d module resources (%d unique OPA docs, %d deduplicated callers)",
+			"Instantiated %d module resources into %d OPA documents (%d deduplicated callers)",
 			totalCallers,
 			len(res.docs),
-			totalCallers-len(res.docs),
+			dedupedCallers(&res),
 		)
 	if !res.ok {
 		return nil, nil, nil
@@ -94,11 +98,17 @@ func (c *Inspector) instantiateLocalModules(
 }
 
 func instantiatedModuleResourceCount(res *moduleResolutionResult) int {
-	count := len(res.docs)
+	return res.resourceCount
+}
+
+// dedupedCallers counts the callers that collapsed onto another caller's
+// document and get their findings cloned after evaluation.
+func dedupedCallers(res *moduleResolutionResult) int {
+	var n int
 	for _, extras := range res.extras {
-		count += len(extras)
+		n += len(extras)
 	}
-	return count
+	return n
 }
 
 func (c *Inspector) buildRemoteResolver() tfeval.RemoteResolver {
@@ -228,6 +238,7 @@ func resolveModuleDocuments(
 	seen := make(map[string]string)
 	extras := make(map[string][]extraCallerInfo)
 	var rootEvalOK bool
+	var resourceCount int
 	actualCalledDirs := make(map[string]bool)
 	var extra []model.Document
 	var syntheticFiles []*model.FileMetadata
@@ -245,9 +256,10 @@ func resolveModuleDocuments(
 		for d := range childDirs {
 			actualCalledDirs[d] = true
 		}
-		docs, syn := instantiatedDocs(resources, byAbsPath, repoPath, seen, extras)
+		docs, syn, n := instantiatedDocs(resources, byAbsPath, repoPath, seen, extras)
 		extra = append(extra, docs...)
 		syntheticFiles = append(syntheticFiles, syn...)
+		resourceCount += n
 	}
 	evaluator.ReleaseCaches()
 
@@ -279,7 +291,14 @@ func resolveModuleDocuments(
 		calledDirs:     strippedDirs,
 		extras:         extras,
 		ok:             true,
+		resourceCount:  resourceCount,
 	}
+}
+
+// instantiatedResource is one resolved resource as it is placed into a document.
+type instantiatedResource struct {
+	typ, baseName, defLine string
+	attrs                  interface{}
 }
 
 // moduleRefEntry holds resolved resource data for _refs injection and dedup.
@@ -288,7 +307,27 @@ type moduleRefEntry struct {
 	attrs                         interface{}
 }
 
-// instantiatedDocs emits one synthetic OPA doc per resolved module resource instance.
+// docGroup collects every resource that one module call contributes to a single
+// defining file.
+type docGroup struct {
+	fm            *model.FileMetadata
+	callChain     string
+	moduleAddress string
+	layer         int
+	entries       []instantiatedResource
+}
+
+// instantiatedDocs emits one synthetic OPA doc per (module call, defining file),
+// holding every resource that call resolved in that file. This mirrors how an
+// ordinary Terraform file reaches Rego - one document, many resources - so rules
+// matching a resource against same-file siblings behave as they do anywhere else.
+//
+// _refs carries the rest of the call's resources so cross-file references inside
+// a module still resolve, and is shared by every doc in the call. Grouping is
+// what makes that affordable: emitting one doc per resource attaches an N-entry
+// map to each of N docs, which is O(N^2) both in memory and in the traversal
+// every walk-based rule performs. Per file it is O(files x N) instead.
+//
 // Identical callers are recorded in extras for post-eval finding cloning.
 func instantiatedDocs(
 	resources []tfeval.ResolvedResource,
@@ -296,113 +335,153 @@ func instantiatedDocs(
 	repoPath string,
 	seen map[string]string,
 	extras map[string][]extraCallerInfo,
-) (docs []model.Document, synthetic []*model.FileMetadata) {
-	// Pass 1: index resources per call chain.
+) (docs []model.Document, synthetic []*model.FileMetadata, resourceCount int) {
+	groups := make(map[string]*docGroup)
+	var order []string
 	cckRefs := make(map[string][]moduleRefEntry)
+	// A base name repeats within one call and file whenever count/for_each
+	// expands a block. Document keys have to stay base-named for line detection
+	// to resolve them against the file's HCL, so repeats spill into another
+	// layer rather than overwriting each other.
+	layers := make(map[string]int)
+
 	for i := range resources {
 		r := &resources[i]
 		if r.ModuleAddress == "" {
 			continue
 		}
+		fm, ok := byAbsPath[absPath(r.DefinedIn, repoPath)]
+		if !ok {
+			continue
+		}
 		cck := callChainKey(r, repoPath)
+		base := tfeval.ResourceBaseName(r.Name)
+		attrs := tfeval.AttributesToDocument(r)
+
 		cckRefs[cck] = append(cckRefs[cck], moduleRefEntry{
 			typ:       r.Type,
 			name:      r.Name,
 			definedIn: absPath(r.DefinedIn, repoPath),
 			defLine:   strconv.Itoa(r.DefLine),
-			attrs:     tfeval.AttributesToDocument(r),
+			attrs:     attrs,
 		})
+
+		slot := cck + "\x00" + fm.ID + "\x00" + r.Type + "\x00" + base
+		layer := layers[slot]
+		layers[slot] = layer + 1
+
+		key := cck + "\x00" + fm.ID + "\x00" + strconv.Itoa(layer)
+		g, exists := groups[key]
+		if !exists {
+			g = &docGroup{fm: fm, callChain: cck, moduleAddress: r.ModuleAddress, layer: layer}
+			groups[key] = g
+			order = append(order, key)
+		}
+		g.entries = append(g.entries, instantiatedResource{
+			typ:      r.Type,
+			baseName: base,
+			defLine:  strconv.Itoa(r.DefLine),
+			attrs:    attrs,
+		})
+		resourceCount++
 	}
-	callContentKeys := make(map[string]string, len(cckRefs))
+
+	// One _refs map per call chain, shared by every doc in it.
+	callRefKeys := make(map[string]uint64, len(cckRefs))
+	callRefs := make(map[string]map[string]interface{}, len(cckRefs))
 	for cck, refs := range cckRefs {
-		callContentKeys[cck] = moduleCallRefsKey(refs)
+		callRefKeys[cck] = xxhash.Sum64String(moduleCallRefsKey(refs))
+		callRefs[cck] = buildSharedRefsMap(refs)
 	}
 
-	// Pass 2: emit one doc per instance.
-	for i := range resources {
-		r := &resources[i]
-		if r.ModuleAddress == "" {
-			continue
-		}
-		abs := absPath(r.DefinedIn, repoPath)
-		fm, ok := byAbsPath[abs]
-		if !ok {
-			continue
-		}
+	for _, key := range order {
+		g := groups[key]
+		docID := g.fm.ID + "\x00" + g.callChain + "\x00" + strconv.Itoa(g.layer)
 
-		cck := callChainKey(r, repoPath)
-		docID := fm.ID + "\x00" + cck + "\x00" + r.Name
-
-		// Identical resolved attributes dedupe to one OPA doc; extras get cloned findings after OPA.
-		contentKey := moduleCallContentKey(r, callContentKeys[cck], repoPath)
+		// Calls that resolve this file to identical content share one OPA doc;
+		// the others are recorded so their findings are cloned after eval.
+		contentKey := groupContentKey(g, callRefKeys[g.callChain])
 		if primaryDocID, dup := seen[contentKey]; dup {
-			extras[primaryDocID] = append(extras[primaryDocID], extraCallerInfo{callChain: cck, docID: docID})
+			extras[primaryDocID] = append(extras[primaryDocID], extraCallerInfo{
+				callChain: g.callChain,
+				docID:     docID,
+			})
 			continue
 		}
 		seen[contentKey] = docID
 
-		refsMap := buildRefsMap(r, cckRefs[cck])
+		resource := make(map[string]interface{})
+		for _, e := range g.entries {
+			byName, ok := resource[e.typ].(map[string]interface{})
+			if !ok {
+				byName = make(map[string]interface{})
+				resource[e.typ] = byName
+			}
+			byName[e.baseName] = e.attrs
+		}
 
 		doc := model.Document{
-			"id":   docID,
-			"file": fm.FilePath,
-			"resource": map[string]interface{}{
-				r.Type: map[string]interface{}{
-					tfeval.ResourceBaseName(r.Name): tfeval.AttributesToDocument(r),
-				},
-			},
+			"id":       docID,
+			"file":     g.fm.FilePath,
+			"resource": resource,
 		}
-		if len(refsMap) > 0 {
+		if refsMap := callRefs[g.callChain]; len(refsMap) > 0 {
 			doc["_refs"] = map[string]interface{}{"resource": refsMap}
 		}
 		docs = append(docs, doc)
-		synthetic = append(synthetic, newInstanceFileMetadata(fm, docID, cck))
+		synthetic = append(synthetic, newInstanceFileMetadata(g.fm, docID, g.callChain))
 	}
-	return docs, synthetic
+	return docs, synthetic, resourceCount
 }
 
-func moduleCallRefsKey(allInCall []moduleRefEntry) string {
-	type row struct{ typ, name, definedIn, defLine, attrKey string }
-	rows := make([]row, 0, len(allInCall))
-	for _, e := range allInCall {
+// groupContentKey identifies a document by its module address, defining file,
+// the content it resolved to, and the call's reference set.
+//
+// The module address keeps two distinct calls in one configuration apart even
+// when they resolve identically, since an aggregating rule must still see both;
+// leaving out the calling root is what lets the same call dedup across roots.
+// The reference set has to be part of the identity because it is part of the
+// document: two calls resolving this file identically can still expose
+// different siblings through _refs.
+func groupContentKey(g *docGroup, refsKey uint64) string {
+	rows := make([]string, 0, len(g.entries))
+	for _, e := range g.entries {
 		b, _ := json.Marshal(e.attrs)
-		rows = append(rows, row{e.typ, e.name, e.definedIn, e.defLine, strconv.FormatUint(xxhash.Sum64(b), 16)})
+		rows = append(rows, strings.Join(
+			[]string{e.typ, e.baseName, e.defLine, strconv.FormatUint(xxhash.Sum64(b), 16)},
+			"\x1f",
+		))
 	}
-	sort.Slice(rows, func(i, j int) bool {
-		for _, pair := range [][2]string{
-			{rows[i].typ, rows[j].typ},
-			{rows[i].name, rows[j].name},
-			{rows[i].definedIn, rows[j].definedIn},
-			{rows[i].defLine, rows[j].defLine},
-			{rows[i].attrKey, rows[j].attrKey},
-		} {
-			if pair[0] != pair[1] {
-				return pair[0] < pair[1]
-			}
-		}
-		return false
-	})
-	var parts []string
-	for _, r := range rows {
-		parts = append(parts, r.typ, r.name, r.definedIn, r.defLine, r.attrKey)
-	}
-	return strings.Join(parts, "\x00")
-}
-
-func moduleCallContentKey(self *tfeval.ResolvedResource, refsKey, repoPath string) string {
+	sort.Strings(rows)
 	return strings.Join([]string{
-		self.ModuleAddress, self.Type, self.Name,
-		absPath(self.DefinedIn, repoPath), strconv.Itoa(self.DefLine), refsKey,
+		g.moduleAddress,
+		g.fm.ID,
+		strconv.Itoa(g.layer),
+		strconv.FormatUint(refsKey, 16),
+		strings.Join(rows, "\x1e"),
 	}, "\x00")
 }
 
-// buildRefsMap returns sibling resources in the same module call (for walk-based rules).
-func buildRefsMap(self *tfeval.ResolvedResource, allInCall []moduleRefEntry) map[string]interface{} {
+func moduleCallRefsKey(allInCall []moduleRefEntry) string {
+	rows := make([]string, 0, len(allInCall))
+	for _, e := range allInCall {
+		b, _ := json.Marshal(e.attrs)
+		rows = append(rows, strings.Join(
+			[]string{e.typ, e.name, e.definedIn, e.defLine, strconv.FormatUint(xxhash.Sum64(b), 16)},
+			"\x1f",
+		))
+	}
+	sort.Strings(rows)
+	return strings.Join(rows, "\x00")
+}
+
+// buildSharedRefsMap returns every resource in a module call, for rules that
+// resolve a reference against another file of the same module. It is built once
+// per call chain and shared by all of that call's docs, so unlike a
+// self-excluding map it also includes the doc's own resources.
+func buildSharedRefsMap(allInCall []moduleRefEntry) map[string]interface{} {
 	refs := make(map[string]interface{})
 	for _, e := range allInCall {
-		if e.typ == self.Type && e.name == self.Name {
-			continue
-		}
 		inner, _ := refs[e.typ].(map[string]interface{})
 		if inner == nil {
 			inner = make(map[string]interface{})

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -10,6 +10,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -17,6 +19,7 @@ import (
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/tfeval"
 	"github.com/rs/zerolog"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // docFileID is the prefix of synthetic doc ids: fileID\x00callChain.
@@ -635,17 +638,152 @@ module "bucket" {
 	}
 }
 
-func TestInstantiatedModuleResourceCountIncludesDeduplicatedCallers(t *testing.T) {
+// A document holds many resources, so the reported resource count cannot be
+// derived from the document count. Keeping them separate is what stops the
+// metric silently changing meaning.
+func TestInstantiatedModuleResourceCountIsResourcesNotDocuments(t *testing.T) {
 	res := moduleResolutionResult{
-		docs: []model.Document{{}, {}},
+		docs:          []model.Document{{}, {}},
+		resourceCount: 37,
 		extras: map[string][]extraCallerInfo{
 			"first":  {{}, {}},
 			"second": {{}},
 		},
 	}
 
-	if got := instantiatedModuleResourceCount(&res); got != 5 {
-		t.Fatalf("instantiatedModuleResourceCount() = %d, want 5", got)
+	if got := instantiatedModuleResourceCount(&res); got != 37 {
+		t.Fatalf("instantiatedModuleResourceCount() = %d, want 37 resources", got)
+	}
+	if got := dedupedCallers(&res); got != 3 {
+		t.Fatalf("dedupedCallers() = %d, want 3", got)
+	}
+}
+
+// Every resource a call resolves in one file belongs to a single document, the
+// way an ordinary Terraform file is presented to Rego. One document per resource
+// would attach an N-entry _refs map to each of N documents, which is quadratic
+// in both memory and the traversal walk-based rules perform.
+func TestInstantiatedDocs_GroupsCallResourcesPerFile(t *testing.T) {
+	const n = 40
+	fm := fileMeta("mod-id", "/repo/monitoring/main.tf")
+	byAbsPath := map[string]*model.FileMetadata{"/repo/monitoring/main.tf": fm}
+
+	resources := make([]tfeval.ResolvedResource, 0, n)
+	for i := 0; i < n; i++ {
+		resources = append(resources, tfeval.ResolvedResource{
+			Type:          "datadog_monitor",
+			Name:          "m" + strconv.Itoa(i),
+			Attributes:    map[string]cty.Value{"name": cty.StringVal("svc")},
+			DefinedIn:     "/repo/monitoring/main.tf",
+			DefLine:       i + 1,
+			ModuleAddress: "module.monitoring",
+			CallChain: []tfeval.CallSite{{
+				ModuleName: "monitoring",
+				Source:     "./monitoring",
+				CalledFrom: "/repo/main.tf",
+				CalledLine: 1,
+			}},
+		})
+	}
+
+	docs, synthetic, _ := instantiatedDocs(resources, byAbsPath, "/repo", map[string]string{}, map[string][]extraCallerInfo{})
+	if len(docs) != 1 {
+		t.Fatalf("got %d docs, want 1 for %d resources of one call in one file", len(docs), n)
+	}
+	if len(synthetic) != 1 {
+		t.Fatalf("got %d synthetic files, want 1 per document", len(synthetic))
+	}
+
+	monitors, _ := docs[0]["resource"].(map[string]interface{})["datadog_monitor"].(map[string]interface{})
+	if len(monitors) != n {
+		t.Fatalf("document holds %d monitors, want all %d", len(monitors), n)
+	}
+}
+
+// count/for_each expansion repeats a base name within one call and file.
+// Document keys stay base-named so line detection can resolve them, so the
+// repeats have to spill into further documents instead of overwriting.
+func TestInstantiatedDocs_RepeatedBaseNamesSpillIntoLayers(t *testing.T) {
+	const instances = 3
+	fm := fileMeta("mod-id", "/repo/monitoring/main.tf")
+	byAbsPath := map[string]*model.FileMetadata{"/repo/monitoring/main.tf": fm}
+
+	resources := make([]tfeval.ResolvedResource, 0, instances)
+	for i := 0; i < instances; i++ {
+		resources = append(resources, tfeval.ResolvedResource{
+			Type:          "datadog_monitor",
+			Name:          "m[" + strconv.Itoa(i) + "]",
+			Attributes:    map[string]cty.Value{"name": cty.StringVal("svc" + strconv.Itoa(i))},
+			DefinedIn:     "/repo/monitoring/main.tf",
+			DefLine:       1,
+			ModuleAddress: "module.monitoring",
+			CallChain: []tfeval.CallSite{{
+				ModuleName: "monitoring",
+				Source:     "./monitoring",
+				CalledFrom: "/repo/main.tf",
+				CalledLine: 1,
+			}},
+		})
+	}
+
+	docs, _, _ := instantiatedDocs(resources, byAbsPath, "/repo", map[string]string{}, map[string][]extraCallerInfo{})
+	if len(docs) != instances {
+		t.Fatalf("got %d docs, want %d so no instance is dropped", len(docs), instances)
+	}
+
+	seenNames := map[string]bool{}
+	for i, doc := range docs {
+		monitors, _ := doc["resource"].(map[string]interface{})["datadog_monitor"].(map[string]interface{})
+		if len(monitors) != 1 {
+			t.Fatalf("doc %d holds %d monitors, want 1", i, len(monitors))
+		}
+		for name, attrs := range monitors {
+			if name != "m" {
+				t.Fatalf("doc %d keyed by %q, want the base name %q so line detection resolves", i, name, "m")
+			}
+			seenNames[attrs.(map[string]interface{})["name"].(string)] = true
+		}
+	}
+	if len(seenNames) != instances {
+		t.Fatalf("kept %d distinct instances, want %d: %v", len(seenNames), instances, seenNames)
+	}
+}
+
+// _refs is what lets a rule resolve a reference into another file of the same
+// module, so it must stay scoped to its own call.
+func TestInstantiatedDocs_DifferentCallChainsGetDistinctRefsMaps(t *testing.T) {
+	fm := fileMeta("mod-id", "/repo/monitoring/main.tf")
+	byAbsPath := map[string]*model.FileMetadata{"/repo/monitoring/main.tf": fm}
+
+	makeResource := func(name, callerFile string, line int) tfeval.ResolvedResource {
+		return tfeval.ResolvedResource{
+			Type:          "datadog_monitor",
+			Name:          name,
+			Attributes:    map[string]cty.Value{"name": cty.StringVal("svc")},
+			DefinedIn:     "/repo/monitoring/main.tf",
+			DefLine:       1,
+			ModuleAddress: "module.monitoring",
+			CallChain: []tfeval.CallSite{{
+				ModuleName: "monitoring",
+				Source:     "./monitoring",
+				CalledFrom: callerFile,
+				CalledLine: line,
+			}},
+		}
+	}
+
+	resources := []tfeval.ResolvedResource{
+		makeResource("a", "/repo/stack-a/main.tf", 1),
+		makeResource("b", "/repo/stack-b/main.tf", 1),
+	}
+	docs, _, _ := instantiatedDocs(resources, byAbsPath, "/repo", map[string]string{}, map[string][]extraCallerInfo{})
+	if len(docs) != 2 {
+		t.Fatalf("got %d docs, want 2", len(docs))
+	}
+	refsA := docs[0]["_refs"].(map[string]interface{})["resource"]
+	refsB := docs[1]["_refs"].(map[string]interface{})["resource"]
+	if reflect.ValueOf(refsA).Pointer() == reflect.ValueOf(refsB).Pointer() {
+		t.Fatal("distinct call chains must not share the same _refs map")
 	}
 }
 

--- a/test/fixtures/test_local_module_fanout/main.tf
+++ b/test/fixtures/test_local_module_fanout/main.tf
@@ -1,0 +1,4 @@
+module "monitoring" {
+  source = "./monitoring"
+  env    = "prod"
+}

--- a/test/fixtures/test_local_module_fanout/monitoring/main.tf
+++ b/test/fixtures/test_local_module_fanout/monitoring/main.tf
@@ -1,0 +1,183 @@
+variable "env" {
+  type = string
+}
+
+resource "datadog_monitor" "m0" {
+  count   = 5
+  name    = "svc-0 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc0.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-0 is erroring in ${var.env}"
+  tags    = ["service:svc-0", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m1" {
+  count   = 5
+  name    = "svc-1 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc1.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-1 is erroring in ${var.env}"
+  tags    = ["service:svc-1", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m2" {
+  count   = 5
+  name    = "svc-2 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc2.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-2 is erroring in ${var.env}"
+  tags    = ["service:svc-2", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m3" {
+  count   = 5
+  name    = "svc-3 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc3.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-3 is erroring in ${var.env}"
+  tags    = ["service:svc-3", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m4" {
+  count   = 5
+  name    = "svc-4 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc4.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-4 is erroring in ${var.env}"
+  tags    = ["service:svc-4", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m5" {
+  count   = 5
+  name    = "svc-5 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc5.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-5 is erroring in ${var.env}"
+  tags    = ["service:svc-5", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m6" {
+  count   = 5
+  name    = "svc-6 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc6.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-6 is erroring in ${var.env}"
+  tags    = ["service:svc-6", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m7" {
+  count   = 5
+  name    = "svc-7 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc7.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-7 is erroring in ${var.env}"
+  tags    = ["service:svc-7", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m8" {
+  count   = 5
+  name    = "svc-8 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc8.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-8 is erroring in ${var.env}"
+  tags    = ["service:svc-8", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m9" {
+  count   = 5
+  name    = "svc-9 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc9.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-9 is erroring in ${var.env}"
+  tags    = ["service:svc-9", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m10" {
+  count   = 5
+  name    = "svc-10 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc10.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-10 is erroring in ${var.env}"
+  tags    = ["service:svc-10", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m11" {
+  count   = 5
+  name    = "svc-11 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc11.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-11 is erroring in ${var.env}"
+  tags    = ["service:svc-11", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m12" {
+  count   = 5
+  name    = "svc-12 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc12.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-12 is erroring in ${var.env}"
+  tags    = ["service:svc-12", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m13" {
+  count   = 5
+  name    = "svc-13 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc13.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-13 is erroring in ${var.env}"
+  tags    = ["service:svc-13", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m14" {
+  count   = 5
+  name    = "svc-14 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc14.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-14 is erroring in ${var.env}"
+  tags    = ["service:svc-14", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m15" {
+  count   = 5
+  name    = "svc-15 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc15.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-15 is erroring in ${var.env}"
+  tags    = ["service:svc-15", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m16" {
+  count   = 5
+  name    = "svc-16 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc16.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-16 is erroring in ${var.env}"
+  tags    = ["service:svc-16", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m17" {
+  count   = 5
+  name    = "svc-17 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc17.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-17 is erroring in ${var.env}"
+  tags    = ["service:svc-17", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m18" {
+  count   = 5
+  name    = "svc-18 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc18.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-18 is erroring in ${var.env}"
+  tags    = ["service:svc-18", "env:${var.env}"]
+}
+
+resource "datadog_monitor" "m19" {
+  count   = 5
+  name    = "svc-19 error rate ${var.env}"
+  type    = "metric alert"
+  query   = "avg(last_5m):sum:svc19.errors{env:${var.env}}.as_count() > 100"
+  message = "svc-19 is erroring in ${var.env}"
+  tags    = ["service:svc-19", "env:${var.env}"]
+}


### PR DESCRIPTION
## Motivation

Enabling local module evaluation (`--x-local-module-eval`) caused pod OOM kills, and the repository that triggered them was also too slow to scan once the memory was fixed. Both come from the same shape.

Instantiation emitted **one document per resolved resource**, and attached the call's other resources to each of them so cross-file references inside a module could still resolve. For a module call resolving N resources that is N documents each carrying an N-entry map: O(N²).

The first cost is memory, and it is what killed the pods. The second is CPU, and it is why the repo stayed slow after the memory was fixed: 60 rules do `some doc in input.document` then `walk(doc)`, so every one of the N documents gets its N-entry reference map traversed, N times over per rule.

## Change

Emit one document per **(module call, defining file)** holding every resource that call resolved in that file, rather than one per resource. This is how an ordinary Terraform file already reaches Rego — one document, many resources — so same-file sibling matching works by construction.

`_refs` stays, shared per call, so cross-file references inside a module still resolve. Grouping is what makes it affordable: the map is attached once per *file* rather than once per *resource*, turning O(N²) into O(files × N).

Three details that keep behaviour identical:

- **`count`/`for_each` instances.** A base name repeats within one call and file when a block expands. Document keys must stay base-named or line detection cannot resolve them against the file's HCL, so repeats spill into additional documents instead of overwriting each other. Merging them under one key would silently drop every instance but the first, including a vulnerable one among safe siblings.
- **Dedup identity.** Keyed on module address, defining file, resolved content and the call's reference set. The module address keeps two distinct calls in one configuration apart so an aggregating rule still sees both; leaving out the calling root is what lets the same call dedup across roots. The reference set is included because it is part of the document.
- **Metric meaning.** Documents now hold many resources, so the count can no longer be derived from the document count. `module_resources_instantiated` still reports resources and is unchanged; `module_documents_instantiated` is added alongside it, since documents are what now predicts evaluation cost.

## Results

Large flat monorepo — 4,149 module resources:

| | Before | After |
|---|---:|---:|
| Documents | 4,149 | **510** |
| Wall time | 64.2 s | 60.3 s |
| Peak RSS | 1.02 GB | 0.95 GB |
| Findings | 2,531 | **2,531, zero set difference** |

Triggering repository — 607,696 module resources across 32,914 calls, widest call 6,069, Σnᵢ² = 2.81e9:

| | Documents | Wall time | Peak RSS |
|---|---:|---:|---:|
| One doc per resource, map per doc | 545,301 | did not complete (>20 min) | ~920 GB projected, OOM in production |
| One doc per resource, map shared per call | 545,301 | did not complete (>20 min) | 5.94 GB |
| **One doc per (call, file), map shared per call** | **196,785** | **372 s** | **3.64 GB** |

Sharing the map fixes the memory but leaves the traversal quadratic, which is why the middle row still does not finish. Dropping `_refs` altogether was also measured (660 s) but is rejected below.

Fan-out fixture (`test/fixtures/test_local_module_fanout`): 100 resources into 5 documents, 5 s, 0.11 GB.

## Why not just drop `_refs`

It is faster and, on the flat monorepo, produces byte-identical findings — which makes it look safe. It is not. `Combine` presents one document per file, so an ordinary scan lets a rule see every resource in that file; an instantiated module document holds only its own resources, and without `_refs` a rule matching a resource against one declared in a sibling file of the same module stops firing. `TestInspect_CrossFileModuleRefsResolvedBySiblings` covers exactly this, and it fails without `_refs`. Identical findings on one repository means no such rule fired there, not that none exists.

Grouping is what makes keeping `_refs` cheap enough that the trade-off does not have to be made.

## Tests

- `TestInstantiatedDocs_GroupsCallResourcesPerFile` — a call's resources in one file land in one document.
- `TestInstantiatedDocs_RepeatedBaseNamesSpillIntoLayers` — expanded instances all survive, keys stay base-named.
- `TestInstantiatedDocs_DifferentCallChainsGetDistinctRefsMaps` — reference sets stay scoped to their call.
- `TestInstantiatedModuleResourceCountIsResourcesNotDocuments` — the metric cannot drift into counting documents.
- Existing cross-file, cross-root dedup, and aggregate-rule integration tests are unchanged and passing.

## QA Instruction

1. `go test ./pkg/... -count=1`
2. `golangci-lint run -c .golangci.yml ./pkg/... ./cmd/...`
3. Manual memory check (requires git repo with `origin` remote):
   ```bash
   cd test/fixtures/test_local_module_fanout
   git init . && git remote add origin https://github.com/example/fanout.git
   git add -A && git commit -m init
   make -C ../../.. build
   /usr/bin/time -l ../../../bin/datadog-iac-scanner scan \
     -p . -o /tmp/out -t Terraform --x-local-module-eval --log-level info
   ```
   Expect `100 module resources into 5 OPA documents` and peak RSS well under 1 GB.

## Impact

CLI scan path only, when `--x-local-module-eval` / `IacEnableLocalModuleEval` is enabled. Findings verified unchanged on a large real repository. Document IDs for instantiated resources change shape (they now identify a call and file rather than a call and resource), so SARIF fingerprints for instantiated findings will churn once on rollout.

## Known gap

Cost is now linear in a resource count the repository controls, with no upper bound. The triggering repository lands at 372 s and 3.64 GB against a 40 GiB container, but a repository several times larger would still be slow before it was ever at risk of OOM.
