### PR TITLE
Group instantiated module documents to prevent quadratic memory growth

### DIFF
--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -444,15 +444,14 @@ func (c *Inspector) Inspect(
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("engine.Inspect()")
 
-	// Terraform local-module instantiation is gated so it can be disabled remotely.
+	// Temporarily enable Terraform local-module instantiation unconditionally so
+	// regression detection exercises this path.
 	queries := c.getQueriesByPlat(platforms)
 
 	var moduleDocs []model.Document
 	var moduleExtras map[string][]extraCallerInfo
 	var syntheticFiles []*model.FileMetadata
-	if shouldInstantiateLocalModules(platforms, files) &&
-		c.flagEvaluator != nil &&
-		c.flagEvaluator.EvaluateWithOrg(featureflags.IacEnableLocalModuleEval) {
+	if shouldInstantiateLocalModules(platforms, files) {
 		targets := ruleTargetedResourceTypes(queries, c.terraformRuleLibraries()...)
 		moduleDocs, syntheticFiles, moduleExtras = c.instantiateLocalModules(ctx, files, targets)
 	}

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -445,14 +445,16 @@ func (c *Inspector) Inspect(
 	contextLogger.Debug().Msg("engine.Inspect()")
 
 	// Terraform local-module instantiation is gated so it can be disabled remotely.
+	queries := c.getQueriesByPlat(platforms)
+
 	var moduleDocs []model.Document
 	var moduleExtras map[string][]extraCallerInfo
+	var syntheticFiles []*model.FileMetadata
 	if shouldInstantiateLocalModules(platforms, files) &&
 		c.flagEvaluator != nil &&
 		c.flagEvaluator.EvaluateWithOrg(featureflags.IacEnableLocalModuleEval) {
-		var syntheticFiles []*model.FileMetadata
-		moduleDocs, syntheticFiles, moduleExtras = c.instantiateLocalModules(ctx, files)
-		files = append(files, syntheticFiles...)
+		targets := ruleTargetedResourceTypes(queries, c.terraformRuleLibraries()...)
+		moduleDocs, syntheticFiles, moduleExtras = c.instantiateLocalModules(ctx, files, targets)
 	}
 
 	// Must run after module mutations (which suppress module bodies in place).
@@ -480,7 +482,12 @@ func (c *Inspector) Inspect(
 		return nil, err
 	}
 
-	queries := c.getQueriesByPlat(platforms)
+	// Synthetic files stand in for module instantiations of a file that has
+	// already been read; they are only joined once findings need to be
+	// attributed back to a call site. Adding them any earlier would have every
+	// pass over the scan input, module parsing above in particular, redo that
+	// file's work once per instantiation.
+	files = append(files, syntheticFiles...)
 
 	// Compute the file map once and share it (read-only) across all workers and
 	// payload partitioning.

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -387,7 +387,7 @@ func TestInterfaceToPayloadValueMatchesExistingTransformation(t *testing.T) {
 			map[string]interface{}{
 				"id":       "one",
 				"resource": shared,
-				"_refs":    map[string]interface{}{"resource": shared},
+				"mirror":   map[string]interface{}{"resource": shared},
 			},
 		},
 	}

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -329,7 +329,9 @@ func evaluateRootModules(
 		resources, _, childDirs, err := evaluator.EvaluateModule(ctx, dir, tfeval.LoadRootVars(dir))
 		if err != nil {
 			contextLogger.Warn().Err(err).Msgf("tfeval: failed to evaluate root module %s", dir)
-			for _, called := range discoverCalledModuleDirs(ctx, evaluator, filesByDir[dir], repoPath, resolver, dir) {
+			for _, called := range discoverCalledModuleClosure(
+				ctx, evaluator, filesByDir, repoPath, resolver, dir,
+			) {
 				failedRootModuleDirs[called] = true
 			}
 			continue
@@ -575,8 +577,6 @@ func instantiatedDocs(
 		resourceCount++
 	}
 
-	copyStaticResourcesIntoExpandedLayers(groups, order)
-
 	for _, key := range order {
 		g := groups[key]
 		docID := g.fm.ID + "\x00" + g.callChain + "\x00" + strconv.Itoa(g.layer)
@@ -610,51 +610,6 @@ func instantiatedDocs(
 		synthetic = append(synthetic, newInstanceFileMetadata(g.fm, docID, g.callChain))
 	}
 	return docs, synthetic, resourceCount
-}
-
-// copyStaticResourcesIntoExpandedLayers mirrors non-expanded resources into every
-// count/for_each layer document for the same call and file. Without this, a rule
-// that relates resources in one file would see expanded instances in isolation
-// from their siblings.
-func copyStaticResourcesIntoExpandedLayers(groups map[string]*docGroup, order []string) {
-	staticByCallFile := make(map[string][]instantiatedResource)
-	for _, key := range order {
-		g := groups[key]
-		cfKey := g.callChain + "\x00" + g.fm.ID
-		for i := range g.entries {
-			e := &g.entries[i]
-			if e.fullName != e.baseName {
-				continue
-			}
-			staticByCallFile[cfKey] = appendUniqueInstantiated(staticByCallFile[cfKey], *e)
-		}
-	}
-	for _, key := range order {
-		g := groups[key]
-		hasExpanded := false
-		for i := range g.entries {
-			if g.entries[i].fullName != g.entries[i].baseName {
-				hasExpanded = true
-				break
-			}
-		}
-		if !hasExpanded {
-			continue
-		}
-		cfKey := g.callChain + "\x00" + g.fm.ID
-		for _, e := range staticByCallFile[cfKey] {
-			g.entries = appendUniqueInstantiated(g.entries, e)
-		}
-	}
-}
-
-func appendUniqueInstantiated(entries []instantiatedResource, e instantiatedResource) []instantiatedResource {
-	for i := range entries {
-		if entries[i].typ == e.typ && entries[i].fullName == e.fullName {
-			return entries
-		}
-	}
-	return append(entries, e)
 }
 
 // groupContentKey identifies a document by the module call address it belongs
@@ -853,6 +808,38 @@ func discoverCalledModuleDirs(
 		"module resolve: falling back to directory parse for called module discovery",
 	)
 	return evaluator.CalledModuleDirs(dir)
+}
+
+// discoverCalledModuleClosure returns every module transitively reachable from
+// dir. It is used only after root evaluation fails, when suppression must be
+// conservative because no synthetic documents exist for that call chain.
+func discoverCalledModuleClosure(
+	ctx context.Context,
+	evaluator *tfeval.Evaluator,
+	filesByDir map[string][]*model.FileMetadata,
+	repoPath string,
+	resolver tfeval.RemoteResolver,
+	dir string,
+) []string {
+	seen := map[string]bool{dir: true}
+	queue := []string{dir}
+	var closure []string
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for _, called := range discoverCalledModuleDirs(
+			ctx, evaluator, filesByDir[current], repoPath, resolver, current,
+		) {
+			if seen[called] {
+				continue
+			}
+			seen[called] = true
+			closure = append(closure, called)
+			queue = append(queue, called)
+		}
+	}
+	return closure
 }
 
 func calledModuleDirsFromDocuments(

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -7,7 +7,9 @@ package engine
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"maps"
 	"path/filepath"
 	"sort"
@@ -32,9 +34,10 @@ type extraCallerInfo struct {
 type moduleResolutionResult struct {
 	docs           []model.Document
 	syntheticFiles []*model.FileMetadata
-	suppressed     map[string]bool
+	suppressed     instantiatedIndex
 	calledDirs     map[string]bool
 	extras         map[string][]extraCallerInfo
+	resourceCount  int
 	ok             bool
 }
 
@@ -58,15 +61,15 @@ func (c *Inspector) instantiateLocalModules(
 ) ([]model.Document, []*model.FileMetadata, map[string][]extraCallerInfo) {
 	resolver := c.buildRemoteResolver()
 	res := c.resolveModulesSafely(ctx, files, resolver)
-	totalCallers := instantiatedModuleResourceCount(&res)
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Info().
-		Int("module_resources_instantiated", totalCallers).
+		Int("module_resources_instantiated", res.resourceCount).
+		Int("module_documents", len(res.docs)).
 		Msgf(
-			"Instantiated %d module resources (%d unique OPA docs, %d deduplicated callers)",
-			totalCallers,
+			"Instantiated %d module resources into %d documents (%d deduplicated callers)",
+			res.resourceCount,
 			len(res.docs),
-			totalCallers-len(res.docs),
+			deduplicatedCallerCount(&res),
 		)
 	if !res.ok {
 		return nil, nil, nil
@@ -75,15 +78,18 @@ func (c *Inspector) instantiateLocalModules(
 		if f == nil || !isTerraformFile(f.FilePath) {
 			continue
 		}
-		if res.suppressed[f.ID] {
-			// Resource blocks are re-emitted as instantiated synthetic docs, so
-			// drop only those to avoid double-counting; keep the rest of the body
-			// (variable/output/data/locals) so those rules still fire.
-			delete(f.Document, "resource")
+		if replaced := res.suppressed[f.ID]; len(replaced) > 0 {
+			// Only the blocks that came back as instantiated documents are
+			// dropped, so nothing loses its coverage: a resource the evaluator
+			// could not resolve, or one that expanded to no instances, keeps
+			// being scanned where it is written. The rest of the body
+			// (variable/output/data/locals) is always kept so its rules fire as
+			// they do in a standalone scan.
+			removeInstantiatedResources(f.Document, replaced)
 			if err := f.EnsureLineInfoDocument(ctx); err != nil {
 				contextLogger.Err(err).Msgf("failed to build line-info document for file %s", f.FilePath)
 			} else {
-				delete(f.LineInfoDocument, "resource")
+				removeInstantiatedResources(f.LineInfoDocument, replaced)
 			}
 		}
 		// Only remove local module call-sites that were instantiated; remote/registry
@@ -93,8 +99,78 @@ func (c *Inspector) instantiateLocalModules(
 	return res.docs, res.syntheticFiles, res.extras
 }
 
-func instantiatedModuleResourceCount(res *moduleResolutionResult) int {
-	count := len(res.docs)
+// instantiatedIndex records which resource blocks of a file were re-emitted as
+// instantiated documents, as file ID -> resource type -> block name.
+type instantiatedIndex map[string]map[string]map[string]bool
+
+func (idx instantiatedIndex) add(fileID, typ, name string) {
+	byType, ok := idx[fileID]
+	if !ok {
+		byType = make(map[string]map[string]bool)
+		idx[fileID] = byType
+	}
+	names, ok := byType[typ]
+	if !ok {
+		names = make(map[string]bool)
+		byType[typ] = names
+	}
+	names[name] = true
+}
+
+// removeInstantiatedResources deletes the named resource blocks from a parsed
+// file so they are not scanned twice, once where they are written and once
+// instantiated.
+func removeInstantiatedResources(doc map[string]interface{}, replaced map[string]map[string]bool) {
+	resources, ok := asStringMap(doc["resource"])
+	if !ok {
+		return
+	}
+	for typ, names := range replaced {
+		byName, ok := asStringMap(resources[typ])
+		if !ok {
+			// A nameless resource block parses to a list, leaving no name to
+			// match on; drop the type so nothing is counted twice.
+			delete(resources, typ)
+			continue
+		}
+		for name := range names {
+			delete(byName, name)
+		}
+		if onlyMetadataKeys(byName) {
+			delete(resources, typ)
+		}
+	}
+	if onlyMetadataKeys(resources) {
+		delete(doc, "resource")
+	}
+}
+
+// asStringMap accepts either shape a parsed document uses for an object.
+func asStringMap(value interface{}) (map[string]interface{}, bool) {
+	switch m := value.(type) {
+	case model.Document:
+		return m, true
+	case map[string]interface{}:
+		return m, true
+	default:
+		return nil, false
+	}
+}
+
+// onlyMetadataKeys reports whether a map holds nothing but the parser's own
+// bookkeeping (line numbers and the like), which describes content that is no
+// longer there.
+func onlyMetadataKeys(m map[string]interface{}) bool {
+	for key := range m {
+		if !strings.HasPrefix(key, "_") {
+			return false
+		}
+	}
+	return true
+}
+
+func deduplicatedCallerCount(res *moduleResolutionResult) int {
+	count := 0
 	for _, extras := range res.extras {
 		count += len(extras)
 	}
@@ -225,12 +301,14 @@ func resolveModuleDocuments(
 
 	// seen maps a content-based key to the primary docID so duplicate callers can
 	// be recorded in extras rather than emitted as separate OPA documents.
-	seen := make(map[string]string)
+	seen := make(map[docContentKey]string)
 	extras := make(map[string][]extraCallerInfo)
+	instantiated := make(instantiatedIndex)
 	var rootEvalOK bool
 	actualCalledDirs := make(map[string]bool)
 	var extra []model.Document
 	var syntheticFiles []*model.FileMetadata
+	var resourceCount int
 
 	for dir := range dirsWithTf {
 		if staticCalledDirs[dir] {
@@ -245,9 +323,10 @@ func resolveModuleDocuments(
 		for d := range childDirs {
 			actualCalledDirs[d] = true
 		}
-		docs, syn := instantiatedDocs(resources, byAbsPath, repoPath, seen, extras)
+		docs, syn, count := instantiatedDocs(resources, byAbsPath, repoPath, seen, extras, instantiated)
 		extra = append(extra, docs...)
 		syntheticFiles = append(syntheticFiles, syn...)
+		resourceCount += count
 	}
 	evaluator.ReleaseCaches()
 
@@ -257,160 +336,239 @@ func resolveModuleDocuments(
 		return moduleResolutionResult{}
 	}
 
-	suppressed := make(map[string]bool)
-	for dir := range actualCalledDirs {
-		for _, f := range filesByDir[dir] {
-			suppressed[f.ID] = true
-		}
-	}
-
-	// Only strip call sites when that module's files are in the scan (avoid dropping sole coverage).
+	// A call site is only stripped once the module behind it actually produced
+	// instantiated documents. Stripping it otherwise — because evaluation
+	// resolved nothing, or because the module's files are not part of the scan
+	// — would remove the call-site rule branches without putting anything in
+	// their place.
 	strippedDirs := make(map[string]bool, len(actualCalledDirs))
 	for dir := range actualCalledDirs {
-		if len(filesByDir[dir]) > 0 {
-			strippedDirs[dir] = true
+		for _, f := range filesByDir[dir] {
+			if len(instantiated[f.ID]) > 0 {
+				strippedDirs[dir] = true
+				break
+			}
 		}
 	}
 
 	return moduleResolutionResult{
 		docs:           extra,
 		syntheticFiles: syntheticFiles,
-		suppressed:     suppressed,
+		suppressed:     instantiated,
 		calledDirs:     strippedDirs,
 		extras:         extras,
+		resourceCount:  resourceCount,
 		ok:             true,
 	}
 }
 
-// moduleRefEntry holds resolved resource data for _refs injection and dedup.
-type moduleRefEntry struct {
-	typ, name, definedIn, defLine string
-	attrs                         interface{}
+// instantiatedResource is one resolved resource as it is placed into a document.
+type instantiatedResource struct {
+	typ       string
+	baseName  string
+	fullName  string
+	defLine   int
+	attrs     map[string]interface{}
+	attrsHash uint64
 }
 
-// instantiatedDocs emits one synthetic OPA doc per resolved module resource instance.
-// Identical callers are recorded in extras for post-eval finding cloning.
+// docGroup collects every resource one module call resolved in one defining file.
+type docGroup struct {
+	fm            *model.FileMetadata
+	callChain     string
+	moduleAddress string
+	layer         int
+	entries       []instantiatedResource
+}
+
+// docContentKey identifies a document by its content. Two independent digests
+// keep the collision probability negligible across the hundreds of thousands of
+// documents a large repository resolves: a collision would silently merge two
+// different resources into one finding.
+type docContentKey struct{ a, b uint64 }
+
+// instantiatedDocs emits one synthetic OPA document per (module call, defining
+// file), holding every resource that call resolved in that file.
+//
+// This is exactly the shape an ordinary Terraform file has in the payload: one
+// document, all of the file's resources, nothing from its siblings. A rule
+// therefore cannot tell whether a resource was written inline or reached
+// through a module, and cross-file rules are neither better nor worse inside a
+// module than they already are outside one.
+//
+// The shape is also what keeps the payload proportional to the configuration
+// rather than to the call graph. A document per resource, or a document
+// carrying an index of its siblings, ties each document to the call it came
+// from and defeats the deduplication below: on a repository where 77 roots call
+// the same modules, that is the difference between 20k and 197k documents, and
+// every document costs a synthetic file, a payload entry and a pass of every
+// rule.
+//
+// Callers whose resolved content is identical share one document; the rest are
+// recorded in extras so their findings are cloned after evaluation, keeping
+// per-call-site attribution without re-evaluating identical input.
 func instantiatedDocs(
 	resources []tfeval.ResolvedResource,
 	byAbsPath map[string]*model.FileMetadata,
 	repoPath string,
-	seen map[string]string,
+	seen map[docContentKey]string,
 	extras map[string][]extraCallerInfo,
-) (docs []model.Document, synthetic []*model.FileMetadata) {
-	// Pass 1: index resources per call chain.
-	cckRefs := make(map[string][]moduleRefEntry)
-	for i := range resources {
-		r := &resources[i]
-		if r.ModuleAddress == "" {
-			continue
-		}
-		cck := callChainKey(r, repoPath)
-		cckRefs[cck] = append(cckRefs[cck], moduleRefEntry{
-			typ:       r.Type,
-			name:      r.Name,
-			definedIn: absPath(r.DefinedIn, repoPath),
-			defLine:   strconv.Itoa(r.DefLine),
-			attrs:     tfeval.AttributesToDocument(r),
-		})
-	}
-	callContentKeys := make(map[string]string, len(cckRefs))
-	for cck, refs := range cckRefs {
-		callContentKeys[cck] = moduleCallRefsKey(refs)
-	}
+	instantiated instantiatedIndex,
+) (docs []model.Document, synthetic []*model.FileMetadata, resourceCount int) {
+	groups := make(map[string]*docGroup)
+	var order []string
+	// A base name repeats within one call and file whenever count/for_each
+	// expands a block. Document keys stay base-named so line detection can
+	// resolve them against the file's HCL, so repeats spill into a further
+	// document rather than overwriting each other.
+	layers := make(map[string]int)
 
-	// Pass 2: emit one doc per instance.
 	for i := range resources {
 		r := &resources[i]
 		if r.ModuleAddress == "" {
 			continue
 		}
-		abs := absPath(r.DefinedIn, repoPath)
-		fm, ok := byAbsPath[abs]
+		fm, ok := byAbsPath[absPath(r.DefinedIn, repoPath)]
 		if !ok {
 			continue
 		}
-
 		cck := callChainKey(r, repoPath)
-		docID := fm.ID + "\x00" + cck + "\x00" + r.Name
+		base := tfeval.ResourceBaseName(r.Name)
+		attrs := tfeval.AttributesToDocument(r)
+		entry := instantiatedResource{
+			typ:       r.Type,
+			baseName:  base,
+			fullName:  r.Name,
+			defLine:   r.DefLine,
+			attrs:     attrs,
+			attrsHash: hashAttributes(attrs),
+		}
 
-		// Identical resolved attributes dedupe to one OPA doc; extras get cloned findings after OPA.
-		contentKey := moduleCallContentKey(r, callContentKeys[cck], repoPath)
+		slot := cck + "\x00" + fm.ID + "\x00" + r.Type + "\x00" + base
+		layer := layers[slot]
+		layers[slot] = layer + 1
+
+		key := cck + "\x00" + fm.ID + "\x00" + strconv.Itoa(layer)
+		g, exists := groups[key]
+		if !exists {
+			g = &docGroup{fm: fm, callChain: cck, moduleAddress: r.ModuleAddress, layer: layer}
+			groups[key] = g
+			order = append(order, key)
+		}
+		g.entries = append(g.entries, entry)
+		// Recorded before deduplication: a document that dedupes away still
+		// covers its resource, through a finding cloned onto its call site.
+		instantiated.add(fm.ID, r.Type, base)
+		resourceCount++
+	}
+
+	for _, key := range order {
+		g := groups[key]
+		docID := g.fm.ID + "\x00" + g.callChain + "\x00" + strconv.Itoa(g.layer)
+
+		contentKey := groupContentKey(g)
 		if primaryDocID, dup := seen[contentKey]; dup {
-			extras[primaryDocID] = append(extras[primaryDocID], extraCallerInfo{callChain: cck, docID: docID})
+			extras[primaryDocID] = append(extras[primaryDocID], extraCallerInfo{
+				callChain: g.callChain,
+				docID:     docID,
+			})
 			continue
 		}
 		seen[contentKey] = docID
 
-		refsMap := buildRefsMap(r, cckRefs[cck])
-
-		doc := model.Document{
-			"id":   docID,
-			"file": fm.FilePath,
-			"resource": map[string]interface{}{
-				r.Type: map[string]interface{}{
-					tfeval.ResourceBaseName(r.Name): tfeval.AttributesToDocument(r),
-				},
-			},
-		}
-		if len(refsMap) > 0 {
-			doc["_refs"] = map[string]interface{}{"resource": refsMap}
-		}
-		docs = append(docs, doc)
-		synthetic = append(synthetic, newInstanceFileMetadata(fm, docID, cck))
-	}
-	return docs, synthetic
-}
-
-func moduleCallRefsKey(allInCall []moduleRefEntry) string {
-	type row struct{ typ, name, definedIn, defLine, attrKey string }
-	rows := make([]row, 0, len(allInCall))
-	for _, e := range allInCall {
-		b, _ := json.Marshal(e.attrs)
-		rows = append(rows, row{e.typ, e.name, e.definedIn, e.defLine, strconv.FormatUint(xxhash.Sum64(b), 16)})
-	}
-	sort.Slice(rows, func(i, j int) bool {
-		for _, pair := range [][2]string{
-			{rows[i].typ, rows[j].typ},
-			{rows[i].name, rows[j].name},
-			{rows[i].definedIn, rows[j].definedIn},
-			{rows[i].defLine, rows[j].defLine},
-			{rows[i].attrKey, rows[j].attrKey},
-		} {
-			if pair[0] != pair[1] {
-				return pair[0] < pair[1]
+		resource := make(map[string]interface{})
+		for i := range g.entries {
+			e := &g.entries[i]
+			byName, ok := resource[e.typ].(map[string]interface{})
+			if !ok {
+				byName = make(map[string]interface{})
+				resource[e.typ] = byName
 			}
+			byName[e.baseName] = e.attrs
 		}
-		return false
+
+		docs = append(docs, model.Document{
+			"id":       docID,
+			"file":     g.fm.FilePath,
+			"resource": resource,
+		})
+		synthetic = append(synthetic, newInstanceFileMetadata(g.fm, docID, g.callChain))
+	}
+	return docs, synthetic, resourceCount
+}
+
+// groupContentKey identifies a document by the module call address it belongs
+// to, its defining file, and the content it resolved to.
+//
+// The module address keeps two distinct calls in one configuration apart even
+// when they resolve identically, since a rule that aggregates across documents
+// must still see both; leaving out the calling root is what lets the same call
+// deduplicate across roots.
+func groupContentKey(g *docGroup) docContentKey {
+	sortInstantiated(g.entries)
+
+	h := newContentHasher()
+	h.str(g.moduleAddress)
+	h.str(g.fm.ID)
+	h.u64(uint64(g.layer))
+	for i := range g.entries {
+		e := &g.entries[i]
+		h.str(e.typ)
+		h.str(e.baseName)
+		h.u64(uint64(e.defLine))
+		h.u64(e.attrsHash)
+	}
+	return h.key()
+}
+
+func sortInstantiated(entries []instantiatedResource) {
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].typ != entries[j].typ {
+			return entries[i].typ < entries[j].typ
+		}
+		if entries[i].fullName != entries[j].fullName {
+			return entries[i].fullName < entries[j].fullName
+		}
+		return entries[i].defLine < entries[j].defLine
 	})
-	var parts []string
-	for _, r := range rows {
-		parts = append(parts, r.typ, r.name, r.definedIn, r.defLine, r.attrKey)
-	}
-	return strings.Join(parts, "\x00")
 }
 
-func moduleCallContentKey(self *tfeval.ResolvedResource, refsKey, repoPath string) string {
-	return strings.Join([]string{
-		self.ModuleAddress, self.Type, self.Name,
-		absPath(self.DefinedIn, repoPath), strconv.Itoa(self.DefLine), refsKey,
-	}, "\x00")
+func hashAttributes(attrs map[string]interface{}) uint64 {
+	b, err := json.Marshal(attrs)
+	if err != nil {
+		// Unmarshalable attributes must never collapse onto each other, so fall
+		// back to a value that cannot match another resource's content.
+		return xxhash.Sum64String(fmt.Sprintf("%v", attrs))
+	}
+	return xxhash.Sum64(b)
 }
 
-// buildRefsMap returns sibling resources in the same module call (for walk-based rules).
-func buildRefsMap(self *tfeval.ResolvedResource, allInCall []moduleRefEntry) map[string]interface{} {
-	refs := make(map[string]interface{})
-	for _, e := range allInCall {
-		if e.typ == self.Type && e.name == self.Name {
-			continue
-		}
-		inner, _ := refs[e.typ].(map[string]interface{})
-		if inner == nil {
-			inner = make(map[string]interface{})
-			refs[e.typ] = inner
-		}
-		inner[e.name] = e.attrs
+// contentHasher folds fields into a 128-bit key using two independent digests.
+type contentHasher struct{ a, b *xxhash.Digest }
+
+func newContentHasher() contentHasher {
+	h := contentHasher{a: xxhash.New(), b: xxhash.New()}
+	_, _ = h.b.WriteString("\x00datadog-iac-scanner\x00")
+	return h
+}
+
+func (h contentHasher) str(s string) {
+	for _, d := range [...]*xxhash.Digest{h.a, h.b} {
+		_, _ = d.WriteString(s)
+		_, _ = d.WriteString("\x1f")
 	}
-	return refs
+}
+
+func (h contentHasher) u64(v uint64) {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], v)
+	for _, d := range [...]*xxhash.Digest{h.a, h.b} {
+		_, _ = d.Write(buf[:])
+	}
+}
+
+func (h contentHasher) key() docContentKey {
+	return docContentKey{a: h.a.Sum64(), b: h.b.Sum64()}
 }
 
 // newInstanceFileMetadata clones fm for a synthetic doc (empty Document so Combine skips it).

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -58,9 +58,10 @@ type moduleResolutionResult struct {
 func (c *Inspector) instantiateLocalModules(
 	ctx context.Context,
 	files model.FileMetadatas,
+	targets *ruleTargets,
 ) ([]model.Document, []*model.FileMetadata, map[string][]extraCallerInfo) {
 	resolver := c.buildRemoteResolver()
-	res := c.resolveModulesSafely(ctx, files, resolver)
+	res := c.resolveModulesSafely(ctx, files, resolver, targets)
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Info().
 		Int("module_resources_instantiated", res.resourceCount).
@@ -97,6 +98,29 @@ func (c *Inspector) instantiateLocalModules(
 		stripModuleCalls(f.Document, f.FilePath, c.repoPath, res.calledDirs, resolver)
 	}
 	return res.docs, res.syntheticFiles, res.extras
+}
+
+// declaresTargetedResource reports whether any scanned Terraform file declares
+// a resource type some rule can match by name.
+func declaresTargetedResource(files model.FileMetadatas, targets *ruleTargets) bool {
+	if targets == nil {
+		return true
+	}
+	for _, f := range files {
+		if f == nil || !isTerraformFile(f.FilePath) {
+			continue
+		}
+		resources, ok := asStringMap(f.Document["resource"])
+		if !ok {
+			continue
+		}
+		for typ := range resources {
+			if targets.matches(typ) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // instantiatedIndex records which resource blocks of a file were re-emitted as
@@ -250,6 +274,7 @@ func (c *Inspector) resolveModulesSafely(
 	ctx context.Context,
 	files model.FileMetadatas,
 	resolver tfeval.RemoteResolver,
+	targets *ruleTargets,
 ) (res moduleResolutionResult) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -260,7 +285,7 @@ func (c *Inspector) resolveModulesSafely(
 			res = moduleResolutionResult{}
 		}
 	}()
-	return resolveModuleDocuments(ctx, files, c.repoPath, resolver)
+	return resolveModuleDocuments(ctx, files, c.repoPath, resolver, targets)
 }
 
 // resolveModuleDocuments instantiates all local modules referenced by the
@@ -277,9 +302,16 @@ func resolveModuleDocuments(
 	files model.FileMetadatas,
 	repoPath string,
 	resolver tfeval.RemoteResolver,
+	targets *ruleTargets,
 ) moduleResolutionResult {
 	byAbsPath, filesByDir, dirsWithTf := indexTerraformFiles(ctx, files, repoPath)
 	if len(dirsWithTf) == 0 {
+		return moduleResolutionResult{}
+	}
+	// Evaluating a module tree is the expensive part, and it is pure waste when
+	// the repository declares nothing any rule can match by name. The block
+	// labels are already in the parsed documents, so this costs nothing.
+	if !declaresTargetedResource(files, targets) {
 		return moduleResolutionResult{}
 	}
 
@@ -323,7 +355,8 @@ func resolveModuleDocuments(
 		for d := range childDirs {
 			actualCalledDirs[d] = true
 		}
-		docs, syn, count := instantiatedDocs(resources, byAbsPath, repoPath, seen, extras, instantiated)
+		docs, syn, count := instantiatedDocs(
+			resources, byAbsPath, repoPath, targets, seen, extras, instantiated)
 		extra = append(extra, docs...)
 		syntheticFiles = append(syntheticFiles, syn...)
 		resourceCount += count
@@ -411,6 +444,7 @@ func instantiatedDocs(
 	resources []tfeval.ResolvedResource,
 	byAbsPath map[string]*model.FileMetadata,
 	repoPath string,
+	targets *ruleTargets,
 	seen map[docContentKey]string,
 	extras map[string][]extraCallerInfo,
 	instantiated instantiatedIndex,
@@ -426,6 +460,12 @@ func instantiatedDocs(
 	for i := range resources {
 		r := &resources[i]
 		if r.ModuleAddress == "" {
+			continue
+		}
+		if !targets.matches(r.Type) {
+			// No rule can match this type by name, so resolving its values
+			// cannot change a finding. It keeps being scanned where it is
+			// written, exactly as it is without module evaluation.
 			continue
 		}
 		fm, ok := byAbsPath[absPath(r.DefinedIn, repoPath)]

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -78,6 +78,7 @@ func (c *Inspector) instantiateLocalModules(
 	if !res.ok {
 		return nil, nil, nil
 	}
+	rootDirs := newRootIndex(res.rootDirs)
 	for _, f := range files {
 		if f == nil || !isTerraformFile(f.FilePath) {
 			continue
@@ -101,7 +102,7 @@ func (c *Inspector) instantiateLocalModules(
 		}
 		// Only remove local module call-sites that were instantiated; remote/registry
 		// module blocks must remain so the corresponding Rego branches can still fire.
-		stripModuleCalls(f.Document, f.FilePath, c.repoPath, res.calledDirs, res.successfulRoots, res.rootDirs, resolver)
+		stripModuleCalls(f.Document, f.FilePath, c.repoPath, res.calledDirs, res.successfulRoots, rootDirs, resolver)
 	}
 	return res.docs, res.syntheticFiles, res.extras
 }
@@ -767,17 +768,19 @@ func stripModuleCalls(
 	filePath, repoPath string,
 	calledDirs map[string]bool,
 	successfulRoots map[string]bool,
-	rootDirs []string,
+	rootDirs rootIndex,
 	resolver tfeval.RemoteResolver,
 ) {
-	if root := owningRoot(filePath, repoPath, rootDirs); root == "" || !successfulRoots[root] {
-		return
-	}
+	// Checked before ownership because most files declare no module calls at all,
+	// and resolving the owning root is the more expensive of the two guards.
 	modules := docAsMap(doc["module"])
 	if modules == nil {
 		return
 	}
 	fileDir := filepath.Dir(absPath(filePath, repoPath))
+	if root := rootDirs.owningRoot(fileDir); root == "" || !successfulRoots[root] {
+		return
+	}
 	for name, callRaw := range modules {
 		call := docAsMap(callRaw)
 		if call == nil {
@@ -804,19 +807,33 @@ func moduleFileDir(filePath, repoPath string) string {
 	return filepath.Dir(absPath(filePath, repoPath))
 }
 
-// owningRoot returns the root module directory that contains filePath.
-func owningRoot(filePath, repoPath string, roots []string) string {
-	abs := absPath(filePath, repoPath)
-	var best string
+// rootIndex resolves which root module directory owns a file. Roots are already
+// absolute and cleaned, so ownership is a walk up the file's parents rather than
+// a scan of every root: on a repository with thousands of independent stacks the
+// scan is the dominant cost of the whole instantiation pass.
+type rootIndex map[string]bool
+
+func newRootIndex(roots []string) rootIndex {
+	idx := make(rootIndex, len(roots))
 	for _, root := range roots {
-		rootAbs := absPath(root, repoPath)
-		if abs == rootAbs || strings.HasPrefix(abs, rootAbs+string(filepath.Separator)) {
-			if len(root) > len(best) {
-				best = root
-			}
-		}
+		idx[root] = true
 	}
-	return best
+	return idx
+}
+
+// owningRoot returns the innermost root module directory containing fileDir,
+// or "" when no root does.
+func (idx rootIndex) owningRoot(fileDir string) string {
+	for dir := fileDir; ; {
+		if idx[dir] {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
 }
 
 func discoverCalledModuleDirs(

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -32,13 +32,16 @@ type extraCallerInfo struct {
 
 // moduleResolutionResult bundles all outputs of resolveModuleDocuments.
 type moduleResolutionResult struct {
-	docs           []model.Document
-	syntheticFiles []*model.FileMetadata
-	suppressed     instantiatedIndex
-	calledDirs     map[string]bool
-	extras         map[string][]extraCallerInfo
-	resourceCount  int
-	ok             bool
+	docs                 []model.Document
+	syntheticFiles       []*model.FileMetadata
+	suppressed           instantiatedIndex
+	calledDirs           map[string]bool
+	successfulRoots      map[string]bool
+	rootDirs             []string
+	failedRootModuleDirs map[string]bool
+	extras               map[string][]extraCallerInfo
+	resourceCount        int
+	ok                   bool
 }
 
 // instantiateLocalModules evaluates local modules and injects resolved resource
@@ -80,6 +83,9 @@ func (c *Inspector) instantiateLocalModules(
 			continue
 		}
 		if replaced := res.suppressed[f.ID]; len(replaced) > 0 {
+			if res.failedRootModuleDirs[moduleFileDir(f.FilePath, c.repoPath)] {
+				continue
+			}
 			// Only the blocks that came back as instantiated documents are
 			// dropped, so nothing loses its coverage: a resource the evaluator
 			// could not resolve, or one that expanded to no instances, keeps
@@ -95,7 +101,7 @@ func (c *Inspector) instantiateLocalModules(
 		}
 		// Only remove local module call-sites that were instantiated; remote/registry
 		// module blocks must remain so the corresponding Rego branches can still fire.
-		stripModuleCalls(f.Document, f.FilePath, c.repoPath, res.calledDirs, resolver)
+		stripModuleCalls(f.Document, f.FilePath, c.repoPath, res.calledDirs, res.successfulRoots, res.rootDirs, resolver)
 	}
 	return res.docs, res.syntheticFiles, res.extras
 }
@@ -297,6 +303,65 @@ func (c *Inspector) resolveModulesSafely(
 // `ok` is true when at least one root module evaluated successfully and the
 // caller should apply call-site / suppression mutations; otherwise it is false
 // and the returned maps are nil.
+func evaluateRootModules(
+	ctx context.Context,
+	evaluator *tfeval.Evaluator,
+	roots []string,
+	filesByDir map[string][]*model.FileMetadata,
+	repoPath string,
+	resolver tfeval.RemoteResolver,
+	targets *ruleTargets,
+	byAbsPath map[string]*model.FileMetadata,
+	seen map[docContentKey]string,
+	extras map[string][]extraCallerInfo,
+	instantiated instantiatedIndex,
+	successfulRoots map[string]bool,
+	failedRootModuleDirs map[string]bool,
+	actualCalledDirs map[string]bool,
+	extra *[]model.Document,
+	syntheticFiles *[]*model.FileMetadata,
+	resourceCount *int,
+	rootEvalOK *bool,
+) {
+	contextLogger := logger.FromContext(ctx)
+	for _, dir := range roots {
+		resources, _, childDirs, err := evaluator.EvaluateModule(ctx, dir, tfeval.LoadRootVars(dir))
+		if err != nil {
+			contextLogger.Warn().Err(err).Msgf("tfeval: failed to evaluate root module %s", dir)
+			for _, called := range discoverCalledModuleDirs(ctx, evaluator, filesByDir[dir], repoPath, resolver, dir) {
+				failedRootModuleDirs[called] = true
+			}
+			continue
+		}
+		*rootEvalOK = true
+		successfulRoots[dir] = true
+		for d := range childDirs {
+			actualCalledDirs[d] = true
+		}
+		docs, syn, count := instantiatedDocs(
+			resources, byAbsPath, repoPath, targets, seen, extras, instantiated)
+		*extra = append(*extra, docs...)
+		*syntheticFiles = append(*syntheticFiles, syn...)
+		*resourceCount += count
+	}
+}
+
+func scrubInstantiatedForFailedRoots(
+	instantiated instantiatedIndex,
+	files model.FileMetadatas,
+	failedRootModuleDirs map[string]bool,
+	repoPath string,
+) {
+	for _, f := range files {
+		if f == nil {
+			continue
+		}
+		if failedRootModuleDirs[moduleFileDir(f.FilePath, repoPath)] {
+			delete(instantiated, f.ID)
+		}
+	}
+}
+
 func resolveModuleDocuments(
 	ctx context.Context,
 	files model.FileMetadatas,
@@ -315,7 +380,6 @@ func resolveModuleDocuments(
 		return moduleResolutionResult{}
 	}
 
-	contextLogger := logger.FromContext(ctx)
 	evaluator := tfeval.New()
 	if resolver != nil {
 		evaluator.SetRemoteResolver(resolver)
@@ -338,29 +402,30 @@ func resolveModuleDocuments(
 	instantiated := make(instantiatedIndex)
 	var rootEvalOK bool
 	actualCalledDirs := make(map[string]bool)
+	successfulRoots := make(map[string]bool)
+	failedRootModuleDirs := make(map[string]bool)
 	var extra []model.Document
 	var syntheticFiles []*model.FileMetadata
 	var resourceCount int
 
+	// Roots are taken in a fixed order: which of several identical callers ends
+	// up owning a shared document decides that document's id, and ids reach
+	// finding fingerprints.
+	roots := make([]string, 0, len(dirsWithTf))
 	for dir := range dirsWithTf {
 		if staticCalledDirs[dir] {
 			continue // instantiated via a module call, not a root
 		}
-		resources, _, childDirs, err := evaluator.EvaluateModule(ctx, dir, tfeval.LoadRootVars(dir))
-		if err != nil {
-			contextLogger.Warn().Err(err).Msgf("tfeval: failed to evaluate root module %s", dir)
-			continue
-		}
-		rootEvalOK = true
-		for d := range childDirs {
-			actualCalledDirs[d] = true
-		}
-		docs, syn, count := instantiatedDocs(
-			resources, byAbsPath, repoPath, targets, seen, extras, instantiated)
-		extra = append(extra, docs...)
-		syntheticFiles = append(syntheticFiles, syn...)
-		resourceCount += count
+		roots = append(roots, dir)
 	}
+	sort.Strings(roots)
+
+	evaluateRootModules(
+		ctx, evaluator, roots, filesByDir, repoPath, resolver, targets,
+		byAbsPath, seen, extras, instantiated,
+		successfulRoots, failedRootModuleDirs, actualCalledDirs,
+		&extra, &syntheticFiles, &resourceCount, &rootEvalOK,
+	)
 	evaluator.ReleaseCaches()
 
 	// If every root evaluation failed, do not strip or suppress module bodies: that would
@@ -384,14 +449,19 @@ func resolveModuleDocuments(
 		}
 	}
 
+	scrubInstantiatedForFailedRoots(instantiated, files, failedRootModuleDirs, repoPath)
+
 	return moduleResolutionResult{
-		docs:           extra,
-		syntheticFiles: syntheticFiles,
-		suppressed:     instantiated,
-		calledDirs:     strippedDirs,
-		extras:         extras,
-		resourceCount:  resourceCount,
-		ok:             true,
+		docs:                 extra,
+		syntheticFiles:       syntheticFiles,
+		suppressed:           instantiated,
+		calledDirs:           strippedDirs,
+		successfulRoots:      successfulRoots,
+		rootDirs:             roots,
+		failedRootModuleDirs: failedRootModuleDirs,
+		extras:               extras,
+		resourceCount:        resourceCount,
+		ok:                   true,
 	}
 }
 
@@ -498,9 +568,13 @@ func instantiatedDocs(
 		g.entries = append(g.entries, entry)
 		// Recorded before deduplication: a document that dedupes away still
 		// covers its resource, through a finding cloned onto its call site.
-		instantiated.add(fm.ID, r.Type, base)
+		if !r.ExpansionTruncated {
+			instantiated.add(fm.ID, r.Type, base)
+		}
 		resourceCount++
 	}
+
+	copyStaticResourcesIntoExpandedLayers(groups, order)
 
 	for _, key := range order {
 		g := groups[key]
@@ -535,6 +609,51 @@ func instantiatedDocs(
 		synthetic = append(synthetic, newInstanceFileMetadata(g.fm, docID, g.callChain))
 	}
 	return docs, synthetic, resourceCount
+}
+
+// copyStaticResourcesIntoExpandedLayers mirrors non-expanded resources into every
+// count/for_each layer document for the same call and file. Without this, a rule
+// that relates resources in one file would see expanded instances in isolation
+// from their siblings.
+func copyStaticResourcesIntoExpandedLayers(groups map[string]*docGroup, order []string) {
+	staticByCallFile := make(map[string][]instantiatedResource)
+	for _, key := range order {
+		g := groups[key]
+		cfKey := g.callChain + "\x00" + g.fm.ID
+		for i := range g.entries {
+			e := &g.entries[i]
+			if e.fullName != e.baseName {
+				continue
+			}
+			staticByCallFile[cfKey] = appendUniqueInstantiated(staticByCallFile[cfKey], *e)
+		}
+	}
+	for _, key := range order {
+		g := groups[key]
+		hasExpanded := false
+		for i := range g.entries {
+			if g.entries[i].fullName != g.entries[i].baseName {
+				hasExpanded = true
+				break
+			}
+		}
+		if !hasExpanded {
+			continue
+		}
+		cfKey := g.callChain + "\x00" + g.fm.ID
+		for _, e := range staticByCallFile[cfKey] {
+			g.entries = appendUniqueInstantiated(g.entries, e)
+		}
+	}
+}
+
+func appendUniqueInstantiated(entries []instantiatedResource, e instantiatedResource) []instantiatedResource {
+	for i := range entries {
+		if entries[i].typ == e.typ && entries[i].fullName == e.fullName {
+			return entries
+		}
+	}
+	return append(entries, e)
 }
 
 // groupContentKey identifies a document by the module call address it belongs
@@ -641,7 +760,19 @@ func callChainKey(r *tfeval.ResolvedResource, repoPath string) string {
 
 // stripModuleCalls drops module blocks whose target dir is in calledDirs.
 // Remote/registry sources stay so existing Rego call-site rules still match.
-func stripModuleCalls(doc model.Document, filePath, repoPath string, calledDirs map[string]bool, resolver tfeval.RemoteResolver) {
+// Call sites under a root whose evaluation failed are left in place so a
+// failed instantiation does not remove coverage with no synthetic replacement.
+func stripModuleCalls(
+	doc model.Document,
+	filePath, repoPath string,
+	calledDirs map[string]bool,
+	successfulRoots map[string]bool,
+	rootDirs []string,
+	resolver tfeval.RemoteResolver,
+) {
+	if root := owningRoot(filePath, repoPath, rootDirs); root == "" || !successfulRoots[root] {
+		return
+	}
 	modules := docAsMap(doc["module"])
 	if modules == nil {
 		return
@@ -666,6 +797,26 @@ func stripModuleCalls(doc model.Document, filePath, repoPath string, calledDirs 
 	if len(modules) == 0 {
 		delete(doc, "module")
 	}
+}
+
+// moduleFileDir returns the absolute directory containing a scanned Terraform file.
+func moduleFileDir(filePath, repoPath string) string {
+	return filepath.Dir(absPath(filePath, repoPath))
+}
+
+// owningRoot returns the root module directory that contains filePath.
+func owningRoot(filePath, repoPath string, roots []string) string {
+	abs := absPath(filePath, repoPath)
+	var best string
+	for _, root := range roots {
+		rootAbs := absPath(root, repoPath)
+		if abs == rootAbs || strings.HasPrefix(abs, rootAbs+string(filepath.Separator)) {
+			if len(root) > len(best) {
+				best = root
+			}
+		}
+	}
+	return best
 }
 
 func discoverCalledModuleDirs(

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -485,8 +485,13 @@ sg_is_used(sgName, doc) if {
 }
 `
 
-// Cross-file SG reference in a module must suppress sg_not_used.
-func TestInspect_CrossFileModuleRefsResolvedBySiblings(t *testing.T) {
+// A rule that decides by looking at one whole document sees a module's files
+// separately, exactly as it sees the files of any other directory. Giving
+// instantiated documents a cross-file view their inline equivalents do not have
+// would both change findings depending on where code lives and tie every
+// document to the call it came from, which is what makes deduplication
+// collapse on repositories with many roots.
+func TestInspect_CrossFileModuleRefsMatchInlineBehaviour(t *testing.T) {
 	root := t.TempDir()
 
 	rootDir := filepath.Join(root, "stack")
@@ -543,7 +548,54 @@ resource "aws_instance" "app" {
 	require.NoError(t, err)
 	require.Empty(t, ins.GetFailedQueries())
 
-	require.Empty(t, vulns, "sg_not_used must not fire when the SG is referenced in a sibling module file")
+	inline := inlineEquivalentFindings(t, root, sgNotUsedRule)
+	require.Len(t, vulns, inline,
+		"a module's cross-file references must be seen exactly as the same code inlined would be")
+	require.Len(t, vulns, 1, "one document per file, so the sibling reference is not visible")
+}
+
+// inlineEquivalentFindings scans the same two files as a plain directory, with
+// no module call, and reports how many findings the rule produces.
+func inlineEquivalentFindings(t *testing.T, root, rule string) int {
+	t.Helper()
+	dir := filepath.Join(root, "inline")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	sgPath := filepath.Join(dir, "sg.tf")
+	instancePath := filepath.Join(dir, "instance.tf")
+	require.NoError(t, os.WriteFile(sgPath, []byte(`
+resource "aws_security_group" "web" {
+  name = "web-sg"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(instancePath, []byte(`
+resource "aws_instance" "app" {
+  ami                    = "ami-12345678"
+  vpc_security_group_ids = ["aws_security_group.web.id"]
+}
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, sgPath)...)
+	files = append(files, parseTerraform(t, instancePath)...)
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries: []model.QueryMetadata{{
+			Query:       "sg_not_used_rule",
+			Content:     rule,
+			InputData:   "{}",
+			Platform:    "terraform",
+			Metadata:    map[string]interface{}{"id": "sg-not-used"},
+			Aggregation: 1,
+		}},
+		repoPath:      dir,
+		vb:            DefaultVulnerabilityBuilder,
+		flagEvaluator: moduleEvalEnabled(),
+	})
+
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
+	require.NoError(t, err)
+	return len(vulns)
 }
 
 func TestInspect_CrossFileUnusedSGStillFires(t *testing.T) {
@@ -606,7 +658,10 @@ resource "aws_instance" "app" {
 	require.Equal(t, "aws_security_group", vulns[0].ResourceType)
 }
 
-func TestInspect_CrossRootDivergentSiblingNotDeduped(t *testing.T) {
+// Two roots calling the same module with the same inputs resolve to identical
+// content, so they share one evaluated document — but each call site still gets
+// its own finding, since a fix has to be applied per deployment.
+func TestInspect_IdenticalCallsShareADocumentAndReportEveryCallSite(t *testing.T) {
 	root := t.TempDir()
 
 	modDir := filepath.Join(root, "modules", "net")
@@ -666,7 +721,12 @@ resource "aws_instance" "server" {
 	require.NoError(t, err)
 	require.Empty(t, ins.GetFailedQueries())
 
-	require.Empty(t, vulns, "sg_not_used must not fire when the SG is referenced in a sibling module file")
+	require.Len(t, vulns, 2, "one finding per call site")
+	chains := []string{vulns[0].ModuleCallChain, vulns[1].ModuleCallChain}
+	require.ElementsMatch(t,
+		[]string{"stack-a/main.tf|module.net", "stack-b/main.tf|module.net"},
+		chains,
+		"each call site must keep its own attribution after deduplication")
 }
 
 func TestInspect_CountExpansionBothInstancesScanned(t *testing.T) {

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -826,7 +826,7 @@ resource "aws_s3_bucket" "this" {
 
 // TestInspect_LocalModuleEvalWithFlagEnabled confirms that local module evaluation
 // runs when the feature flag is on and synthetic docs are injected for resolved modules.
-func TestInspect_LocalModuleEvalAlwaysRuns(t *testing.T) {
+func TestInspect_LocalModuleEvalWithFlagEnabled(t *testing.T) {
 	root := t.TempDir()
 	rootPath := filepath.Join(root, "main.tf")
 	modDir := filepath.Join(root, "modules", "s3")

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -826,7 +826,7 @@ resource "aws_s3_bucket" "this" {
 
 // TestInspect_LocalModuleEvalWithFlagEnabled confirms that local module evaluation
 // runs when the feature flag is on and synthetic docs are injected for resolved modules.
-func TestInspect_LocalModuleEvalWithFlagEnabled(t *testing.T) {
+func TestInspect_LocalModuleEvalAlwaysRuns(t *testing.T) {
 	root := t.TempDir()
 	rootPath := filepath.Join(root, "main.tf")
 	modDir := filepath.Join(root, "modules", "s3")

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -116,7 +116,7 @@ func TestStripModuleCallsRemovesResolvedRemoteCallSites(t *testing.T) {
 	calledDirs := map[string]bool{"/cache/vpc": true}
 	successfulRoots := map[string]bool{root: true}
 
-	stripModuleCalls(doc, rootFile, root, calledDirs, successfulRoots, []string{root}, func(source, version, callerFile, moduleName string) (string, bool) {
+	stripModuleCalls(doc, rootFile, root, calledDirs, successfulRoots, newRootIndex([]string{root}), func(source, version, callerFile, moduleName string) (string, bool) {
 		if source == "terraform-aws-modules/vpc/aws" && version == "1.0.0" && callerFile == rootFile && moduleName == "remote" {
 			return "/cache/vpc", true
 		}
@@ -147,7 +147,7 @@ module "bucket" {
 	calledDirs := map[string]bool{filepath.Join(root, "modules", "bucket"): true}
 	successfulRoots := map[string]bool{stackA: true} // stack-b eval failed
 
-	stripModuleCalls(doc, rootFileB, root, calledDirs, successfulRoots, []string{stackA, stackB}, nil)
+	stripModuleCalls(doc, rootFileB, root, calledDirs, successfulRoots, newRootIndex([]string{stackA, stackB}), nil)
 
 	if _, ok := doc["module"]; !ok {
 		t.Fatal("module call under a failed root must not be stripped")

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -114,8 +114,9 @@ func TestStripModuleCallsRemovesResolvedRemoteCallSites(t *testing.T) {
 		},
 	}
 	calledDirs := map[string]bool{"/cache/vpc": true}
+	successfulRoots := map[string]bool{root: true}
 
-	stripModuleCalls(doc, rootFile, root, calledDirs, func(source, version, callerFile, moduleName string) (string, bool) {
+	stripModuleCalls(doc, rootFile, root, calledDirs, successfulRoots, []string{root}, func(source, version, callerFile, moduleName string) (string, bool) {
 		if source == "terraform-aws-modules/vpc/aws" && version == "1.0.0" && callerFile == rootFile && moduleName == "remote" {
 			return "/cache/vpc", true
 		}
@@ -124,6 +125,162 @@ func TestStripModuleCallsRemovesResolvedRemoteCallSites(t *testing.T) {
 
 	if _, ok := doc["module"]; ok {
 		t.Fatalf("expected resolved remote module call to be stripped")
+	}
+}
+
+func TestStripModuleCalls_SkipsFailedRoot(t *testing.T) {
+	root := t.TempDir()
+	stackA := filepath.Join(root, "stack-a")
+	stackB := filepath.Join(root, "stack-b")
+	rootFileB := writeFile(t, stackB, "main.tf", `
+module "bucket" {
+  source = "../modules/bucket"
+}
+`)
+	doc := model.Document{
+		"module": map[string]interface{}{
+			"bucket": map[string]interface{}{
+				"source": "../modules/bucket",
+			},
+		},
+	}
+	calledDirs := map[string]bool{filepath.Join(root, "modules", "bucket"): true}
+	successfulRoots := map[string]bool{stackA: true} // stack-b eval failed
+
+	stripModuleCalls(doc, rootFileB, root, calledDirs, successfulRoots, []string{stackA, stackB}, nil)
+
+	if _, ok := doc["module"]; !ok {
+		t.Fatal("module call under a failed root must not be stripped")
+	}
+}
+
+func TestCopyStaticResourcesIntoExpandedLayers(t *testing.T) {
+	fm := fileMeta("mod-id", "/repo/modules/app/main.tf")
+	groups := map[string]*docGroup{
+		"static": {
+			fm: fm, callChain: "stack/main.tf|module.app", layer: 0,
+			entries: []instantiatedResource{
+				{typ: "aws_s3_bucket", baseName: "shared", fullName: "shared"},
+			},
+		},
+		"expanded0": {
+			fm: fm, callChain: "stack/main.tf|module.app", layer: 0,
+			entries: []instantiatedResource{
+				{typ: "aws_s3_bucket", baseName: "replica", fullName: "replica[0]"},
+			},
+		},
+		"expanded1": {
+			fm: fm, callChain: "stack/main.tf|module.app", layer: 1,
+			entries: []instantiatedResource{
+				{typ: "aws_s3_bucket", baseName: "replica", fullName: "replica[1]"},
+			},
+		},
+	}
+	order := []string{"static", "expanded0", "expanded1"}
+
+	copyStaticResourcesIntoExpandedLayers(groups, order)
+
+	for _, key := range []string{"expanded0", "expanded1"} {
+		layer := groups[key].entries
+		hasShared := false
+		for _, e := range layer {
+			if e.typ == "aws_s3_bucket" && e.fullName == "shared" {
+				hasShared = true
+			}
+		}
+		if !hasShared {
+			t.Fatalf("%s must include static siblings: %#v", key, layer)
+		}
+	}
+}
+
+func TestResolveModuleDocuments_PartialRootFailureKeepsModuleBody(t *testing.T) {
+	root := t.TempDir()
+	stackA := filepath.Join(root, "stack-a")
+	stackB := filepath.Join(root, "stack-b")
+	modDir := filepath.Join(root, "modules", "bucket")
+
+	rootFileA := writeFile(t, stackA, "main.tf", `
+module "bucket" {
+  source = "../modules/bucket"
+  name   = "a"
+}
+`)
+	writeFile(t, stackB, "main.tf", `
+module "bucket" {
+  source = "../modules/bucket"
+  name   = "b"
+}
+`)
+	writeFile(t, stackB, "broken.tf", `resource "bad" {`) // unreadable root dir fails eval
+	modFile := writeFile(t, modDir, "main.tf", `
+variable "name" { type = string }
+resource "aws_s3_bucket" "this" { bucket = var.name }
+`)
+
+	bRootPath := filepath.Join(stackB, "main.tf")
+	files := model.FileMetadatas{
+		fileMeta("a-root", rootFileA),
+		fileMeta("mod-id", modFile),
+	}
+	bRoot := fileMeta("b-root", bRootPath)
+	bRoot.Document = model.Document{
+		"module": map[string]interface{}{
+			"bucket": map[string]interface{}{
+				"source": "../modules/bucket",
+				"name":   "b",
+			},
+		},
+	}
+	files = append(files, bRoot)
+
+	// Remove stack-b from disk so root evaluation fails reliably (chmod 000 is
+	// ignored for root users in CI). Module discovery for the failed root uses
+	// the parsed document still held in memory.
+	if err := os.RemoveAll(stackB); err != nil {
+		t.Fatalf("remove stack-b: %v", err)
+	}
+
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	if !res.ok {
+		t.Fatal("expected partial module resolution to succeed")
+	}
+	if len(res.suppressed["mod-id"]) != 0 {
+		t.Fatalf("shared module must not be suppressed when another root failed eval: %#v", res.suppressed)
+	}
+}
+
+func TestResolveModuleDocuments_TruncatedCountKeepsSourceBlock(t *testing.T) {
+	root := t.TempDir()
+	rootDir := filepath.Join(root, "stack")
+	modDir := filepath.Join(root, "modules", "buckets")
+
+	rootFile := writeFile(t, rootDir, "main.tf", `
+module "buckets" {
+  source = "../modules/buckets"
+}
+`)
+	modFile := writeFile(t, modDir, "main.tf", `
+resource "aws_s3_bucket" "replica" {
+  count  = 12
+  bucket = "bucket-${count.index}"
+}
+`)
+
+	files := model.FileMetadatas{
+		fileMeta("root-id", rootFile),
+		fileMeta("mod-id", modFile),
+	}
+
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	if !res.ok {
+		t.Fatal("expected module resolution to succeed")
+	}
+	if len(res.docs) != 10 {
+		t.Fatalf("expected 10 instantiated docs for truncated count, got %d", len(res.docs))
+	}
+	if len(res.suppressed["mod-id"]["aws_s3_bucket"]) != 0 {
+		t.Fatalf("truncated expansion must not suppress the source block: %#v", res.suppressed)
 	}
 }
 
@@ -425,23 +582,38 @@ func TestResolveModuleDocuments_DocumentMirrorsItsFile(t *testing.T) {
 }
 
 // Document ids feed finding fingerprints, so the same repository must always
-// produce the same ones.
+// produce the same ones. Roots are discovered by walking a map, so nothing but
+// an explicit ordering keeps the same caller owning a shared document.
 func TestResolveModuleDocuments_DocumentIDsAreStable(t *testing.T) {
-	repo, files := writeFanOut(t, 4, true)
+	// All roots resolve identically, so every document but one is deduplicated
+	// and something has to decide which caller owns it.
+	repo, files := writeFanOut(t, 8, false)
 
-	ids := func() []string {
+	snapshot := func() ([]string, map[string][]string) {
 		res := resolveModuleDocuments(context.Background(), files, repo, nil, nil)
-		out := make([]string, 0, len(res.docs))
+		ids := make([]string, 0, len(res.docs))
 		for _, doc := range res.docs {
-			out = append(out, doc["id"].(string))
+			ids = append(ids, doc["id"].(string))
 		}
-		sort.Strings(out)
-		return out
+		extras := map[string][]string{}
+		for primary, callers := range res.extras {
+			for _, c := range callers {
+				extras[primary] = append(extras[primary], c.docID)
+			}
+			sort.Strings(extras[primary])
+		}
+		return ids, extras
 	}
 
-	first, second := ids(), ids()
-	if !reflect.DeepEqual(first, second) {
-		t.Fatalf("document ids changed between runs:\n%v\n%v", first, second)
+	wantIDs, wantExtras := snapshot()
+	for run := range 3 {
+		ids, extras := snapshot()
+		if !reflect.DeepEqual(ids, wantIDs) {
+			t.Fatalf("run %d: documents changed between runs:\n%v\n%v", run, ids, wantIDs)
+		}
+		if !reflect.DeepEqual(extras, wantExtras) {
+			t.Fatalf("run %d: deduplicated callers changed between runs:\n%v\n%v", run, extras, wantExtras)
+		}
 	}
 }
 

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -154,43 +154,56 @@ module "bucket" {
 	}
 }
 
-func TestCopyStaticResourcesIntoExpandedLayers(t *testing.T) {
-	fm := fileMeta("mod-id", "/repo/modules/app/main.tf")
-	groups := map[string]*docGroup{
-		"static": {
-			fm: fm, callChain: "stack/main.tf|module.app", layer: 0,
-			entries: []instantiatedResource{
-				{typ: "aws_s3_bucket", baseName: "shared", fullName: "shared"},
-			},
-		},
-		"expanded0": {
-			fm: fm, callChain: "stack/main.tf|module.app", layer: 0,
-			entries: []instantiatedResource{
-				{typ: "aws_s3_bucket", baseName: "replica", fullName: "replica[0]"},
-			},
-		},
-		"expanded1": {
-			fm: fm, callChain: "stack/main.tf|module.app", layer: 1,
-			entries: []instantiatedResource{
-				{typ: "aws_s3_bucket", baseName: "replica", fullName: "replica[1]"},
-			},
-		},
+func TestInstantiatedDocs_DoesNotDuplicateStaticResourcesAcrossExpansionLayers(t *testing.T) {
+	root := t.TempDir()
+	modulePath := writeFile(t, filepath.Join(root, "modules", "app"), "main.tf", `
+resource "aws_s3_bucket" "shared" {
+  bucket = "shared"
+}
+
+resource "aws_s3_bucket" "replica" {
+  count  = 2
+  bucket = "replica-${count.index}"
+}
+`)
+	fm := fileMeta("mod-id", modulePath)
+	resources := []tfeval.ResolvedResource{
+		{Type: "aws_s3_bucket", Name: "shared", DefinedIn: modulePath, ModuleAddress: "module.app"},
+		{Type: "aws_s3_bucket", Name: "replica[0]", DefinedIn: modulePath, ModuleAddress: "module.app"},
+		{Type: "aws_s3_bucket", Name: "replica[1]", DefinedIn: modulePath, ModuleAddress: "module.app"},
 	}
-	order := []string{"static", "expanded0", "expanded1"}
 
-	copyStaticResourcesIntoExpandedLayers(groups, order)
+	docs, _, _ := instantiatedDocs(
+		resources,
+		map[string]*model.FileMetadata{absPath(modulePath, root): fm},
+		root,
+		nil,
+		make(map[docContentKey]string),
+		make(map[string][]extraCallerInfo),
+		make(instantiatedIndex),
+	)
 
-	for _, key := range []string{"expanded0", "expanded1"} {
-		layer := groups[key].entries
-		hasShared := false
-		for _, e := range layer {
-			if e.typ == "aws_s3_bucket" && e.fullName == "shared" {
-				hasShared = true
-			}
+	if len(docs) != 2 {
+		t.Fatalf("expected one document per expansion layer, got %d", len(docs))
+	}
+	var shared, replicas int
+	for _, doc := range docs {
+		byType, ok := asStringMap(docAsMap(doc["resource"])["aws_s3_bucket"])
+		if !ok {
+			t.Fatalf("resource document has unexpected shape: %#v", doc)
 		}
-		if !hasShared {
-			t.Fatalf("%s must include static siblings: %#v", key, layer)
+		if _, ok := byType["shared"]; ok {
+			shared++
 		}
+		if _, ok := byType["replica"]; ok {
+			replicas++
+		}
+	}
+	if shared != 1 {
+		t.Fatalf("static resource appears %d times, want exactly once", shared)
+	}
+	if replicas != 2 {
+		t.Fatalf("expanded resource appears %d times, want one per instance", replicas)
 	}
 }
 
@@ -247,6 +260,61 @@ resource "aws_s3_bucket" "this" { bucket = var.name }
 	}
 	if len(res.suppressed["mod-id"]) != 0 {
 		t.Fatalf("shared module must not be suppressed when another root failed eval: %#v", res.suppressed)
+	}
+}
+
+func TestResolveModuleDocuments_PartialRootFailureKeepsTransitiveModuleBody(t *testing.T) {
+	root := t.TempDir()
+	successfulRoot := filepath.Join(root, "successful")
+	failedRoot := filepath.Join(root, "failed")
+	middleDir := filepath.Join(root, "modules", "middle")
+	leafDir := filepath.Join(root, "modules", "leaf")
+
+	successfulFile := writeFile(t, successfulRoot, "main.tf", `
+module "leaf" {
+  source = "../modules/leaf"
+}
+`)
+	failedFile := writeFile(t, failedRoot, "main.tf", `
+module "middle" {
+  source = "../modules/middle"
+}
+`)
+	middleFile := writeFile(t, middleDir, "main.tf", `
+module "leaf" {
+  source = "../leaf"
+}
+`)
+	leafFile := writeFile(t, leafDir, "main.tf", `
+resource "aws_s3_bucket" "this" {
+  bucket = "logs"
+}
+`)
+
+	files := model.FileMetadatas{
+		fileMeta("successful-root", successfulFile),
+		fileMeta("middle-id", middleFile),
+		fileMeta("leaf-id", leafFile),
+	}
+	failed := fileMeta("failed-root", failedFile)
+	failed.Document = model.Document{
+		"module": map[string]interface{}{
+			"middle": map[string]interface{}{"source": "../modules/middle"},
+		},
+	}
+	files = append(files, failed)
+
+	// Preserve the parsed root document but make its on-disk evaluation fail.
+	if err := os.RemoveAll(failedRoot); err != nil {
+		t.Fatalf("remove failed root: %v", err)
+	}
+
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	if !res.ok {
+		t.Fatal("expected the other root to evaluate successfully")
+	}
+	if len(res.suppressed["leaf-id"]) != 0 {
+		t.Fatalf("transitive module beneath failed root must not be suppressed: %#v", res.suppressed)
 	}
 }
 

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -8,8 +8,11 @@ package engine
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -151,7 +154,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", modFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -291,7 +294,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", filepath.Join("modules", "bucket", "main.tf")),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -304,6 +307,141 @@ resource "aws_s3_bucket" "this" {
 	}
 	if len(res.suppressed["mod-id"]) == 0 || len(res.suppressed["root-id"]) != 0 {
 		t.Fatalf("unexpected suppression map: %#v", res.suppressed)
+	}
+}
+
+// writeFanOut builds a repository where roots roots all call one module. The
+// module spans two files and declares three resources, so the fixture also
+// covers grouping. When vary is set each root passes a different value, so
+// nothing can be shared between them.
+func writeFanOut(t *testing.T, roots int, vary bool) (string, model.FileMetadatas) {
+	t.Helper()
+	root := t.TempDir()
+	modDir := filepath.Join(root, "modules", "app")
+
+	writeFile(t, modDir, "buckets.tf", `
+variable "name" { type = string }
+
+resource "aws_s3_bucket" "primary" {
+  bucket = var.name
+}
+
+resource "aws_s3_bucket" "backup" {
+  bucket = "${var.name}-backup"
+}
+`)
+	writeFile(t, modDir, "queue.tf", `
+resource "aws_sqs_queue" "events" {
+  name = var.name
+}
+`)
+
+	files := model.FileMetadatas{
+		fileMeta("mod-buckets", filepath.Join(modDir, "buckets.tf")),
+		fileMeta("mod-queue", filepath.Join(modDir, "queue.tf")),
+	}
+	for i := range roots {
+		name := "shared"
+		if vary {
+			name = fmt.Sprintf("root-%d", i)
+		}
+		dir := filepath.Join(root, fmt.Sprintf("stack-%d", i))
+		writeFile(t, dir, "main.tf", fmt.Sprintf(`
+module "app" {
+  source = "../modules/app"
+  name   = %q
+}
+`, name))
+		files = append(files, fileMeta(fmt.Sprintf("root-%d", i), filepath.Join(dir, "main.tf")))
+	}
+	return root, files
+}
+
+// The payload has to stay proportional to the configuration. Roots that call a
+// module with the same inputs resolve to the same content and must share
+// documents; only genuinely different content may add any.
+func TestResolveModuleDocuments_DocumentsDoNotGrowWithCallSites(t *testing.T) {
+	const modFiles = 2
+
+	for _, roots := range []int{1, 4, 32} {
+		repo, files := writeFanOut(t, roots, false)
+		res := resolveModuleDocuments(context.Background(), files, repo, nil, nil)
+		if !res.ok {
+			t.Fatalf("roots=%d: resolveModuleDocuments ok = false", roots)
+		}
+		if len(res.docs) != modFiles {
+			t.Fatalf("roots=%d: %d documents, want %d — identical calls must share documents",
+				roots, len(res.docs), modFiles)
+		}
+		// Every call site still has to be reported, through cloned findings.
+		if got := deduplicatedCallerCount(&res); got != (roots-1)*modFiles {
+			t.Fatalf("roots=%d: %d deduplicated callers, want %d", roots, got, (roots-1)*modFiles)
+		}
+		if got := len(res.syntheticFiles); got != modFiles {
+			t.Fatalf("roots=%d: %d synthetic files, want one per document", roots, got)
+		}
+	}
+
+	// Different inputs genuinely produce different content, so those do scale.
+	repo, files := writeFanOut(t, 8, true)
+	res := resolveModuleDocuments(context.Background(), files, repo, nil, nil)
+	if len(res.docs) != 8*modFiles {
+		t.Fatalf("%d documents for 8 differing roots, want %d", len(res.docs), 8*modFiles)
+	}
+}
+
+// A module file reaches Rego the way any other Terraform file does: one
+// document holding that file's resources, and nothing else.
+func TestResolveModuleDocuments_DocumentMirrorsItsFile(t *testing.T) {
+	repo, files := writeFanOut(t, 1, false)
+	res := resolveModuleDocuments(context.Background(), files, repo, nil, nil)
+	if !res.ok {
+		t.Fatal("resolveModuleDocuments ok = false")
+	}
+
+	byFile := map[string]model.Document{}
+	for _, doc := range res.docs {
+		byFile[docFileID(doc["id"])] = doc
+	}
+	if len(byFile) != 2 {
+		t.Fatalf("expected one document per module file, got %#v", byFile)
+	}
+
+	buckets, _ := asStringMap(byFile["mod-buckets"]["resource"])
+	byName, _ := asStringMap(buckets["aws_s3_bucket"])
+	if len(buckets) != 1 || len(byName) != 2 {
+		t.Fatalf("both resources of buckets.tf belong in one document: %#v", buckets)
+	}
+	if _, leaked := buckets["aws_sqs_queue"]; leaked {
+		t.Fatalf("a document must not carry another file's resources: %#v", buckets)
+	}
+	for _, doc := range res.docs {
+		for key := range doc {
+			if key != "id" && key != "file" && key != "resource" {
+				t.Fatalf("unexpected key %q: a document must look like a parsed file", key)
+			}
+		}
+	}
+}
+
+// Document ids feed finding fingerprints, so the same repository must always
+// produce the same ones.
+func TestResolveModuleDocuments_DocumentIDsAreStable(t *testing.T) {
+	repo, files := writeFanOut(t, 4, true)
+
+	ids := func() []string {
+		res := resolveModuleDocuments(context.Background(), files, repo, nil, nil)
+		out := make([]string, 0, len(res.docs))
+		for _, doc := range res.docs {
+			out = append(out, doc["id"].(string))
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	first, second := ids(), ids()
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("document ids changed between runs:\n%v\n%v", first, second)
 	}
 }
 
@@ -348,7 +486,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", modFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -431,7 +569,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", modFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -528,7 +666,7 @@ resource "aws_s3_bucket" "this" { bucket = var.name }
 		fileMeta("mod-b", modBFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -566,7 +704,7 @@ module "bucket" {
 		fileMeta("root-id", filepath.Join("stack", "main.tf")),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
 	if res.ok {
 		t.Fatalf("resolveModuleDocuments ok = true, want false when all roots fail")
 	}
@@ -593,7 +731,7 @@ resource "aws_s3_bucket" "this" {
 
 	files := model.FileMetadatas{fileMeta("orphan-id", orphanFile)}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true for orphan root")
 	}
@@ -636,7 +774,7 @@ resource "aws_s3_bucket" "leaf" {
 		fileMeta("leaf-id", leafFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -697,7 +835,7 @@ module "bucket" {
 	})
 	var logs bytes.Buffer
 	ctx := zerolog.New(&logs).WithContext(context.Background())
-	if docs, synthetic, extras := ins.instantiateLocalModules(ctx, files); docs != nil || synthetic != nil || extras != nil {
+	if docs, synthetic, extras := ins.instantiateLocalModules(ctx, files, nil); docs != nil || synthetic != nil || extras != nil {
 		t.Fatalf("instantiateLocalModules = (%#v, %#v, %#v), want nil when resolve aborts", docs, synthetic, extras)
 	}
 	if _, has := rootFM.Document["module"]; !has {

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -187,12 +187,80 @@ resource "aws_s3_bucket" "this" {
 
 	// The module body must be suppressed (so it isn't scanned standalone), but
 	// the root file must still be scanned.
-	if !res.suppressed["mod-id"] {
+	if len(res.suppressed["mod-id"]) == 0 {
 		t.Fatalf("module file should be suppressed")
 	}
-	if res.suppressed["root-id"] {
+	if len(res.suppressed["root-id"]) != 0 {
 		t.Fatalf("root file should not be suppressed")
 	}
+}
+
+// Only the blocks that came back instantiated may be dropped from the file they
+// are written in. Dropping the whole file would lose the coverage the scanner
+// has today for everything else in it.
+func TestRemoveInstantiatedResources(t *testing.T) {
+	newDoc := func() model.Document {
+		return model.Document{
+			"resource": model.Document{
+				"aws_s3_bucket": model.Document{
+					"replaced": model.Document{"bucket": "x"},
+					"kept":     model.Document{"bucket": "y"},
+				},
+				"aws_sqs_queue": model.Document{
+					"untouched": model.Document{"name": "q"},
+				},
+				"_dd_lines": map[string]model.LineObject{},
+			},
+			"variable": model.Document{"name": model.Document{}},
+		}
+	}
+
+	t.Run("removes only the instantiated block", func(t *testing.T) {
+		doc := newDoc()
+		removeInstantiatedResources(doc, map[string]map[string]bool{
+			"aws_s3_bucket": {"replaced": true},
+		})
+
+		resources, _ := asStringMap(doc["resource"])
+		buckets, _ := asStringMap(resources["aws_s3_bucket"])
+		if _, gone := buckets["replaced"]; gone {
+			t.Fatalf("instantiated block must not be scanned in place too: %#v", buckets)
+		}
+		if _, kept := buckets["kept"]; !kept {
+			t.Fatalf("a block that produced no instance must keep its coverage: %#v", buckets)
+		}
+		if _, kept := resources["aws_sqs_queue"]; !kept {
+			t.Fatalf("untouched resource types must remain: %#v", resources)
+		}
+		if _, kept := doc["variable"]; !kept {
+			t.Fatalf("non-resource blocks must never be dropped")
+		}
+	})
+
+	t.Run("drops the resource key once nothing is left under it", func(t *testing.T) {
+		doc := newDoc()
+		removeInstantiatedResources(doc, map[string]map[string]bool{
+			"aws_s3_bucket": {"replaced": true, "kept": true},
+			"aws_sqs_queue": {"untouched": true},
+		})
+
+		if _, still := doc["resource"]; still {
+			t.Fatalf("only parser line metadata was left, so resource should be gone: %#v", doc)
+		}
+	})
+
+	t.Run("drops a nameless block's whole type", func(t *testing.T) {
+		doc := model.Document{
+			"resource": model.Document{
+				"aws_lb": []interface{}{model.Document{"name": "one"}},
+			},
+		}
+		removeInstantiatedResources(doc, map[string]map[string]bool{"aws_lb": {"": true}})
+
+		if _, still := doc["resource"]; still {
+			t.Fatalf("a nameless block has no name to match, so its type must go: %#v", doc)
+		}
+	})
 }
 
 func TestResolveModuleDocuments_RelativeFilePaths(t *testing.T) {
@@ -234,7 +302,7 @@ resource "aws_s3_bucket" "this" {
 	if doc := res.docs[0]; docFileID(doc["id"]) != "mod-id" {
 		t.Fatalf("instantiated doc id prefix = %v, want mod-id", docFileID(doc["id"]))
 	}
-	if !res.suppressed["mod-id"] || res.suppressed["root-id"] {
+	if len(res.suppressed["mod-id"]) == 0 || len(res.suppressed["root-id"]) != 0 {
 		t.Fatalf("unexpected suppression map: %#v", res.suppressed)
 	}
 }
@@ -315,7 +383,7 @@ resource "aws_s3_bucket" "this" {
 	if len(chains) != 2 {
 		t.Fatalf("want 2 distinct module call chains (one per root), got %d: %#v", len(chains), chains)
 	}
-	if !res.suppressed["mod-id"] {
+	if len(res.suppressed["mod-id"]) == 0 {
 		t.Fatalf("shared module file should be suppressed")
 	}
 }
@@ -532,7 +600,7 @@ resource "aws_s3_bucket" "this" {
 	if len(res.docs) != 0 {
 		t.Fatalf("orphan module should not instantiate resources, got %#v", res.docs)
 	}
-	if res.suppressed["orphan-id"] {
+	if len(res.suppressed["orphan-id"]) != 0 {
 		t.Fatalf("orphan module should not be suppressed")
 	}
 }
@@ -587,10 +655,15 @@ resource "aws_s3_bucket" "leaf" {
 		t.Fatalf("leaf bucket = %#v, want deep", leaf["bucket"])
 	}
 
-	if !res.suppressed["a-id"] || !res.suppressed["leaf-id"] {
-		t.Fatalf("intermediate and leaf module files should be suppressed: %#v", res.suppressed)
+	if !res.suppressed["leaf-id"]["aws_s3_bucket"]["leaf"] {
+		t.Fatalf("the instantiated leaf resource should be replaced: %#v", res.suppressed)
 	}
-	if res.suppressed["root-id"] {
+	// The intermediate module only calls another module, so it has no resource
+	// block to replace and nothing about it should be dropped.
+	if len(res.suppressed["a-id"]) != 0 {
+		t.Fatalf("intermediate module declares no resources, nothing to replace: %#v", res.suppressed)
+	}
+	if len(res.suppressed["root-id"]) != 0 {
 		t.Fatalf("root file should not be suppressed")
 	}
 }
@@ -635,7 +708,7 @@ module "bucket" {
 	}
 }
 
-func TestInstantiatedModuleResourceCountIncludesDeduplicatedCallers(t *testing.T) {
+func TestDeduplicatedCallerCount(t *testing.T) {
 	res := moduleResolutionResult{
 		docs: []model.Document{{}, {}},
 		extras: map[string][]extraCallerInfo{
@@ -644,8 +717,8 @@ func TestInstantiatedModuleResourceCountIncludesDeduplicatedCallers(t *testing.T
 		},
 	}
 
-	if got := instantiatedModuleResourceCount(&res); got != 5 {
-		t.Fatalf("instantiatedModuleResourceCount() = %d, want 5", got)
+	if got := deduplicatedCallerCount(&res); got != 3 {
+		t.Fatalf("deduplicatedCallerCount() = %d, want 3", got)
 	}
 }
 

--- a/pkg/engine/rule_resource_types.go
+++ b/pkg/engine/rule_resource_types.go
@@ -1,0 +1,108 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package engine
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+// A rule names the resource types it can match, either by reading them off a
+// document (`input.document[i].resource.aws_s3_bucket[name]`) or by passing
+// them to a library helper (`module_equivalent_key("aws", source,
+// "aws_s3_bucket", key)`). Both forms are picked up here.
+var (
+	resourceFieldPattern = regexp.MustCompile(`resource\.([a-z][a-z0-9_]*)`)
+	resourceIndexPattern = regexp.MustCompile(`resource\[\s*"([^"\s]+)"\s*\]`)
+	typeLiteralPattern   = regexp.MustCompile(`"([a-z][a-z0-9]*(?:_[a-z0-9]+)+)"`)
+	// Rules that apply to a whole provider select it by prefix, as in
+	// `startswith(resource_type, "aws_")`.
+	typePrefixPattern = regexp.MustCompile(`startswith\([^,]+,\s*"([a-z][a-z0-9]*_)"\s*\)`)
+)
+
+// ruleTargets decides whether a resource type can be matched by name by any of
+// the loaded rules.
+type ruleTargets struct {
+	types    map[string]bool
+	prefixes []string
+}
+
+// matches reports whether some rule names this resource type, directly or
+// through the provider prefix it belongs to.
+func (t *ruleTargets) matches(resourceType string) bool {
+	if t == nil {
+		return true
+	}
+	if t.types[resourceType] {
+		return true
+	}
+	for _, prefix := range t.prefixes {
+		if strings.HasPrefix(resourceType, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// ruleTargetedResourceTypes collects every Terraform resource type the given
+// rules can match by name, either individually or by provider prefix.
+//
+// Resolving a module's variables only changes a finding if some rule reads the
+// resource whose values were resolved, so this is what decides which resources
+// are worth instantiating. Skipping a resource never removes it from the scan:
+// it keeps being read where it is written, with the same unresolved values it
+// has today. The cost of missing a type is therefore a finding this feature
+// could have improved, not one the scanner used to report — but the collection
+// still errs towards including too much, since a wrongly included type only
+// costs a little work. Most of what it over-collects (helper names, attribute
+// names) never matches a resource type anyway.
+//
+// Returns nil when nothing could be collected, which turns the filter off
+// rather than silently narrowing a scan.
+func ruleTargetedResourceTypes(queries []model.QueryMetadata, libraries ...string) *ruleTargets {
+	targets := ruleTargets{types: make(map[string]bool)}
+	prefixes := make(map[string]bool)
+	collect := func(source string) {
+		for _, pattern := range []*regexp.Regexp{
+			resourceFieldPattern, resourceIndexPattern, typeLiteralPattern,
+		} {
+			for _, m := range pattern.FindAllStringSubmatch(source, -1) {
+				targets.types[m[1]] = true
+			}
+		}
+		for _, m := range typePrefixPattern.FindAllStringSubmatch(source, -1) {
+			prefixes[m[1]] = true
+		}
+	}
+	for i := range queries {
+		collect(queries[i].Content)
+		collect(queries[i].InputData)
+	}
+	for _, library := range libraries {
+		collect(library)
+	}
+	if len(targets.types) == 0 {
+		return nil
+	}
+	for prefix := range prefixes {
+		targets.prefixes = append(targets.prefixes, prefix)
+	}
+	sort.Strings(targets.prefixes)
+	return &targets
+}
+
+// terraformRuleLibraries returns the Rego libraries that Terraform rules are
+// compiled against, so type names spelled only in shared helpers are seen too.
+func (c *Inspector) terraformRuleLibraries() []string {
+	libraries := []string{c.QueryLoader.commonLibrary.LibraryCode}
+	if platform, ok := c.QueryLoader.platformLibraries["terraform"]; ok {
+		libraries = append(libraries, platform.LibraryCode)
+	}
+	return libraries
+}

--- a/pkg/engine/rule_resource_types_test.go
+++ b/pkg/engine/rule_resource_types_test.go
@@ -1,0 +1,122 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package engine
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+func TestRuleTargetedResourceTypes(t *testing.T) {
+	queries := []model.QueryMetadata{
+		{Content: `
+DatadogPolicy contains result if {
+	resource := input.document[i].resource.aws_s3_bucket[name]
+	resource.acl == "public-read"
+}
+`},
+		{Content: `
+DatadogPolicy contains result if {
+	some resource in input.document[i].resource["google_storage_bucket"]
+	not resource.uniform_bucket_level_access
+}
+`},
+		{Content: `
+DatadogPolicy contains result if {
+	module := input.document[i].module[name]
+	common_lib.module_equivalent_key("aws", module.source, "aws_sqs_queue", key)
+}
+`},
+		{Content: `
+taggable contains resource if {
+	some resource_type, resource in doc.resource
+	startswith(resource_type, "azurerm_")
+}
+`},
+	}
+	library := `check_supports_tags(t) if { t == "aws_instance" }`
+
+	targets := ruleTargetedResourceTypes(queries, library)
+	if targets == nil {
+		t.Fatal("expected targets from a non-empty ruleset")
+	}
+
+	for _, typ := range []string{
+		"aws_s3_bucket",           // read off a document by field
+		"google_storage_bucket",   // read off a document by key
+		"aws_sqs_queue",           // passed to a library helper
+		"aws_instance",            // named only in a library
+		"azurerm_anything_at_all", // whole provider selected by prefix
+	} {
+		if !targets.matches(typ) {
+			t.Errorf("%s should be matched by some rule", typ)
+		}
+	}
+	for _, typ := range []string{"vault_identity_group", "datadog_monitor"} {
+		if targets.matches(typ) {
+			t.Errorf("%s is named by no rule and should not be matched", typ)
+		}
+	}
+}
+
+// With no rule text to read, the filter must not narrow the scan.
+func TestRuleTargetedResourceTypes_EmptyRulesetDisablesFiltering(t *testing.T) {
+	if targets := ruleTargetedResourceTypes(nil); targets != nil {
+		t.Fatalf("expected nil targets, got %#v", targets)
+	}
+	var none *ruleTargets
+	if !none.matches("anything_at_all") {
+		t.Fatal("a nil filter must match everything")
+	}
+}
+
+func TestDeclaresTargetedResource(t *testing.T) {
+	withTypes := func(path string, types ...string) *model.FileMetadata {
+		resources := model.Document{}
+		for _, typ := range types {
+			resources[typ] = model.Document{"this": model.Document{}}
+		}
+		return &model.FileMetadata{FilePath: path, Document: model.Document{"resource": resources}}
+	}
+	targets := &ruleTargets{types: map[string]bool{"aws_s3_bucket": true}}
+
+	cases := []struct {
+		name  string
+		files model.FileMetadatas
+		want  bool
+	}{
+		{
+			name:  "nothing a rule can match",
+			files: model.FileMetadatas{withTypes("a.tf", "vault_policy", "random_id")},
+			want:  false,
+		},
+		{
+			name: "one targeted type anywhere is enough",
+			files: model.FileMetadatas{
+				withTypes("a.tf", "vault_policy"),
+				withTypes("b.tf", "aws_s3_bucket"),
+			},
+			want: true,
+		},
+		{
+			name:  "non-terraform files are ignored",
+			files: model.FileMetadatas{withTypes("main.yaml", "aws_s3_bucket")},
+			want:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := declaresTargetedResource(tc.files, targets); got != tc.want {
+				t.Fatalf("declaresTargetedResource() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	if !declaresTargetedResource(model.FileMetadatas{withTypes("a.tf", "vault_policy")}, nil) {
+		t.Fatal("a nil filter must never skip evaluation")
+	}
+}

--- a/pkg/parser/terraform/tfeval/document.go
+++ b/pkg/parser/terraform/tfeval/document.go
@@ -8,6 +8,7 @@ package tfeval
 
 import (
 	"encoding/json"
+	"strings"
 
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 	"github.com/hashicorp/hcl/v2"
@@ -22,22 +23,52 @@ const UnknownAttributePlaceholder = "__DD_TFEVAL_UNKNOWN__"
 
 // AttributesToDocument converts a resolved resource's attributes into the
 // map[string]interface{} shape the rule pipeline consumes. Every attribute is
-// always included: unknown or unsupported values use UnknownAttributePlaceholder
-// so presence-based rules do not fire false positives on unresolved expressions.
+// always included: a value evaluation could not resolve falls back to its
+// reference text, or to UnknownAttributePlaceholder when it has none, so
+// presence-based rules do not fire false positives on unresolved expressions.
 func AttributesToDocument(r *ResolvedResource) map[string]interface{} {
-	out := make(map[string]interface{}, len(r.Attributes))
-	for key, val := range r.Attributes {
-		out[key] = ctyValueToDocument(val)
+	return attributesToDocument(r.Attributes, r.Body)
+}
+
+// attrSource locates the HCL that produced a value so unresolved values can fall
+// back to their reference text. Exactly one field is set, or none when the value
+// cannot be traced back to a specific expression or block.
+type attrSource struct {
+	expr   hclsyntax.Expression // attribute value expression
+	body   *hclsyntax.Body      // body of a single nested block
+	blocks []*hclsyntax.Block   // nested blocks sharing one type
+}
+
+func attributesToDocument(attrs map[string]cty.Value, body *hclsyntax.Body) map[string]interface{} {
+	out := make(map[string]interface{}, len(attrs))
+	for key, val := range attrs {
+		out[key] = ctyValueToDocument(val, sourceFor(body, key))
 	}
 	return out
 }
 
-// ctyValueToDocument converts a cty.Value to a JSON-serializable value.
-// Unknowns and any type that cannot be represented become UnknownAttributePlaceholder
-// so every attribute key is preserved in the output document.
-func ctyValueToDocument(v cty.Value) interface{} {
+// sourceFor finds the attribute expression or nested blocks that produced key.
+func sourceFor(body *hclsyntax.Body, key string) attrSource {
+	if body == nil {
+		return attrSource{}
+	}
+	if attr, ok := body.Attributes[key]; ok && attr != nil {
+		return attrSource{expr: attr.Expr}
+	}
+	var blocks []*hclsyntax.Block
+	for _, b := range body.Blocks {
+		if b.Type == key {
+			blocks = append(blocks, b)
+		}
+	}
+	return attrSource{blocks: blocks}
+}
+
+// ctyValueToDocument converts a cty.Value to a JSON-serializable value, using
+// src to recover what an unresolved value looked like in the configuration.
+func ctyValueToDocument(v cty.Value, src attrSource) interface{} {
 	if !v.IsKnown() {
-		return UnknownAttributePlaceholder
+		return unresolvedToDocument(src.expr)
 	}
 	if v.IsNull() {
 		return nil
@@ -56,35 +87,174 @@ func ctyValueToDocument(v cty.Value) interface{} {
 
 	switch {
 	case t.IsTupleType(), t.IsListType(), t.IsSetType():
-		return ctySeqToDocument(v)
+		return ctySeqToDocument(v, src)
 	case t.IsObjectType(), t.IsMapType():
-		return ctyMapToDocument(v)
+		return ctyMapToDocument(v, src)
 	}
 	return UnknownAttributePlaceholder
 }
 
 // ctySeqToDocument converts a tuple/list/set to a slice.
-func ctySeqToDocument(v cty.Value) []interface{} {
-	list := make([]interface{}, 0, v.LengthInt())
-	for it := v.ElementIterator(); it.Next(); {
+func ctySeqToDocument(v cty.Value, src attrSource) []interface{} {
+	n := v.LengthInt()
+	elemSrcs := seqElementSources(src, n)
+	list := make([]interface{}, 0, n)
+	i := 0
+	for it := v.ElementIterator(); it.Next(); i++ {
 		_, ev := it.Element()
-		list = append(list, ctyValueToDocument(ev))
+		var es attrSource
+		if i < len(elemSrcs) {
+			es = elemSrcs[i]
+		}
+		list = append(list, ctyValueToDocument(ev, es))
 	}
 	return list
 }
 
+// seqElementSources pairs sequence elements with the HCL they came from, which
+// only holds when the lengths line up (evaluation preserves element order).
+func seqElementSources(src attrSource, n int) []attrSource {
+	if len(src.blocks) == n {
+		out := make([]attrSource, n)
+		for i, b := range src.blocks {
+			out[i] = attrSource{body: b.Body}
+		}
+		return out
+	}
+	if tuple, ok := src.expr.(*hclsyntax.TupleConsExpr); ok && len(tuple.Exprs) == n {
+		out := make([]attrSource, n)
+		for i, e := range tuple.Exprs {
+			out[i] = attrSource{expr: e}
+		}
+		return out
+	}
+	return nil
+}
+
 // ctyMapToDocument converts an object/map to a Go map; non-string or unknown
 // keys are skipped (keys are always strings in well-formed Terraform).
-func ctyMapToDocument(v cty.Value) map[string]interface{} {
+func ctyMapToDocument(v cty.Value, src attrSource) map[string]interface{} {
+	body := src.body
+	if body == nil && len(src.blocks) == 1 {
+		body = src.blocks[0].Body
+	}
+	items := objectConsSources(src.expr)
+
 	obj := make(map[string]interface{}, v.LengthInt())
 	for it := v.ElementIterator(); it.Next(); {
 		key, ev := it.Element()
 		if key.Type() != cty.String || !key.IsKnown() {
 			continue
 		}
-		obj[key.AsString()] = ctyValueToDocument(ev)
+		name := key.AsString()
+		var es attrSource
+		switch {
+		case body != nil:
+			es = sourceFor(body, name)
+		case items[name] != nil:
+			es = attrSource{expr: items[name]}
+		}
+		obj[name] = ctyValueToDocument(ev, es)
 	}
 	return obj
+}
+
+// objectConsSources maps the statically known keys of an object constructor to
+// their value expressions.
+func objectConsSources(expr hclsyntax.Expression) map[string]hclsyntax.Expression {
+	cons, ok := expr.(*hclsyntax.ObjectConsExpr)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]hclsyntax.Expression, len(cons.Items))
+	for _, item := range cons.Items {
+		k, diags := item.KeyExpr.Value(nil)
+		if diags.HasErrors() || !k.IsKnown() || k.IsNull() || k.Type() != cty.String {
+			continue
+		}
+		out[k.AsString()] = item.ValueExpr
+	}
+	return out
+}
+
+// unresolvedToDocument recovers whatever a value that failed to evaluate can
+// still offer rules: reference text for references, literals for parts that need
+// no context, and the same treatment element-wise for collection constructors.
+// A collection is reported as unknown as a whole when any part of it is, so it
+// has to be rebuilt from the expression rather than from the value.
+func unresolvedToDocument(expr hclsyntax.Expression) interface{} {
+	if expr == nil {
+		return UnknownAttributePlaceholder
+	}
+	if ref, ok := referenceText(expr); ok {
+		return ref
+	}
+	if val, diags := expr.Value(nil); !diags.HasErrors() && val.IsWhollyKnown() {
+		return ctyValueToDocument(val, attrSource{})
+	}
+	switch e := expr.(type) {
+	case *hclsyntax.TupleConsExpr:
+		list := make([]interface{}, 0, len(e.Exprs))
+		for _, elem := range e.Exprs {
+			list = append(list, unresolvedToDocument(elem))
+		}
+		return list
+	case *hclsyntax.ObjectConsExpr:
+		items := objectConsSources(e)
+		obj := make(map[string]interface{}, len(items))
+		for name, valExpr := range items {
+			obj[name] = unresolvedToDocument(valExpr)
+		}
+		return obj
+	}
+	return UnknownAttributePlaceholder
+}
+
+// referenceText renders a reference expression back to the interpolated form the
+// plain HCL parser emits for unresolved values, e.g. "${aws_s3_bucket.b.id}".
+// Rules link resources by parsing these strings, so keeping them is what lets an
+// instantiated resource still be matched against the resource it points at.
+func referenceText(expr hclsyntax.Expression) (string, bool) {
+	if expr == nil {
+		return "", false
+	}
+	traversal, diags := hcl.AbsTraversalForExpr(expr)
+	if diags.HasErrors() {
+		return "", false
+	}
+	rendered, ok := renderTraversal(traversal)
+	if !ok {
+		return "", false
+	}
+	return "${" + rendered + "}", true
+}
+
+func renderTraversal(traversal hcl.Traversal) (string, bool) {
+	if len(traversal) == 0 {
+		return "", false
+	}
+	var sb strings.Builder
+	for _, step := range traversal {
+		switch s := step.(type) {
+		case hcl.TraverseRoot:
+			sb.WriteString(s.Name)
+		case hcl.TraverseAttr:
+			sb.WriteByte('.')
+			sb.WriteString(s.Name)
+		case hcl.TraverseIndex:
+			switch s.Key.Type() {
+			case cty.String:
+				sb.WriteString(`["` + s.Key.AsString() + `"]`)
+			case cty.Number:
+				sb.WriteString("[" + s.Key.AsBigFloat().Text('f', -1) + "]")
+			default:
+				return "", false
+			}
+		default:
+			return "", false
+		}
+	}
+	return sb.String(), true
 }
 
 // RemoteResolver maps a non-local module call to its materialized directory on disk.

--- a/pkg/parser/terraform/tfeval/document_test.go
+++ b/pkg/parser/terraform/tfeval/document_test.go
@@ -6,6 +6,7 @@
 package tfeval
 
 import (
+	"context"
 	"encoding/json"
 	"path/filepath"
 	"reflect"
@@ -40,7 +41,7 @@ func TestCtyValueToDocument(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ctyValueToDocument(tt.value)
+			got := ctyValueToDocument(tt.value, attrSource{})
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("got %#v, want %#v", got, tt.want)
 			}
@@ -61,6 +62,94 @@ func TestAttributesToDocumentPreservesUnknownKeys(t *testing.T) {
 	}
 	if got, ok := doc["acl"]; !ok || got != UnknownAttributePlaceholder {
 		t.Fatalf("unknown attribute acl = %#v, want %q", got, UnknownAttributePlaceholder)
+	}
+}
+
+// documentFor evaluates dir and returns the document of one resolved resource.
+func documentFor(t *testing.T, dir, typ, name string) map[string]interface{} {
+	t.Helper()
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	r := findResource(t, resources, typ, name)
+	return AttributesToDocument(&r)
+}
+
+func TestAttributesToDocumentKeepsReferenceText(t *testing.T) {
+	dir := writeModule(t, t.TempDir(), "mod", map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "logs" {
+  bucket = "logs"
+}
+
+resource "aws_s3_bucket_logging" "this" {
+  bucket        = aws_s3_bucket.target.id
+  target_bucket = aws_s3_bucket.logs.bucket
+  keys          = [aws_kms_key.a.arn, "literal-key"]
+  indexed       = aws_subnet.private[0].id
+  computed      = timestamp()
+
+  rule {
+    role_arn = aws_iam_role.replication.arn
+  }
+}
+`,
+	})
+
+	doc := documentFor(t, dir, "aws_s3_bucket_logging", "this")
+
+	// A reference to a resource outside the module stays unresolved, but the
+	// reference text is what lets rules associate the two resources.
+	if got := doc["bucket"]; got != "${aws_s3_bucket.target.id}" {
+		t.Errorf("bucket = %#v, want ${aws_s3_bucket.target.id}", got)
+	}
+	// A reference that does resolve keeps its resolved value.
+	if got := doc["target_bucket"]; got != "logs" {
+		t.Errorf("target_bucket = %#v, want logs", got)
+	}
+	// A list is unknown as a whole once one element is, so the resolvable
+	// elements have to survive alongside the recovered reference.
+	want := []interface{}{"${aws_kms_key.a.arn}", "literal-key"}
+	if got := doc["keys"]; !reflect.DeepEqual(got, want) {
+		t.Errorf("keys = %#v, want %#v", got, want)
+	}
+	if got := doc["indexed"]; got != "${aws_subnet.private[0].id}" {
+		t.Errorf("indexed = %#v, want ${aws_subnet.private[0].id}", got)
+	}
+	// Not a reference, so there is nothing to recover.
+	if got := doc["computed"]; got != UnknownAttributePlaceholder {
+		t.Errorf("computed = %#v, want %q", got, UnknownAttributePlaceholder)
+	}
+
+	rules, ok := doc["rule"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("rule = %#v, want object", doc["rule"])
+	}
+	if got := rules["role_arn"]; got != "${aws_iam_role.replication.arn}" {
+		t.Errorf("rule.role_arn = %#v, want ${aws_iam_role.replication.arn}", got)
+	}
+}
+
+// Reference text is recovered only when building the document, so a resource
+// that reads an unresolved attribute of a sibling reports its own reference
+// rather than inheriting the sibling's.
+func TestAttributesToDocumentReferenceTextDoesNotChain(t *testing.T) {
+	dir := writeModule(t, t.TempDir(), "mod", map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "a" {
+  bucket = var.never_set
+}
+
+resource "aws_s3_bucket_versioning" "b" {
+  bucket = aws_s3_bucket.a.bucket
+}
+`,
+	})
+
+	doc := documentFor(t, dir, "aws_s3_bucket_versioning", "b")
+	if got := doc["bucket"]; got != "${aws_s3_bucket.a.bucket}" {
+		t.Fatalf("bucket = %#v, want ${aws_s3_bucket.a.bucket}", got)
 	}
 }
 

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -45,6 +45,10 @@ type ResolvedResource struct {
 	Type       string
 	Name       string
 	Attributes map[string]cty.Value
+	// Body is the resource's HCL body, used to recover the reference text of
+	// attributes evaluation could not resolve. It is not consulted during
+	// evaluation, so recovered references never feed back into resolved values.
+	Body *hclsyntax.Body
 
 	// Source location and module address for finding attribution.
 	DefinedIn     string
@@ -426,6 +430,7 @@ func (e *Evaluator) expandResourceBlock(
 			Type:          typeName,
 			Name:          name,
 			Attributes:    e.evalBody(rb.Body, ctx, nil),
+			Body:          rb.Body,
 			DefinedIn:     rb.TypeRange.Filename,
 			DefLine:       rb.TypeRange.Start.Line,
 			ModuleAddress: addr,
@@ -699,6 +704,15 @@ func (e *Evaluator) evalBody(
 	}
 	for _, t := range order {
 		list := grouped[t]
+		// Match how a parsed Terraform file represents nested blocks: a block
+		// written once is an object, and only a repeated one becomes a list.
+		// Rules are written against that shape — `resource.ingress.cidr_blocks`
+		// reads straight through a single block — so a list here would make a
+		// rule quietly stop matching resources that came from a module.
+		if len(list) == 1 {
+			out[t] = list[0]
+			continue
+		}
 		out[t] = cty.TupleVal(list)
 	}
 	return out

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -55,6 +55,9 @@ type ResolvedResource struct {
 	DefLine       int
 	ModuleAddress string // "" for root module resources
 	CallChain     []CallSite
+	// ExpansionTruncated is set when count/for_each produced more instances than
+	// maxCountExpansion; the source block must stay in the scan for the rest.
+	ExpansionTruncated bool
 }
 
 // CallSite records one hop in a module call chain.
@@ -467,6 +470,7 @@ func (e *Evaluator) expandCountInstances(
 			return nil, true
 		}
 		nExpand := n
+		truncated := n > maxCountExpansion
 		if nExpand > maxCountExpansion {
 			nExpand = maxCountExpansion
 		}
@@ -478,7 +482,9 @@ func (e *Evaluator) expandCountInstances(
 					"index": cty.NumberIntVal(int64(i)),
 				}),
 			}
-			out = append(out, makeOne(fmt.Sprintf("%s[%d]", resName, i), child))
+			res := makeOne(fmt.Sprintf("%s[%d]", resName, i), child)
+			res.ExpansionTruncated = truncated
+			out = append(out, res)
 		}
 		return out, true
 	}
@@ -509,6 +515,8 @@ func (e *Evaluator) expandForEachInstances(
 				return nil, true
 			}
 			out := make([]ResolvedResource, 0)
+			total := fv.LengthInt()
+			truncated := total > maxCountExpansion
 			i := 0
 			for it := fv.ElementIterator(); it.Next() && i < maxCountExpansion; i++ {
 				k, kv := it.Element()
@@ -523,7 +531,9 @@ func (e *Evaluator) expandForEachInstances(
 						"value": kv,
 					}),
 				}
-				out = append(out, makeOne(fmt.Sprintf("%s[%q]", resName, keyStr), child))
+				res := makeOne(fmt.Sprintf("%s[%q]", resName, keyStr), child)
+				res.ExpansionTruncated = truncated
+				out = append(out, res)
 			}
 			return out, true
 		}

--- a/pkg/parser/terraform/tfeval/evaluator_test.go
+++ b/pkg/parser/terraform/tfeval/evaluator_test.go
@@ -1195,13 +1195,28 @@ module "m" {
 	}
 }
 
-func TestEvaluateModule_SingleNestedBlockIsSingletonTuple(t *testing.T) {
+// Nested blocks have to reach a rule in the same shape a parsed Terraform file
+// gives them, or a rule written for one will silently skip the other. The
+// parser writes a block that appears once as an object and only a repeated one
+// as a list, which is why `resource.ingress.cidr_blocks` is how rules are
+// written.
+func TestEvaluateModule_NestedBlockShapeMatchesParser(t *testing.T) {
 	root := t.TempDir()
 	dir := writeModule(t, root, "mod", map[string]string{
 		"main.tf": `
-resource "aws_s3_bucket" "this" {
+resource "aws_s3_bucket" "single" {
   versioning {
     enabled = true
+  }
+}
+
+resource "aws_security_group" "repeated" {
+  ingress {
+    from_port = 22
+  }
+
+  ingress {
+    from_port = 443
   }
 }
 `,
@@ -1212,21 +1227,19 @@ resource "aws_s3_bucket" "this" {
 		t.Fatalf("EvaluateModule: %v", err)
 	}
 
-	r := findResource(t, resources, "aws_s3_bucket", "this")
-	versioning, ok := r.Attributes["versioning"]
-	if !ok {
-		t.Fatalf("versioning block missing")
+	versioning := findResource(t, resources, "aws_s3_bucket", "single").Attributes["versioning"]
+	if !versioning.Type().IsObjectType() {
+		t.Fatalf("versioning = %s, want an object for a block written once",
+			versioning.Type().FriendlyName())
 	}
-	if !versioning.Type().IsTupleType() || versioning.LengthInt() != 1 {
-		t.Fatalf("versioning = %s (len %d), want 1-tuple", versioning.Type().FriendlyName(), versioning.LengthInt())
+	if enabled := versioning.GetAttr("enabled"); !enabled.True() {
+		t.Fatalf("versioning.enabled = %#v, want true", enabled)
 	}
-	block := versioning.Index(cty.NumberIntVal(0))
-	if !block.Type().IsObjectType() {
-		t.Fatalf("versioning[0] = %s, want object", block.Type().FriendlyName())
-	}
-	enabled := block.GetAttr("enabled")
-	if !enabled.True() {
-		t.Fatalf("versioning[0].enabled = %#v, want true", enabled)
+
+	ingress := findResource(t, resources, "aws_security_group", "repeated").Attributes["ingress"]
+	if !ingress.Type().IsTupleType() || ingress.LengthInt() != 2 {
+		t.Fatalf("ingress = %s (len %d), want a 2-tuple for a repeated block",
+			ingress.Type().FriendlyName(), ingress.LengthInt())
 	}
 }
 


### PR DESCRIPTION
## Motivation

Local module evaluation used to emit one OPA document per resolved resource. Each document also carried a full map of every resource in the module call, so large, repeatedly instantiated modules grew quadratically in memory and could exhaust the scanner limit before rule evaluation finished.

This branch is the **regression-detection** variant: local module evaluation runs unconditionally so CI and large-fixture comparisons can exercise the path without org flag configuration. The production-shaped, flag-gated version is in [#304](https://github.com/DataDog/datadog-iac-scanner/pull/304).

## Changes

Same module-instantiation work as [#304](https://github.com/DataDog/datadog-iac-scanner/pull/304), plus a temporary always-on bypass for regression detection (see last commit).

**Document construction**

Emit one synthetic document per module call chain, defining file, and count/`for_each` layer, the same shape as an ordinary Terraform file, instead of one document per resource. Identical callers with the same resolved content share one OPA document; findings for duplicate callers are expanded after evaluation so attribution stays caller-specific.

**Coverage and suppression**

Only the specific resource blocks that were actually re-emitted as instantiated documents are removed from the original files. Anything the evaluator could not resolve, or that expanded to no instances, keeps being scanned where it is written. Variable, output, data, and locals blocks in called modules are always kept.

**Scan pipeline**

Instantiate local modules before module-path parsing, and append synthetic files only after that step, so synthetic documents are not re-parsed on the way into OPA.

**Rule relevance**

Extract Terraform resource types from loaded rule and library Rego so module evaluation only instantiates resource types a rule can match. Skip the entire evaluation path when a repository declares none of those types.

**Evaluator fidelity**

When a nested block is written once, represent it as an object rather than a one-element list so module-instantiated documents match parser output. When evaluation cannot resolve an attribute but the expression is a resource reference, keep the reference text so cross-resource rules keep matching.

**Deterministic document IDs**

Evaluate root modules in sorted order so deduplicated document IDs and finding fingerprints stay stable across runs.

**Edge-case hardening**

Partial root evaluation failure preserves the full transitive module closure beneath failed roots, so shared descendant module bodies remain scannable when another root succeeds. Static resources remain unique in layer 0 while later count/`for_each` layers contain only additional instances, preventing payload-wide duplicate resources. Truncated expansions keep the source block scannable for instances beyond the cap.

**Performance**

Resolve a file's owning root by walking its parent directories instead of scanning every root module directory, which keeps instantiation linear on repositories with thousands of independent stacks.

**Temporary always-on bypass**

Module instantiation ignores the org flag on this branch only. Revert before release; merge [#304](https://github.com/DataDog/datadog-iac-scanner/pull/304) for production behaviour.

## Commit structure

1. Group instantiated module documents and selective resource suppression
2. Rule-targeted instantiation filter
3. Evaluator output fidelity (nested blocks and reference text)
4. Edge-case hardening and stable root evaluation order
5. Linear root ownership lookup
6. Unique expansion-layer resources and transitive failed-root preservation
7. Temporary always-on bypass (this branch only)

## Regression detector notes

Compared against `main` with the flag off, so finding-count deltas and modest wall-time increases on cloud-inventory and dd-source reflect the cost and behaviour change of always-on module eval, not a performance regression from the grouping work. Peak RSS is flat or lower. After the owning-root fix, cloud-inventory wall time dropped from +680% to +56% vs baseline.

## QA Instruction

1. `go test ./pkg/engine/... ./pkg/parser/terraform/tfeval/... -count=1`
2. `golangci-lint run -c .golangci.yml ./pkg/engine/... ./pkg/parser/terraform/tfeval/...`
3. `make build` then scan a Terraform repository with repeated module calls and confirm the log reports resources grouped into fewer OPA documents.
4. Scan vault-config and an engaged Terraform fixture; compare findings and memory against baseline.
5. Run the same repository twice and confirm document IDs and finding fingerprints are stable when callers dedupe.

## Impact

Terraform local module evaluation only. Rule assets unchanged. This branch temporarily bypasses `k9-iac-enable-local-module-eval`; do not ship without reverting the last commit.

**Related branches:** production merge target [#304](https://github.com/DataDog/datadog-iac-scanner/pull/304); `chakib.hamie/experiment_rule_prefilter` stacks the same module commits with always-on eval plus the env-gated rule prefilter experiment.