### PR TITLE
Fix fetch-bundle config exit code

### DIFF
--- a/cmd/scanner/fetch_bundle.go
+++ b/cmd/scanner/fetch_bundle.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -72,7 +73,7 @@ func fetchBundle(ctx context.Context, c *cli.Command) error {
 
 	_, cfgBytes, err := config.ReadConfiguration(ctx, repoPath, config.WithDatadog(client, c.String("repo-url")))
 	if err != nil {
-		return errorWithExitCode(fmt.Errorf("error reading the configuration: %w", err), constants.EngineErrorCode)
+		return configurationReadError(err)
 	}
 	if err := os.WriteFile(filepath.Join(outputDir, bundleConfigFileName), cfgBytes, filePerms); err != nil {
 		return errorWithExitCode(fmt.Errorf("error writing the configuration bundle: %w", err), constants.EngineErrorCode)
@@ -122,6 +123,14 @@ func fetchBundle(ctx context.Context, c *cli.Command) error {
 
 	fmt.Printf("Wrote offline bundle (%d rules, %d libraries) to %s\n", len(ruleset.Rules), len(libraries), outputDir)
 	return nil
+}
+
+func configurationReadError(err error) error {
+	outErr := fmt.Errorf("error reading the configuration: %w", err)
+	if te := (*config.InvalidLocalConfigError)(nil); errors.As(err, &te) {
+		return errorWithExitCode(outErr, constants.InvalidConfigErrorCode)
+	}
+	return errorWithExitCode(outErr, constants.EngineErrorCode)
 }
 
 // readBundleManifest reads and parses the manifest written by fetchBundle,

--- a/cmd/scanner/fetch_bundle_test.go
+++ b/cmd/scanner/fetch_bundle_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/internal/constants"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchBundleInvalidLocalConfigExitCode(t *testing.T) {
+	repoPath := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoPath, "code-security.datadog.yaml"),
+		[]byte("schema-version: [invalid"),
+		0600,
+	))
+
+	err := fetchBundleAction.Run(t.Context(), []string{
+		"fetch-bundle",
+		"--repo-path", repoPath,
+		"--repo-url", "https://example.com/repo",
+		"--output-dir", t.TempDir(),
+	})
+
+	var exitErr *withExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, constants.InvalidConfigErrorCode, exitErr.code)
+}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"126bb39f-ca6a-405e-9c87-b558b9ee355c","source":"chat","resourceId":"f391935b-2779-41d3-9a74-c330c7ae34b3","workflowId":"6110d4b5-b1bb-46e6-bde2-deec1ddd7d5c","codeChangeId":"6110d4b5-b1bb-46e6-bde2-deec1ddd7d5c","sourceType":"bits_ai_sre"} -->
## Motivation

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/ce1a6ab7-b3b1-42b3-b8ee-e237fffaf080)

Malformed repository-local IaC YAML reached the offline-bundle path during the Terrapin rollout. `fetch-bundle` classified this deterministic input error as an engine failure (exit 126), causing downstream retries and terminal task failures instead of the invalid-configuration outcome (exit 127).

Investigation: https://app.datadoghq.com/bits-ai/investigations/ce1a6ab7-b3b1-42b3-b8ee-e237fffaf080?type=CONCLUSION

JIRA Ticket

Not provided.

## Changes

- Update `cmd/scanner/fetch_bundle.go` to detect `config.InvalidLocalConfigError` through wrapped errors and return `constants.InvalidConfigErrorCode` (127).
- Preserve `constants.EngineErrorCode` (126) for remote configuration and other engine failures.
- Add `cmd/scanner/fetch_bundle_test.go` covering malformed YAML through the real `fetch-bundle` CLI action.

## Testing

- `go test ./cmd/scanner -count=1`
- `/tmp/golangci-lint-v2.4.0/golangci-lint run -c .golangci.yml --timeout 20m`

## Author Checklist

- [ ] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Review `cmd/scanner/fetch_bundle_test.go` and verify malformed local configuration produces exit code 127, while remote configuration failures continue to use exit code 126.

## Blast Radius

Only the Datadog IaC Scanner `fetch-bundle` command is changed. Valid bundles and remote/engine error classification are otherwise unchanged.

## Additional Notes

This addresses the incident’s retry amplification by allowing downstream `iac-scanning` consumers to treat malformed local configuration as a deterministic invalid-input outcome.

I submit this contribution under the Apache-2.0 license.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/f391935b-2779-41d3-9a74-c330c7ae34b3)

Comment @datadog to request changes