### PR TITLE
Preserve invalid config exit code in fetch-bundle

### DIFF
--- a/cmd/scanner/fetch_bundle.go
+++ b/cmd/scanner/fetch_bundle.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -72,7 +73,7 @@ func fetchBundle(ctx context.Context, c *cli.Command) error {
 
 	_, cfgBytes, err := config.ReadConfiguration(ctx, repoPath, config.WithDatadog(client, c.String("repo-url")))
 	if err != nil {
-		return errorWithExitCode(fmt.Errorf("error reading the configuration: %w", err), constants.EngineErrorCode)
+		return fetchBundleConfigurationError(err)
 	}
 	if err := os.WriteFile(filepath.Join(outputDir, bundleConfigFileName), cfgBytes, filePerms); err != nil {
 		return errorWithExitCode(fmt.Errorf("error writing the configuration bundle: %w", err), constants.EngineErrorCode)
@@ -122,6 +123,14 @@ func fetchBundle(ctx context.Context, c *cli.Command) error {
 
 	fmt.Printf("Wrote offline bundle (%d rules, %d libraries) to %s\n", len(ruleset.Rules), len(libraries), outputDir)
 	return nil
+}
+
+func fetchBundleConfigurationError(err error) error {
+	code := constants.EngineErrorCode
+	if te := (*config.InvalidLocalConfigError)(nil); errors.As(err, &te) {
+		code = constants.InvalidConfigErrorCode
+	}
+	return errorWithExitCode(fmt.Errorf("error reading the configuration: %w", err), code)
 }
 
 // readBundleManifest reads and parses the manifest written by fetchBundle,

--- a/cmd/scanner/fetch_bundle_test.go
+++ b/cmd/scanner/fetch_bundle_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/internal/constants"
+	"github.com/DataDog/datadog-iac-scanner/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchBundleInvalidLocalConfigExitCode(t *testing.T) {
+	repoPath := t.TempDir()
+	configPath := filepath.Join(repoPath, config.ConfigFileNameBase+".yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("schema-version: v1.4\niac: [\n"), 0644))
+
+	err := fetchBundleAction.Run(t.Context(), []string{
+		"fetch-bundle",
+		"--repo-path", repoPath,
+		"--repo-url", "https://example.com/repo",
+		"--output-dir", t.TempDir(),
+	})
+
+	var exitErr *withExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, constants.InvalidConfigErrorCode, exitErr.code)
+	require.ErrorContains(t, err, "error reading the configuration")
+}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"25612ade-f27d-4897-91ae-b5f139013835","source":"chat","resourceId":"3b42eac9-4368-4c2f-9de0-1c9b467ede25","workflowId":"19469852-5377-4b4c-802f-1ae1b1c3618a","codeChangeId":"19469852-5377-4b4c-802f-1ae1b1c3618a","sourceType":"bits_ai_sre"} -->
## Motivation

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/68b8ed59-69b0-4fb2-ba1c-fbd8f3dc67a6)

Malformed repository-local IaC YAML currently causes `fetch-bundle` to return the generic engine exit code 126 instead of the invalid-configuration exit code 127. This makes iac-scanning retry a permanent customer input error, potentially exhausting retries and producing DLQ failures. Datadog Bits investigation: https://app.datadoghq.com/bits-ai/investigations/68b8ed59-69b0-4fb2-ba1c-fbd8f3dc67a6?type=CONCLUSION

JIRA Ticket

N/A

## Changes

- Preserve `config.InvalidLocalConfigError` in `cmd/scanner/fetch_bundle.go` as `constants.InvalidConfigErrorCode` (127).
- Add a command-level regression test covering malformed local YAML.

## Testing/Validation

- `go test ./cmd/scanner -run 'Test(FetchBundleInvalidLocalConfigExitCode|_E2EFetchBundleThenOfflineScan)$' -v -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0 run -c .golangci.yml --timeout 20m`

## Author Checklist

- [ ] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Create a repository containing a malformed `code-security.datadog.yaml`, run `fetch-bundle`, and verify it exits with code 127 rather than 126. A valid repository should continue to produce the bundle files successfully.

## Blast Radius

Only the DataDog IaC Scanner `fetch-bundle` command and its downstream iac-scanning retry classification are impacted. Valid configurations and other fetch-bundle failures retain their existing behavior.

## Additional Notes

This change aligns `fetch-bundle` with the existing `scan` command classification for `InvalidLocalConfigError`.

I submit this contribution under the Apache-2.0 license.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/3b42eac9-4368-4c2f-9de0-1c9b467ede25)

Comment @datadog to request changes