### PR TITLE
Fix fetch-bundle config exit code for malformed local config

### DIFF
--- a/cmd/scanner/fetch_bundle.go
+++ b/cmd/scanner/fetch_bundle.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -72,7 +73,7 @@ func fetchBundle(ctx context.Context, c *cli.Command) error {
 
 	_, cfgBytes, err := config.ReadConfiguration(ctx, repoPath, config.WithDatadog(client, c.String("repo-url")))
 	if err != nil {
-		return errorWithExitCode(fmt.Errorf("error reading the configuration: %w", err), constants.EngineErrorCode)
+		return configurationReadError(err)
 	}
 	if err := os.WriteFile(filepath.Join(outputDir, bundleConfigFileName), cfgBytes, filePerms); err != nil {
 		return errorWithExitCode(fmt.Errorf("error writing the configuration bundle: %w", err), constants.EngineErrorCode)
@@ -122,6 +123,19 @@ func fetchBundle(ctx context.Context, c *cli.Command) error {
 
 	fmt.Printf("Wrote offline bundle (%d rules, %d libraries) to %s\n", len(ruleset.Rules), len(libraries), outputDir)
 	return nil
+}
+
+// configurationReadError classifies a config.ReadConfiguration failure the
+// same way scan.go's non-offline-bundle path does: a malformed repo-local
+// configuration file is the customer's input error (InvalidConfigErrorCode),
+// while any other read failure (e.g. a remote config fetch problem) remains
+// an undifferentiated engine failure.
+func configurationReadError(err error) error {
+	outErr := fmt.Errorf("error reading the configuration: %w", err)
+	if te := (*config.InvalidLocalConfigError)(nil); errors.As(err, &te) {
+		return errorWithExitCode(outErr, constants.InvalidConfigErrorCode)
+	}
+	return errorWithExitCode(outErr, constants.EngineErrorCode)
 }
 
 // readBundleManifest reads and parses the manifest written by fetchBundle,

--- a/cmd/scanner/fetch_bundle_test.go
+++ b/cmd/scanner/fetch_bundle_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/internal/constants"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchBundleInvalidLocalConfigExitCode(t *testing.T) {
+	repoPath := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoPath, "code-security.datadog.yaml"),
+		[]byte("schema-version: [invalid"),
+		0600,
+	))
+
+	err := fetchBundleAction.Run(t.Context(), []string{
+		"fetch-bundle",
+		"--repo-path", repoPath,
+		"--repo-url", "https://example.com/repo",
+		"--output-dir", t.TempDir(),
+	})
+
+	var exitErr *withExitCodeError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, constants.InvalidConfigErrorCode, exitErr.code)
+}


### PR DESCRIPTION
## Motivation

[K9CODESEC-5219](https://datadoghq.atlassian.net/browse/K9CODESEC-5219)

Malformed repository-local IaC YAML reaches the offline-bundle path during the Terrapin rollout on `iac-scanning`. `fetch-bundle` classifies this deterministic input error as an engine failure (exit 126), causing downstream retries and Error-level task failures instead of the invalid-configuration outcome (exit 127) that `scan` already produces for the exact same error.

Confirmed in production against org 244250 (bayzat): every push fails with
```
exit status 126 [Program failed: error reading the configuration: could not parse configuration file: yaml: did not find expected key]
```

## Changes

- `cmd/scanner/fetch_bundle.go`: detect `*config.InvalidLocalConfigError` through wrapped errors and return `constants.InvalidConfigErrorCode` (127), matching `cmd/scanner/scan.go`'s existing classification for the same error type. Remote-configuration and other engine failures keep `constants.EngineErrorCode` (126).
- `cmd/scanner/fetch_bundle_test.go`: covers malformed local YAML through the real `fetch-bundle` CLI action.

## Testing

- `go test ./cmd/scanner/...`
- `go build ./cmd/scanner/...`
- `gofmt -l` clean

## Blast Radius

Only `fetch-bundle`'s error classification changes. Valid bundles, remote-config error handling, and all other exit codes are unchanged.

## Companion change

A matching companion PR is needed on the `dd-source` side (`iac-scanning`'s `fetchOfflineBundleWithExecutable`), since it currently doesn't inspect `fetch-bundle`'s exit code at all — see the linked ticket for details. That PR is tracked separately and links back here.

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-5219]: https://datadoghq.atlassian.net/browse/K9CODESEC-5219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ