### PR TITLE
[K9CODESEC-5290] Harden HTTP and registry module fetches against SSRF

### DIFF
--- a/pkg/parser/terraform/modules/resolver/archive_extract_test.go
+++ b/pkg/parser/terraform/modules/resolver/archive_extract_test.go
@@ -8,7 +8,9 @@ package resolver
 import (
 	"archive/tar"
 	"bytes"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -92,4 +94,57 @@ func TestExtractRegularFilesRejectsEscapingPaths(t *testing.T) {
 			require.ErrorIs(t, err, os.ErrNotExist)
 		})
 	}
+}
+
+func TestExtractArchiveCommandStreamsOutput(t *testing.T) {
+	archive := tarBytes(t, tarEntry{name: "main.tf", typeflag: tar.TypeReg, body: "content"})
+	archivePath := filepath.Join(t.TempDir(), "archive.tar")
+	require.NoError(t, os.WriteFile(archivePath, archive, 0o600))
+	dest := t.TempDir()
+	extracted := int64(0)
+
+	require.NoError(t, extractArchiveCommandWithLimit(
+		archiveHelperCommand(t, archivePath), dest, &extracted, int64(len(archive)),
+	))
+	data, err := os.ReadFile(filepath.Join(dest, "main.tf"))
+	require.NoError(t, err)
+	require.Equal(t, "content", string(data))
+}
+
+func TestExtractArchiveCommandBoundsStreamBeforeExtraction(t *testing.T) {
+	archive := tarBytes(t, tarEntry{name: "main.tf", typeflag: tar.TypeReg, body: "content"})
+	archivePath := filepath.Join(t.TempDir(), "archive.tar")
+	require.NoError(t, os.WriteFile(archivePath, archive, 0o600))
+	extracted := int64(0)
+
+	err := extractArchiveCommandWithLimit(
+		archiveHelperCommand(t, archivePath), t.TempDir(), &extracted, int64(len(archive)-1),
+	)
+
+	require.ErrorContains(t, err, "git archive exceeds")
+}
+
+func archiveHelperCommand(t *testing.T, archivePath string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=TestArchiveCommandHelper", "--", archivePath)
+	cmd.Env = append(os.Environ(), "GO_WANT_ARCHIVE_COMMAND_HELPER=1")
+	return cmd
+}
+
+func TestArchiveCommandHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_ARCHIVE_COMMAND_HELPER") != "1" {
+		return
+	}
+	archivePath := os.Args[len(os.Args)-1]
+	archive, err := os.Open(archivePath)
+	if err != nil {
+		os.Exit(1)
+	}
+	if _, err := io.Copy(os.Stdout, archive); err != nil {
+		os.Exit(1)
+	}
+	if err := archive.Close(); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
 }

--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -479,12 +480,41 @@ func extractArchiveSubdir(
 		archiveArgs = append(archiveArgs, "--", filepath.ToSlash(subdir))
 	}
 	archive := gitInDir(ctx, gitDir, archiveArgs...)
-	output, err := archive.Output()
-	if err != nil {
-		return fmt.Errorf("git archive %s path %q: %w", archiveArg, subdir, err)
-	}
-	if err := extractRegularFilesWithBudget(bytes.NewReader(output), dest, extracted); err != nil {
+	if err := extractArchiveCommand(archive, dest, extracted); err != nil {
 		return fmt.Errorf("extracting git archive %s: %w", archiveArg, err)
+	}
+	return nil
+}
+
+func extractArchiveCommand(cmd *exec.Cmd, dest string, extracted *int64) error {
+	return extractArchiveCommandWithLimit(cmd, dest, extracted, maxArchiveExtractBytes)
+}
+
+func extractArchiveCommandWithLimit(cmd *exec.Cmd, dest string, extracted *int64, maxBytes int64) error {
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("opening git archive stream: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting git archive: %w", err)
+	}
+
+	stream := &io.LimitedReader{R: stdout, N: maxBytes + 1}
+	extractErr := extractRegularFilesWithBudget(stream, dest, extracted)
+	if extractErr == nil {
+		_, extractErr = io.Copy(io.Discard, stream)
+	}
+	if extractErr != nil || stream.N == 0 {
+		_ = stdout.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		if stream.N == 0 {
+			return fmt.Errorf("git archive exceeds %d byte limit", maxBytes)
+		}
+		return extractErr
+	}
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("running git archive: %w", err)
 	}
 	return nil
 }

--- a/pkg/parser/terraform/modules/resolver/gogetter.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter.go
@@ -510,12 +510,14 @@ func (r *GoGetterResolver) fetchOnce(ctx context.Context, getterSrc string) (str
 	defer cancel()
 
 	client := &getter.Client{
-		Ctx:     fetchCtx,
-		Src:     getterSrc,
-		Dst:     tmpDir,
-		Pwd:     tmpDir,
-		Mode:    getter.ClientModeDir,
-		Getters: r.getters(),
+		Ctx:  fetchCtx,
+		Src:  getterSrc,
+		Dst:  tmpDir,
+		Pwd:  tmpDir,
+		Mode: getter.ClientModeDir,
+		Options: []getter.ClientOption{
+			getter.WithGetters(r.getters(getterSrc)),
+		},
 	}
 	if err := client.Get(); err != nil {
 		_ = os.RemoveAll(tmpDir)
@@ -524,10 +526,12 @@ func (r *GoGetterResolver) fetchOnce(ctx context.Context, getterSrc string) (str
 	return tmpDir, nil
 }
 
-func (r *GoGetterResolver) getters() map[string]getter.Getter {
+func (r *GoGetterResolver) getters(source string) map[string]getter.Getter {
 	getters := make(map[string]getter.Getter, len(getter.Getters))
-	for scheme, protocolGetter := range getter.Getters {
-		getters[scheme] = protocolGetter
+	if !isHTTPGetterSource(source) {
+		for scheme, protocolGetter := range getter.Getters {
+			getters[scheme] = protocolGetter
+		}
 	}
 	httpGetter := &getter.HttpGetter{
 		Netrc:              true,
@@ -537,6 +541,17 @@ func (r *GoGetterResolver) getters() map[string]getter.Getter {
 	getters["http"] = httpGetter
 	getters["https"] = httpGetter
 	return getters
+}
+
+func isHTTPGetterSource(source string) bool {
+	if forced, rest, ok := strings.Cut(source, "::"); ok {
+		if forced != "" {
+			return forced == "http" || forced == "https"
+		}
+		source = rest
+	}
+	parsed, err := url.Parse(source)
+	return err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https")
 }
 
 func modifyGitURL(rawURL string, modify func(url.Values) bool) string {

--- a/pkg/parser/terraform/modules/resolver/gogetter.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter.go
@@ -91,16 +91,14 @@ type GoGetterConfig struct {
 	fetchCount atomic.Int64
 }
 
-// NewGoGetterConfig returns defaults with a fetch semaphore and a fresh registry cache.
+// NewGoGetterConfig returns default fetch limits and concurrency controls.
 func NewGoGetterConfig() *GoGetterConfig {
-	cfg := &GoGetterConfig{
+	return &GoGetterConfig{
 		FetchTimeout:   DefaultFetchTimeout,
 		MaxModuleBytes: DefaultMaxModuleBytes,
 		MaxTotalBytes:  DefaultMaxTotalBytes,
 		fetchSem:       make(chan struct{}, FetchConcurrency),
 	}
-	cfg.RegistryCache = NewRegistryCache(cfg.FetchTimeout)
-	return cfg
 }
 
 // GoGetterResolver downloads modules via hashicorp/go-getter (registry translation, caps, cache).
@@ -111,6 +109,9 @@ type GoGetterResolver struct {
 func NewGoGetterResolver(cfg *GoGetterConfig) *GoGetterResolver {
 	if cfg.httpClient == nil {
 		cfg.httpClient = newPolicyHTTPClient(cfg.FetchTimeout, cfg.HostAllowlist)
+	}
+	if cfg.RegistryCache == nil {
+		cfg.RegistryCache = NewRegistryCache(cfg.FetchTimeout, cfg.HostAllowlist...)
 	}
 	return &GoGetterResolver{cfg: cfg}
 }

--- a/pkg/parser/terraform/modules/resolver/gogetter.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter.go
@@ -546,12 +546,12 @@ func (r *GoGetterResolver) getters(source string) map[string]getter.Getter {
 func isHTTPGetterSource(source string) bool {
 	if forced, rest, ok := strings.Cut(source, "::"); ok {
 		if forced != "" {
-			return forced == "http" || forced == "https"
+			return forced == httpScheme || forced == httpsScheme
 		}
 		source = rest
 	}
 	parsed, err := url.Parse(source)
-	return err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https")
+	return err == nil && (parsed.Scheme == httpScheme || parsed.Scheme == httpsScheme)
 }
 
 func modifyGitURL(rawURL string, modify func(url.Values) bool) string {

--- a/pkg/parser/terraform/modules/resolver/gogetter.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"math/rand"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -77,6 +78,7 @@ type GoGetterConfig struct {
 	HostAllowlist []string
 	Cache         *moduleCache
 	RegistryCache *registryCache
+	httpClient    *http.Client
 
 	TmpDir string
 
@@ -107,6 +109,9 @@ type GoGetterResolver struct {
 }
 
 func NewGoGetterResolver(cfg *GoGetterConfig) *GoGetterResolver {
+	if cfg.httpClient == nil {
+		cfg.httpClient = newPolicyHTTPClient(cfg.FetchTimeout, cfg.HostAllowlist)
+	}
 	return &GoGetterResolver{cfg: cfg}
 }
 
@@ -504,17 +509,33 @@ func (r *GoGetterResolver) fetchOnce(ctx context.Context, getterSrc string) (str
 	defer cancel()
 
 	client := &getter.Client{
-		Ctx:  fetchCtx,
-		Src:  getterSrc,
-		Dst:  tmpDir,
-		Pwd:  tmpDir,
-		Mode: getter.ClientModeDir,
+		Ctx:     fetchCtx,
+		Src:     getterSrc,
+		Dst:     tmpDir,
+		Pwd:     tmpDir,
+		Mode:    getter.ClientModeDir,
+		Getters: r.getters(),
 	}
 	if err := client.Get(); err != nil {
 		_ = os.RemoveAll(tmpDir)
 		return "", &tfmodules.UnresolvedError{Reason: "fetch failed: " + err.Error()}
 	}
 	return tmpDir, nil
+}
+
+func (r *GoGetterResolver) getters() map[string]getter.Getter {
+	getters := make(map[string]getter.Getter, len(getter.Getters))
+	for scheme, protocolGetter := range getter.Getters {
+		getters[scheme] = protocolGetter
+	}
+	httpGetter := &getter.HttpGetter{
+		Netrc:              true,
+		Client:             r.cfg.httpClient,
+		XTerraformGetLimit: maxHTTPRedirects,
+	}
+	getters["http"] = httpGetter
+	getters["https"] = httpGetter
+	return getters
 }
 
 func modifyGitURL(rawURL string, modify func(url.Values) bool) string {

--- a/pkg/parser/terraform/modules/resolver/gogetter_test.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter_test.go
@@ -35,6 +35,22 @@ func TestGoGetterHTTPRejectsPrivateDestinationWithoutAllowlist(t *testing.T) {
 	}
 }
 
+func TestGoGetterConfigAppliesAllowlistToRegistryClient(t *testing.T) {
+	cfg := NewGoGetterConfig()
+	cfg.HostAllowlist = []string{"registry.terraform.io"}
+	r := NewGoGetterResolver(cfg)
+
+	_, err := discoverModulesEndpoint(
+		t.Context(),
+		r.cfg.RegistryCache.client,
+		"https://example.com",
+	)
+
+	if err == nil || !strings.Contains(err.Error(), "not in --module-host-allowlist") {
+		t.Fatalf("expected registry client to use resolver allowlist, got %v", err)
+	}
+}
+
 func TestGoGetterHTTPValidatesXTerraformGetDestination(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("X-Terraform-Get", "http://metadata.internal/latest")

--- a/pkg/parser/terraform/modules/resolver/gogetter_test.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter_test.go
@@ -52,8 +52,9 @@ func TestGoGetterConfigAppliesAllowlistToRegistryClient(t *testing.T) {
 }
 
 func TestGoGetterHTTPValidatesXTerraformGetDestination(t *testing.T) {
+	var target string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("X-Terraform-Get", "http://metadata.internal/latest")
+		w.Header().Set("X-Terraform-Get", target)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -82,11 +83,30 @@ func TestGoGetterHTTPValidatesXTerraformGetDestination(t *testing.T) {
 	cfg.httpClient = newPolicyHTTPClientWithPolicy(time.Second, policy)
 	r := NewGoGetterResolver(cfg)
 
-	_, err = r.fetchOnce(t.Context(), "http://source.example:"+port+"/module")
-
-	if err == nil || !strings.Contains(err.Error(), "metadata.internal") ||
-		!strings.Contains(err.Error(), "not a public unicast destination") {
-		t.Fatalf("expected X-Terraform-Get metadata destination to be rejected, got %v", err)
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "private HTTP destination",
+			source: "http://metadata.internal/latest",
+			want:   "not a public unicast destination",
+		},
+		{
+			name:   "protocol switch",
+			source: "git::http://169.254.169.254/repository.git",
+			want:   `no getter available for X-Terraform-Get source protocol: "git"`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			target = test.source
+			_, fetchErr := r.fetchOnce(t.Context(), "http://source.example:"+port+"/module")
+			if fetchErr == nil || !strings.Contains(fetchErr.Error(), test.want) {
+				t.Fatalf("expected X-Terraform-Get source to be rejected with %q, got %v", test.want, fetchErr)
+			}
+		})
 	}
 }
 

--- a/pkg/parser/terraform/modules/resolver/gogetter_test.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter_test.go
@@ -9,6 +9,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,6 +22,57 @@ import (
 
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
+
+func TestGoGetterHTTPRejectsPrivateDestinationWithoutAllowlist(t *testing.T) {
+	cfg := NewGoGetterConfig()
+	cfg.TmpDir = t.TempDir()
+	r := NewGoGetterResolver(cfg)
+
+	_, err := r.fetchOnce(t.Context(), "http://169.254.169.254/module.zip")
+
+	if err == nil || !strings.Contains(err.Error(), "not a public unicast destination") {
+		t.Fatalf("expected metadata destination to be rejected, got %v", err)
+	}
+}
+
+func TestGoGetterHTTPValidatesXTerraformGetDestination(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Terraform-Get", "http://metadata.internal/latest")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	_, port, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(_ context.Context, _, host string) ([]net.IP, error) {
+		switch host {
+		case "source.example":
+			return []net.IP{net.ParseIP("93.184.216.34")}, nil
+		case "metadata.internal":
+			return []net.IP{net.ParseIP("169.254.169.254")}, nil
+		default:
+			return nil, fmt.Errorf("unexpected host %q", host)
+		}
+	}
+	policy.dial = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
+	}
+
+	cfg := NewGoGetterConfig()
+	cfg.TmpDir = t.TempDir()
+	cfg.httpClient = newPolicyHTTPClientWithPolicy(time.Second, policy)
+	r := NewGoGetterResolver(cfg)
+
+	_, err = r.fetchOnce(t.Context(), "http://source.example:"+port+"/module")
+
+	if err == nil || !strings.Contains(err.Error(), "metadata.internal") ||
+		!strings.Contains(err.Error(), "not a public unicast destination") {
+		t.Fatalf("expected X-Terraform-Get metadata destination to be rejected, got %v", err)
+	}
+}
 
 func TestGetterSourceForPreservesHTTPSGit(t *testing.T) {
 	r := NewGoGetterResolver(NewGoGetterConfig())

--- a/pkg/parser/terraform/modules/resolver/http_policy.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy.go
@@ -80,14 +80,37 @@ func (p *httpDestinationPolicy) dialContext(ctx context.Context, network, addres
 		return nil, err
 	}
 
-	var dialErrs []error
-	for _, ip := range addresses {
-		conn, dialErr := p.dial(ctx, network, net.JoinHostPort(ip.String(), port))
-		if dialErr == nil {
-			return conn, nil
-		}
-		dialErrs = append(dialErrs, dialErr)
+	type dialResult struct {
+		conn net.Conn
+		err  error
 	}
+	dialCtx, cancel := context.WithCancel(ctx)
+	results := make(chan dialResult, len(addresses))
+	for _, ip := range addresses {
+		target := net.JoinHostPort(ip.String(), port)
+		go func() {
+			conn, dialErr := p.dial(dialCtx, network, target)
+			results <- dialResult{conn: conn, err: dialErr}
+		}()
+	}
+
+	dialErrs := make([]error, 0, len(addresses))
+	for i := 0; i < len(addresses); i++ {
+		result := <-results
+		if result.err == nil {
+			cancel()
+			go func(remaining int) {
+				for range remaining {
+					if pending := <-results; pending.conn != nil {
+						_ = pending.conn.Close()
+					}
+				}
+			}(len(addresses) - i - 1)
+			return result.conn, nil
+		}
+		dialErrs = append(dialErrs, result.err)
+	}
+	cancel()
 	return nil, fmt.Errorf("dialing HTTP destination %q: %w", host, errors.Join(dialErrs...))
 }
 

--- a/pkg/parser/terraform/modules/resolver/http_policy.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy.go
@@ -17,7 +17,10 @@ import (
 	"time"
 )
 
-const maxHTTPRedirects = 10
+const (
+	maxHTTPRedirects       = 10
+	maxConcurrentHTTPDials = 4
+)
 
 type lookupNetIPFunc func(context.Context, string, string) ([]net.IP, error)
 type dialContextFunc func(context.Context, string, string) (net.Conn, error)
@@ -86,11 +89,21 @@ func (p *httpDestinationPolicy) dialContext(ctx context.Context, network, addres
 	}
 	dialCtx, cancel := context.WithCancel(ctx)
 	results := make(chan dialResult, len(addresses))
-	for _, ip := range addresses {
-		target := net.JoinHostPort(ip.String(), port)
+	targets := make(chan string, len(addresses))
+	for _, address := range addresses {
+		targets <- net.JoinHostPort(address.String(), port)
+	}
+	close(targets)
+	for range min(maxConcurrentHTTPDials, len(addresses)) {
 		go func() {
-			conn, dialErr := p.dial(dialCtx, network, target)
-			results <- dialResult{conn: conn, err: dialErr}
+			for target := range targets {
+				if err := dialCtx.Err(); err != nil {
+					results <- dialResult{err: err}
+					continue
+				}
+				conn, dialErr := p.dial(dialCtx, network, target)
+				results <- dialResult{conn: conn, err: dialErr}
+			}
 		}()
 	}
 
@@ -140,6 +153,7 @@ func (p *httpDestinationPolicy) resolveHost(ctx context.Context, host string) ([
 	}
 
 	addresses := make([]netip.Addr, 0, len(resolved))
+	seen := make(map[netip.Addr]struct{}, len(resolved))
 	for _, candidate := range resolved {
 		addr, ok := netip.AddrFromSlice(candidate)
 		if !ok {
@@ -149,6 +163,10 @@ func (p *httpDestinationPolicy) resolveHost(ctx context.Context, host string) ([
 		if err := validatePublicAddress(addr); err != nil {
 			return nil, fmt.Errorf("HTTP destination host %q resolved to %s: %w", host, addr, err)
 		}
+		if _, ok := seen[addr]; ok {
+			continue
+		}
+		seen[addr] = struct{}{}
 		addresses = append(addresses, addr)
 	}
 	return addresses, nil

--- a/pkg/parser/terraform/modules/resolver/http_policy.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy.go
@@ -38,6 +38,7 @@ var blockedSpecialUsePrefixes = func() []netip.Prefix {
 		"240.0.0.0/4",
 		"100::/64",
 		"64:ff9b::/96",
+		"64:ff9b:1::/48",
 		"2001:10::/28",
 		"2001:20::/28",
 		"2001:db8::/32",

--- a/pkg/parser/terraform/modules/resolver/http_policy.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy.go
@@ -39,6 +39,10 @@ func newHTTPDestinationPolicy(hostAllowlist []string) *httpDestinationPolicy {
 
 func newPolicyHTTPClient(timeout time.Duration, hostAllowlist []string) *http.Client {
 	policy := newHTTPDestinationPolicy(hostAllowlist)
+	return newPolicyHTTPClientWithPolicy(timeout, policy)
+}
+
+func newPolicyHTTPClientWithPolicy(timeout time.Duration, policy *httpDestinationPolicy) *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.Proxy = nil
 	transport.DialContext = policy.dialContext

--- a/pkg/parser/terraform/modules/resolver/http_policy.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy.go
@@ -1,0 +1,152 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const maxHTTPRedirects = 10
+
+type lookupNetIPFunc func(context.Context, string, string) ([]net.IP, error)
+type dialContextFunc func(context.Context, string, string) (net.Conn, error)
+
+type httpDestinationPolicy struct {
+	hostAllowlist []string
+	lookupNetIP   lookupNetIPFunc
+	dial          dialContextFunc
+}
+
+func newHTTPDestinationPolicy(hostAllowlist []string) *httpDestinationPolicy {
+	dialer := &net.Dialer{}
+	return &httpDestinationPolicy{
+		hostAllowlist: append([]string(nil), hostAllowlist...),
+		lookupNetIP:   net.DefaultResolver.LookupIP,
+		dial:          dialer.DialContext,
+	}
+}
+
+func newPolicyHTTPClient(timeout time.Duration, hostAllowlist []string) *http.Client {
+	policy := newHTTPDestinationPolicy(hostAllowlist)
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = policy.dialContext
+
+	return &http.Client{
+		Transport: transport,
+		Timeout:   timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxHTTPRedirects {
+				return fmt.Errorf("stopped after %d redirects", maxHTTPRedirects)
+			}
+			return policy.validateURL(req.Context(), req.URL)
+		},
+	}
+}
+
+func (p *httpDestinationPolicy) validateURL(ctx context.Context, target *url.URL) error {
+	if target == nil {
+		return errors.New("HTTP destination URL is missing")
+	}
+	if target.Scheme != "http" && target.Scheme != "https" {
+		return fmt.Errorf("HTTP destination scheme %q is not allowed", target.Scheme)
+	}
+	_, err := p.resolveHost(ctx, target.Hostname())
+	return err
+}
+
+func (p *httpDestinationPolicy) dialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("parsing HTTP destination %q: %w", address, err)
+	}
+	addresses, err := p.resolveHost(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+
+	var dialErrs []error
+	for _, ip := range addresses {
+		conn, dialErr := p.dial(ctx, network, net.JoinHostPort(ip.String(), port))
+		if dialErr == nil {
+			return conn, nil
+		}
+		dialErrs = append(dialErrs, dialErr)
+	}
+	return nil, fmt.Errorf("dialing HTTP destination %q: %w", host, errors.Join(dialErrs...))
+}
+
+func (p *httpDestinationPolicy) resolveHost(ctx context.Context, host string) ([]netip.Addr, error) {
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if host == "" {
+		return nil, errors.New("HTTP destination host is missing")
+	}
+	if !hostMatchesAllowlist(host, p.hostAllowlist) {
+		return nil, fmt.Errorf("HTTP destination host %q is not in --module-host-allowlist", host)
+	}
+
+	if literal, err := netip.ParseAddr(host); err == nil {
+		literal = literal.Unmap()
+		if err := validatePublicAddress(literal); err != nil {
+			return nil, fmt.Errorf("HTTP destination host %q: %w", host, err)
+		}
+		return []netip.Addr{literal}, nil
+	}
+
+	resolved, err := p.lookupNetIP(ctx, "ip", host)
+	if err != nil {
+		return nil, fmt.Errorf("resolving HTTP destination host %q: %w", host, err)
+	}
+	if len(resolved) == 0 {
+		return nil, fmt.Errorf("HTTP destination host %q resolved to no addresses", host)
+	}
+
+	addresses := make([]netip.Addr, 0, len(resolved))
+	for _, candidate := range resolved {
+		addr, ok := netip.AddrFromSlice(candidate)
+		if !ok {
+			return nil, fmt.Errorf("HTTP destination host %q resolved to an invalid address", host)
+		}
+		addr = addr.Unmap()
+		if err := validatePublicAddress(addr); err != nil {
+			return nil, fmt.Errorf("HTTP destination host %q resolved to %s: %w", host, addr, err)
+		}
+		addresses = append(addresses, addr)
+	}
+	return addresses, nil
+}
+
+func hostMatchesAllowlist(host string, allowlist []string) bool {
+	if len(allowlist) == 0 {
+		return true
+	}
+	for _, allowed := range allowlist {
+		allowed = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(allowed)), ".")
+		if allowed != "" && (host == allowed || strings.HasSuffix(host, "."+allowed)) {
+			return true
+		}
+	}
+	return false
+}
+
+func validatePublicAddress(addr netip.Addr) error {
+	if !addr.IsValid() || !addr.IsGlobalUnicast() || addr.IsLoopback() || addr.IsPrivate() ||
+		addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() {
+		return fmt.Errorf("address %s is not a public unicast destination", addr)
+	}
+	if netip.MustParsePrefix("100.64.0.0/10").Contains(addr) {
+		return fmt.Errorf("address %s is in the shared address space", addr)
+	}
+	return nil
+}

--- a/pkg/parser/terraform/modules/resolver/http_policy.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy.go
@@ -20,6 +20,8 @@ import (
 const (
 	maxHTTPRedirects       = 10
 	maxConcurrentHTTPDials = 4
+	httpScheme             = "http"
+	httpsScheme            = "https"
 )
 
 type lookupNetIPFunc func(context.Context, string, string) ([]net.IP, error)
@@ -66,7 +68,7 @@ func (p *httpDestinationPolicy) validateURL(ctx context.Context, target *url.URL
 	if target == nil {
 		return errors.New("HTTP destination URL is missing")
 	}
-	if target.Scheme != "http" && target.Scheme != "https" {
+	if target.Scheme != httpScheme && target.Scheme != httpsScheme {
 		return fmt.Errorf("HTTP destination scheme %q is not allowed", target.Scheme)
 	}
 	_, err := p.resolveHost(ctx, target.Hostname())

--- a/pkg/parser/terraform/modules/resolver/http_policy.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy.go
@@ -24,25 +24,27 @@ const (
 	httpsScheme            = "https"
 )
 
-// blockedSpecialUsePrefixes lists IANA special-purpose ranges that Go still
-// classifies as global unicast (RFC 6890 and successors).
+// Synced with the IANA special-purpose address registries updated 2025-10-09.
 var blockedSpecialUsePrefixes = func() []netip.Prefix {
 	cidrs := []string{
 		"0.0.0.0/8",
 		"100.64.0.0/10",
 		"192.0.0.0/24",
 		"192.0.2.0/24",
+		"192.88.99.0/24",
 		"198.18.0.0/15",
 		"198.51.100.0/24",
 		"203.0.113.0/24",
 		"240.0.0.0/4",
-		"100::/64",
 		"64:ff9b::/96",
 		"64:ff9b:1::/48",
-		"2001:10::/28",
-		"2001:20::/28",
+		"100::/64",
+		"100:0:0:1::/64",
+		"2001::/23",
 		"2001:db8::/32",
 		"2002::/16",
+		"3fff::/20",
+		"5f00::/16",
 	}
 	prefixes := make([]netip.Prefix, len(cidrs))
 	for i, cidr := range cidrs {

--- a/pkg/parser/terraform/modules/resolver/http_policy.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy.go
@@ -24,6 +24,32 @@ const (
 	httpsScheme            = "https"
 )
 
+// blockedSpecialUsePrefixes lists IANA special-purpose ranges that Go still
+// classifies as global unicast (RFC 6890 and successors).
+var blockedSpecialUsePrefixes = func() []netip.Prefix {
+	cidrs := []string{
+		"0.0.0.0/8",
+		"100.64.0.0/10",
+		"192.0.0.0/24",
+		"192.0.2.0/24",
+		"198.18.0.0/15",
+		"198.51.100.0/24",
+		"203.0.113.0/24",
+		"240.0.0.0/4",
+		"100::/64",
+		"64:ff9b::/96",
+		"2001:10::/28",
+		"2001:20::/28",
+		"2001:db8::/32",
+		"2002::/16",
+	}
+	prefixes := make([]netip.Prefix, len(cidrs))
+	for i, cidr := range cidrs {
+		prefixes[i] = netip.MustParsePrefix(cidr)
+	}
+	return prefixes
+}()
+
 type lookupNetIPFunc func(context.Context, string, string) ([]net.IP, error)
 type dialContextFunc func(context.Context, string, string) (net.Conn, error)
 
@@ -192,8 +218,10 @@ func validatePublicAddress(addr netip.Addr) error {
 		addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() {
 		return fmt.Errorf("address %s is not a public unicast destination", addr)
 	}
-	if netip.MustParsePrefix("100.64.0.0/10").Contains(addr) {
-		return fmt.Errorf("address %s is in the shared address space", addr)
+	for _, prefix := range blockedSpecialUsePrefixes {
+		if prefix.Contains(addr) {
+			return fmt.Errorf("address %s is in a special-use network", addr)
+		}
 	}
 	return nil
 }

--- a/pkg/parser/terraform/modules/resolver/http_policy_test.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy_test.go
@@ -35,6 +35,7 @@ func TestHTTPDestinationPolicyRejectsNonPublicAddresses(t *testing.T) {
 		"fd00:ec2::254",
 		"2001:db8::1",
 		"100::1",
+		"64:ff9b:1::1",
 	}
 	policy := newHTTPDestinationPolicy(nil)
 

--- a/pkg/parser/terraform/modules/resolver/http_policy_test.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy_test.go
@@ -83,6 +83,42 @@ func TestHTTPDestinationPolicyPinsValidatedAddress(t *testing.T) {
 	}
 }
 
+func TestHTTPDestinationPolicyDialsValidatedAddressesConcurrently(t *testing.T) {
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{
+			net.ParseIP("2001:db8::1"),
+			net.ParseIP("93.184.216.34"),
+		}, nil
+	}
+	firstCanceled := make(chan struct{})
+	policy.dial = func(ctx context.Context, _, address string) (net.Conn, error) {
+		if strings.HasPrefix(address, "[2001:db8::1]") {
+			<-ctx.Done()
+			close(firstCanceled)
+			return nil, ctx.Err()
+		}
+		client, server := net.Pipe()
+		t.Cleanup(func() {
+			_ = client.Close()
+			_ = server.Close()
+		})
+		return client, nil
+	}
+
+	conn, err := policy.dialContext(t.Context(), "tcp", "modules.example.com:443")
+
+	if err != nil {
+		t.Fatalf("dialContext: %v", err)
+	}
+	_ = conn.Close()
+	select {
+	case <-firstCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("slower validated address was not canceled")
+	}
+}
+
 func TestHTTPDestinationPolicyAppliesHostAllowlist(t *testing.T) {
 	policy := newHTTPDestinationPolicy([]string{"example.com"})
 	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {

--- a/pkg/parser/terraform/modules/resolver/http_policy_test.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy_test.go
@@ -1,0 +1,125 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHTTPDestinationPolicyRejectsNonPublicAddresses(t *testing.T) {
+	tests := []string{
+		"127.0.0.1",
+		"10.0.0.1",
+		"172.16.0.1",
+		"192.168.0.1",
+		"169.254.169.254",
+		"100.64.0.1",
+		"::1",
+		"fe80::1",
+		"fd00:ec2::254",
+	}
+	policy := newHTTPDestinationPolicy(nil)
+
+	for _, address := range tests {
+		t.Run(address, func(t *testing.T) {
+			_, err := policy.resolveHost(t.Context(), address)
+			if err == nil || !strings.Contains(err.Error(), "not a public unicast destination") &&
+				!strings.Contains(err.Error(), "shared address space") {
+				t.Fatalf("expected %s to be rejected, got %v", address, err)
+			}
+		})
+	}
+}
+
+func TestHTTPDestinationPolicyRejectsHostnameWithPrivateAnswer(t *testing.T) {
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{
+			net.ParseIP("93.184.216.34"),
+			net.ParseIP("169.254.169.254"),
+		}, nil
+	}
+
+	_, err := policy.resolveHost(t.Context(), "modules.example.com")
+
+	if err == nil || !strings.Contains(err.Error(), "169.254.169.254") {
+		t.Fatalf("expected mixed DNS answer to be rejected, got %v", err)
+	}
+}
+
+func TestHTTPDestinationPolicyPinsValidatedAddress(t *testing.T) {
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	var dialed string
+	policy.dial = func(_ context.Context, _, address string) (net.Conn, error) {
+		dialed = address
+		client, server := net.Pipe()
+		t.Cleanup(func() {
+			_ = client.Close()
+			_ = server.Close()
+		})
+		return client, nil
+	}
+
+	conn, err := policy.dialContext(t.Context(), "tcp", "modules.example.com:443")
+
+	if err != nil {
+		t.Fatalf("dialContext: %v", err)
+	}
+	_ = conn.Close()
+	if dialed != "93.184.216.34:443" {
+		t.Fatalf("dialed %q, want validated IP", dialed)
+	}
+}
+
+func TestHTTPDestinationPolicyAppliesHostAllowlist(t *testing.T) {
+	policy := newHTTPDestinationPolicy([]string{"example.com"})
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+
+	if _, err := policy.resolveHost(t.Context(), "modules.example.com"); err != nil {
+		t.Fatalf("expected subdomain to pass allowlist: %v", err)
+	}
+	if _, err := policy.resolveHost(t.Context(), "example.net"); err == nil {
+		t.Fatal("expected unrelated host to fail allowlist")
+	}
+}
+
+func TestPolicyHTTPClientValidatesRedirectDestination(t *testing.T) {
+	client := newPolicyHTTPClient(time.Second, nil)
+	redirectURL, err := url.Parse("http://169.254.169.254/latest/meta-data")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &http.Request{URL: redirectURL}
+
+	err = client.CheckRedirect(req, []*http.Request{{}})
+
+	if err == nil || !strings.Contains(err.Error(), "not a public unicast destination") {
+		t.Fatalf("expected redirect to metadata endpoint to be rejected, got %v", err)
+	}
+}
+
+func TestPolicyHTTPClientLimitsRedirects(t *testing.T) {
+	client := newPolicyHTTPClient(time.Second, nil)
+	req := &http.Request{URL: &url.URL{Scheme: "https", Host: "example.com"}}
+	via := make([]*http.Request, maxHTTPRedirects)
+
+	err := client.CheckRedirect(req, via)
+
+	if err == nil || !strings.Contains(err.Error(), "stopped after 10 redirects") {
+		t.Fatalf("expected redirect limit error, got %v", err)
+	}
+}

--- a/pkg/parser/terraform/modules/resolver/http_policy_test.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy_test.go
@@ -24,25 +24,50 @@ func TestHTTPDestinationPolicyRejectsNonPublicAddresses(t *testing.T) {
 		"172.16.0.1",
 		"192.168.0.1",
 		"169.254.169.254",
-		"100.64.0.1",
-		"198.18.0.1",
-		"192.0.2.1",
-		"198.51.100.1",
-		"203.0.113.1",
-		"240.0.0.1",
 		"::1",
 		"fe80::1",
 		"fd00:ec2::254",
-		"2001:db8::1",
-		"100::1",
-		"64:ff9b:1::1",
 	}
 	policy := newHTTPDestinationPolicy(nil)
 
 	for _, address := range tests {
 		t.Run(address, func(t *testing.T) {
-			_, err := policy.resolveHost(t.Context(), address)
-			if err == nil || !strings.Contains(err.Error(), "not a public unicast destination") &&
+			if _, err := policy.resolveHost(t.Context(), address); err == nil ||
+				!strings.Contains(err.Error(), "not a public unicast destination") {
+				t.Fatalf("expected %s to be rejected, got %v", address, err)
+			}
+		})
+	}
+}
+
+func TestHTTPDestinationPolicyRejectsSpecialUseAddresses(t *testing.T) {
+	tests := []string{
+		"0.0.0.1",
+		"100.64.0.1",
+		"192.0.0.1",
+		"192.0.2.1",
+		"192.88.99.2",
+		"198.18.0.1",
+		"198.51.100.1",
+		"203.0.113.1",
+		"240.0.0.1",
+		"64:ff9b::1",
+		"64:ff9b:1::1",
+		"100::1",
+		"100:0:0:1::1",
+		"2001::1",
+		"2001:2::1",
+		"2001:20::1",
+		"2001:db8::1",
+		"2002::1",
+		"3fff::1",
+		"5f00::1",
+	}
+	policy := newHTTPDestinationPolicy(nil)
+
+	for _, address := range tests {
+		t.Run(address, func(t *testing.T) {
+			if _, err := policy.resolveHost(t.Context(), address); err == nil ||
 				!strings.Contains(err.Error(), "special-use network") {
 				t.Fatalf("expected %s to be rejected, got %v", address, err)
 			}

--- a/pkg/parser/terraform/modules/resolver/http_policy_test.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy_test.go
@@ -7,10 +7,12 @@ package resolver
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -116,6 +118,64 @@ func TestHTTPDestinationPolicyDialsValidatedAddressesConcurrently(t *testing.T) 
 	case <-firstCanceled:
 	case <-time.After(time.Second):
 		t.Fatal("slower validated address was not canceled")
+	}
+}
+
+func TestHTTPDestinationPolicyBoundsConcurrentDials(t *testing.T) {
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		addresses := make([]net.IP, 12)
+		for i := range addresses {
+			addresses[i] = net.IPv4(192, 0, 2, byte(i+1))
+		}
+		return addresses, nil
+	}
+	var inFlight atomic.Int32
+	var peak atomic.Int32
+	policy.dial = func(context.Context, string, string) (net.Conn, error) {
+		current := inFlight.Add(1)
+		for {
+			previous := peak.Load()
+			if current <= previous || peak.CompareAndSwap(previous, current) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+		inFlight.Add(-1)
+		return nil, errors.New("unreachable")
+	}
+
+	_, err := policy.dialContext(t.Context(), "tcp", "modules.example.com:443")
+
+	if err == nil {
+		t.Fatal("expected all addresses to fail")
+	}
+	if got := peak.Load(); got > maxConcurrentHTTPDials {
+		t.Fatalf("peak concurrent dials = %d, want at most %d", got, maxConcurrentHTTPDials)
+	}
+}
+
+func TestHTTPDestinationPolicyDeduplicatesDNSAnswers(t *testing.T) {
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{
+			net.ParseIP("93.184.216.34"),
+			net.ParseIP("93.184.216.34"),
+		}, nil
+	}
+	var calls atomic.Int32
+	policy.dial = func(context.Context, string, string) (net.Conn, error) {
+		calls.Add(1)
+		return nil, errors.New("unreachable")
+	}
+
+	_, err := policy.dialContext(t.Context(), "tcp", "modules.example.com:443")
+
+	if err == nil {
+		t.Fatal("expected address to fail")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("dial calls = %d, want one per unique address", got)
 	}
 }
 

--- a/pkg/parser/terraform/modules/resolver/http_policy_test.go
+++ b/pkg/parser/terraform/modules/resolver/http_policy_test.go
@@ -25,9 +25,16 @@ func TestHTTPDestinationPolicyRejectsNonPublicAddresses(t *testing.T) {
 		"192.168.0.1",
 		"169.254.169.254",
 		"100.64.0.1",
+		"198.18.0.1",
+		"192.0.2.1",
+		"198.51.100.1",
+		"203.0.113.1",
+		"240.0.0.1",
 		"::1",
 		"fe80::1",
 		"fd00:ec2::254",
+		"2001:db8::1",
+		"100::1",
 	}
 	policy := newHTTPDestinationPolicy(nil)
 
@@ -35,10 +42,26 @@ func TestHTTPDestinationPolicyRejectsNonPublicAddresses(t *testing.T) {
 		t.Run(address, func(t *testing.T) {
 			_, err := policy.resolveHost(t.Context(), address)
 			if err == nil || !strings.Contains(err.Error(), "not a public unicast destination") &&
-				!strings.Contains(err.Error(), "shared address space") {
+				!strings.Contains(err.Error(), "special-use network") {
 				t.Fatalf("expected %s to be rejected, got %v", address, err)
 			}
 		})
+	}
+}
+
+func TestHTTPDestinationPolicyRejectsHostnameWithSpecialUseAnswer(t *testing.T) {
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{
+			net.ParseIP("93.184.216.34"),
+			net.ParseIP("198.18.0.1"),
+		}, nil
+	}
+
+	_, err := policy.resolveHost(t.Context(), "modules.example.com")
+
+	if err == nil || !strings.Contains(err.Error(), "198.18.0.1") {
+		t.Fatalf("expected mixed DNS answer to be rejected, got %v", err)
 	}
 }
 
@@ -89,13 +112,13 @@ func TestHTTPDestinationPolicyDialsValidatedAddressesConcurrently(t *testing.T) 
 	policy := newHTTPDestinationPolicy(nil)
 	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
 		return []net.IP{
-			net.ParseIP("2001:db8::1"),
+			net.ParseIP("2001:4860:4860::8888"),
 			net.ParseIP("93.184.216.34"),
 		}, nil
 	}
 	firstCanceled := make(chan struct{})
 	policy.dial = func(ctx context.Context, _, address string) (net.Conn, error) {
-		if strings.HasPrefix(address, "[2001:db8::1]") {
+		if strings.HasPrefix(address, "[2001:4860:4860::8888]") {
 			<-ctx.Done()
 			close(firstCanceled)
 			return nil, ctx.Err()
@@ -126,7 +149,7 @@ func TestHTTPDestinationPolicyBoundsConcurrentDials(t *testing.T) {
 	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
 		addresses := make([]net.IP, 12)
 		for i := range addresses {
-			addresses[i] = net.IPv4(192, 0, 2, byte(i+1))
+			addresses[i] = net.IPv4(93, 184, 216, byte(i+1))
 		}
 		return addresses, nil
 	}

--- a/pkg/parser/terraform/modules/resolver/registry_cache.go
+++ b/pkg/parser/terraform/modules/resolver/registry_cache.go
@@ -120,9 +120,9 @@ type registryCache struct {
 	dlSF     singleflight.Group
 }
 
-func NewRegistryCache(timeout time.Duration) *registryCache {
+func NewRegistryCache(timeout time.Duration, hostAllowlist ...string) *registryCache {
 	c := &registryCache{
-		client:     &http.Client{Timeout: timeout},
+		client:     newPolicyHTTPClient(timeout, hostAllowlist),
 		discMap:    make(map[string]string),
 		discErrMap: make(map[string]error),
 		verMap:     make(map[string]string),

--- a/pkg/parser/terraform/modules/resolver/registry_test.go
+++ b/pkg/parser/terraform/modules/resolver/registry_test.go
@@ -25,6 +25,34 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+func TestRegistryClientRejectsPrivateDestinationWithoutAllowlist(t *testing.T) {
+	cache := NewRegistryCache(time.Second)
+
+	_, err := discoverModulesEndpoint(
+		t.Context(),
+		cache.client,
+		"https://169.254.169.254",
+	)
+
+	if err == nil || !strings.Contains(err.Error(), "not a public unicast destination") {
+		t.Fatalf("expected registry metadata destination to be rejected, got %v", err)
+	}
+}
+
+func TestRegistryClientAppliesHostAllowlist(t *testing.T) {
+	cache := NewRegistryCache(time.Second, "registry.terraform.io")
+
+	_, err := discoverModulesEndpoint(
+		t.Context(),
+		cache.client,
+		"https://example.com",
+	)
+
+	if err == nil || !strings.Contains(err.Error(), "not in --module-host-allowlist") {
+		t.Fatalf("expected registry host outside allowlist to be rejected, got %v", err)
+	}
+}
+
 func TestResolveRegistryVersionInvalidConstraint(t *testing.T) {
 	client := &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -130,10 +130,10 @@ func (c *Client) buildModuleResolverChain(ctx context.Context, moduleDiscoveryPa
 	ggCfg.Disabled = !c.ScanParams.EnableRemoteModules
 	if t := c.ScanParams.ModuleFetchTimeout; t > 0 {
 		ggCfg.FetchTimeout = t
-		ggCfg.RegistryCache = tfresolver.NewRegistryCache(ggCfg.FetchTimeout)
 	}
 	ggCfg.MaxTotalBytes = c.ScanParams.MaxModuleBytesTotal
 	ggCfg.HostAllowlist = c.ScanParams.RemoteModulesHostAllowlist
+	ggCfg.RegistryCache = tfresolver.NewRegistryCache(ggCfg.FetchTimeout, ggCfg.HostAllowlist...)
 
 	if !ggCfg.Disabled {
 		cache, err := tfresolver.NewModuleCache()

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -133,7 +133,6 @@ func (c *Client) buildModuleResolverChain(ctx context.Context, moduleDiscoveryPa
 	}
 	ggCfg.MaxTotalBytes = c.ScanParams.MaxModuleBytesTotal
 	ggCfg.HostAllowlist = c.ScanParams.RemoteModulesHostAllowlist
-	ggCfg.RegistryCache = tfresolver.NewRegistryCache(ggCfg.FetchTimeout, ggCfg.HostAllowlist...)
 
 	if !ggCfg.Disabled {
 		cache, err := tfresolver.NewModuleCache()


### PR DESCRIPTION
## Motivation

Remote module fetching used default HTTP clients with no destination policy: private, loopback, link-local, and metadata addresses were reachable, redirects and `X-Terraform-Get` hops were not revalidated, and DNS rebinding was possible because hostname checks were not bound to the connection. This change adds a shared HTTP destination policy for registry and go-getter HTTP paths so module acquisition cannot be steered to internal endpoints.

Related Ticket: [K9CODESEC-5290](https://datadoghq.atlassian.net/browse/K9CODESEC-5290)

## Changes

**HTTP destination policy**

Introduce a shared policy that rejects non-public unicast destinations, validates every redirect hop, resolves DNS once per hop, dials only validated addresses, deduplicates DNS answers, and bounds concurrent dial attempts. Proxy bypass is disabled on the secured transport.

**Registry client**

Wire the policy into Terraform registry discovery, version lookup, and download requests. The registry cache is built after resolver options are finalized so the host allowlist applies consistently.

**go-getter HTTP**

Route HTTP/HTTPS module fetches through the policy-controlled client. HTTP-origin `X-Terraform-Get` indirection stays within HTTP(S) so nested hops cannot switch to git, file, or cloud getters. Git, SSH, S3, and GCS transports remain unchanged for a follow-up.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

Tested on repository A, and the scan time/memory/finding count is the same as before.

## QA Instruction

1. `go test ./pkg/parser/terraform/modules/resolver/... ./pkg/scan/...`
2. `go test -race ./pkg/parser/terraform/modules/resolver`
3. `make build && ./bin/datadog-iac-scanner scan -p <terraform-fixture> -t Terraform -o /tmp/out --x-remote-modules --x-remote-modules-allowed-host registry.terraform.io`
4. Confirm resolver tests cover direct private-IP rejection, redirect validation, `X-Terraform-Get` private destinations, and allowlist enforcement.

## Blast Radius

This affects only the Datadog IaC Scanner remote-module resolver when network fetching is enabled (`--x-remote-modules`). It does not change rule assets, SARIF shape, or subprocess git/SSH/S3/GCS fetch behavior.

## Additional Notes

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-5290]: https://datadoghq.atlassian.net/browse/K9CODESEC-5290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[K9CODESEC-2662]: https://datadoghq.atlassian.net/browse/K9CODESEC-2662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ