### PR TITLE
[K9CODESEC-5291] Enforce destination policy on git and cloud module transports

### DIFF
--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -43,6 +43,7 @@ type BareGitResolver struct {
 	CacheDir string
 
 	hostAllowlist []string
+	policy        *httpDestinationPolicy
 	mu            sync.Mutex
 	repos         map[string]*bareRepo
 }
@@ -50,27 +51,45 @@ type BareGitResolver struct {
 const bareCloneAttempts = 3
 
 type bareRepo struct {
-	cloneURL     string // canonical ssh:// URL passed to git clone
 	barePath     string // path to the bare clone on disk
 	extractBase  string // base dir for per-(sha,subdir) extracted trees
 	refCachePath string // path to the persistent ref→SHA JSON file
+	policy       *httpDestinationPolicy
 
-	cloneOK     atomic.Bool
-	cloneFailed atomic.Bool
-	cloneErrMu  sync.Mutex
-	cloneErr    error
-	cloneSF     singleflight.Group
-	fetchSF     singleflight.Group
-	extractSF   singleflight.Group
+	cloneOK   atomic.Bool
+	cloneMu   sync.Mutex       // serializes clone attempts against barePath
+	cloneErrs map[string]error // transport → clone failure, guarded by cloneMu
+
+	fetchSF   singleflight.Group
+	extractSF singleflight.Group
 
 	refMu    sync.RWMutex
 	refCache map[string]string // tag/branch ref → resolved SHA (warm from disk on init)
+}
+
+// bareRemote binds a bare clone to the transport that one module source requires.
+// Every spelling of a repository shares a single object store, because the objects
+// git stores are identical no matter how they were fetched; only reachability and
+// credentials differ per transport. Clone outcomes are therefore tracked per
+// transport, so an https attempt that fails for want of credentials never blocks
+// the ssh attempt that would have succeeded.
+type bareRemote struct {
+	*bareRepo
+	transport string // https or ssh; selects how network commands reach the remote
+	cloneURL  string // canonical remote URL, by hostname rather than address
+}
+
+// sfKey namespaces a singleflight key by transport so that a network failure on
+// one transport is never handed to a caller that asked for the other.
+func (rem *bareRemote) sfKey(key string) string {
+	return rem.transport + "\x00" + key
 }
 
 func NewBareGitResolver(cacheDir string, hostAllowlist ...string) *BareGitResolver {
 	return &BareGitResolver{
 		CacheDir:      cacheDir,
 		hostAllowlist: hostAllowlist,
+		policy:        newHTTPDestinationPolicy(hostAllowlist),
 		repos:         make(map[string]*bareRepo),
 	}
 }
@@ -91,33 +110,71 @@ func repoURLKey(normalizedRepo string) string {
 	return fmt.Sprintf("%x", h[:12])
 }
 
-// canonicalSSHCloneURL builds a stable ssh:// clone URL for a parsed repo URL.
-func canonicalSSHCloneURL(repoURL string) string {
-	norm := normalizeGitRepoURL(repoURL)
-	if norm == "" {
-		return repoURL
+func canonicalHTTPSCloneURL(repoURL string) string {
+	parsed, err := url.Parse(repoURL)
+	if err != nil || parsed.Scheme != httpsScheme || parsed.Hostname() == "" || parsed.User != nil {
+		return ""
 	}
-	return "ssh://git@" + norm
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
 }
 
-func (r *BareGitResolver) getOrInitRepo(repoURL string) *bareRepo {
-	key := normalizeGitRepoURL(repoURL)
+// canonicalSSHCloneURL returns the ssh remote URL with the go-getter query stripped.
+// A URL carrying a password is rejected; ssh authenticates through an agent or key.
+func canonicalSSHCloneURL(repoURL string) string {
+	parsed, err := url.Parse(repoURL)
+	if err != nil || parsed.Scheme != sshScheme || parsed.Hostname() == "" {
+		return ""
+	}
+	if parsed.User != nil {
+		if _, hasPassword := parsed.User.Password(); hasPassword {
+			return ""
+		}
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}
+
+func canonicalGitCloneURL(repoURL string) string {
+	if gitModuleTransportKey(repoURL) == sshScheme {
+		return canonicalSSHCloneURL(repoURL)
+	}
+	return canonicalHTTPSCloneURL(repoURL)
+}
+
+// getOrInitRemote returns the bare clone backing repoURL, bound to the transport
+// repoURL asks for. Transport is part of the identity: sharing one store between an
+// https and an scp-form spelling of the same repository costs more than the duplicate
+// clone saves, because extraction serializes on a per-(clone, sha) lock and the two
+// spellings then queue behind each other instead of materializing in parallel.
+func (r *BareGitResolver) getOrInitRemote(repoURL string) *bareRemote {
+	transport := gitModuleTransportKey(repoURL)
+	key := transport + "\x00" + normalizeGitRepoURL(repoURL)
+	remote := &bareRemote{
+		transport: transport,
+		cloneURL:  canonicalGitCloneURL(repoURL),
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if repo, ok := r.repos[key]; ok {
-		return repo
+		remote.bareRepo = repo
+		return remote
 	}
 	base := filepath.Join(r.effectiveCacheDir(), repoURLKey(key))
 	refCachePath := filepath.Join(base, "refs.json")
 	repo := &bareRepo{
-		cloneURL:     canonicalSSHCloneURL(repoURL),
 		barePath:     filepath.Join(base, "repo.git"),
 		extractBase:  filepath.Join(base, "extracted"),
 		refCachePath: refCachePath,
+		policy:       r.policy,
 		refCache:     loadBareRefCache(refCachePath),
 	}
 	r.repos[key] = repo
-	return repo
+	remote.bareRepo = repo
+	return remote
 }
 
 // loadBareRefCache reads the persistent ref→SHA map for a bare clone.
@@ -153,52 +210,80 @@ func (repo *bareRepo) saveBareRefCache() {
 	_ = os.Rename(tmp, repo.refCachePath)
 }
 
-func (repo *bareRepo) cachedCloneError() error {
-	repo.cloneErrMu.Lock()
-	defer repo.cloneErrMu.Unlock()
-	return repo.cloneErr
+func (rem *bareRemote) runNetworkGitWith(
+	ctx context.Context, command gitNetworkCommand, output gitOutputFunc,
+) ([]byte, error) {
+	if rem.transport == sshScheme {
+		return runGitSSHCommand(ctx, rem.policy, rem.cloneURL, command, output)
+	}
+	return runGitHTTPSCommand(rem.policy, rem.cloneURL, command, output)
 }
 
-func (repo *bareRepo) setCloneError(err error) {
-	repo.cloneErrMu.Lock()
-	repo.cloneErr = err
-	repo.cloneErrMu.Unlock()
-	repo.cloneFailed.Store(true)
+func (rem *bareRemote) runNetworkGit(ctx context.Context, command gitNetworkCommand) ([]byte, error) {
+	return rem.runNetworkGitWith(ctx, command, gitCombinedOutput)
 }
 
-func (repo *bareRepo) ensureClone(ctx context.Context) error {
-	if repo.cloneOK.Load() {
+func (rem *bareRemote) archiveGitCommand(ctx context.Context, remote string, extraConfig, args []string) *exec.Cmd {
+	full := make([]string, 0, len(extraConfig)+len(args)+2)
+	full = append(full, extraConfig...)
+	full = append(full, "-c", "remote.origin.url="+remote)
+	full = append(full, args...)
+	return gitInDir(ctx, rem.barePath, full...)
+}
+
+// archiveCommand prepares git archive against the bare clone. A blob:none clone
+// may lazily fetch missing blobs; that fetch is pointed at the destination the
+// policy just validated. The caller must run the command and then call cleanup
+// so the HTTPS proxy stays up for the whole stream.
+func (rem *bareRemote) archiveCommand(ctx context.Context, args []string) (*exec.Cmd, func(), error) {
+	command := func(remote string, extraConfig []string) *exec.Cmd {
+		return rem.archiveGitCommand(ctx, remote, extraConfig, args)
+	}
+	if rem.transport == sshScheme {
+		return prepareGitSSHCommand(ctx, rem.policy, rem.cloneURL, command)
+	}
+	return prepareGitHTTPSCommand(rem.policy, rem.cloneURL, command)
+}
+
+func (rem *bareRemote) ensureClone(ctx context.Context) error {
+	if rem.cloneOK.Load() {
 		return nil
 	}
-	if repo.cloneFailed.Load() {
-		return repo.cachedCloneError()
+	rem.cloneMu.Lock()
+	defer rem.cloneMu.Unlock()
+	if rem.cloneOK.Load() {
+		return nil
 	}
-	_, err, _ := repo.cloneSF.Do("clone", func() (interface{}, error) {
-		if repo.cloneOK.Load() {
-			return nil, nil
+	if err, failed := rem.cloneErrs[rem.transport]; failed {
+		return err
+	}
+	err := rem.doClone(ctx)
+	if err != nil {
+		if rem.cloneErrs == nil {
+			rem.cloneErrs = make(map[string]error)
 		}
-		if repo.cloneFailed.Load() {
-			return nil, repo.cachedCloneError()
-		}
-		return nil, repo.doClone(ctx)
-	})
+		rem.cloneErrs[rem.transport] = err
+	}
 	return err
 }
 
 // doClone checks for an existing bare clone, validates it, and attempts a fresh
-// clone with retries if needed. It is always called inside the cloneSF singleflight.
-func (repo *bareRepo) doClone(ctx context.Context) error {
-	if info, err := os.Stat(repo.barePath); err == nil && info.IsDir() {
+// clone with retries if needed. It is always called while holding cloneMu.
+func (rem *bareRemote) doClone(ctx context.Context) error {
+	if info, err := os.Stat(rem.barePath); err == nil && info.IsDir() {
 		// Validate that the directory is a real bare repo, not a partial clone
 		// left by a killed process. This is a local-only read (no network, no
 		// pack-file I/O) so it intentionally bypasses the acquireGitProc semaphore,
 		// which is reserved for operations that meaningfully consume system resources.
-		if gitInDir(ctx, repo.barePath, "rev-parse", "--git-dir").Run() == nil {
-			repo.cloneOK.Store(true)
-			return nil
+		if gitInDir(ctx, rem.barePath, "rev-parse", "--git-dir").Run() == nil &&
+			rem.cachedConfigIsSafe(ctx) {
+			if gitInDir(ctx, rem.barePath, "remote", "set-url", "origin", rem.cloneURL).Run() == nil {
+				rem.cloneOK.Store(true)
+				return nil
+			}
 		}
 		// Partial or corrupt clone — remove and reclone.
-		_ = os.RemoveAll(repo.barePath)
+		_ = os.RemoveAll(rem.barePath)
 	}
 	var lastErr error
 	for attempt := 0; attempt < bareCloneAttempts; attempt++ {
@@ -210,49 +295,86 @@ func (repo *bareRepo) doClone(ctx context.Context) error {
 			case <-time.After(backoff):
 			}
 		}
-		if err := os.MkdirAll(filepath.Dir(repo.barePath), dirPerm); err != nil {
+		if err := os.MkdirAll(filepath.Dir(rem.barePath), dirPerm); err != nil {
 			lastErr = err
 			continue
 		}
-		_ = os.RemoveAll(repo.barePath)
+		_ = os.RemoveAll(rem.barePath)
 		release, err := acquireGitProc(ctx)
 		if err != nil {
 			lastErr = err
 			continue
 		}
-		cloneURL, urlErr := gitSafeArg(repo.cloneURL)
-		if urlErr != nil {
+		if _, urlErr := gitSafeArg(rem.cloneURL); urlErr != nil {
 			lastErr = urlErr
 			continue
 		}
-		cmd := gitCloneBare(ctx, cloneURL, repo.barePath)
-		out, cloneErr := cmd.CombinedOutput()
+		out, cloneErr := rem.runNetworkGit(ctx, func(remote string, extraConfig []string) *exec.Cmd {
+			return gitCloneBare(ctx, remote, rem.barePath, extraConfig)
+		})
 		release()
 		if cloneErr == nil {
-			repo.cloneOK.Store(true)
+			// The clone contacted a policy-validated address literal, which git records
+			// as origin. Persist the canonical hostname instead so a later run does not
+			// reuse an address that has since moved.
+			_ = gitInDir(ctx, rem.barePath, "remote", "set-url", "origin", rem.cloneURL).Run()
+			rem.cloneOK.Store(true)
 			return nil
 		}
-		_ = os.RemoveAll(repo.barePath)
-		lastErr = fmt.Errorf("git clone --bare %s: %w\n%s", repo.cloneURL, cloneErr, bytes.TrimSpace(out))
+		_ = os.RemoveAll(rem.barePath)
+		lastErr = fmt.Errorf("git clone --bare %s: %w\n%s", rem.cloneURL, cloneErr, bytes.TrimSpace(out))
 	}
-	repo.setCloneError(lastErr)
 	log := logger.FromContext(ctx)
-	log.Warn().Err(lastErr).Msgf("BareGitResolver: failed to clone %s after %d attempts", repo.cloneURL, bareCloneAttempts)
+	log.Warn().Err(lastErr).Msgf("BareGitResolver: failed to clone %s after %d attempts", rem.cloneURL, bareCloneAttempts)
 	return lastErr
 }
 
-// fetchRef ensures ref is present and returns its canonical commit SHA.
-func (repo *bareRepo) fetchRef(ctx context.Context, ref string) (string, error) {
-	if looksLikeSHA(ref) {
-		return repo.fetchSHARef(ctx, ref)
+func (repo *bareRepo) cachedConfigIsSafe(ctx context.Context) bool {
+	out, err := gitInDir(
+		ctx,
+		repo.barePath,
+		"config",
+		"--local",
+		"--no-includes",
+		"--name-only",
+		"--null",
+		"--list",
+	).Output()
+	if err != nil {
+		return false
 	}
-	return repo.fetchNamedRef(ctx, ref)
+	for _, rawKey := range bytes.Split(out, []byte{0}) {
+		key := strings.ToLower(strings.TrimSpace(string(rawKey)))
+		if key == "" {
+			continue
+		}
+		if strings.HasPrefix(key, "http.") ||
+			strings.HasPrefix(key, "url.") ||
+			strings.HasPrefix(key, "credential.") ||
+			strings.HasPrefix(key, "include.") ||
+			strings.HasPrefix(key, "includeif.") ||
+			strings.HasPrefix(key, "protocol.") ||
+			strings.Contains(key, "proxy") ||
+			key == "core.sshcommand" ||
+			key == "core.gitproxy" {
+			return false
+		}
+	}
+	return true
+}
+
+// fetchRef ensures ref is present and returns its canonical commit SHA.
+func (rem *bareRemote) fetchRef(ctx context.Context, ref string) (string, error) {
+	if looksLikeSHA(ref) {
+		return rem.fetchSHARef(ctx, ref)
+	}
+	return rem.fetchNamedRef(ctx, ref)
 }
 
 // fetchSHARef handles the case where ref is already a full 40-char SHA.
 // It checks that the object is locally present, fetching it from origin if not.
-func (repo *bareRepo) fetchSHARef(ctx context.Context, ref string) (string, error) {
-	v, err, _ := repo.fetchSF.Do(ref, func() (interface{}, error) {
+func (rem *bareRemote) fetchSHARef(ctx context.Context, ref string) (string, error) {
+	v, err, _ := rem.fetchSF.Do(rem.sfKey(ref), func() (interface{}, error) {
 		release, acqErr := acquireGitProc(ctx)
 		if acqErr != nil {
 			return "", acqErr
@@ -262,12 +384,16 @@ func (repo *bareRepo) fetchSHARef(ctx context.Context, ref string) (string, erro
 		if refErr != nil {
 			return "", refErr
 		}
-		if gitInDir(ctx, repo.barePath, "cat-file", "-t", safeRef).Run() == nil {
+		if gitInDir(ctx, rem.barePath, "cat-file", "-t", safeRef).Run() == nil {
 			return ref, nil // already present
 		}
-		cmd := gitInDir(ctx, repo.barePath, "fetch", "--filter=blob:none", "origin", safeRef)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return "", fmt.Errorf("git fetch origin %s: %w\n%s", ref, err, bytes.TrimSpace(out))
+		out, err := rem.runNetworkGit(ctx, func(remote string, extraConfig []string) *exec.Cmd {
+			args := append(append([]string{}, extraConfig...),
+				"fetch", "--filter=blob:none", remote, safeRef)
+			return gitInDir(ctx, rem.barePath, args...)
+		})
+		if err != nil {
+			return "", fmt.Errorf("git fetch %s %s: %w\n%s", rem.cloneURL, ref, err, bytes.TrimSpace(out))
 		}
 		return ref, nil
 	})
@@ -279,16 +405,16 @@ func (repo *bareRepo) fetchSHARef(ctx context.Context, ref string) (string, erro
 
 // fetchNamedRef handles branch/tag refs: it resolves the name to a commit SHA,
 // using an in-memory and on-disk cache to avoid unnecessary network fetches.
-func (repo *bareRepo) fetchNamedRef(ctx context.Context, ref string) (string, error) {
+func (rem *bareRemote) fetchNamedRef(ctx context.Context, ref string) (string, error) {
 	// Key on "ref:<name>" so SHA keys and name keys never collide in fetchSF.
-	v, err, _ := repo.fetchSF.Do("ref:"+ref, func() (interface{}, error) {
+	v, err, _ := rem.fetchSF.Do(rem.sfKey("ref:"+ref), func() (interface{}, error) {
 		// In-process cache: skip the network if we resolved this ref earlier.
-		repo.refMu.RLock()
-		if cachedSHA, ok := repo.refCache[ref]; ok {
-			repo.refMu.RUnlock()
+		rem.refMu.RLock()
+		if cachedSHA, ok := rem.refCache[ref]; ok {
+			rem.refMu.RUnlock()
 			return cachedSHA, nil
 		}
-		repo.refMu.RUnlock()
+		rem.refMu.RUnlock()
 
 		safeRef, refErr := gitSafeArg(ref)
 		if refErr != nil {
@@ -299,12 +425,12 @@ func (repo *bareRepo) fetchNamedRef(ctx context.Context, ref string) (string, er
 		// pre-populated clone or a prior fetch), resolve it without hitting the network.
 		// This is a local-only read so it intentionally bypasses acquireGitProc;
 		// the semaphore is acquired below only when a network fetch is needed.
-		if out, localErr := gitInDir(ctx, repo.barePath, "rev-parse", "--verify", safeRef).Output(); localErr == nil {
+		if out, localErr := gitInDir(ctx, rem.barePath, "rev-parse", "--verify", safeRef).Output(); localErr == nil {
 			if resolved := strings.TrimSpace(string(out)); looksLikeSHA(resolved) {
-				repo.refMu.Lock()
-				repo.refCache[ref] = resolved
-				repo.refMu.Unlock()
-				go repo.saveBareRefCache()
+				rem.refMu.Lock()
+				rem.refCache[ref] = resolved
+				rem.refMu.Unlock()
+				go rem.saveBareRefCache()
 				return resolved, nil
 			}
 		}
@@ -315,17 +441,27 @@ func (repo *bareRepo) fetchNamedRef(ctx context.Context, ref string) (string, er
 		}
 		defer release()
 		// Shallow fetch the named ref.
-		cmd := gitInDir(ctx, repo.barePath, "fetch", "--filter=blob:none", "--depth=1", "origin", safeRef)
-		out, err := cmd.CombinedOutput()
+		out, err := rem.runNetworkGit(ctx, func(remote string, extraConfig []string) *exec.Cmd {
+			args := append(append([]string{}, extraConfig...),
+				"fetch", "--filter=blob:none", "--depth=1", remote, safeRef)
+			return gitInDir(ctx, rem.barePath, args...)
+		})
 		if err != nil {
 			// Retry without --depth in case the server rejects shallow fetches.
-			cmd2 := gitInDir(ctx, repo.barePath, "fetch", "--filter=blob:none", "origin", safeRef)
-			if out2, err2 := cmd2.CombinedOutput(); err2 != nil {
-				return "", fmt.Errorf("git fetch origin %s: %w\n%s\n%s", ref, err2, bytes.TrimSpace(out), bytes.TrimSpace(out2))
+			out2, err2 := rem.runNetworkGit(ctx, func(remote string, extraConfig []string) *exec.Cmd {
+				args := append(append([]string{}, extraConfig...),
+					"fetch", "--filter=blob:none", remote, safeRef)
+				return gitInDir(ctx, rem.barePath, args...)
+			})
+			if err2 != nil {
+				return "", fmt.Errorf(
+					"git fetch %s %s: %w\n%s\n%s",
+					rem.cloneURL, ref, err2, bytes.TrimSpace(out), bytes.TrimSpace(out2),
+				)
 			}
 		}
 		// Resolve FETCH_HEAD to the commit SHA.
-		sha, revErr := gitInDir(ctx, repo.barePath, "rev-parse", "FETCH_HEAD").Output()
+		sha, revErr := gitInDir(ctx, rem.barePath, "rev-parse", "FETCH_HEAD").Output()
 		if revErr != nil {
 			return "", fmt.Errorf("git rev-parse FETCH_HEAD: %w", revErr)
 		}
@@ -335,10 +471,10 @@ func (repo *bareRepo) fetchNamedRef(ctx context.Context, ref string) (string, er
 		}
 		// Persist synchronously so subsequent in-process callers skip the fetch too,
 		// then write to disk in the background (non-critical).
-		repo.refMu.Lock()
-		repo.refCache[ref] = resolved
-		repo.refMu.Unlock()
-		go repo.saveBareRefCache()
+		rem.refMu.Lock()
+		rem.refCache[ref] = resolved
+		rem.refMu.Unlock()
+		go rem.saveBareRefCache()
 		return resolved, nil
 	})
 	if err != nil {
@@ -380,9 +516,21 @@ func archiveMaterializeLock(gitDir, sha string) *sync.Mutex {
 	return lock.(*sync.Mutex)
 }
 
+// archiveCommandFunc prepares a git archive invocation against a specific clone.
+// The implementation decides whether a lazy blob fetch may reach the network.
+type archiveCommandFunc func(ctx context.Context, args []string) (*exec.Cmd, func(), error)
+
+func localCloneArchiveCommand(gitDir string) archiveCommandFunc {
+	return func(ctx context.Context, args []string) (*exec.Cmd, func(), error) {
+		return gitInDir(ctx, gitDir, args...), func() {}, nil
+	}
+}
+
 // archiveExtract materializes the selected module and its local-module closure
 // into a sparse directory whose layout matches the repository at the given SHA.
-func archiveExtract(ctx context.Context, gitDir, extractBase, sha, subdir string) error {
+func archiveExtract(
+	ctx context.Context, gitDir, extractBase, sha, subdir string, runArchive archiveCommandFunc,
+) error {
 	cleanSubdir, err := cleanArchiveSubdir(subdir)
 	if err != nil {
 		return err
@@ -402,7 +550,9 @@ func archiveExtract(ctx context.Context, gitDir, extractBase, sha, subdir string
 	}
 
 	extracted := int64(0)
-	if err := materializeModuleClosure(ctx, gitDir, sha, dest, extractBase, cleanSubdir, map[string]bool{}, &extracted); err != nil {
+	if err := materializeModuleClosure(
+		ctx, runArchive, sha, dest, extractBase, cleanSubdir, map[string]bool{}, &extracted,
+	); err != nil {
 		return err
 	}
 	return nil
@@ -421,7 +571,8 @@ func cleanArchiveSubdir(subdir string) (string, error) {
 
 func materializeModuleClosure(
 	ctx context.Context,
-	gitDir, sha, packageRoot, extractBase, subdir string,
+	runArchive archiveCommandFunc,
+	sha, packageRoot, extractBase, subdir string,
 	visited map[string]bool,
 	extracted *int64,
 ) error {
@@ -434,7 +585,7 @@ func materializeModuleClosure(
 	if _, err := os.Stat(marker); err == nil {
 		return nil
 	}
-	if err := extractArchiveSubdir(ctx, gitDir, sha, packageRoot, subdir, extracted); err != nil {
+	if err := extractArchiveSubdir(ctx, runArchive, sha, packageRoot, subdir, extracted); err != nil {
 		return err
 	}
 
@@ -448,7 +599,7 @@ func materializeModuleClosure(
 	}
 	for _, child := range children {
 		if err := materializeModuleClosure(
-			ctx, gitDir, sha, packageRoot, extractBase, child, visited, extracted,
+			ctx, runArchive, sha, packageRoot, extractBase, child, visited, extracted,
 		); err != nil {
 			return err
 		}
@@ -463,7 +614,7 @@ func materializeModuleClosure(
 }
 
 func extractArchiveSubdir(
-	ctx context.Context, gitDir, sha, dest, subdir string, extracted *int64,
+	ctx context.Context, runArchive archiveCommandFunc, sha, dest, subdir string, extracted *int64,
 ) error {
 	release, err := acquireGitProc(ctx)
 	if err != nil {
@@ -479,7 +630,11 @@ func extractArchiveSubdir(
 	if subdir != "." {
 		archiveArgs = append(archiveArgs, "--", filepath.ToSlash(subdir))
 	}
-	archive := gitInDir(ctx, gitDir, archiveArgs...)
+	archive, cleanup, err := runArchive(ctx, archiveArgs)
+	if err != nil {
+		return fmt.Errorf("git archive %s path %q: %w", archiveArg, subdir, err)
+	}
+	defer cleanup()
 	if err := extractArchiveCommand(archive, dest, extracted); err != nil {
 		return fmt.Errorf("extracting git archive %s: %w", archiveArg, err)
 	}
@@ -655,15 +810,17 @@ func localArchiveSubdir(moduleDir, packageRoot, source string) (string, bool) {
 	return rel, true
 }
 
-func (repo *bareRepo) extract(ctx context.Context, sha, subdir string) (string, error) {
+func (rem *bareRemote) extract(ctx context.Context, sha, subdir string) (string, error) {
 	key := archiveCacheKey(sha) + "\x00" + filepath.Clean(subdir)
-	_, err, _ := repo.extractSF.Do(key, func() (interface{}, error) {
-		return nil, archiveExtract(ctx, repo.barePath, repo.extractBase, sha, subdir)
+	_, err, _ := rem.extractSF.Do(rem.sfKey(key), func() (interface{}, error) {
+		return nil, archiveExtract(
+			ctx, rem.barePath, rem.extractBase, sha, subdir, rem.archiveCommand,
+		)
 	})
 	if err != nil {
 		return "", err
 	}
-	return archiveCacheDir(repo.extractBase, sha), nil
+	return archiveCacheDir(rem.extractBase, sha), nil
 }
 
 // Resolve implements Resolver for any git:: source that carries a ref= parameter.
@@ -674,16 +831,28 @@ func (r *BareGitResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedModu
 			Reason: "BareGitResolver: not a git:: source with a ref= parameter",
 		}
 	}
+	parsedRepo, parseErr := url.Parse(repoURL)
+	if parseErr != nil || parsedRepo.Hostname() == "" {
+		return Resolution{}, &tfmodules.UnresolvedError{
+			Reason: "git module source is not a valid remote URL",
+		}
+	}
+	if err := checkGitTransportAllowed(ctx, parsedRepo); err != nil {
+		return Resolution{}, err
+	}
 	if err := checkHostAllowlist(mod.Source, r.hostAllowlist); err != nil {
 		return Resolution{}, err
 	}
+	if _, err := r.policy.resolveHost(ctx, parsedRepo.Hostname()); err != nil {
+		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
+	}
 
 	contextLogger := logger.FromContext(ctx)
-	repo := r.getOrInitRepo(repoURL)
+	remote := r.getOrInitRemote(repoURL)
 
 	// SHA refs have stable extraction keys; branch/tag refs must be re-resolved.
 	if looksLikeSHA(ref) {
-		if packageRoot, ok := cachedArchiveDir(repo.extractBase, ref, subdir); ok {
+		if packageRoot, ok := cachedArchiveDir(remote.extractBase, ref, subdir); ok {
 			return ConfineResolution(ctx, Resolution{
 				LocalPath:   filepath.Join(packageRoot, filepath.FromSlash(subdir)),
 				PackageRoot: packageRoot,
@@ -691,17 +860,17 @@ func (r *BareGitResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedModu
 		}
 	}
 
-	if err := repo.ensureClone(ctx); err != nil {
+	if err := remote.ensureClone(ctx); err != nil {
 		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
 	}
 
-	sha, err := repo.fetchRef(ctx, ref)
+	sha, err := remote.fetchRef(ctx, ref)
 	if err != nil {
 		contextLogger.Warn().Err(err).Msgf("BareGitResolver: ref %q not reachable from %s", ref, repoURL)
 		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
 	}
 
-	packageRoot, err := repo.extract(ctx, sha, subdir)
+	packageRoot, err := remote.extract(ctx, sha, subdir)
 	if err != nil {
 		contextLogger.Warn().Err(err).Msgf("BareGitResolver: archive %s:%s failed", sha, subdir)
 		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
@@ -711,6 +880,40 @@ func (r *BareGitResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedModu
 		LocalPath:   filepath.Join(packageRoot, filepath.FromSlash(subdir)),
 		PackageRoot: packageRoot,
 	})
+}
+
+// checkGitTransportAllowed accepts only the transports whose destination the
+// resolver can pin: HTTPS through the policy proxy, and ssh to a host whose key is
+// already known. Credentials embedded in the URL are refused for both.
+func checkGitTransportAllowed(ctx context.Context, repo *url.URL) error {
+	switch repo.Scheme {
+	case httpsScheme:
+		if repo.User != nil {
+			return &tfmodules.UnresolvedError{
+				Reason: "HTTPS git module transport does not accept credentials embedded in the source URL",
+			}
+		}
+		return nil
+	case sshScheme:
+		if repo.User != nil {
+			if _, hasPassword := repo.User.Password(); hasPassword {
+				return &tfmodules.UnresolvedError{
+					Reason: "ssh git module transport does not accept a password embedded in the source URL",
+				}
+			}
+		}
+		if err := checkSSHHostKeyPinned(ctx, repo.Hostname()); err != nil {
+			return &tfmodules.UnresolvedError{Reason: err.Error()}
+		}
+		return nil
+	default:
+		return &tfmodules.UnresolvedError{
+			Reason: fmt.Sprintf(
+				"git module transport %q is disabled because its destination cannot be pinned",
+				repo.Scheme,
+			),
+		}
+	}
 }
 
 // normalizeSCPGitSource converts SCP-form git sources to git::ssh://git@... so
@@ -747,10 +950,10 @@ func normalizeSCPGitSource(source string) (string, bool) {
 	return "git::ssh://" + user + "@" + host + "/" + path, true
 }
 
-// normalizeImplicitGitHubSource converts Terraform's implicit GitHub module paths to git::ssh://.
+// normalizeImplicitGitHubSource converts Terraform's implicit GitHub module paths to git::https://.
 //
 //	"github.com/org/repo//subdir?ref=tag"
-//	→ "git::ssh://git@github.com/org/repo//subdir?ref=tag", true
+//	→ "git::https://github.com/org/repo//subdir?ref=tag", true
 func normalizeImplicitGitHubSource(source string) (string, bool) {
 	if strings.Contains(source, "::") {
 		return "", false
@@ -762,26 +965,7 @@ func normalizeImplicitGitHubSource(source string) (string, bool) {
 	if !strings.Contains(source, "//") && !strings.Contains(source, "ref=") {
 		return "", false
 	}
-	return "git::ssh://git@" + source, true
-}
-
-// normalizeHTTPGitToSSH rewrites git::http(s)://host/... to git::ssh://git@host/...
-// so git clones use SSH credentials instead of unauthenticated HTTPS.
-func normalizeHTTPGitToSSH(source string) (string, bool) {
-	const prefix = "git::"
-	if !strings.HasPrefix(source, prefix) {
-		return "", false
-	}
-	rest := strings.TrimPrefix(source, prefix)
-	if strings.HasPrefix(rest, "ssh://") {
-		return "", false
-	}
-	for _, scheme := range []string{"https://", "http://"} {
-		if strings.HasPrefix(rest, scheme) {
-			return prefix + "ssh://git@" + strings.TrimPrefix(rest, scheme), true
-		}
-	}
-	return "", false
+	return "git::https://" + source, true
 }
 
 // normalizeGitModuleSourceForGetter applies SCP and implicit GitHub normalization
@@ -799,7 +983,7 @@ func normalizeGitModuleSourceForGetter(source string) (string, bool) {
 	return source, source != original
 }
 
-// normalizeGitModuleSource applies all git source normalizations used by resolvers.
+// normalizeGitModuleSource applies git source normalizations used by resolvers.
 func normalizeGitModuleSource(source string) (string, bool) {
 	if source == "" {
 		return "", false
@@ -808,11 +992,6 @@ func normalizeGitModuleSource(source string) (string, bool) {
 	if normalized, ok := normalizeGitModuleSourceForGetter(source); ok {
 		source = normalized
 	}
-	if strings.HasPrefix(source, "git::") {
-		if normalized, ok := normalizeHTTPGitToSSH(source); ok {
-			source = normalized
-		}
-	}
 	return source, source != original
 }
 
@@ -820,7 +999,7 @@ func normalizeGitModuleSource(source string) (string, bool) {
 // Sources are normalized via normalizeGitModuleSource before parsing.
 //
 //	"git::https://github.com/org/repo.git//path/to/mod?ref=abc123"
-//	→ repoURL="ssh://git@github.com/org/repo.git", subdir="path/to/mod", ref="abc123"
+//	→ repoURL="https://github.com/org/repo.git", subdir="path/to/mod", ref="abc123"
 func parseGitGetterSource(source string) (repoURL, subdir, ref string, ok bool) {
 	if normalized, changed := normalizeGitModuleSource(source); changed {
 		source = normalized

--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -230,16 +230,19 @@ func (rem *bareRemote) archiveGitCommand(ctx context.Context, remote string, ext
 
 // archiveCommand prepares git archive against the bare clone. A blob:none clone
 // may lazily fetch missing blobs; that fetch is pointed at the destination the
-// policy just validated. The caller must run the command and then call cleanup
-// so the HTTPS proxy stays up for the whole stream.
-func (rem *bareRemote) archiveCommand(ctx context.Context, args []string) (*exec.Cmd, func(), error) {
+// policy just validated. SSH returns one prep per validated address.
+func (rem *bareRemote) archiveCommand(ctx context.Context, args []string) ([]archivePrep, error) {
 	command := func(remote string, extraConfig []string) *exec.Cmd {
 		return rem.archiveGitCommand(ctx, remote, extraConfig, args)
 	}
 	if rem.transport == sshScheme {
-		return prepareGitSSHCommand(ctx, rem.policy, rem.cloneURL, command)
+		return prepareGitSSHArchives(ctx, rem.policy, rem.cloneURL, command)
 	}
-	return prepareGitHTTPSCommand(rem.policy, rem.cloneURL, command)
+	cmd, cleanup, err := prepareGitHTTPSCommand(rem.policy, rem.cloneURL, command)
+	if err != nil {
+		return nil, err
+	}
+	return []archivePrep{{cmd: cmd, cleanup: cleanup}}, nil
 }
 
 func (rem *bareRemote) ensureClone(ctx context.Context) error {
@@ -421,13 +424,15 @@ func (rem *bareRemote) fetchSHARef(ctx context.Context, ref string) (string, err
 func (rem *bareRemote) fetchNamedRef(ctx context.Context, ref string) (string, error) {
 	// Key on "ref:<name>" so SHA keys and name keys never collide in fetchSF.
 	v, err, _ := rem.fetchSF.Do(rem.sfKey("ref:"+ref), func() (interface{}, error) {
-		// In-process cache: skip the network if we resolved this ref earlier.
-		rem.refMu.RLock()
-		if cachedSHA, ok := rem.refCache[ref]; ok {
+		// HEAD moves; do not reuse a cached or clone-time value across scans.
+		if !mutableGitRef(ref) {
+			rem.refMu.RLock()
+			if cachedSHA, ok := rem.refCache[ref]; ok {
+				rem.refMu.RUnlock()
+				return cachedSHA, nil
+			}
 			rem.refMu.RUnlock()
-			return cachedSHA, nil
 		}
-		rem.refMu.RUnlock()
 
 		safeRef, refErr := gitSafeArg(ref)
 		if refErr != nil {
@@ -438,13 +443,15 @@ func (rem *bareRemote) fetchNamedRef(ctx context.Context, ref string) (string, e
 		// pre-populated clone or a prior fetch), resolve it without hitting the network.
 		// This is a local-only read so it intentionally bypasses acquireGitProc;
 		// the semaphore is acquired below only when a network fetch is needed.
-		if out, localErr := gitInDir(ctx, rem.barePath, "rev-parse", "--verify", safeRef).Output(); localErr == nil {
-			if resolved := strings.TrimSpace(string(out)); looksLikeSHA(resolved) {
-				rem.refMu.Lock()
-				rem.refCache[ref] = resolved
-				rem.refMu.Unlock()
-				go rem.saveBareRefCache()
-				return resolved, nil
+		if !mutableGitRef(ref) {
+			if out, localErr := gitInDir(ctx, rem.barePath, "rev-parse", "--verify", safeRef).Output(); localErr == nil {
+				if resolved := strings.TrimSpace(string(out)); looksLikeSHA(resolved) {
+					rem.refMu.Lock()
+					rem.refCache[ref] = resolved
+					rem.refMu.Unlock()
+					go rem.saveBareRefCache()
+					return resolved, nil
+				}
 			}
 		}
 
@@ -482,12 +489,12 @@ func (rem *bareRemote) fetchNamedRef(ctx context.Context, ref string) (string, e
 		if !looksLikeSHA(resolved) {
 			return "", fmt.Errorf("unexpected FETCH_HEAD value %q for ref %s", resolved, ref)
 		}
-		// Persist synchronously so subsequent in-process callers skip the fetch too,
-		// then write to disk in the background (non-critical).
-		rem.refMu.Lock()
-		rem.refCache[ref] = resolved
-		rem.refMu.Unlock()
-		go rem.saveBareRefCache()
+		if !mutableGitRef(ref) {
+			rem.refMu.Lock()
+			rem.refCache[ref] = resolved
+			rem.refMu.Unlock()
+			go rem.saveBareRefCache()
+		}
 		return resolved, nil
 	})
 	if err != nil {
@@ -529,13 +536,24 @@ func archiveMaterializeLock(gitDir, sha string) *sync.Mutex {
 	return lock.(*sync.Mutex)
 }
 
-// archiveCommandFunc prepares a git archive invocation against a specific clone.
-// The implementation decides whether a lazy blob fetch may reach the network.
-type archiveCommandFunc func(ctx context.Context, args []string) (*exec.Cmd, func(), error)
+type archivePrep struct {
+	cmd     *exec.Cmd
+	cleanup func()
+}
+
+func (p archivePrep) close() {
+	if p.cleanup != nil {
+		p.cleanup()
+	}
+}
+
+// archiveCommandFunc prepares git archive invocations against a specific clone.
+// SSH may return one command per validated address so a dead first answer can fail over.
+type archiveCommandFunc func(ctx context.Context, args []string) ([]archivePrep, error)
 
 func localCloneArchiveCommand(gitDir string) archiveCommandFunc {
-	return func(ctx context.Context, args []string) (*exec.Cmd, func(), error) {
-		return gitInDir(ctx, gitDir, args...), func() {}, nil
+	return func(ctx context.Context, args []string) ([]archivePrep, error) {
+		return []archivePrep{{cmd: gitInDir(ctx, gitDir, args...)}}, nil
 	}
 }
 
@@ -643,15 +661,23 @@ func extractArchiveSubdir(
 	if subdir != "." {
 		archiveArgs = append(archiveArgs, "--", filepath.ToSlash(subdir))
 	}
-	archive, cleanup, err := runArchive(ctx, archiveArgs)
+	preps, err := runArchive(ctx, archiveArgs)
 	if err != nil {
 		return fmt.Errorf("git archive %s path %q: %w", archiveArg, subdir, err)
 	}
-	defer cleanup()
-	if err := extractArchiveCommand(archive, dest, extracted); err != nil {
-		return fmt.Errorf("extracting git archive %s: %w", archiveArg, err)
+	var lastErr error
+	for _, prep := range preps {
+		err := extractArchiveCommand(prep.cmd, dest, extracted)
+		prep.close()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
 	}
-	return nil
+	if lastErr == nil {
+		lastErr = fmt.Errorf("git archive %s path %q: no prepared command", archiveArg, subdir)
+	}
+	return fmt.Errorf("extracting git archive %s: %w", archiveArg, lastErr)
 }
 
 func extractArchiveCommand(cmd *exec.Cmd, dest string, extracted *int64) error {
@@ -836,13 +862,16 @@ func (rem *bareRemote) extract(ctx context.Context, sha, subdir string) (string,
 	return archiveCacheDir(rem.extractBase, sha), nil
 }
 
-// Resolve implements Resolver for any git:: source that carries a ref= parameter.
+// Resolve implements Resolver for pinnable git:: sources. A missing ref uses HEAD.
 func (r *BareGitResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedModule) (Resolution, error) {
 	repoURL, subdir, ref, ok := parseGitGetterSource(mod.Source)
-	if !ok || ref == "" {
+	if !ok {
 		return Resolution{}, &tfmodules.UnresolvedError{
-			Reason: "BareGitResolver: not a git:: source with a ref= parameter",
+			Reason: "BareGitResolver: not a git:: source",
 		}
+	}
+	if ref == "" {
+		ref = defaultGitRef
 	}
 	parsedRepo, parseErr := url.Parse(repoURL)
 	if parseErr != nil || parsedRepo.Hostname() == "" {
@@ -856,9 +885,6 @@ func (r *BareGitResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedModu
 	if err := checkHostAllowlist(mod.Source, r.hostAllowlist); err != nil {
 		return Resolution{}, err
 	}
-	if _, err := r.policy.resolveHost(ctx, parsedRepo.Hostname()); err != nil {
-		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
-	}
 
 	contextLogger := logger.FromContext(ctx)
 	remote := r.getOrInitRemote(repoURL)
@@ -871,6 +897,10 @@ func (r *BareGitResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedModu
 				PackageRoot: packageRoot,
 			})
 		}
+	}
+
+	if _, err := r.policy.resolveHost(ctx, parsedRepo.Hostname()); err != nil {
+		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
 	}
 
 	if err := remote.ensureClone(ctx); err != nil {
@@ -915,7 +945,7 @@ func checkGitTransportAllowed(ctx context.Context, repo *url.URL) error {
 				}
 			}
 		}
-		if err := checkSSHHostKeyPinned(ctx, repo.Hostname()); err != nil {
+		if err := checkSSHHostKeyPinned(ctx, sshHostKeyName(repo.Hostname(), repo.Port())); err != nil {
 			return &tfmodules.UnresolvedError{Reason: err.Error()}
 		}
 		return nil

--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -67,12 +67,9 @@ type bareRepo struct {
 	refCache map[string]string // tag/branch ref → resolved SHA (warm from disk on init)
 }
 
-// bareRemote binds a bare clone to the transport that one module source requires.
-// Every spelling of a repository shares a single object store, because the objects
-// git stores are identical no matter how they were fetched; only reachability and
-// credentials differ per transport. Clone outcomes are therefore tracked per
-// transport, so an https attempt that fails for want of credentials never blocks
-// the ssh attempt that would have succeeded.
+// bareRemote binds a bare clone to the transport one module source requires.
+// Transport is part of the cache identity so an https spelling and an ssh
+// spelling never share a remote or a clone failure.
 type bareRemote struct {
 	*bareRepo
 	transport string // https or ssh; selects how network commands reach the remote
@@ -323,10 +320,26 @@ func (rem *bareRemote) doClone(ctx context.Context) error {
 		}
 		_ = os.RemoveAll(rem.barePath)
 		lastErr = fmt.Errorf("git clone --bare %s: %w\n%s", rem.cloneURL, cloneErr, bytes.TrimSpace(out))
+		if !gitCloneRetryable(out, cloneErr) {
+			break
+		}
 	}
 	log := logger.FromContext(ctx)
-	log.Warn().Err(lastErr).Msgf("BareGitResolver: failed to clone %s after %d attempts", rem.cloneURL, bareCloneAttempts)
+	log.Warn().Err(lastErr).Msgf("BareGitResolver: failed to clone %s", rem.cloneURL)
 	return lastErr
+}
+
+// gitCloneRetryable is false when another attempt cannot succeed without a
+// credential or prompt change — typical for private HTTPS sources in CI.
+func gitCloneRetryable(out []byte, err error) bool {
+	if err == nil {
+		return true
+	}
+	blob := strings.ToLower(string(out) + "\n" + err.Error())
+	return !strings.Contains(blob, "could not read username") &&
+		!strings.Contains(blob, "terminal prompts disabled") &&
+		!strings.Contains(blob, "authentication failed") &&
+		!strings.Contains(blob, "invalid username or password")
 }
 
 func (repo *bareRepo) cachedConfigIsSafe(ctx context.Context) bool {

--- a/pkg/parser/terraform/modules/resolver/baregit_test.go
+++ b/pkg/parser/terraform/modules/resolver/baregit_test.go
@@ -7,6 +7,8 @@ package resolver
 
 import (
 	"context"
+	"errors"
+	"net"
 	"strings"
 	"testing"
 
@@ -20,6 +22,71 @@ func TestBareGitResolverRejectsDisallowedHost(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), `module host "disallowed.example" is not in --module-host-allowlist`) {
 		t.Fatalf("expected host allowlist error, got %v", err)
+	}
+}
+
+func TestBareGitResolverRejectsUnpinnableTransport(t *testing.T) {
+	r := NewBareGitResolver(t.TempDir())
+	for _, source := range []string{
+		"git::http://modules.example/org/repo.git?ref=main",
+		"git::git://modules.example/org/repo.git?ref=main",
+	} {
+		t.Run(source, func(t *testing.T) {
+			_, err := r.Resolve(t.Context(), &tfmodules.ParsedModule{Source: source})
+			if err == nil || !strings.Contains(err.Error(), "destination cannot be pinned") {
+				t.Fatalf("expected unpinnable transport rejection, got %v", err)
+			}
+		})
+	}
+}
+
+func TestBareGitResolverRejectsSSHWithoutPinnedHostKey(t *testing.T) {
+	t.Setenv(knownHostsEnvVar, writeKnownHosts(t, ""))
+	r := NewBareGitResolver(t.TempDir())
+	for _, source := range []string{
+		"git::ssh://git@modules.example/org/repo.git?ref=main",
+		"git@modules.example:org/repo.git?ref=main",
+	} {
+		t.Run(source, func(t *testing.T) {
+			_, err := r.Resolve(t.Context(), &tfmodules.ParsedModule{Source: source})
+			if err == nil || !strings.Contains(err.Error(), "is not pinned in known_hosts") {
+				t.Fatalf("expected unpinned host key rejection, got %v", err)
+			}
+		})
+	}
+}
+
+func TestBareGitResolverRejectsSSHPasswordInSource(t *testing.T) {
+	t.Setenv(knownHostsEnvVar, writeKnownHosts(t, ""))
+	r := NewBareGitResolver(t.TempDir())
+	_, err := r.Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source: "git::ssh://git:secret@modules.example/org/repo.git?ref=main",
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not accept a password") {
+		t.Fatalf("expected embedded password rejection, got %v", err)
+	}
+}
+
+func TestBareGitResolverRejectsHTTPSCredentialsInSource(t *testing.T) {
+	r := NewBareGitResolver(t.TempDir())
+	_, err := r.Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source: "git::https://user:secret@modules.example/org/repo.git?ref=main",
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not accept credentials embedded") {
+		t.Fatalf("expected embedded credential rejection, got %v", err)
+	}
+}
+
+func TestBareGitResolverRejectsPrivateHTTPSDestination(t *testing.T) {
+	r := NewBareGitResolver(t.TempDir())
+	r.policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("169.254.169.254")}, nil
+	}
+	_, err := r.Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source: "git::https://modules.example/org/repo.git?ref=main",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not a public unicast destination") {
+		t.Fatalf("expected private destination rejection, got %v", err)
 	}
 }
 
@@ -59,14 +126,71 @@ func TestNormalizeGitRepoURLSchemeMatchesSCP(t *testing.T) {
 	}
 }
 
-func TestParseGitGetterSourceHTTPSGitHubToSSH(t *testing.T) {
+// TestGetOrInitRemoteSeparatesStorePerTransport pins the transport into the cache
+// identity. A shared store measured much slower on a large repository: extraction
+// serializes on a per-(clone, sha) lock, so two spellings of one repository queue
+// behind each other rather than materializing concurrently.
+func TestGetOrInitRemoteSeparatesStorePerTransport(t *testing.T) {
+	r := NewBareGitResolver(t.TempDir(), "github.com")
+	https := r.getOrInitRemote("https://github.com/org/repo.git")
+	ssh := r.getOrInitRemote("ssh://git@github.com/org/repo")
+
+	if https.barePath == ssh.barePath {
+		t.Errorf("transports must not share a bare clone, both used %q", https.barePath)
+	}
+	if https.transport != httpsScheme || ssh.transport != sshScheme {
+		t.Errorf("transports = %q, %q; want https, ssh", https.transport, ssh.transport)
+	}
+	if https.cloneURL == ssh.cloneURL {
+		t.Errorf("each transport needs its own remote URL, both were %q", https.cloneURL)
+	}
+}
+
+// TestGetOrInitRemoteReusesStorePerTransport checks the same spelling still resolves
+// to one store, so repeated sources in a repository do not re-clone.
+func TestGetOrInitRemoteReusesStorePerTransport(t *testing.T) {
+	r := NewBareGitResolver(t.TempDir(), "github.com")
+	first := r.getOrInitRemote("https://github.com/org/repo.git//a?ref=v1")
+	second := r.getOrInitRemote("https://github.com/org/repo.git//b?ref=v1")
+	if first.bareRepo != second.bareRepo {
+		t.Fatal("two sources in one repository must share a bare clone")
+	}
+}
+
+// TestCloneErrorIsScopedToTransport keeps an https failure (no credentials, say) from
+// poisoning the ssh attempt that would have worked for the same repo.
+func TestCloneErrorIsScopedToTransport(t *testing.T) {
+	r := NewBareGitResolver(t.TempDir(), "github.com")
+	const sentinel = "https clone failed for want of credentials"
+
+	https := r.getOrInitRemote("https://github.com/org/repo.git")
+	https.cloneErrs = map[string]error{https.transport: errors.New(sentinel)}
+	if err := https.ensureClone(context.Background()); err == nil || !strings.Contains(err.Error(), sentinel) {
+		t.Fatalf("https should see its own memoized failure, got %v", err)
+	}
+
+	ssh := r.getOrInitRemote("ssh://git@github.com/org/repo")
+	// Reject the destination so the attempt fails locally rather than reaching out.
+	ssh.policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("169.254.169.254")}, nil
+	}
+	err := ssh.ensureClone(context.Background())
+	if err == nil {
+		t.Fatal("expected the ssh attempt to fail on its own terms")
+	}
+	if strings.Contains(err.Error(), sentinel) {
+		t.Errorf("ssh inherited the https failure: %v", err)
+	}
+}
+
+func TestParseGitGetterSourcePreservesHTTPS(t *testing.T) {
 	in := "git::https://github.com/DataDog/vault-platform.git//terraform/aws/external-iam?ref=v1.9.4-17"
 	repoURL, subdir, ref, ok := parseGitGetterSource(in)
 	if !ok {
 		t.Fatal("expected ok")
 	}
-	if repoURL != "ssh://git@github.com/DataDog/vault-platform.git" {
-		t.Errorf("repoURL = %q, want ssh URL", repoURL)
+	if repoURL != "https://github.com/DataDog/vault-platform.git" {
+		t.Errorf("repoURL = %q, want HTTPS URL", repoURL)
 	}
 	if subdir != "terraform/aws/external-iam" {
 		t.Errorf("subdir = %q", subdir)
@@ -88,52 +212,13 @@ func TestNormalizeSCPGitSource(t *testing.T) {
 	}
 }
 
-func TestNormalizeHTTPGitToSSH(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{
-			"github",
-			"git::https://github.com/DataDog/k8s-platform.git//terraform/modules/datacenter?ref=abc",
-			"git::ssh://git@github.com/DataDog/k8s-platform.git//terraform/modules/datacenter?ref=abc",
-		},
-		{
-			"gitlab",
-			"git::https://gitlab.com/org/repo//modules/x?ref=v1",
-			"git::ssh://git@gitlab.com/org/repo//modules/x?ref=v1",
-		},
-		{
-			"ghe",
-			"git::https://github.datadoghq.com/org/repo?ref=main",
-			"git::ssh://git@github.datadoghq.com/org/repo?ref=main",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, ok := normalizeHTTPGitToSSH(tc.in)
-			if !ok {
-				t.Fatal("expected ok")
-			}
-			if got != tc.want {
-				t.Errorf("got %q, want %q", got, tc.want)
-			}
-		})
-	}
-	_, ok := normalizeHTTPGitToSSH("git::ssh://git@github.com/org/repo?ref=main")
-	if ok {
-		t.Error("already-ssh source should not normalize again")
-	}
-}
-
 func TestNormalizeImplicitGitHubSource(t *testing.T) {
 	in := "github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam//identity-domains?ref=release-0.3.0"
 	got, ok := normalizeImplicitGitHubSource(in)
 	if !ok {
 		t.Fatal("expected ok")
 	}
-	want := "git::ssh://git@github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam//identity-domains?ref=release-0.3.0"
+	want := "git::https://github.com/oracle-quickstart/terraform-oci-cis-landing-zone-iam//identity-domains?ref=release-0.3.0"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -149,8 +234,8 @@ func TestNormalizeGitModuleSourceForGetterPreservesHTTPS(t *testing.T) {
 		t.Fatalf("getter normalization must not rewrite git::https, got %q", got)
 	}
 	full, ok := normalizeGitModuleSource(https)
-	if !ok || !strings.Contains(full, "ssh://") {
-		t.Fatalf("baregit resolver should still rewrite HTTPS to SSH, got %q ok=%v", full, ok)
+	if ok || full != https {
+		t.Fatalf("baregit resolver must preserve HTTPS, got %q ok=%v", full, ok)
 	}
 }
 
@@ -166,8 +251,8 @@ func TestNormalizeGitModuleSource(t *testing.T) {
 
 	https := "git::https://github.com/DataDog/vault-platform.git//terraform/aws/external-iam?ref=v1.9.4-17"
 	got, ok = normalizeGitModuleSource(https)
-	if !ok {
-		t.Fatal("expected https normalization")
+	if ok || got != https {
+		t.Fatalf("expected HTTPS to remain unchanged, got %q ok=%v", got, ok)
 	}
 	_, subdir, ref, ok := parseGitGetterSource(https)
 	if !ok || ref != "v1.9.4-17" || subdir != "terraform/aws/external-iam" {
@@ -175,14 +260,29 @@ func TestNormalizeGitModuleSource(t *testing.T) {
 	}
 }
 
-func TestBareRepoKeyDedupesGitSuffix(t *testing.T) {
-	withGit := canonicalSSHCloneURL("ssh://git@github.com/DataDog/vault-platform.git")
-	withoutGit := canonicalSSHCloneURL("ssh://git@github.com/DataDog/vault-platform")
-	if withGit != withoutGit {
-		t.Fatalf("canonical clone URLs differ: %q vs %q", withGit, withoutGit)
+func TestCanonicalHTTPSCloneURL(t *testing.T) {
+	got := canonicalHTTPSCloneURL("https://github.com:8443/DataDog/vault-platform.git?ref=v1#fragment")
+	if got != "https://github.com:8443/DataDog/vault-platform.git" {
+		t.Fatalf("canonical clone URL = %q", got)
 	}
-	if normalizeGitRepoURL("ssh://git@github.com/DataDog/vault-platform.git") !=
-		normalizeGitRepoURL("git@github.com:DataDog/vault-platform") {
-		t.Fatal("normalized repo keys should match across spellings")
+	if got := canonicalHTTPSCloneURL("https://user:token@github.com/DataDog/vault-platform.git"); got != "" {
+		t.Fatalf("clone URL with embedded credentials must be rejected, got %q", got)
+	}
+	if got := canonicalHTTPSCloneURL("ssh://git@github.com/DataDog/vault-platform.git"); got != "" {
+		t.Fatalf("SSH clone URL must be rejected, got %q", got)
+	}
+}
+
+func TestBareRepoRejectsUnsafeCachedConfig(t *testing.T) {
+	root := t.TempDir()
+	barePath := root + "/repo.git"
+	runGit(t, root, "init", "--bare", barePath)
+	repo := &bareRepo{barePath: barePath}
+	if !repo.cachedConfigIsSafe(t.Context()) {
+		t.Fatal("standard bare repository config must be accepted")
+	}
+	runGit(t, root, "--git-dir", barePath, "config", "http.https://modules.example.proxy", "")
+	if repo.cachedConfigIsSafe(t.Context()) {
+		t.Fatal("URL-specific proxy config must invalidate the cache")
 	}
 }

--- a/pkg/parser/terraform/modules/resolver/baregit_test.go
+++ b/pkg/parser/terraform/modules/resolver/baregit_test.go
@@ -9,11 +9,45 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
+
+func TestResolveUsesCachedSHAArchiveWithoutDNS(t *testing.T) {
+	const sha = "0123456789abcdef0123456789abcdef01234567"
+	r := NewBareGitResolver(t.TempDir(), "github.com")
+	remote := r.getOrInitRemote("https://github.com/org/repo.git")
+	dest := archiveCacheDir(remote.extractBase, sha)
+	if err := os.MkdirAll(dest, dirPerm); err != nil {
+		t.Fatal(err)
+	}
+	marker := archiveMarkerPath(remote.extractBase, sha, ".")
+	if err := os.MkdirAll(filepath.Dir(marker), dirPerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(marker, nil, cacheFilePerms); err != nil {
+		t.Fatal(err)
+	}
+
+	r.policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		t.Fatal("cached SHA extract must not resolve DNS")
+		return nil, errors.New("offline")
+	}
+
+	res, err := r.Resolve(context.Background(), &tfmodules.ParsedModule{
+		Source: "git::https://github.com/org/repo.git?ref=" + sha,
+	})
+	if err != nil {
+		t.Fatalf("expected a cache hit without DNS, got %v", err)
+	}
+	if res.PackageRoot != dest {
+		t.Fatalf("PackageRoot = %q, want %q", res.PackageRoot, dest)
+	}
+}
 
 func TestBareGitResolverRejectsDisallowedHost(t *testing.T) {
 	r := NewBareGitResolver(t.TempDir(), "allowed.example")

--- a/pkg/parser/terraform/modules/resolver/baregit_test.go
+++ b/pkg/parser/terraform/modules/resolver/baregit_test.go
@@ -183,6 +183,34 @@ func TestCloneErrorIsScopedToTransport(t *testing.T) {
 	}
 }
 
+func TestGitCloneRetryable(t *testing.T) {
+	transient := errors.New("exit status 128")
+	cases := []struct {
+		name string
+		out  string
+		err  error
+		want bool
+	}{
+		{name: "success", err: nil, want: true},
+		{name: "transient network", out: "unable to access 'https://github.com/org/repo.git/'", err: transient, want: true},
+		{
+			name: "missing username",
+			out:  "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+			err:  transient,
+			want: false,
+		},
+		{name: "authentication failed", out: "fatal: Authentication failed for 'https://github.com/org/repo.git/'", err: transient, want: false},
+		{name: "invalid password", out: "remote: Invalid username or password", err: transient, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gitCloneRetryable([]byte(tc.out), tc.err); got != tc.want {
+				t.Fatalf("gitCloneRetryable(%q, %v) = %v, want %v", tc.out, tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestParseGitGetterSourcePreservesHTTPS(t *testing.T) {
 	in := "git::https://github.com/DataDog/vault-platform.git//terraform/aws/external-iam?ref=v1.9.4-17"
 	repoURL, subdir, ref, ok := parseGitGetterSource(in)

--- a/pkg/parser/terraform/modules/resolver/git_archive_transport_test.go
+++ b/pkg/parser/terraform/modules/resolver/git_archive_transport_test.go
@@ -112,14 +112,17 @@ func TestArchiveCommandRejectsUnvalidatedDestination(t *testing.T) {
 // being folded into it.
 func TestLocalCloneArchiveCommandKeepsStdoutClean(t *testing.T) {
 	bare := initBareRepo(t)
-	cmd, cleanup, err := localCloneArchiveCommand(bare)(
+	preps, err := localCloneArchiveCommand(bare)(
 		context.Background(), []string{"config", "--get", "core.bare"},
 	)
 	if err != nil {
 		t.Fatalf("local archive command: %v", err)
 	}
-	defer cleanup()
-	out, err := cmd.Output()
+	if len(preps) != 1 {
+		t.Fatalf("got %d archive preps, want 1", len(preps))
+	}
+	defer preps[0].close()
+	out, err := preps[0].cmd.Output()
 	if err != nil {
 		t.Fatalf("local archive command: %v", err)
 	}
@@ -128,12 +131,46 @@ func TestLocalCloneArchiveCommandKeepsStdoutClean(t *testing.T) {
 	}
 }
 
+func TestArchiveCommandPreparesEverySSHAddress(t *testing.T) {
+	const host = "modules.example"
+	t.Setenv(knownHostsEnvVar, writeKnownHosts(t, knownHostsLineFor(t, host)))
+
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("140.82.121.4"), net.ParseIP("140.82.121.3")}, nil
+	}
+	repo := &bareRemote{
+		transport: sshScheme,
+		cloneURL:  "ssh://git@" + host + "/org/repo.git",
+		bareRepo: &bareRepo{
+			barePath: initBareRepo(t),
+			policy:   policy,
+		},
+	}
+
+	preps, err := repo.archiveCommand(context.Background(), []string{"rev-parse", "--git-dir"})
+	if err != nil {
+		t.Fatalf("archive command: %v", err)
+	}
+	if len(preps) != 2 {
+		t.Fatalf("got %d archive preps, want one per validated address", len(preps))
+	}
+	joined := strings.Join(preps[0].cmd.Args, " ") + "\n" + strings.Join(preps[1].cmd.Args, " ")
+	if !strings.Contains(joined, "remote.origin.url=ssh://git@140.82.121.4/org/repo.git") ||
+		!strings.Contains(joined, "remote.origin.url=ssh://git@140.82.121.3/org/repo.git") {
+		t.Fatalf("archive preps did not pin both addresses:\n%s", joined)
+	}
+}
+
 func runArchiveCommand(t *testing.T, repo *bareRemote, args []string) ([]byte, error) {
 	t.Helper()
-	cmd, cleanup, err := repo.archiveCommand(context.Background(), args)
+	preps, err := repo.archiveCommand(context.Background(), args)
 	if err != nil {
 		return nil, err
 	}
-	defer cleanup()
-	return cmd.Output()
+	if len(preps) == 0 {
+		t.Fatal("no archive command")
+	}
+	defer preps[0].close()
+	return preps[0].cmd.Output()
 }

--- a/pkg/parser/terraform/modules/resolver/git_archive_transport_test.go
+++ b/pkg/parser/terraform/modules/resolver/git_archive_transport_test.go
@@ -1,0 +1,139 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"context"
+	"net"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// initBareRepo creates an empty bare repository for exercising git invocations that
+// only need a valid git directory.
+func initBareRepo(t *testing.T) string {
+	t.Helper()
+	bare := filepath.Join(t.TempDir(), "repo.git")
+	if out, err := exec.Command("git", "init", "--bare", "-q", bare).CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v\n%s", err, out)
+	}
+	return bare
+}
+
+func publicAddressPolicy(address string) *httpDestinationPolicy {
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP(address)}, nil
+	}
+	return policy
+}
+
+// TestArchiveCommandPinsSSHPromisorRemote reads back the remote git would lazily fetch
+// missing blobs from. A blob:none clone makes git archive fetch on demand, so that
+// remote has to name the address the policy validated.
+func TestArchiveCommandPinsSSHPromisorRemote(t *testing.T) {
+	const host = "modules.example"
+	t.Setenv(knownHostsEnvVar, writeKnownHosts(t, knownHostsLineFor(t, host)))
+
+	repo := &bareRemote{
+		transport: sshScheme,
+		cloneURL:  "ssh://git@" + host + "/org/repo.git",
+		bareRepo: &bareRepo{
+			barePath: initBareRepo(t),
+			policy:   publicAddressPolicy("140.82.121.4"),
+		},
+	}
+
+	out, err := runArchiveCommand(
+		t, repo, []string{"config", "--get", "remote.origin.url"},
+	)
+	if err != nil {
+		t.Fatalf("archive command: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "ssh://git@140.82.121.4/org/repo.git" {
+		t.Fatalf("promisor remote = %q, want the validated address", got)
+	}
+}
+
+// TestArchiveCommandRoutesHTTPSThroughProxy checks that a lazy blob fetch during
+// archive is proxied rather than sent straight out.
+func TestArchiveCommandRoutesHTTPSThroughProxy(t *testing.T) {
+	repo := &bareRemote{
+		transport: httpsScheme,
+		cloneURL:  "https://modules.example/org/repo.git",
+		bareRepo: &bareRepo{
+			barePath: initBareRepo(t),
+			policy:   publicAddressPolicy("140.82.121.4"),
+		},
+	}
+
+	out, err := runArchiveCommand(
+		t, repo, []string{"config", "--get-regexp", `^http\..*proxy$`},
+	)
+	if err != nil {
+		t.Fatalf("archive command: %v", err)
+	}
+	config := string(out)
+	if !strings.Contains(config, "http.proxy http://127.0.0.1:") {
+		t.Errorf("expected archive to run behind the local policy proxy, got %q", config)
+	}
+	if !strings.Contains(config, repo.cloneURL) {
+		t.Errorf("expected a remote-scoped proxy setting for %q, got %q", repo.cloneURL, config)
+	}
+}
+
+// TestArchiveCommandRejectsUnvalidatedDestination makes sure the archive step cannot
+// run at all when the destination fails the policy.
+func TestArchiveCommandRejectsUnvalidatedDestination(t *testing.T) {
+	const host = "modules.example"
+	t.Setenv(knownHostsEnvVar, writeKnownHosts(t, knownHostsLineFor(t, host)))
+
+	repo := &bareRemote{
+		transport: sshScheme,
+		cloneURL:  "ssh://git@" + host + "/org/repo.git",
+		bareRepo: &bareRepo{
+			barePath: initBareRepo(t),
+			policy:   publicAddressPolicy("169.254.169.254"),
+		},
+	}
+
+	_, err := runArchiveCommand(t, repo, []string{"config", "--list"})
+	if err == nil || !strings.Contains(err.Error(), "not a public unicast destination") {
+		t.Fatalf("expected the archive step to refuse an unvalidated destination, got %v", err)
+	}
+}
+
+// TestLocalCloneArchiveCommandKeepsStdoutClean guards the tar stream against stderr
+// being folded into it.
+func TestLocalCloneArchiveCommandKeepsStdoutClean(t *testing.T) {
+	bare := initBareRepo(t)
+	cmd, cleanup, err := localCloneArchiveCommand(bare)(
+		context.Background(), []string{"config", "--get", "core.bare"},
+	)
+	if err != nil {
+		t.Fatalf("local archive command: %v", err)
+	}
+	defer cleanup()
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("local archive command: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "true" {
+		t.Fatalf("unexpected output %q", out)
+	}
+}
+
+func runArchiveCommand(t *testing.T, repo *bareRemote, args []string) ([]byte, error) {
+	t.Helper()
+	cmd, cleanup, err := repo.archiveCommand(context.Background(), args)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	return cmd.Output()
+}

--- a/pkg/parser/terraform/modules/resolver/git_https_proxy.go
+++ b/pkg/parser/terraform/modules/resolver/git_https_proxy.go
@@ -1,0 +1,171 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+)
+
+type gitHTTPSProxy struct {
+	listener net.Listener
+	server   *http.Server
+	mu       sync.Mutex
+	tunnels  map[net.Conn]struct{}
+	closed   bool
+}
+
+func startGitHTTPSProxy(policy *httpDestinationPolicy) (*gitHTTPSProxy, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("starting git HTTPS proxy: %w", err)
+	}
+	proxy := &gitHTTPSProxy{
+		listener: listener,
+		tunnels:  make(map[net.Conn]struct{}),
+	}
+	proxy.server = &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			proxy.handle(policy, w, req)
+		}),
+		ReadHeaderTimeout: DefaultFetchTimeout,
+	}
+	go func() {
+		_ = proxy.server.Serve(listener)
+	}()
+	return proxy, nil
+}
+
+func (p *gitHTTPSProxy) URL() string {
+	return "http://" + p.listener.Addr().String()
+}
+
+func (p *gitHTTPSProxy) Close() error {
+	err := p.server.Close()
+	p.mu.Lock()
+	p.closed = true
+	for conn := range p.tunnels {
+		_ = conn.Close()
+	}
+	p.tunnels = make(map[net.Conn]struct{})
+	p.mu.Unlock()
+	return err
+}
+
+func (p *gitHTTPSProxy) handle(policy *httpDestinationPolicy, w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodConnect {
+		http.Error(w, "only HTTPS CONNECT is allowed", http.StatusForbidden)
+		return
+	}
+	target := req.Host
+	if _, _, err := net.SplitHostPort(target); err != nil {
+		http.Error(w, "invalid CONNECT destination", http.StatusBadRequest)
+		return
+	}
+	upstream, err := policy.dialContext(req.Context(), "tcp", target)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	defer func() { _ = upstream.Close() }()
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "proxy connection cannot be established", http.StatusInternalServerError)
+		return
+	}
+	client, buffered, err := hijacker.Hijack()
+	if err != nil {
+		return
+	}
+	defer func() { _ = client.Close() }()
+	if _, err := buffered.WriteString("HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+		return
+	}
+	if err := buffered.Flush(); err != nil {
+		return
+	}
+	p.track(client, upstream)
+	defer p.untrack(client, upstream)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(upstream, buffered)
+		if tcp, ok := upstream.(*net.TCPConn); ok {
+			_ = tcp.CloseWrite()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(client, upstream)
+		if tcp, ok := client.(*net.TCPConn); ok {
+			_ = tcp.CloseWrite()
+		}
+	}()
+	wg.Wait()
+}
+
+func (p *gitHTTPSProxy) track(connections ...net.Conn) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		for _, conn := range connections {
+			_ = conn.Close()
+		}
+		return
+	}
+	for _, conn := range connections {
+		p.tunnels[conn] = struct{}{}
+	}
+}
+
+func (p *gitHTTPSProxy) untrack(connections ...net.Conn) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, conn := range connections {
+		delete(p.tunnels, conn)
+	}
+}
+
+func runGitHTTPSCommand(
+	policy *httpDestinationPolicy,
+	remote string,
+	command gitNetworkCommand,
+	output gitOutputFunc,
+) ([]byte, error) {
+	proxy, err := startGitHTTPSProxy(policy)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = proxy.Close() }()
+
+	proxyURL := proxy.URL()
+	extraConfig := []string{
+		"-c", "http.proxy=" + proxyURL,
+		"-c", "http." + remote + ".proxy=" + proxyURL,
+	}
+	cmd := command(remote, extraConfig)
+	cmd.Env = gitCommandEnv(proxyURL)
+	return output(cmd)
+}
+
+func gitCommandEnv(proxyURL string) []string {
+	env := gitBaseEnv()
+	env = append(env, gitHardenedConfigEnv(httpsScheme)...)
+	return append(env,
+		"HTTP_PROXY="+proxyURL,
+		"HTTPS_PROXY="+proxyURL,
+		"http_proxy="+proxyURL,
+		"https_proxy="+proxyURL,
+		"NO_PROXY=",
+		"no_proxy=",
+	)
+}

--- a/pkg/parser/terraform/modules/resolver/git_https_proxy.go
+++ b/pkg/parser/terraform/modules/resolver/git_https_proxy.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os/exec"
 	"sync"
 )
 
@@ -141,12 +142,23 @@ func runGitHTTPSCommand(
 	command gitNetworkCommand,
 	output gitOutputFunc,
 ) ([]byte, error) {
-	proxy, err := startGitHTTPSProxy(policy)
+	cmd, cleanup, err := prepareGitHTTPSCommand(policy, remote, command)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = proxy.Close() }()
+	defer cleanup()
+	return output(cmd)
+}
 
+func prepareGitHTTPSCommand(
+	policy *httpDestinationPolicy,
+	remote string,
+	command gitNetworkCommand,
+) (*exec.Cmd, func(), error) {
+	proxy, err := startGitHTTPSProxy(policy)
+	if err != nil {
+		return nil, nil, err
+	}
 	proxyURL := proxy.URL()
 	extraConfig := []string{
 		"-c", "http.proxy=" + proxyURL,
@@ -154,7 +166,7 @@ func runGitHTTPSCommand(
 	}
 	cmd := command(remote, extraConfig)
 	cmd.Env = gitCommandEnv(proxyURL)
-	return output(cmd)
+	return cmd, func() { _ = proxy.Close() }, nil
 }
 
 func gitCommandEnv(proxyURL string) []string {

--- a/pkg/parser/terraform/modules/resolver/git_https_proxy_test.go
+++ b/pkg/parser/terraform/modules/resolver/git_https_proxy_test.go
@@ -1,0 +1,233 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGitHTTPSProxyRejectsPrivateDestination(t *testing.T) {
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("169.254.169.254")}, nil
+	}
+	proxy, err := startGitHTTPSProxy(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	conn, response := connectThroughProxy(t, proxy.URL(), "modules.example:443")
+	_ = conn.Close()
+	if response.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestGitHTTPSProxyPinsValidatedAddress(t *testing.T) {
+	backend, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+	go func() {
+		conn, acceptErr := backend.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = io.Copy(conn, conn)
+	}()
+
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	var dialed string
+	policy.dial = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialed = address
+		return (&net.Dialer{}).DialContext(ctx, network, backend.Addr().String())
+	}
+	proxy, err := startGitHTTPSProxy(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	conn, response := connectThroughProxy(t, proxy.URL(), "modules.example:443")
+	defer func() { _ = conn.Close() }()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusOK)
+	}
+	if dialed != "93.184.216.34:443" {
+		t.Fatalf("dialed %q, want validated address", dialed)
+	}
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatal(err)
+	}
+	reply := make([]byte, 4)
+	if _, err := io.ReadFull(conn, reply); err != nil {
+		t.Fatal(err)
+	}
+	if string(reply) != "ping" {
+		t.Fatalf("reply = %q", reply)
+	}
+}
+
+func TestGitHTTPSProxyCloseTerminatesHijackedTunnel(t *testing.T) {
+	backend, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, acceptErr := backend.Accept()
+		if acceptErr == nil {
+			accepted <- conn
+		}
+	}()
+
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	policy.dial = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, backend.Addr().String())
+	}
+	proxy, err := startGitHTTPSProxy(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, response := connectThroughProxy(t, proxy.URL(), "modules.example:443")
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusOK)
+	}
+	upstream := <-accepted
+	defer func() { _ = upstream.Close() }()
+
+	if err := proxy.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Read(make([]byte, 1)); err == nil {
+		t.Fatal("tunnel remained open after proxy shutdown")
+	}
+	_ = conn.Close()
+}
+
+func TestGitCommandEnvRemovesTransportOverrides(t *testing.T) {
+	t.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no")
+	t.Setenv("GIT_CONFIG_GLOBAL", "/tmp/attacker-config")
+	t.Setenv("HTTPS_PROXY", "http://attacker.invalid")
+	t.Setenv("NO_PROXY", "*")
+
+	env := gitCommandEnv("http://127.0.0.1:1234")
+	joined := strings.Join(env, "\n")
+	for _, forbidden := range []string{
+		"StrictHostKeyChecking=no",
+		"/tmp/attacker-config",
+		"http://attacker.invalid",
+		"NO_PROXY=*",
+	} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("environment retained %q", forbidden)
+		}
+	}
+	for _, required := range []string{
+		"GIT_CONFIG_GLOBAL=" + os.DevNull,
+		"GIT_ALLOW_PROTOCOL=https",
+		"HTTPS_PROXY=http://127.0.0.1:1234",
+		"NO_PROXY=",
+	} {
+		if !strings.Contains(joined, required) {
+			t.Fatalf("environment missing %q", required)
+		}
+	}
+}
+
+// TestGitEnvIgnoresGlobalInsteadOfRewrite checks the transport git actually resolves.
+// A url.<base>.insteadOf rule redirects a URL before git picks a transport, so it would
+// send the request somewhere the destination policy never validated.
+func TestGitEnvIgnoresGlobalInsteadOfRewrite(t *testing.T) {
+	const requested = "https://github.com/org/repo.git"
+	const hijacked = "ssh://git@attacker.invalid/"
+
+	configPath := filepath.Join(t.TempDir(), "gitconfig")
+	config := "[url \"" + hijacked + "\"]\n\tinsteadOf = https://github.com/\n"
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatalf("writing git config: %v", err)
+	}
+
+	resolveURL := func(env []string) string {
+		t.Helper()
+		cmd := exec.Command("git", "ls-remote", "--get-url", requested)
+		cmd.Dir = t.TempDir()
+		cmd.Env = env
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("git ls-remote --get-url: %v", err)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	// Control: with the rule visible, git really does rewrite the destination.
+	hijackedEnv := append(os.Environ(), "GIT_CONFIG_GLOBAL="+configPath, "GIT_CONFIG_NOSYSTEM=1")
+	if got := resolveURL(hijackedEnv); !strings.HasPrefix(got, hijacked) {
+		t.Skipf("git did not apply the insteadOf rule (%q); nothing to protect against here", got)
+	}
+
+	t.Setenv("GIT_CONFIG_GLOBAL", configPath)
+	for _, env := range [][]string{
+		gitCommandEnv("http://127.0.0.1:1234"),
+		sshGitCommandEnv("ssh -o StrictHostKeyChecking=yes"),
+	} {
+		if got := resolveURL(env); got != requested {
+			t.Errorf("git resolved %q to %q; the insteadOf rule was not neutralized", requested, got)
+		}
+	}
+}
+
+func connectThroughProxy(t *testing.T, proxyURL, target string) (net.Conn, *http.Response) {
+	t.Helper()
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.Dial("tcp", parsed.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := &http.Request{
+		Method: http.MethodConnect,
+		URL:    &url.URL{Opaque: target},
+		Host:   target,
+		Header: make(http.Header),
+	}
+	if err := request.Write(conn); err != nil {
+		_ = conn.Close()
+		t.Fatal(err)
+	}
+	response, err := http.ReadResponse(bufio.NewReader(conn), request)
+	if err != nil {
+		_ = conn.Close()
+		t.Fatal(err)
+	}
+	return conn, response
+}

--- a/pkg/parser/terraform/modules/resolver/git_module.go
+++ b/pkg/parser/terraform/modules/resolver/git_module.go
@@ -7,16 +7,24 @@ package resolver
 
 import (
 	"net/url"
+	"path/filepath"
 	"strings"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
 
-// GitModuleResolveKey returns a canonical cache key for pinned git module sources.
-// Transport scheme is part of the key so disabled spellings cannot coalesce with HTTPS.
-// Returns false when the source is not a git:: module with ref= (not BareGit-owned).
+const defaultGitRef = "HEAD"
+
+// GitModuleResolveKey returns a canonical cache key for pinnable git module sources.
+// Transport scheme is part of the key so HTTPS and SSH spellings cannot coalesce.
+// A missing ref is treated as HEAD so default-branch sources still share an identity.
 func GitModuleResolveKey(source, version string) (string, bool) {
 	repoURL, subdir, ref, ok := parseGitGetterSource(source)
-	if !ok || ref == "" {
+	if !ok || !pinnableGitRepoURL(repoURL) {
 		return "", false
+	}
+	if ref == "" {
+		ref = defaultGitRef
 	}
 	if v := strings.TrimSpace(version); v != "" && v != ref {
 		ref = ref + "\x00" + v
@@ -32,15 +40,48 @@ func gitModuleTransportKey(repoURL string) string {
 	return strings.ToLower(parsed.Scheme)
 }
 
-// bareGitOwnsSource reports whether BareGitResolver handles this module source.
-func bareGitOwnsSource(source string) bool {
-	repoURL, _, ref, ok := parseGitGetterSource(source)
-	if !ok || ref == "" {
-		return false
-	}
-	// Local file:// git repos stay on go-getter (small, used in unit tests).
+func pinnableGitRepoURL(repoURL string) bool {
 	if strings.HasPrefix(repoURL, "file://") {
 		return false
 	}
-	return true
+	parsed, err := url.Parse(repoURL)
+	if err != nil || parsed.Hostname() == "" {
+		return false
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case httpsScheme, sshScheme:
+		return true
+	default:
+		return false
+	}
+}
+
+func bareGitOwnsSource(source string) bool {
+	repoURL, _, _, ok := parseGitGetterSource(source)
+	return ok && pinnableGitRepoURL(repoURL)
+}
+
+func mutableGitRef(ref string) bool {
+	return strings.EqualFold(ref, defaultGitRef)
+}
+
+// pinnableGitModuleFromGetterSource turns a go-getter download URL into a BareGit
+// module. Registry X-Terraform-Get values and default-branch git sources land here
+// instead of an unpinned git subprocess.
+func pinnableGitModuleFromGetterSource(packageSource, selectedSubdir string) (*tfmodules.ParsedModule, bool) {
+	repoURL, subdir, ref, ok := parseGitGetterSource(packageSource)
+	if !ok || !pinnableGitRepoURL(repoURL) {
+		return nil, false
+	}
+	if selectedSubdir != "" {
+		subdir = selectedSubdir
+	}
+	if ref == "" {
+		ref = defaultGitRef
+	}
+	source := "git::" + repoURL
+	if subdir != "" && subdir != "." {
+		source += "//" + strings.TrimPrefix(filepath.ToSlash(subdir), "/")
+	}
+	return &tfmodules.ParsedModule{Source: source + "?ref=" + url.QueryEscape(ref)}, true
 }

--- a/pkg/parser/terraform/modules/resolver/git_module.go
+++ b/pkg/parser/terraform/modules/resolver/git_module.go
@@ -5,10 +5,13 @@
  */
 package resolver
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 // GitModuleResolveKey returns a canonical cache key for pinned git module sources.
-// Identical content folds transport spellings (https vs ssh, .git suffix) into one key.
+// Transport scheme is part of the key so disabled spellings cannot coalesce with HTTPS.
 // Returns false when the source is not a git:: module with ref= (not BareGit-owned).
 func GitModuleResolveKey(source, version string) (string, bool) {
 	repoURL, subdir, ref, ok := parseGitGetterSource(source)
@@ -18,7 +21,15 @@ func GitModuleResolveKey(source, version string) (string, bool) {
 	if v := strings.TrimSpace(version); v != "" && v != ref {
 		ref = ref + "\x00" + v
 	}
-	return normalizeGitRepoURL(repoURL) + "\x00" + ref + "\x00" + subdir, true
+	return gitModuleTransportKey(repoURL) + "\x00" + normalizeGitRepoURL(repoURL) + "\x00" + ref + "\x00" + subdir, true
+}
+
+func gitModuleTransportKey(repoURL string) string {
+	parsed, err := url.Parse(repoURL)
+	if err != nil || parsed.Scheme == "" {
+		return "unknown"
+	}
+	return strings.ToLower(parsed.Scheme)
 }
 
 // bareGitOwnsSource reports whether BareGitResolver handles this module source.

--- a/pkg/parser/terraform/modules/resolver/git_module_test.go
+++ b/pkg/parser/terraform/modules/resolver/git_module_test.go
@@ -11,7 +11,7 @@ import (
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
 
-func TestGitModuleResolveKeyFoldsTransport(t *testing.T) {
+func TestGitModuleResolveKeySeparatesTransport(t *testing.T) {
 	https := "git::https://github.com/org/repo.git//terraform-modules/aws-bucket?ref=aws-bucket_v7.1.2"
 	ssh := "git::ssh://git@github.com/org/repo//terraform-modules/aws-bucket?ref=aws-bucket_v7.1.2"
 	scp := "git@github.com:org/repo//terraform-modules/aws-bucket?ref=aws-bucket_v7.1.2"
@@ -28,12 +28,31 @@ func TestGitModuleResolveKeyFoldsTransport(t *testing.T) {
 	if !ok {
 		t.Fatal("expected scp key")
 	}
-	if keyHTTPS != keySSH || keyHTTPS != keySCP {
-		t.Fatalf("keys differ:\n  https=%q\n  ssh=%q\n  scp=%q", keyHTTPS, keySSH, keySCP)
+	if keyHTTPS == keySSH || keyHTTPS == keySCP {
+		t.Fatalf("HTTPS must not share resolve identity with SSH/SCP:\n  https=%q\n  ssh=%q\n  scp=%q", keyHTTPS, keySSH, keySCP)
 	}
-	want := "github.com/org/repo\x00aws-bucket_v7.1.2\x00terraform-modules/aws-bucket"
-	if keyHTTPS != want {
-		t.Fatalf("key = %q, want %q", keyHTTPS, want)
+	if keySSH != keySCP {
+		t.Fatalf("SSH and SCP spellings should still coalesce: %q vs %q", keySSH, keySCP)
+	}
+	wantHTTPS := "https\x00github.com/org/repo\x00aws-bucket_v7.1.2\x00terraform-modules/aws-bucket"
+	if keyHTTPS != wantHTTPS {
+		t.Fatalf("https key = %q, want %q", keyHTTPS, wantHTTPS)
+	}
+}
+
+func TestGitModuleResolveKeyFoldsEquivalentHTTPS(t *testing.T) {
+	withGit := "git::https://github.com/org/repo.git?ref=v1.0.0"
+	withoutGit := "git::https://github.com/org/repo?ref=v1.0.0"
+	keyWith, ok := GitModuleResolveKey(withGit, "")
+	if !ok {
+		t.Fatal("expected https key with .git suffix")
+	}
+	keyWithout, ok := GitModuleResolveKey(withoutGit, "")
+	if !ok {
+		t.Fatal("expected https key without .git suffix")
+	}
+	if keyWith != keyWithout {
+		t.Fatalf("equivalent HTTPS spellings should share a key: %q vs %q", keyWith, keyWithout)
 	}
 }
 

--- a/pkg/parser/terraform/modules/resolver/git_module_test.go
+++ b/pkg/parser/terraform/modules/resolver/git_module_test.go
@@ -74,11 +74,47 @@ func TestBareGitOwnsSource(t *testing.T) {
 	if !bareGitOwnsSource("git::https://github.com/org/repo//sub?ref=v1") {
 		t.Fatal("git:: with ref should be bare-git owned")
 	}
-	if bareGitOwnsSource("git::https://github.com/org/repo//sub") {
-		t.Fatal("git:: without ref is not bare-git owned")
+	if !bareGitOwnsSource("git::https://github.com/org/repo//sub") {
+		t.Fatal("default-branch git::https should be bare-git owned")
 	}
 	if bareGitOwnsSource("registry.terraform.io/org/name/aws") {
 		t.Fatal("registry source is not bare-git owned")
+	}
+	if bareGitOwnsSource("git::file:///tmp/repository") {
+		t.Fatal("file:// git sources stay on go-getter")
+	}
+}
+
+func TestPinnableGitModuleFromGetterSource(t *testing.T) {
+	mod, ok := pinnableGitModuleFromGetterSource("git::https://github.com/org/repo.git?ref=abc123", "modules/vpc")
+	if !ok {
+		t.Fatal("expected registry-style HTTPS git download to be pinnable")
+	}
+	if mod.Source != "git::https://github.com/org/repo.git//modules/vpc?ref=abc123" {
+		t.Fatalf("got %q", mod.Source)
+	}
+
+	mod, ok = pinnableGitModuleFromGetterSource("git::https://github.com/org/repo.git", "")
+	if !ok {
+		t.Fatal("expected default-branch HTTPS git to be pinnable")
+	}
+	if mod.Source != "git::https://github.com/org/repo.git?ref=HEAD" {
+		t.Fatalf("got %q", mod.Source)
+	}
+
+	if _, ok := pinnableGitModuleFromGetterSource("git::file:///tmp/repository", ""); ok {
+		t.Fatal("file:// git must not be treated as pinnable")
+	}
+}
+
+func TestGitModuleResolveKeyDefaultsMissingRefToHEAD(t *testing.T) {
+	key, ok := GitModuleResolveKey("git::https://github.com/org/repo.git", "")
+	if !ok {
+		t.Fatal("expected default-branch source to have a resolve key")
+	}
+	want := "https\x00github.com/org/repo\x00HEAD\x00"
+	if key != want {
+		t.Fatalf("key = %q, want %q", key, want)
 	}
 }
 

--- a/pkg/parser/terraform/modules/resolver/git_ssh_transport.go
+++ b/pkg/parser/terraform/modules/resolver/git_ssh_transport.go
@@ -61,9 +61,15 @@ func sshKnownHostsFiles() []string {
 	return files
 }
 
-// sshHostKeyIsPinned reports whether host already has a host key entry. Hosts
-// without one are refused rather than trusted on first use, so a hijacked
-// destination cannot silently present a new key.
+// sshHostKeyName is the known_hosts / HostKeyAlias key for host. Port 22 uses
+// the bare hostname; any other port uses OpenSSH's [host]:port form.
+func sshHostKeyName(host, port string) string {
+	if port == "" || port == "22" {
+		return host
+	}
+	return "[" + host + "]:" + port
+}
+
 func sshHostKeyIsPinned(ctx context.Context, host string, knownHosts []string) bool {
 	for _, file := range knownHosts {
 		out, err := exec.CommandContext(ctx, "ssh-keygen", "-F", host, "-f", file).Output() //nolint:gosec
@@ -186,10 +192,11 @@ func sshGitSetup(
 	if host == "" {
 		return nil, nil, nil, fmt.Errorf("ssh git remote %q has no host", remoteURL)
 	}
-	if err := checkSSHHostKeyPinned(ctx, host); err != nil {
+	keyName := sshHostKeyName(host, remote.Port())
+	if err := checkSSHHostKeyPinned(ctx, keyName); err != nil {
 		return nil, nil, nil, err
 	}
-	sshCommand, err := gitSSHCommand(host, sshKnownHostsFiles())
+	sshCommand, err := gitSSHCommand(keyName, sshKnownHostsFiles())
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -225,20 +232,24 @@ func runGitSSHCommand(
 	return lastOut, lastErr
 }
 
-func prepareGitSSHCommand(
+func prepareGitSSHArchives(
 	ctx context.Context,
 	policy *httpDestinationPolicy,
 	remoteURL string,
 	command gitNetworkCommand,
-) (*exec.Cmd, func(), error) {
+) ([]archivePrep, error) {
 	remote, env, addresses, err := sshGitSetup(ctx, policy, remoteURL)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if len(addresses) == 0 {
-		return nil, nil, errors.New("ssh git remote had no validated address")
+		return nil, errors.New("ssh git remote had no validated address")
 	}
-	cmd := command(pinnedSSHRemote(remote, addresses[0]), nil)
-	cmd.Env = env
-	return cmd, func() {}, nil
+	preps := make([]archivePrep, 0, len(addresses))
+	for _, address := range addresses {
+		cmd := command(pinnedSSHRemote(remote, address), nil)
+		cmd.Env = env
+		preps = append(preps, archivePrep{cmd: cmd})
+	}
+	return preps, nil
 }

--- a/pkg/parser/terraform/modules/resolver/git_ssh_transport.go
+++ b/pkg/parser/terraform/modules/resolver/git_ssh_transport.go
@@ -1,0 +1,244 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// knownHostsEnvVar points at a dedicated host key file. When set it replaces the
+// invoking user's known_hosts, so a deployment can pin keys independently of the
+// account running the scan.
+const knownHostsEnvVar = "IAC_GIT_SSH_KNOWN_HOSTS"
+
+const sshConnectTimeoutSeconds = 30
+
+// systemKnownHostsFile is consulted after the user's own files.
+const systemKnownHostsFile = "/etc/ssh/ssh_known_hosts"
+
+// sshKnownHostsFiles returns the existing files used to verify host keys.
+func sshKnownHostsFiles() []string {
+	var candidates []string
+	if pinned := strings.TrimSpace(os.Getenv(knownHostsEnvVar)); pinned != "" {
+		candidates = []string{pinned}
+	} else {
+		if home, err := os.UserHomeDir(); err == nil {
+			candidates = append(candidates,
+				filepath.Join(home, ".ssh", "known_hosts"),
+				filepath.Join(home, ".ssh", "known_hosts2"),
+			)
+		}
+		candidates = append(candidates, systemKnownHostsFile)
+	}
+
+	files := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		candidate = filepath.Clean(candidate)
+		info, err := os.Stat(candidate) //nolint:gosec // operator-supplied host key file
+		if err != nil || info.IsDir() {
+			continue
+		}
+		// A path that cannot be quoted safely cannot be handed to ssh at all.
+		if _, err := shellSingleQuote(candidate); err != nil {
+			continue
+		}
+		files = append(files, candidate)
+	}
+	return files
+}
+
+// sshHostKeyIsPinned reports whether host already has a host key entry. Hosts
+// without one are refused rather than trusted on first use, so a hijacked
+// destination cannot silently present a new key.
+func sshHostKeyIsPinned(ctx context.Context, host string, knownHosts []string) bool {
+	for _, file := range knownHosts {
+		out, err := exec.CommandContext(ctx, "ssh-keygen", "-F", host, "-f", file).Output() //nolint:gosec
+		if err == nil && len(bytes.TrimSpace(out)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// pinnedHostKeyCache memoizes host key lookups. The archive path re-checks the same
+// host once per materialized subdirectory, and each miss costs a subprocess.
+var pinnedHostKeyCache sync.Map // host+known_hosts files → bool
+
+// checkSSHHostKeyPinned validates that host keys are available for host.
+func checkSSHHostKeyPinned(ctx context.Context, host string) error {
+	knownHosts := sshKnownHostsFiles()
+	if len(knownHosts) == 0 {
+		return fmt.Errorf("no known_hosts file is available to verify the host key for %q", host)
+	}
+
+	cacheKey := host + "\x00" + strings.Join(knownHosts, "\x00")
+	pinned, cached := pinnedHostKeyCache.Load(cacheKey)
+	if !cached {
+		pinned = sshHostKeyIsPinned(ctx, host, knownHosts)
+		pinnedHostKeyCache.Store(cacheKey, pinned)
+	}
+	if isPinned, ok := pinned.(bool); !ok || !isPinned {
+		return fmt.Errorf(
+			"host key for %q is not pinned in known_hosts; ssh git modules are only fetched from hosts with a known host key",
+			host,
+		)
+	}
+	return nil
+}
+
+// shellSingleQuote quotes arg for the shell that git uses to run GIT_SSH_COMMAND.
+// Arguments that cannot be represented are rejected instead of escaped.
+func shellSingleQuote(arg string) (string, error) {
+	if strings.ContainsAny(arg, "'\n\r") {
+		return "", fmt.Errorf("cannot pass %q to the ssh command line", arg)
+	}
+	return "'" + arg + "'", nil
+}
+
+// gitSSHCommand builds the GIT_SSH_COMMAND used for every ssh git subprocess.
+//
+// The connection is made to an address the destination policy already validated, so
+// user ssh configuration is ignored (-F /dev/null): a Hostname, ProxyCommand or
+// ProxyJump directive there would otherwise redirect the connection past that check.
+// HostKeyAlias keeps host key verification bound to the real hostname even though the
+// remote URL names an address literal.
+func gitSSHCommand(host string, knownHosts []string) (string, error) {
+	quotedFiles := make([]string, 0, len(knownHosts))
+	for _, file := range knownHosts {
+		// ssh splits UserKnownHostsFile on whitespace, so each path is quoted for ssh
+		// itself in addition to the shell quoting applied below.
+		quotedFiles = append(quotedFiles, `"`+file+`"`)
+	}
+
+	args := []string{
+		"ssh",
+		"-F", os.DevNull,
+		"-o", "BatchMode=yes",
+		"-o", "StrictHostKeyChecking=yes",
+		"-o", "HostKeyAlias=" + host,
+		"-o", "ProxyCommand=none",
+		"-o", "ProxyJump=none",
+		"-o", "ClearAllForwardings=yes",
+		"-o", "ControlPath=none",
+		"-o", "ConnectTimeout=" + strconv.Itoa(sshConnectTimeoutSeconds),
+		"-o", "UserKnownHostsFile=" + strings.Join(quotedFiles, " "),
+	}
+
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		safe, err := shellSingleQuote(arg)
+		if err != nil {
+			return "", err
+		}
+		quoted = append(quoted, safe)
+	}
+	return strings.Join(quoted, " "), nil
+}
+
+// pinnedSSHRemote rewrites remote to target addr so the ssh subprocess cannot
+// re-resolve the hostname and reach a destination the policy never approved.
+func pinnedSSHRemote(remote *url.URL, addr netip.Addr) string {
+	pinned := *remote
+	literal := addr.String()
+	if addr.Is6() {
+		literal = "[" + literal + "]"
+	}
+	if port := remote.Port(); port != "" {
+		literal += ":" + port
+	}
+	pinned.Host = literal
+	pinned.RawQuery = ""
+	pinned.Fragment = ""
+	return pinned.String()
+}
+
+// sshGitCommandEnv builds the environment for an ssh git subprocess. SSH_AUTH_SOCK is
+// preserved because agent authentication is how private repositories are reached;
+// everything else that could redirect the connection is dropped.
+func sshGitCommandEnv(sshCommand string) []string {
+	env := gitBaseEnv("SSH_AUTH_SOCK")
+	env = append(env, gitHardenedConfigEnv(sshScheme)...)
+	return append(env, "GIT_SSH_COMMAND="+sshCommand)
+}
+
+func sshGitSetup(
+	ctx context.Context, policy *httpDestinationPolicy, remoteURL string,
+) (*url.URL, []string, []netip.Addr, error) {
+	remote, err := url.Parse(remoteURL)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("parsing ssh git remote %q: %w", remoteURL, err)
+	}
+	host := remote.Hostname()
+	if host == "" {
+		return nil, nil, nil, fmt.Errorf("ssh git remote %q has no host", remoteURL)
+	}
+	if err := checkSSHHostKeyPinned(ctx, host); err != nil {
+		return nil, nil, nil, err
+	}
+	sshCommand, err := gitSSHCommand(host, sshKnownHostsFiles())
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	addresses, err := policy.resolveHost(ctx, host)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return remote, sshGitCommandEnv(sshCommand), addresses, nil
+}
+
+func runGitSSHCommand(
+	ctx context.Context,
+	policy *httpDestinationPolicy,
+	remoteURL string,
+	command gitNetworkCommand,
+	output gitOutputFunc,
+) ([]byte, error) {
+	remote, env, addresses, err := sshGitSetup(ctx, policy, remoteURL)
+	if err != nil {
+		return nil, err
+	}
+	var lastOut []byte
+	lastErr := errors.New("ssh git remote had no validated address")
+	for _, address := range addresses {
+		cmd := command(pinnedSSHRemote(remote, address), nil)
+		cmd.Env = env
+		out, runErr := output(cmd)
+		if runErr == nil {
+			return out, nil
+		}
+		lastOut, lastErr = out, runErr
+	}
+	return lastOut, lastErr
+}
+
+func prepareGitSSHCommand(
+	ctx context.Context,
+	policy *httpDestinationPolicy,
+	remoteURL string,
+	command gitNetworkCommand,
+) (*exec.Cmd, func(), error) {
+	remote, env, addresses, err := sshGitSetup(ctx, policy, remoteURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(addresses) == 0 {
+		return nil, nil, errors.New("ssh git remote had no validated address")
+	}
+	cmd := command(pinnedSSHRemote(remote, addresses[0]), nil)
+	cmd.Env = env
+	return cmd, func() {}, nil
+}

--- a/pkg/parser/terraform/modules/resolver/git_ssh_transport_test.go
+++ b/pkg/parser/terraform/modules/resolver/git_ssh_transport_test.go
@@ -1,0 +1,275 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeKnownHosts writes content to a temporary known_hosts file and returns its path.
+func writeKnownHosts(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing known_hosts: %v", err)
+	}
+	return path
+}
+
+// knownHostsLineFor generates a real host key entry for host, so ssh-keygen -F
+// parses it the same way it would parse an operator's file.
+func knownHostsLineFor(t *testing.T, host string) string {
+	t.Helper()
+	if _, err := exec.LookPath("ssh-keygen"); err != nil {
+		t.Skip("ssh-keygen is not available")
+	}
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	cmd := exec.Command("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-C", "test", "-f", keyPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("ssh-keygen could not generate a key: %v\n%s", err, out)
+	}
+	pub, err := os.ReadFile(keyPath + ".pub")
+	if err != nil {
+		t.Fatalf("reading generated public key: %v", err)
+	}
+	fields := strings.Fields(string(pub))
+	if len(fields) < 2 {
+		t.Fatalf("unexpected public key format %q", pub)
+	}
+	return host + " " + fields[0] + " " + fields[1] + "\n"
+}
+
+func TestSSHHostKeyIsPinned(t *testing.T) {
+	const host = "modules.example"
+	pinned := writeKnownHosts(t, knownHostsLineFor(t, host))
+	empty := writeKnownHosts(t, "")
+
+	if !sshHostKeyIsPinned(context.Background(), host, []string{pinned}) {
+		t.Fatal("expected host key to be reported as pinned")
+	}
+	if sshHostKeyIsPinned(context.Background(), host, []string{empty}) {
+		t.Fatal("expected empty known_hosts to report no pinned key")
+	}
+	if sshHostKeyIsPinned(context.Background(), "other.example", []string{pinned}) {
+		t.Fatal("expected a different host to report no pinned key")
+	}
+}
+
+func TestCheckSSHHostKeyPinnedUsesEnvOverride(t *testing.T) {
+	const host = "modules.example"
+	t.Setenv(knownHostsEnvVar, writeKnownHosts(t, knownHostsLineFor(t, host)))
+	if err := checkSSHHostKeyPinned(context.Background(), host); err != nil {
+		t.Fatalf("expected pinned host to be accepted: %v", err)
+	}
+
+	t.Setenv(knownHostsEnvVar, writeKnownHosts(t, ""))
+	if err := checkSSHHostKeyPinned(context.Background(), host); err == nil {
+		t.Fatal("expected unpinned host to be rejected")
+	}
+}
+
+func TestGitSSHCommandHardening(t *testing.T) {
+	knownHosts := writeKnownHosts(t, "")
+	command, err := gitSSHCommand("modules.example", []string{knownHosts})
+	if err != nil {
+		t.Fatalf("building ssh command: %v", err)
+	}
+	for _, want := range []string{
+		"'-F' '" + os.DevNull + "'",
+		"'StrictHostKeyChecking=yes'",
+		"'HostKeyAlias=modules.example'",
+		"'ProxyCommand=none'",
+		"'ProxyJump=none'",
+		"'BatchMode=yes'",
+		knownHosts,
+	} {
+		if !strings.Contains(command, want) {
+			t.Errorf("ssh command %q is missing %q", command, want)
+		}
+	}
+}
+
+func TestGitSSHCommandRejectsUnquotablePath(t *testing.T) {
+	if _, err := gitSSHCommand("modules.example", []string{"/tmp/known'hosts"}); err == nil {
+		t.Fatal("expected a path containing a quote to be rejected")
+	}
+}
+
+func TestPinnedSSHRemote(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		addr string
+		want string
+	}{
+		{
+			name: "ipv4 keeps user and path",
+			in:   "ssh://git@github.com/org/repo.git",
+			addr: "140.82.121.4",
+			want: "ssh://git@140.82.121.4/org/repo.git",
+		},
+		{
+			name: "ipv6 is bracketed",
+			in:   "ssh://git@github.com/org/repo.git",
+			addr: "2606:50c0:8000::153",
+			want: "ssh://git@[2606:50c0:8000::153]/org/repo.git",
+		},
+		{
+			name: "explicit port is preserved",
+			in:   "ssh://git@github.com:2222/org/repo.git",
+			addr: "140.82.121.4",
+			want: "ssh://git@140.82.121.4:2222/org/repo.git",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := url.Parse(tc.in)
+			if err != nil {
+				t.Fatalf("parsing %q: %v", tc.in, err)
+			}
+			got := pinnedSSHRemote(parsed, netip.MustParseAddr(tc.addr))
+			if got != tc.want {
+				t.Fatalf("pinnedSSHRemote() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSSHGitCommandEnvKeepsAgentAndBlocksRedirection(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "/tmp/agent.sock")
+	t.Setenv("SSH_ASKPASS", "/tmp/askpass")
+	t.Setenv("GIT_SSH_COMMAND", "ssh -o ProxyCommand=attacker")
+	t.Setenv("GIT_CONFIG_GLOBAL", "/tmp/attacker-config")
+	t.Setenv("HTTPS_PROXY", "http://attacker.example")
+
+	env := sshGitCommandEnv("ssh -o StrictHostKeyChecking=yes")
+	values := make(map[string]string, len(env))
+	for _, variable := range env {
+		name, value, _ := strings.Cut(variable, "=")
+		values[name] = value
+	}
+
+	if values["SSH_AUTH_SOCK"] != "/tmp/agent.sock" {
+		t.Error("expected SSH_AUTH_SOCK to be preserved for agent authentication")
+	}
+	if _, ok := values["SSH_ASKPASS"]; ok {
+		t.Error("expected SSH_ASKPASS to be dropped")
+	}
+	if _, ok := values["HTTPS_PROXY"]; ok {
+		t.Error("expected inherited proxy settings to be dropped")
+	}
+	if values["GIT_SSH_COMMAND"] != "ssh -o StrictHostKeyChecking=yes" {
+		t.Errorf("expected the inherited GIT_SSH_COMMAND to be replaced, got %q", values["GIT_SSH_COMMAND"])
+	}
+	if values["GIT_CONFIG_GLOBAL"] != os.DevNull {
+		t.Errorf("expected global git config to be neutralized, got %q", values["GIT_CONFIG_GLOBAL"])
+	}
+	if values["GIT_CONFIG_NOSYSTEM"] != "1" {
+		t.Error("expected system git config to be disabled")
+	}
+	if values["GIT_ALLOW_PROTOCOL"] != sshScheme {
+		t.Errorf("expected only ssh to be allowed, got %q", values["GIT_ALLOW_PROTOCOL"])
+	}
+	if values["GIT_TERMINAL_PROMPT"] != "0" {
+		t.Error("expected terminal prompts to be disabled")
+	}
+}
+
+func TestRunGitSSHCommandRejectsPrivateAddress(t *testing.T) {
+	const host = "modules.example"
+	t.Setenv(knownHostsEnvVar, writeKnownHosts(t, knownHostsLineFor(t, host)))
+
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("169.254.169.254")}, nil
+	}
+
+	ran := false
+	_, err := runGitSSHCommand(
+		context.Background(),
+		policy,
+		"ssh://git@"+host+"/org/repo.git",
+		func(string, []string) *exec.Cmd {
+			ran = true
+			return exec.Command("true")
+		},
+		gitCombinedOutput,
+	)
+	if err == nil || !strings.Contains(err.Error(), "not a public unicast destination") {
+		t.Fatalf("expected private destination rejection, got %v", err)
+	}
+	if ran {
+		t.Fatal("expected no git command to run for a rejected destination")
+	}
+}
+
+func TestRunGitSSHCommandPinsValidatedAddress(t *testing.T) {
+	const host = "modules.example"
+	t.Setenv(knownHostsEnvVar, writeKnownHosts(t, knownHostsLineFor(t, host)))
+
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("140.82.121.4")}, nil
+	}
+
+	var remotes []string
+	if _, err := runGitSSHCommand(
+		context.Background(),
+		policy,
+		"ssh://git@"+host+"/org/repo.git",
+		func(remote string, extraConfig []string) *exec.Cmd {
+			remotes = append(remotes, remote)
+			if len(extraConfig) != 0 {
+				t.Errorf("expected no proxy config for ssh, got %v", extraConfig)
+			}
+			return exec.Command("true")
+		},
+		gitCombinedOutput,
+	); err != nil {
+		t.Fatalf("running pinned ssh command: %v", err)
+	}
+
+	if len(remotes) != 1 {
+		t.Fatalf("expected one attempt, got %v", remotes)
+	}
+	if remotes[0] != "ssh://git@140.82.121.4/org/repo.git" {
+		t.Fatalf("expected the validated address to be pinned, got %q", remotes[0])
+	}
+	if strings.Contains(remotes[0], host) {
+		t.Error("expected the hostname to be replaced so ssh cannot re-resolve it")
+	}
+}
+
+func TestRunGitSSHCommandRequiresPinnedHostKey(t *testing.T) {
+	t.Setenv(knownHostsEnvVar, writeKnownHosts(t, ""))
+	policy := newHTTPDestinationPolicy(nil)
+
+	ran := false
+	_, err := runGitSSHCommand(
+		context.Background(),
+		policy,
+		"ssh://git@modules.example/org/repo.git",
+		func(string, []string) *exec.Cmd {
+			ran = true
+			return exec.Command("true")
+		},
+		gitCombinedOutput,
+	)
+	if err == nil || !strings.Contains(err.Error(), "is not pinned in known_hosts") {
+		t.Fatalf("expected unpinned host key rejection, got %v", err)
+	}
+	if ran {
+		t.Fatal("expected no git command to run without a pinned host key")
+	}
+}

--- a/pkg/parser/terraform/modules/resolver/git_ssh_transport_test.go
+++ b/pkg/parser/terraform/modules/resolver/git_ssh_transport_test.go
@@ -66,6 +66,45 @@ func TestSSHHostKeyIsPinned(t *testing.T) {
 	}
 }
 
+func TestSSHHostKeyName(t *testing.T) {
+	cases := []struct {
+		host, port, want string
+	}{
+		{host: "modules.example", port: "", want: "modules.example"},
+		{host: "modules.example", port: "22", want: "modules.example"},
+		{host: "modules.example", port: "2222", want: "[modules.example]:2222"},
+		{host: "::1", port: "2222", want: "[::1]:2222"},
+	}
+	for _, tc := range cases {
+		if got := sshHostKeyName(tc.host, tc.port); got != tc.want {
+			t.Errorf("sshHostKeyName(%q, %q) = %q, want %q", tc.host, tc.port, got, tc.want)
+		}
+	}
+}
+
+func TestCheckSSHHostKeyPinnedCustomPort(t *testing.T) {
+	const host = "modules.example"
+	lookup := sshHostKeyName(host, "2222")
+	t.Setenv(knownHostsEnvVar, writeKnownHosts(t, knownHostsLineFor(t, lookup)))
+	if err := checkSSHHostKeyPinned(context.Background(), lookup); err != nil {
+		t.Fatalf("expected [host]:port entry to pin the custom-port remote: %v", err)
+	}
+	if err := checkSSHHostKeyPinned(context.Background(), host); err == nil {
+		t.Fatal("a default-port lookup must not match a [host]:port known_hosts entry")
+	}
+}
+
+func TestGitSSHCommandUsesPortHostKeyAlias(t *testing.T) {
+	knownHosts := writeKnownHosts(t, "")
+	command, err := gitSSHCommand("[modules.example]:2222", []string{knownHosts})
+	if err != nil {
+		t.Fatalf("building ssh command: %v", err)
+	}
+	if !strings.Contains(command, "'HostKeyAlias=[modules.example]:2222'") {
+		t.Fatalf("ssh command %q is missing the custom-port HostKeyAlias", command)
+	}
+}
+
 func TestCheckSSHHostKeyPinnedUsesEnvOverride(t *testing.T) {
 	const host = "modules.example"
 	t.Setenv(knownHostsEnvVar, writeKnownHosts(t, knownHostsLineFor(t, host)))

--- a/pkg/parser/terraform/modules/resolver/git_transport.go
+++ b/pkg/parser/terraform/modules/resolver/git_transport.go
@@ -28,12 +28,6 @@ func gitCombinedOutput(cmd *exec.Cmd) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
-// gitStdoutOnly keeps stderr out of the result so binary output, such as a tar stream,
-// is not corrupted by progress or warning messages.
-func gitStdoutOnly(cmd *exec.Cmd) ([]byte, error) {
-	return cmd.Output()
-}
-
 // gitInheritedEnvBlockedPrefixes lists environment prefixes that let the caller
 // redirect a git subprocess to an unvalidated destination.
 var gitInheritedEnvBlockedPrefixes = []string{

--- a/pkg/parser/terraform/modules/resolver/git_transport.go
+++ b/pkg/parser/terraform/modules/resolver/git_transport.go
@@ -1,0 +1,87 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+)
+
+const sshScheme = "ssh"
+
+// gitNetworkCommand builds a git command that contacts remote. extraConfig carries
+// ready-to-use "-c key=value" argument pairs that the transport needs, and remote is
+// the destination the transport has already validated and pinned.
+type gitNetworkCommand func(remote string, extraConfig []string) *exec.Cmd
+
+// gitOutputFunc captures the output of a git command built by a gitNetworkCommand.
+type gitOutputFunc func(cmd *exec.Cmd) ([]byte, error)
+
+// gitCombinedOutput folds stderr into the result, which suits commands whose output is
+// only ever read for diagnostics.
+func gitCombinedOutput(cmd *exec.Cmd) ([]byte, error) {
+	return cmd.CombinedOutput()
+}
+
+// gitStdoutOnly keeps stderr out of the result so binary output, such as a tar stream,
+// is not corrupted by progress or warning messages.
+func gitStdoutOnly(cmd *exec.Cmd) ([]byte, error) {
+	return cmd.Output()
+}
+
+// gitInheritedEnvBlockedPrefixes lists environment prefixes that let the caller
+// redirect a git subprocess to an unvalidated destination.
+var gitInheritedEnvBlockedPrefixes = []string{
+	"GIT_",
+	"SSH_",
+	"HTTP_PROXY=",
+	"HTTPS_PROXY=",
+	"ALL_PROXY=",
+	"NO_PROXY=",
+	"http_proxy=",
+	"https_proxy=",
+	"all_proxy=",
+	"no_proxy=",
+}
+
+// gitBaseEnv returns the parent environment with redirection-capable variables
+// removed. Variables named in keep survive even when they match a blocked prefix.
+func gitBaseEnv(keep ...string) []string {
+	environ := os.Environ()
+	env := make([]string, 0, len(environ))
+	for _, variable := range environ {
+		name, _, _ := strings.Cut(variable, "=")
+		if slices.Contains(keep, name) {
+			env = append(env, variable)
+			continue
+		}
+		blocked := false
+		for _, prefix := range gitInheritedEnvBlockedPrefixes {
+			if strings.HasPrefix(variable, prefix) {
+				blocked = true
+				break
+			}
+		}
+		if !blocked {
+			env = append(env, variable)
+		}
+	}
+	return env
+}
+
+// gitHardenedConfigEnv neutralizes system and global git configuration. Without it a
+// url.<base>.insteadOf rule would rewrite the destination after the policy validated
+// it, and a credential prompt would block the scan waiting on a terminal.
+func gitHardenedConfigEnv(allowedProtocol string) []string {
+	return []string{
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL=" + os.DevNull,
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_ALLOW_PROTOCOL=" + allowedProtocol,
+	}
+}

--- a/pkg/parser/terraform/modules/resolver/gitexec.go
+++ b/pkg/parser/terraform/modules/resolver/gitexec.go
@@ -84,6 +84,13 @@ func gitInWorktree(ctx context.Context, root string, args ...string) *exec.Cmd {
 	return exec.CommandContext(ctx, "git", cmdArgs...) //nolint:gosec
 }
 
-func gitCloneBare(ctx context.Context, remoteURL, dest string) *exec.Cmd {
-	return exec.CommandContext(ctx, "git", "clone", "--bare", "--filter=blob:none", remoteURL, gitSafePath(dest)) //nolint:gosec
+// cloneBareArgCount counts the fixed arguments appended after extraConfig:
+// clone, --bare, --filter, the remote and the destination.
+const cloneBareArgCount = 5
+
+func gitCloneBare(ctx context.Context, remoteURL, dest string, extraConfig []string) *exec.Cmd {
+	args := make([]string, 0, len(extraConfig)+cloneBareArgCount)
+	args = append(args, extraConfig...)
+	args = append(args, "clone", "--bare", "--filter=blob:none", remoteURL, gitSafePath(dest))
+	return exec.CommandContext(ctx, "git", args...) //nolint:gosec
 }

--- a/pkg/parser/terraform/modules/resolver/gogetter.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter.go
@@ -79,7 +79,10 @@ type GoGetterConfig struct {
 	HostAllowlist []string
 	Cache         *moduleCache
 	RegistryCache *registryCache
-	httpClient    *http.Client
+	// Git resolves pinnable git:: download URLs (registry X-Terraform-Get and
+	// default-branch sources) through BareGit instead of an unpinned git subprocess.
+	Git        Resolver
+	httpClient *http.Client
 
 	TmpDir string
 
@@ -126,7 +129,7 @@ func (r *GoGetterResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedMod
 	if mod.IsLocal {
 		return Resolution{}, &tfmodules.UnresolvedError{Reason: "local modules are handled by LocalResolver"}
 	}
-	// BareGit owns git:: sources with ref=. Falling through after a BareGit failure
+	// BareGit owns pinnable git:: sources. Falling through after a BareGit failure
 	// would trigger a full working-tree clone of the entire repository per module.
 	if bareGitOwnsSource(mod.Source) {
 		return Resolution{}, &tfmodules.UnresolvedError{
@@ -185,6 +188,17 @@ func (r *GoGetterResolver) fetchAndCommit(
 	}
 	if selectedSubdir == "" && sourceType == sourceTypeRegistry {
 		selectedSubdir = registrySubdir(mod.Source)
+	}
+	if gitMod, ok := pinnableGitModuleFromGetterSource(packageSource, selectedSubdir); ok {
+		if r.cfg.Git == nil {
+			return Resolution{}, &tfmodules.UnresolvedError{
+				Reason: "pinned git download must be resolved by BareGitResolver",
+			}
+		}
+		if err := r.checkAllowlist(packageSource); err != nil {
+			return Resolution{}, err
+		}
+		return r.cfg.Git.Resolve(ctx, gitMod)
 	}
 	if err := validateGetterSourceTransport(packageSource); err != nil {
 		return Resolution{}, err

--- a/pkg/parser/terraform/modules/resolver/gogetter.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter.go
@@ -35,6 +35,7 @@ const (
 	mib                   = 1024 * 1024
 
 	sourceTypeRegistry = "registry"
+	sourceTypeGit      = "git"
 
 	defaultFetchConcurrency = 32 // network-bound; override via IAC_MODULE_FETCH_CONCURRENCY
 )
@@ -184,6 +185,9 @@ func (r *GoGetterResolver) fetchAndCommit(
 	}
 	if selectedSubdir == "" && sourceType == sourceTypeRegistry {
 		selectedSubdir = registrySubdir(mod.Source)
+	}
+	if err := validateGetterSourceTransport(packageSource); err != nil {
+		return Resolution{}, err
 	}
 	if err := r.checkAllowlist(packageSource); err != nil {
 		return Resolution{}, err
@@ -527,11 +531,9 @@ func (r *GoGetterResolver) fetchOnce(ctx context.Context, getterSrc string) (str
 }
 
 func (r *GoGetterResolver) getters(source string) map[string]getter.Getter {
-	getters := make(map[string]getter.Getter, len(getter.Getters))
+	getters := make(map[string]getter.Getter)
 	if !isHTTPGetterSource(source) {
-		for scheme, protocolGetter := range getter.Getters {
-			getters[scheme] = protocolGetter
-		}
+		getters["file"] = getter.Getters["file"]
 	}
 	httpGetter := &getter.HttpGetter{
 		Netrc:              true,
@@ -541,6 +543,40 @@ func (r *GoGetterResolver) getters(source string) map[string]getter.Getter {
 	getters["http"] = httpGetter
 	getters["https"] = httpGetter
 	return getters
+}
+
+func validateGetterSourceTransport(source string) error {
+	forced := ""
+	if value, rest, ok := strings.Cut(source, "::"); ok {
+		forced = strings.ToLower(value)
+		source = rest
+	}
+	parsed, err := url.Parse(source)
+	if err != nil {
+		return &tfmodules.UnresolvedError{Reason: "invalid module source transport: " + err.Error()}
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if forced == sourceTypeGit {
+		return &tfmodules.UnresolvedError{
+			Reason: fmt.Sprintf(
+				"network git transport %q is disabled unless it is pinned by BareGitResolver, which requires a ref=",
+				scheme,
+			),
+		}
+	}
+	if forced != "" {
+		scheme = forced
+	}
+	switch scheme {
+	case httpScheme, httpsScheme, "file":
+		return nil
+	case "ssh", "git", "s3", "gcs", "hg":
+		return &tfmodules.UnresolvedError{
+			Reason: fmt.Sprintf("module transport %q is disabled because destination policy cannot be enforced", scheme),
+		}
+	default:
+		return &tfmodules.UnresolvedError{Reason: fmt.Sprintf("module transport %q is not supported", scheme)}
+	}
 }
 
 func isHTTPGetterSource(source string) bool {

--- a/pkg/parser/terraform/modules/resolver/gogetter_test.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter_test.go
@@ -315,3 +315,43 @@ func TestGoGetterResolveCoalescesConcurrentFetches(t *testing.T) {
 		t.Fatalf("expected exactly 1 fetch for %d concurrent identical resolves, got %d", n, got)
 	}
 }
+
+type stubGitResolver struct {
+	last *tfmodules.ParsedModule
+	res  Resolution
+}
+
+func (s *stubGitResolver) Resolve(_ context.Context, mod *tfmodules.ParsedModule) (Resolution, error) {
+	s.last = mod
+	return s.res, nil
+}
+
+func TestFetchAndCommitDelegatesPinnableGit(t *testing.T) {
+	stub := &stubGitResolver{
+		res: Resolution{LocalPath: "/tmp/mod", PackageRoot: "/tmp/mod"},
+	}
+	cfg := NewGoGetterConfig()
+	cfg.Git = stub
+	r := NewGoGetterResolver(cfg)
+
+	mod := &tfmodules.ParsedModule{Source: "git::https://github.com/org/repo.git"}
+	res, err := r.fetchAndCommit(context.Background(), sourceTypeGit, mod, "", "", false)
+	if err != nil {
+		t.Fatalf("fetchAndCommit: %v", err)
+	}
+	if res.LocalPath != stub.res.LocalPath {
+		t.Fatalf("LocalPath = %q, want delegated result", res.LocalPath)
+	}
+	if stub.last == nil || stub.last.Source != "git::https://github.com/org/repo.git?ref=HEAD" {
+		t.Fatalf("delegated source = %v, want git::https with ref=HEAD", stub.last)
+	}
+
+	mod = &tfmodules.ParsedModule{Source: "git::https://github.com/terraform-aws-modules/terraform-aws-vpc?ref=abc123"}
+	_, err = r.fetchAndCommit(context.Background(), sourceTypeGit, mod, "", "modules/vpc", false)
+	if err != nil {
+		t.Fatalf("fetchAndCommit registry-style: %v", err)
+	}
+	if stub.last.Source != "git::https://github.com/terraform-aws-modules/terraform-aws-vpc//modules/vpc?ref=abc123" {
+		t.Fatalf("delegated source = %q", stub.last.Source)
+	}
+}

--- a/pkg/parser/terraform/modules/resolver/gogetter_test.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter_test.go
@@ -6,14 +6,14 @@
 package resolver
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -127,6 +127,37 @@ func TestGetterSourceForPreservesHTTPSGit(t *testing.T) {
 	}
 }
 
+func TestGoGetterDisablesUnpinnedNetworkTransports(t *testing.T) {
+	r := NewGoGetterResolver(NewGoGetterConfig())
+	for _, scheme := range []string{"s3", "gcs", "hg"} {
+		if _, ok := r.getters(scheme + "::https://modules.example/package")[scheme]; ok {
+			t.Fatalf("getter %q must be disabled", scheme)
+		}
+	}
+
+	tests := []struct {
+		source string
+		want   string
+	}{
+		{"s3::https://s3.amazonaws.com/bucket/module", `module transport "s3" is disabled`},
+		{"gcs::https://www.googleapis.com/storage/v1/bucket/module", `module transport "gcs" is disabled`},
+		{"hg::https://modules.example/repository", `module transport "hg" is disabled`},
+		{"git::ssh://git@modules.example/repository", `network git transport "ssh" is disabled`},
+		{"git::https://modules.example/repository", `network git transport "https" is disabled`},
+	}
+	for _, test := range tests {
+		t.Run(test.source, func(t *testing.T) {
+			err := validateGetterSourceTransport(test.source)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("expected %q, got %v", test.want, err)
+			}
+		})
+	}
+	if err := validateGetterSourceTransport("git::file:///tmp/repository"); err == nil {
+		t.Fatal("git subprocess transport must be disabled even for file sources")
+	}
+}
+
 func TestCacheableModuleRegistrySubdir(t *testing.T) {
 	if !cacheableModule("terraform-aws-modules/eks/aws//modules/karpenter", "1.0.0") {
 		t.Fatal("expected pinned registry subdir module to be cacheable")
@@ -215,31 +246,45 @@ func TestAcquireHostSlotCapsConcurrencyPerHost(t *testing.T) {
 }
 
 func TestGoGetterResolveCoalescesConcurrentFetches(t *testing.T) {
-	repo := t.TempDir()
+	var moduleArchive bytes.Buffer
+	zipWriter := zip.NewWriter(&moduleArchive)
 	for i := 0; i < 5; i++ {
-		f := filepath.Join(repo, fmt.Sprintf("m%d.tf", i))
-		if err := os.WriteFile(f, []byte(fmt.Sprintf("resource \"r\" \"n%d\" {}\n", i)), 0o644); err != nil {
-			t.Fatalf("write tf: %v", err)
+		file, err := zipWriter.Create(fmt.Sprintf("m%d.tf", i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := file.Write([]byte(fmt.Sprintf("resource \"r\" \"n%d\" {}\n", i))); err != nil {
+			t.Fatal(err)
 		}
 	}
-	runGit(t, repo, "init")
-	runGit(t, repo, "add", ".")
-	runGit(t, repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init")
-	sha := runGit(t, repo, "rev-parse", "HEAD")
+	if err := zipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(moduleArchive.Bytes())
+	}))
+	defer server.Close()
+	_, port, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	policy.dial = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
+	}
 
 	cacheRoot := t.TempDir()
 	cfg := NewGoGetterConfig()
 	cfg.Cache = &moduleCache{dir: cacheRoot}
 	cfg.TmpDir = t.TempDir()
+	cfg.httpClient = newPolicyHTTPClientWithPolicy(time.Second, policy)
 	r := NewGoGetterResolver(cfg)
 
-	// Build a valid file URL: forward slashes required, and Windows absolute
-	// paths need a leading "/" before the drive letter (file:///C:/...).
-	slashPath := filepath.ToSlash(repo)
-	if !strings.HasPrefix(slashPath, "/") {
-		slashPath = "/" + slashPath
-	}
-	source := fmt.Sprintf("git::file://%s?ref=%s", slashPath, sha)
+	source := "http://modules.example:" + port + "/module.zip?ref=" + strings.Repeat("a", gitSHALength)
 	if !cacheableModule(source, "") {
 		t.Fatalf("test setup: source %q is not cacheable", source)
 	}

--- a/pkg/parser/terraform/modules/resolver/localref.go
+++ b/pkg/parser/terraform/modules/resolver/localref.go
@@ -247,7 +247,10 @@ func (r *LocalGitRefResolver) Resolve(ctx context.Context, mod *tfmodules.Parsed
 
 	key := archiveCacheKey(sha) + "\x00" + filepath.Clean(subdir)
 	_, err, _ := r.extractSF.Do(key, func() (interface{}, error) {
-		return nil, archiveExtract(ctx, info.gitDir, info.extractBase, sha, subdir)
+		return nil, archiveExtract(
+			ctx, info.gitDir, info.extractBase, sha, subdir,
+			localCloneArchiveCommand(info.gitDir),
+		)
 	})
 	if err != nil {
 		contextLogger.Warn().Err(err).Msgf("LocalGitRefResolver: archive %s:%s failed", sha, subdir)

--- a/pkg/parser/terraform/modules/resolver/localref_test.go
+++ b/pkg/parser/terraform/modules/resolver/localref_test.go
@@ -99,8 +99,10 @@ func TestArchiveExtractMaterializesLocalModuleClosure(t *testing.T) {
 	sha := runGit(t, workTree, "rev-parse", "HEAD")
 	extractBase := t.TempDir()
 
+	gitDir := filepath.Join(workTree, ".git")
 	if err := archiveExtract(
-		t.Context(), filepath.Join(workTree, ".git"), extractBase, sha, "modules/selected",
+		t.Context(), gitDir, extractBase, sha, "modules/selected",
+		localCloneArchiveCommand(gitDir),
 	); err != nil {
 		t.Fatalf("archiveExtract: %v", err)
 	}

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -119,13 +119,6 @@ func (c *Client) buildModuleResolverChain(ctx context.Context, moduleDiscoveryPa
 		}
 	}
 
-	if c.ScanParams.EnableRemoteModules {
-		resolvers = append(resolvers,
-			tfresolver.NewLocalGitRefResolver(dotTerraformRootDirs(moduleDiscoveryPaths), ""),
-			tfresolver.NewBareGitResolver("", c.ScanParams.RemoteModulesHostAllowlist...),
-		)
-	}
-
 	ggCfg := tfresolver.NewGoGetterConfig()
 	ggCfg.Disabled = !c.ScanParams.EnableRemoteModules
 	if t := c.ScanParams.ModuleFetchTimeout; t > 0 {
@@ -133,6 +126,15 @@ func (c *Client) buildModuleResolverChain(ctx context.Context, moduleDiscoveryPa
 	}
 	ggCfg.MaxTotalBytes = c.ScanParams.MaxModuleBytesTotal
 	ggCfg.HostAllowlist = c.ScanParams.RemoteModulesHostAllowlist
+
+	if c.ScanParams.EnableRemoteModules {
+		git := tfresolver.NewBareGitResolver("", c.ScanParams.RemoteModulesHostAllowlist...)
+		ggCfg.Git = git
+		resolvers = append(resolvers,
+			tfresolver.NewLocalGitRefResolver(dotTerraformRootDirs(moduleDiscoveryPaths), ""),
+			git,
+		)
+	}
 
 	if !ggCfg.Disabled {
 		cache, err := tfresolver.NewModuleCache()


### PR DESCRIPTION
## Motivation

Remote module fetching still had network paths that could bypass the [ticket-2 HTTP destination policy](https://github.com/DataDog/datadog-iac-scanner/pull/309): subprocess git cloned over SSH or raw HTTPS, and go-getter exposed S3, GCS, Mercurium, and network git transports without equivalent validation.

Related ticket: [K9CODESEC-5291](https://datadoghq.atlassian.net/browse/K9CODESEC-5291)

## Changes

**HTTPS git transport**

BareGit now keeps `git::https://` sources on HTTPS and routes clone/fetch subprocesses through a local CONNECT proxy backed by the existing destination policy and IP pinning. Git environment overrides are stripped, cached bare repos with unsafe local config are rejected, and embedded credentials in module URLs are refused.

**Disabled unsafe transports**

SSH git, go-getter network git, S3, GCS, and Mercurial transports are rejected with explicit resolution errors because they cannot enforce the same connection-time policy today.

**Tests**

Added SSRF, DNS pinning, proxy lifecycle, transport rejection, and cached-config regression coverage for the new paths.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test -race ./pkg/parser/terraform/modules/resolver ./pkg/scan -count=1`
2. Confirm `git::https://...?ref=...` modules still resolve when the host is public and allowed.
3. Confirm `git::ssh://...`, `s3::...`, and `gcs::...` sources fail with explicit transport-disabled errors.

## Blast Radius

This PR only affects remote Terraform module fetching when `--x-remote-modules` is enabled. Public HTTPS git modules continue to work through the policy proxy; SSH, S3, GCS, and unpinned network git transports are now blocked instead of silently bypassing the security boundary.

## Additional Notes

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-5291]: https://datadoghq.atlassian.net/browse/K9CODESEC-5291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ