### PR TITLE
[K9CODESEC-4966] Recompute YAML ignore comments after reference resolution

### DIFF
--- a/pkg/model/comment_yaml.go
+++ b/pkg/model/comment_yaml.go
@@ -61,7 +61,11 @@ func processCommentYAML(comment *comment, position int, content *yaml.Node, kind
 	case IgnoreLine:
 		linesIgnore = append(linesIgnore, processLine(kind, content, position)...)
 	case IgnoreBlock:
-		linesIgnore = append(linesIgnore, processBlock(kind, content.Content, position)...)
+		if kind == yaml.ScalarNode {
+			linesIgnore = append(linesIgnore, processLine(kind, content, position)...)
+		} else {
+			linesIgnore = append(linesIgnore, processBlock(kind, content.Content, position)...)
+		}
 	default:
 		linesIgnore = append(linesIgnore, processRegularLine(string(*comment), content, position, isFooter)...)
 	}
@@ -157,6 +161,13 @@ func processBlock(kind yaml.Kind, content []*yaml.Node, position int) (linesIgno
 		contentToIgnore = content
 	} else {
 		contentToIgnore = content[position+1].Content
+	}
+
+	if len(contentToIgnore) == 0 {
+		if len(content) > position {
+			linesIgnore = append(linesIgnore, content[position].Line, content[position].Line-1)
+		}
+		return linesIgnore
 	}
 
 	linesIgnore = append(linesIgnore, content[position].Line, content[position].Line-1)

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -85,22 +85,36 @@ func GetIgnoreLines(file *FileMetadata) []int {
 
 	ignore := &Ignore{}
 	dec := yaml.NewDecoder(bytes.NewReader([]byte(file.OriginalData)))
-	ctx := context.Background()
 	found := false
 	for {
 		var node yaml.Node
 		if err := dec.Decode(&node); err != nil {
 			break
 		}
-		if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
-			_ = unmarshal(ctx, node.Content[0], ignore)
-			found = true
-		}
+		walkIgnoreCommentsYAML(&node, ignore)
+		found = true
 	}
 	if found {
 		return ignore.GetLines()
 	}
 	return ignoreLines
+}
+
+func walkIgnoreCommentsYAML(node *yaml.Node, ignore *Ignore) {
+	if node == nil {
+		return
+	}
+	ignore.ignoreCommentsYAML(node)
+	switch node.Kind {
+	case yaml.DocumentNode, yaml.MappingNode, yaml.SequenceNode:
+		for _, child := range node.Content {
+			walkIgnoreCommentsYAML(child, ignore)
+		}
+	case yaml.AliasNode:
+		if node.Alias != nil {
+			walkIgnoreCommentsYAML(node.Alias, ignore)
+		}
+	}
 }
 
 // UnmarshalYAML is a custom yaml parser that places line information in the payload

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -91,7 +91,7 @@ func GetIgnoreLines(file *FileMetadata) []int {
 		if err := dec.Decode(&node); err != nil {
 			break
 		}
-		walkIgnoreCommentsYAML(&node, ignore)
+		walkIgnoreCommentsYAML(&node, ignore, make(map[*yaml.Node]bool))
 		found = true
 	}
 	if found {
@@ -100,19 +100,25 @@ func GetIgnoreLines(file *FileMetadata) []int {
 	return ignoreLines
 }
 
-func walkIgnoreCommentsYAML(node *yaml.Node, ignore *Ignore) {
+func walkIgnoreCommentsYAML(node *yaml.Node, ignore *Ignore, visited map[*yaml.Node]bool) {
 	if node == nil {
 		return
 	}
+	if visited[node] {
+		return
+	}
+	visited[node] = true
+	defer delete(visited, node)
+
 	ignore.ignoreCommentsYAML(node)
 	switch node.Kind {
 	case yaml.DocumentNode, yaml.MappingNode, yaml.SequenceNode:
 		for _, child := range node.Content {
-			walkIgnoreCommentsYAML(child, ignore)
+			walkIgnoreCommentsYAML(child, ignore, visited)
 		}
 	case yaml.AliasNode:
 		if node.Alias != nil {
-			walkIgnoreCommentsYAML(node.Alias, ignore)
+			walkIgnoreCommentsYAML(node.Alias, ignore, visited)
 		}
 	}
 }

--- a/pkg/model/model_yaml.go
+++ b/pkg/model/model_yaml.go
@@ -6,10 +6,12 @@
 package model
 
 import (
+	"bytes"
 	"context"
 	json "encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
@@ -72,6 +74,33 @@ func isCloudFormationDocument(value *yaml.Node) bool {
 		}
 	}
 	return hasResources
+}
+
+// GetIgnoreLines recomputes YAML ignore comments from OriginalData after reference resolution shifted line numbers.
+func GetIgnoreLines(file *FileMetadata) []int {
+	ignoreLines := file.LinesIgnore
+	if !utils.Contains(filepath.Ext(file.FilePath), []string{".yml", ".yaml"}) {
+		return ignoreLines
+	}
+
+	ignore := &Ignore{}
+	dec := yaml.NewDecoder(bytes.NewReader([]byte(file.OriginalData)))
+	ctx := context.Background()
+	found := false
+	for {
+		var node yaml.Node
+		if err := dec.Decode(&node); err != nil {
+			break
+		}
+		if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+			_ = unmarshal(ctx, node.Content[0], ignore)
+			found = true
+		}
+	}
+	if found {
+		return ignore.GetLines()
+	}
+	return ignoreLines
 }
 
 // UnmarshalYAML is a custom yaml parser that places line information in the payload

--- a/pkg/model/model_yaml_test.go
+++ b/pkg/model/model_yaml_test.go
@@ -1169,3 +1169,31 @@ enabled: true
 	require.Equal(t, 2.5, d["ratio"], "float 2.5")
 	require.Equal(t, true, d["enabled"], "bool true")
 }
+
+func TestGetIgnoreLines_usesOriginalCoordinates(t *testing.T) {
+	original := `include:
+  - included.yaml
+services:
+  foo:
+    image: alpine
+    # dd-iac-scan ignore-line
+    ports:
+      - "1111:1111"
+`
+	got := GetIgnoreLines(&FileMetadata{
+		FilePath:     "docker-compose.yaml",
+		OriginalData: original,
+		LinesIgnore:  []int{12, 13},
+	})
+	require.Equal(t, []int{6, 7}, got)
+}
+
+func TestGetIgnoreLines_leavesNonYAMLUnchanged(t *testing.T) {
+	got := GetIgnoreLines(&FileMetadata{
+		FilePath:     "main.tf",
+		OriginalData: `// dd-iac-scan ignore-line`,
+		LinesIgnore:  []int{4, 5},
+	})
+	require.Equal(t, []int{4, 5}, got)
+}
+

--- a/pkg/model/model_yaml_test.go
+++ b/pkg/model/model_yaml_test.go
@@ -1197,3 +1197,15 @@ func TestGetIgnoreLines_leavesNonYAMLUnchanged(t *testing.T) {
 	require.Equal(t, []int{4, 5}, got)
 }
 
+func TestGetIgnoreLines_scalarReferenceWithIgnoreBlock(t *testing.T) {
+	original := `# dd-iac-scan ignore-block
+./included.yaml
+`
+	got := GetIgnoreLines(&FileMetadata{
+		FilePath:     "ref.yaml",
+		OriginalData: original,
+		LinesIgnore:  []int{99},
+	})
+	require.ElementsMatch(t, []int{1, 2}, got)
+}
+

--- a/pkg/model/model_yaml_test.go
+++ b/pkg/model/model_yaml_test.go
@@ -1209,3 +1209,22 @@ func TestGetIgnoreLines_scalarReferenceWithIgnoreBlock(t *testing.T) {
 	require.ElementsMatch(t, []int{1, 2}, got)
 }
 
+func TestGetIgnoreLines_anchorCycle(t *testing.T) {
+	original := `cycle: &cycle
+  self: *cycle
+include:
+  - included.yaml
+services:
+  foo:
+    # dd-iac-scan ignore-line
+    ports:
+      - "1111:1111"
+`
+	got := GetIgnoreLines(&FileMetadata{
+		FilePath:     "docker-compose.yaml",
+		OriginalData: original,
+		LinesIgnore:  []int{99},
+	})
+	require.Equal(t, []int{7, 8}, got)
+}
+

--- a/pkg/runner/sink.go
+++ b/pkg/runner/sink.go
@@ -76,6 +76,14 @@ func (s *Service) sinkContent(ctx context.Context, filename, scanID string,
 	}
 	s.Tracker.TrackFileFoundCountLines(linesResolved)
 
+	if len(documents.ResolvedFiles) > 0 {
+		documents.IgnoreLines = model.GetIgnoreLines(&model.FileMetadata{
+			FilePath:     filename,
+			OriginalData: documents.Content,
+			LinesIgnore:  documents.IgnoreLines,
+		})
+	}
+
 	fileCommands := s.Parser.CommentsCommands(ctx, filename, *content)
 
 	// Computed once per file and shared (same pointer) across every document's

--- a/pkg/runner/sink_test.go
+++ b/pkg/runner/sink_test.go
@@ -9,8 +9,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/storage"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser"
 	yamlParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/default"
@@ -211,6 +214,59 @@ func TestSink_ParseFailureLogLevel(t *testing.T) {
 			require.Contains(t, logBuf.String(), tt.wantLevel)
 		})
 	}
+}
+
+func TestSink_IgnoreLinesWithResolvedFiles(t *testing.T) {
+	tests := []struct {
+		name              string
+		filePath          string
+		wantIgnoreLines   []int
+		wantResolvedFiles bool
+	}{
+		{
+			name:              "yaml with include keeps ignore lines on original coordinates",
+			filePath:          filepath.Join("..", "..", "test", "fixtures", "resolve_ignore_lines", "docker-compose.yaml"),
+			wantIgnoreLines:   []int{6, 7},
+			wantResolvedFiles: true,
+		},
+		{
+			name:              "yaml without include keeps parser ignore lines",
+			filePath:          filepath.Join("..", "..", "test", "fixtures", "resolve_ignore_lines", "no-include.yaml"),
+			wantIgnoreLines:   []int{4, 5},
+			wantResolvedFiles: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, err := os.ReadFile(tt.filePath)
+			require.NoError(t, err)
+
+			file := sinkFile(t, tt.filePath, content)
+			require.Equal(t, tt.wantResolvedFiles, len(file.ResolvedFiles) > 0)
+			require.Equal(t, tt.wantIgnoreLines, file.LinesIgnore)
+		})
+	}
+}
+
+func sinkFile(t *testing.T, filename string, content []byte) *model.FileMetadata {
+	t.Helper()
+	ctx := context.Background()
+	parsers, err := parser.NewBuilder(ctx).
+		Add(&yamlParser.Parser{}).
+		Build([]string{""}, []string{""})
+	require.NoError(t, err)
+	require.NotEmpty(t, parsers)
+
+	s := &Service{
+		Parser:      parsers[0],
+		Storage:     storage.NewMemoryStorage(),
+		Tracker:     noopTracker{},
+		MaxFileSize: 5,
+	}
+	require.NoError(t, s.sink(ctx, filename, "scanID", bytes.NewReader(content), make([]byte, mbConst), false, 15))
+	require.Len(t, s.files, 1)
+	return s.files[0]
 }
 
 type noopTracker struct{}

--- a/test/fixtures/resolve_ignore_lines/docker-compose.yaml
+++ b/test/fixtures/resolve_ignore_lines/docker-compose.yaml
@@ -1,0 +1,12 @@
+include:
+  - included.yaml
+services:
+  foo:
+    image: alpine
+    # dd-iac-scan ignore-line
+    ports:
+      - "1111:1111"
+  bar:
+    image: alpine
+    ports:
+      - "2222:2222"

--- a/test/fixtures/resolve_ignore_lines/included.yaml
+++ b/test/fixtures/resolve_ignore_lines/included.yaml
@@ -1,0 +1,7 @@
+services:
+  rabbit:
+    image: rabbitmq:3
+    environment:
+      K0: "0"
+      K1: "1"
+      K2: "2"

--- a/test/fixtures/resolve_ignore_lines/no-include.yaml
+++ b/test/fixtures/resolve_ignore_lines/no-include.yaml
@@ -1,0 +1,6 @@
+services:
+  foo:
+    image: alpine
+    # dd-iac-scan ignore-line
+    ports:
+      - "1111:1111"


### PR DESCRIPTION
## Motivation

`dd-iac-scan ignore-line` and `ignore-block` comments in YAML were collected after referenced files were inlined (`include:`, `$ref`, `include_vars`, and similar), so their line numbers no longer matched the original file. Findings are reported on original coordinates, so suppressions could miss the intended line or suppress a different one.

Related ticket: [K9CODESEC-4966](https://datadoghq.atlassian.net/browse/K9CODESEC-4966)

## Changes

**Scan pipeline**

When a YAML file has resolved references, ignore lines are recomputed from the original file content before they are stored on file metadata. Files without resolved references are unchanged.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/model ./pkg/runner -count=1 -run 'TestGetIgnoreLines|TestSink_IgnoreLinesWithResolvedFiles'`
2. Scan a compose file that `include`s another YAML and has `# dd-iac-scan ignore-line` above a finding. Confirm the finding on that original line is suppressed and later unignored lines still report.

## Blast Radius

This PR only changes how YAML in-source ignore comments are mapped when the parser inlines other files. Finding detection itself is unchanged.

## Additional Notes

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-4966]: https://datadoghq.atlassian.net/browse/K9CODESEC-4966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ