### PR TITLE
[K9CODESEC-5288] Enforce streaming module resource budgets

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -128,7 +128,30 @@ var scanAction = &cli.Command{
 			Name:   "x-remote-modules-max-bytes",
 			Hidden: true,
 			Usage:  "(experimental) total download size limit across all remote modules in bytes (default 200MiB)",
-			Value:  200 * 1024 * 1024,
+			Value:  scan.DefaultRemoteModuleMaxTotalBytes,
+		},
+		&cli.Int64Flag{
+			Name:   "x-remote-modules-max-package-bytes",
+			Hidden: true,
+			Usage:  "(experimental) maximum extracted size of one remote module package in bytes (default 128MiB)",
+			Value:  scan.DefaultRemoteModuleMaxPackageBytes,
+		},
+		&cli.Int64Flag{
+			Name:   "x-remote-modules-max-file-bytes",
+			Hidden: true,
+			Usage:  "(experimental) maximum size of one file in a remote module package in bytes (default 5MiB)",
+			Value:  scan.DefaultRemoteModuleMaxFileBytes,
+		},
+		&cli.IntFlag{
+			Name:   "x-remote-modules-max-package-files",
+			Hidden: true,
+			Usage:  "(experimental) maximum number of files in one remote module package (default 10000)",
+			Value:  scan.DefaultRemoteModuleMaxPackageFiles,
+		},
+		&cli.Int64Flag{
+			Name:   "x-remote-modules-max-parse-bytes",
+			Hidden: true,
+			Usage:  "(experimental) target bytes admitted for repository and remote module parsing (default disabled)",
 		},
 		&cli.BoolFlag{
 			Name:   "x-terraform-plan",
@@ -383,6 +406,10 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		ModuleMaxDepth:              c.Int("x-remote-modules-max-depth"),
 		ModuleFetchTimeout:          c.Duration("x-remote-modules-fetch-timeout"),
 		MaxModuleBytesTotal:         c.Int64("x-remote-modules-max-bytes"),
+		MaxModulePackageBytes:       c.Int64("x-remote-modules-max-package-bytes"),
+		MaxModuleFileBytes:          c.Int64("x-remote-modules-max-file-bytes"),
+		MaxModulePackageFiles:       c.Int("x-remote-modules-max-package-files"),
+		MaxModuleParseBytes:         c.Int64("x-remote-modules-max-parse-bytes"),
 	}
 
 	var opts []scan.ClientOption

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/tree-sitter/tree-sitter-bash v0.25.1
+	github.com/ulikunitz/xz v0.5.15
 	github.com/urfave/cli/v3 v3.6.2
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/yargevad/filepathx v1.0.0
@@ -188,7 +189,6 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/valyala/fastjson v1.6.10 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.32 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -245,7 +245,7 @@ require (
 	github.com/hashicorp/go-version v1.8.0
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jung-kurt/gofpdf v1.16.2 // indirect
-	github.com/klauspost/compress v1.18.5 // indirect
+	github.com/klauspost/compress v1.18.5
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect

--- a/pkg/parser/terraform/modules/modulegraph/admission.go
+++ b/pkg/parser/terraform/modules/modulegraph/admission.go
@@ -1,0 +1,379 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package modulegraph
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+)
+
+func moduleAdmissionLimit(request *Request) (maximum, baseline int64, enforce bool) {
+	if request.ResourceLimits.MaxTotalBytes > 0 {
+		maximum = request.ResourceLimits.MaxTotalBytes
+		enforce = true
+	}
+	if request.TotalParseBytes <= 0 {
+		return maximum, 0, enforce
+	}
+	fsys := request.FS
+	if fsys == nil {
+		fsys = vfs.Default()
+	}
+	seen := make(map[string]bool, len(request.BaselinePaths))
+	for _, path := range request.BaselinePaths {
+		clean := filepath.Clean(path)
+		if seen[clean] {
+			continue
+		}
+		seen[clean] = true
+		info, err := fsys.Stat(clean)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		baseline += info.Size()
+	}
+	available := max(int64(0), request.TotalParseBytes-baseline)
+	if !enforce || available < maximum {
+		maximum = available
+	}
+	return maximum, baseline, true
+}
+
+type admissionNode struct {
+	root     string
+	source   string
+	depth    int
+	direct   bool
+	parents  map[string]bool
+	children map[string]bool
+	usage    resolver.PackageUsage
+}
+
+func shedToTotalLimit(
+	snapshot *walkerSnapshot, budget *resolver.ResourceBudget, maximum int64, enforce bool,
+) {
+	if !enforce || budget.TotalUsage().Bytes <= maximum {
+		return
+	}
+	nodes := admissionNodes(snapshot.modules, budget)
+	accepted := make(map[string]bool, len(nodes))
+	for root := range nodes {
+		accepted[root] = true
+	}
+
+	rank := 0
+	currentBytes := admittedBytes(nodes, accepted)
+	hasCycles := admissionGraphHasCycles(nodes)
+	for _, candidate := range sheddingOrder(nodes) {
+		if currentBytes <= maximum {
+			break
+		}
+		if !accepted[candidate] {
+			continue
+		}
+		removed := removeAdmissionSubtree(nodes, accepted, candidate)
+		if hasCycles && removalMayOrphan(nodes, accepted, removed) {
+			removed = append(removed, pruneUnreachableAdmissionNodes(nodes, accepted)...)
+			sortRemovedNodes(nodes, removed, candidate)
+		}
+		measured := currentBytes
+		for _, root := range removed {
+			rank++
+			node := nodes[root]
+			currentBytes -= node.usage.Bytes
+			snapshot.budgetEvents = append(snapshot.budgetEvents, BudgetEvent{
+				Source:       node.source,
+				Gate:         "pre_parse_admission",
+				Limit:        "module_bytes_total",
+				Maximum:      maximum,
+				Measured:     measured,
+				SheddingRank: rank,
+			})
+		}
+	}
+
+	roots := packageRootsBySpecificity(nodes)
+	snapshot.paths = filterPathsByPackages(snapshot.paths, roots, accepted)
+	snapshot.modules = filterModulesByPackages(snapshot.modules, accepted)
+	for localPath := range snapshot.sourceMappings {
+		if !pathOwnedByAcceptedPackage(localPath, roots, accepted) {
+			delete(snapshot.sourceMappings, localPath)
+		}
+	}
+}
+
+func admissionNodes(modules []ResolvedModule, budget *resolver.ResourceBudget) map[string]*admissionNode {
+	nodes := make(map[string]*admissionNode)
+	for i := range modules {
+		module := &modules[i]
+		root := filepath.Clean(module.PackageRoot)
+		node := nodes[root]
+		if node == nil {
+			usage, _ := budget.Usage(root)
+			node = &admissionNode{
+				root:     root,
+				source:   module.CanonicalSource,
+				depth:    module.Depth,
+				parents:  make(map[string]bool),
+				children: make(map[string]bool),
+				usage:    usage,
+			}
+			nodes[root] = node
+		}
+		if module.CanonicalSource < node.source {
+			node.source = module.CanonicalSource
+		}
+		if module.Depth > node.depth {
+			node.depth = module.Depth
+		}
+		parent := filepath.Clean(module.ParentPackageRoot)
+		if module.ParentPackageRoot == "" {
+			node.direct = true
+			continue
+		}
+		node.parents[parent] = true
+	}
+	for root, node := range nodes {
+		for parent := range node.parents {
+			if parentNode := nodes[parent]; parentNode != nil {
+				parentNode.children[root] = true
+			}
+		}
+	}
+	return nodes
+}
+
+func admittedBytes(nodes map[string]*admissionNode, accepted map[string]bool) int64 {
+	var total int64
+	for root := range accepted {
+		total += nodes[root].usage.Bytes
+	}
+	return total
+}
+
+func sheddingOrder(nodes map[string]*admissionNode) []string {
+	order := make([]string, 0, len(nodes))
+	subtreeBytes := make(map[string]int64, len(nodes))
+	for root := range nodes {
+		order = append(order, root)
+		subtreeBytes[root] = admissionSubtreeBytes(nodes, root)
+	}
+	sort.Slice(order, func(i, j int) bool {
+		left, right := nodes[order[i]], nodes[order[j]]
+		if left.direct != right.direct {
+			return !left.direct
+		}
+		if left.depth != right.depth {
+			return left.depth > right.depth
+		}
+		if subtreeBytes[left.root] != subtreeBytes[right.root] {
+			return subtreeBytes[left.root] > subtreeBytes[right.root]
+		}
+		if left.source != right.source {
+			return left.source < right.source
+		}
+		return left.root < right.root
+	})
+	return order
+}
+
+func admissionSubtreeBytes(nodes map[string]*admissionNode, root string) int64 {
+	seen := make(map[string]bool)
+	queue := []string{root}
+	var total int64
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		if seen[current] {
+			continue
+		}
+		seen[current] = true
+		total += nodes[current].usage.Bytes
+		for child := range nodes[current].children {
+			queue = append(queue, child)
+		}
+	}
+	return total
+}
+
+func removeAdmissionSubtree(
+	nodes map[string]*admissionNode, accepted map[string]bool, candidate string,
+) []string {
+	queue := []string{candidate}
+	removed := make([]string, 0, 1)
+	for len(queue) > 0 {
+		root := queue[0]
+		queue = queue[1:]
+		if !accepted[root] {
+			continue
+		}
+		delete(accepted, root)
+		removed = append(removed, root)
+		for child := range nodes[root].children {
+			if !accepted[child] || nodes[child].direct || hasAcceptedParent(nodes[child], accepted) {
+				continue
+			}
+			queue = append(queue, child)
+		}
+	}
+	sortRemovedNodes(nodes, removed, candidate)
+	return removed
+}
+
+func sortRemovedNodes(nodes map[string]*admissionNode, removed []string, candidate string) {
+	sort.Slice(removed, func(i, j int) bool {
+		if removed[i] == candidate {
+			return true
+		}
+		if removed[j] == candidate {
+			return false
+		}
+		left, right := nodes[removed[i]], nodes[removed[j]]
+		if left.depth != right.depth {
+			return left.depth > right.depth
+		}
+		if left.source != right.source {
+			return left.source < right.source
+		}
+		return left.root < right.root
+	})
+}
+
+func hasAcceptedParent(node *admissionNode, accepted map[string]bool) bool {
+	for parent := range node.parents {
+		if accepted[parent] {
+			return true
+		}
+	}
+	return false
+}
+
+func admissionGraphHasCycles(nodes map[string]*admissionNode) bool {
+	indegree := make(map[string]int, len(nodes))
+	queue := make([]string, 0, len(nodes))
+	for root, node := range nodes {
+		for parent := range node.parents {
+			if nodes[parent] != nil {
+				indegree[root]++
+			}
+		}
+	}
+	for root := range nodes {
+		if indegree[root] == 0 {
+			queue = append(queue, root)
+		}
+	}
+	visited := 0
+	for len(queue) > 0 {
+		root := queue[0]
+		queue = queue[1:]
+		visited++
+		for child := range nodes[root].children {
+			indegree[child]--
+			if indegree[child] == 0 {
+				queue = append(queue, child)
+			}
+		}
+	}
+	return visited != len(nodes)
+}
+
+// removalMayOrphan reports whether this removal could have cut the last path
+// from a direct module to a still-accepted node. Only a child of a removed node
+// can lose its last path, so when no removed node has an accepted child the
+// full reachability sweep can be skipped.
+func removalMayOrphan(
+	nodes map[string]*admissionNode, accepted map[string]bool, removed []string,
+) bool {
+	for _, root := range removed {
+		for child := range nodes[root].children {
+			if accepted[child] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func pruneUnreachableAdmissionNodes(
+	nodes map[string]*admissionNode, accepted map[string]bool,
+) []string {
+	reachable := make(map[string]bool, len(accepted))
+	queue := make([]string, 0, len(accepted))
+	for root := range accepted {
+		if nodes[root].direct {
+			reachable[root] = true
+			queue = append(queue, root)
+		}
+	}
+	for len(queue) > 0 {
+		root := queue[0]
+		queue = queue[1:]
+		for child := range nodes[root].children {
+			if accepted[child] && !reachable[child] {
+				reachable[child] = true
+				queue = append(queue, child)
+			}
+		}
+	}
+	removed := make([]string, 0, len(accepted)-len(reachable))
+	for root := range accepted {
+		if !reachable[root] {
+			delete(accepted, root)
+			removed = append(removed, root)
+		}
+	}
+	return removed
+}
+
+func packageRootsBySpecificity(nodes map[string]*admissionNode) []string {
+	roots := make([]string, 0, len(nodes))
+	for root := range nodes {
+		roots = append(roots, root)
+	}
+	sort.Slice(roots, func(i, j int) bool {
+		if len(roots[i]) != len(roots[j]) {
+			return len(roots[i]) > len(roots[j])
+		}
+		return roots[i] < roots[j]
+	})
+	return roots
+}
+
+func filterPathsByPackages(paths, roots []string, accepted map[string]bool) []string {
+	filtered := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if pathOwnedByAcceptedPackage(path, roots, accepted) {
+			filtered = append(filtered, path)
+		}
+	}
+	return filtered
+}
+
+func filterModulesByPackages(modules []ResolvedModule, accepted map[string]bool) []ResolvedModule {
+	filtered := make([]ResolvedModule, 0, len(modules))
+	for i := range modules {
+		module := &modules[i]
+		if accepted[filepath.Clean(module.PackageRoot)] {
+			filtered = append(filtered, *module)
+		}
+	}
+	return filtered
+}
+
+func pathOwnedByAcceptedPackage(path string, roots []string, accepted map[string]bool) bool {
+	cleanPath := filepath.Clean(path)
+	for _, root := range roots {
+		if cleanPath == root || strings.HasPrefix(cleanPath, root+string(filepath.Separator)) {
+			return accepted[root]
+		}
+	}
+	return false
+}

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -7,6 +7,8 @@ package modulegraph
 
 import (
 	"context"
+	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -28,28 +30,45 @@ const (
 )
 
 type Request struct {
-	RootPaths      []string
-	DiscoveryPaths []string
-	Resolver       resolver.Resolver
-	MaxDepth       int
-	FS             vfs.FS
+	RootPaths       []string
+	DiscoveryPaths  []string
+	Resolver        resolver.Resolver
+	MaxDepth        int
+	ResourceLimits  resolver.ResourceLimits
+	BaselinePaths   []string
+	TotalParseBytes int64
+	FS              vfs.FS
 }
 
 type ResolvedModule struct {
-	CallerRoot      string
-	Source          string
-	Version         string
-	Name            string
-	LocalPath       string
-	PackageRoot     string
-	CanonicalSource string
+	CallerRoot        string
+	Source            string
+	Version           string
+	Name              string
+	LocalPath         string
+	PackageRoot       string
+	ParentPackageRoot string
+	Depth             int
+	CanonicalSource   string
 }
 
 type Result struct {
-	ScanPaths      []string
-	Modules        []ResolvedModule
-	SourceMappings map[string]string
-	Cleanup        func()
+	ScanPaths            []string
+	Modules              []ResolvedModule
+	SourceMappings       map[string]string
+	BudgetEvents         []BudgetEvent
+	BaselineParseBytes   int64
+	ModuleAdmissionBytes int64
+	Cleanup              func()
+}
+
+type BudgetEvent struct {
+	Source       string
+	Gate         string
+	Limit        string
+	Maximum      int64
+	Measured     int64
+	SheddingRank int
 }
 
 type resolvedEntry struct {
@@ -58,8 +77,9 @@ type resolvedEntry struct {
 }
 
 type remoteModuleGroup struct {
-	representative *tfmodules.ParsedModule
-	callers        []*tfmodules.ParsedModule
+	representative    *tfmodules.ParsedModule
+	callers           []*tfmodules.ParsedModule
+	parentPackageRoot string
 }
 
 type walkerSnapshot struct {
@@ -67,6 +87,7 @@ type walkerSnapshot struct {
 	modules        []ResolvedModule
 	sourceMappings map[string]string
 	cleanups       []func()
+	budgetEvents   []BudgetEvent
 }
 
 type visitedSet struct {
@@ -85,6 +106,7 @@ type resultCollector struct {
 	modules        []ResolvedModule
 	sourceMappings map[string]string
 	cleanups       []func()
+	budgetEvents   []BudgetEvent
 }
 
 type moduleParseCache struct {
@@ -92,15 +114,34 @@ type moduleParseCache struct {
 	entries map[string]map[string]tfmodules.ParsedModule
 }
 
+type pendingTraversal struct {
+	seed            string
+	repoAllowedDirs map[string]map[string]bool
+	depth           int
+	packageRoot     string
+}
+
+type pendingTraversalCollector struct {
+	mu      sync.Mutex
+	entries map[string]pendingTraversal
+}
+
 type walker struct {
-	visited     visitedSet
-	resolutions resolutionCache
-	results     resultCollector
-	parseCache  moduleParseCache
-	sf          singleflight.Group
-	resolver    resolver.Resolver
-	maxDepth    int
-	fsys        vfs.FS
+	visited          visitedSet
+	resolutions      resolutionCache
+	results          resultCollector
+	parseCache       moduleParseCache
+	pending          pendingTraversalCollector
+	sf               singleflight.Group
+	measureSF        singleflight.Group
+	resolver         resolver.Resolver
+	budget           *resolver.ResourceBudget
+	measurePackages  bool
+	deferExpansion   bool
+	admissionBytes   int64
+	acquisitionBytes int64
+	maxDepth         int
+	fsys             vfs.FS
 }
 
 func Resolve(ctx context.Context, request *Request) Result {
@@ -112,6 +153,9 @@ func Resolve(ctx context.Context, request *Request) Result {
 		return result
 	}
 	ctx = resolver.WithResolvedPathCache(ctx)
+	budget := resolver.NewResourceBudget(request.ResourceLimits)
+	ctx = resolver.WithResourceBudget(ctx, budget)
+	moduleMaximum, baselineBytes, enforceAdmission := moduleAdmissionLimit(request)
 
 	w := &walker{
 		visited: visitedSet{
@@ -126,9 +170,17 @@ func Resolve(ctx context.Context, request *Request) Result {
 		parseCache: moduleParseCache{
 			entries: make(map[string]map[string]tfmodules.ParsedModule),
 		},
-		resolver: request.Resolver,
-		maxDepth: request.MaxDepth,
-		fsys:     request.FS,
+		pending: pendingTraversalCollector{
+			entries: make(map[string]pendingTraversal),
+		},
+		resolver:         request.Resolver,
+		budget:           budget,
+		measurePackages:  request.ResourceLimits.Enabled() || request.TotalParseBytes > 0,
+		deferExpansion:   enforceAdmission,
+		admissionBytes:   moduleMaximum,
+		acquisitionBytes: acquisitionAllowance(moduleMaximum),
+		maxDepth:         request.MaxDepth,
+		fsys:             request.FS,
 	}
 	seedGroups, repositoryGroups := w.seedGroups(ctx, request.RootPaths, request.DiscoveryPaths)
 
@@ -141,17 +193,32 @@ func Resolve(ctx context.Context, request *Request) Result {
 		})
 	}
 	_ = g.Wait()
+	if enforceAdmission {
+		w.expandAdmittedPackages(ctx, moduleMaximum)
+	}
 
 	snapshot := w.results.snapshot()
+	shedToTotalLimit(&snapshot, budget, moduleMaximum, enforceAdmission)
 	result.ScanPaths = snapshot.paths
 	result.Modules = snapshot.modules
 	result.SourceMappings = snapshot.sourceMappings
+	result.BudgetEvents = snapshot.budgetEvents
+	result.BaselineParseBytes = baselineBytes
+	result.ModuleAdmissionBytes = moduleMaximum
 
 	sort.Strings(result.ScanPaths)
 	sort.Slice(result.Modules, func(i, j int) bool {
 		left, right := result.Modules[i], result.Modules[j]
 		return strings.Join([]string{left.CallerRoot, left.Source, left.Version, left.Name}, "\x00") <
 			strings.Join([]string{right.CallerRoot, right.Source, right.Version, right.Name}, "\x00")
+	})
+	sort.Slice(result.BudgetEvents, func(i, j int) bool {
+		left, right := result.BudgetEvents[i], result.BudgetEvents[j]
+		if left.SheddingRank != right.SheddingRank {
+			return left.SheddingRank < right.SheddingRank
+		}
+		return strings.Join([]string{left.Source, left.Gate, left.Limit}, "\x00") <
+			strings.Join([]string{right.Source, right.Gate, right.Limit}, "\x00")
 	})
 	var once sync.Once
 	result.Cleanup = func() {
@@ -162,6 +229,72 @@ func Resolve(ctx context.Context, request *Request) Result {
 		})
 	}
 	return result
+}
+
+func (w *walker) expandAdmittedPackages(ctx context.Context, maximum int64) {
+	var deferred []pendingTraversal
+	for {
+		pending := make([]pendingTraversal, 0, len(deferred))
+		pending = append(pending, deferred...)
+		pending = append(pending, w.pending.drain()...)
+		if len(pending) == 0 {
+			return
+		}
+
+		snapshot := w.results.snapshot()
+		shedToTotalLimit(&snapshot, w.budget, maximum, true)
+		accepted := make(map[string]bool, len(snapshot.modules))
+		for i := range snapshot.modules {
+			accepted[filepath.Clean(snapshot.modules[i].PackageRoot)] = true
+		}
+		admitted, rejected := partitionPendingTraversals(pending, accepted)
+		if len(admitted) == 0 {
+			return
+		}
+		deferred = rejected
+
+		g, gCtx := errgroup.WithContext(ctx)
+		g.SetLimit(max(1, resolver.FetchConcurrency))
+		for _, traversal := range admitted {
+			g.Go(func() error {
+				w.traverse(
+					gCtx,
+					traversal.seed,
+					nil,
+					traversal.repoAllowedDirs,
+					traversal.depth,
+					traversal.packageRoot,
+				)
+				return nil
+			})
+		}
+		_ = g.Wait()
+	}
+}
+
+func partitionPendingTraversals(
+	pending []pendingTraversal, accepted map[string]bool,
+) (admitted, rejected []pendingTraversal) {
+	admitted = make([]pendingTraversal, 0, len(pending))
+	rejected = make([]pendingTraversal, 0, len(pending))
+	for _, traversal := range pending {
+		if accepted[filepath.Clean(traversal.packageRoot)] {
+			admitted = append(admitted, traversal)
+		} else {
+			rejected = append(rejected, traversal)
+		}
+	}
+	sort.Slice(admitted, func(i, j int) bool {
+		left, right := admitted[i], admitted[j]
+		if left.depth != right.depth {
+			return left.depth < right.depth
+		}
+		if left.packageRoot != right.packageRoot {
+			return left.packageRoot < right.packageRoot
+		}
+		return left.seed < right.seed
+	})
+	return admitted, rejected
 }
 
 func (w *walker) parseModulesInDir(
@@ -224,17 +357,21 @@ func (c *resultCollector) addPaths(paths ...string) {
 	c.paths = append(c.paths, paths...)
 }
 
-func (c *resultCollector) addResolvedModule(mod *tfmodules.ParsedModule, resolution resolver.Resolution) {
+func (c *resultCollector) addResolvedModule(
+	mod *tfmodules.ParsedModule, resolution resolver.Resolution, parentPackageRoot string, depth int,
+) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.modules = append(c.modules, ResolvedModule{
-		CallerRoot:      moduleCallRoot(mod),
-		Source:          mod.Source,
-		Version:         mod.Version,
-		Name:            mod.Name,
-		LocalPath:       resolution.LocalPath,
-		PackageRoot:     resolution.PackageRoot,
-		CanonicalSource: canonicalModuleURL(mod.Source, mod.Version),
+		CallerRoot:        moduleCallRoot(mod),
+		Source:            mod.Source,
+		Version:           mod.Version,
+		Name:              mod.Name,
+		LocalPath:         resolution.LocalPath,
+		PackageRoot:       resolution.PackageRoot,
+		ParentPackageRoot: parentPackageRoot,
+		Depth:             depth,
+		CanonicalSource:   canonicalModuleURL(mod.Source, mod.Version),
 	})
 }
 
@@ -250,6 +387,18 @@ func (c *resultCollector) addCleanup(cleanup func()) {
 	c.cleanups = append(c.cleanups, cleanup)
 }
 
+func (c *resultCollector) addBudgetEvent(source string, budgetErr *resolver.BudgetExceededError) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.budgetEvents = append(c.budgetEvents, BudgetEvent{
+		Source:   source,
+		Gate:     budgetErr.Gate,
+		Limit:    budgetErr.Limit,
+		Maximum:  budgetErr.Maximum,
+		Measured: budgetErr.Measured,
+	})
+}
+
 func (c *resultCollector) snapshot() walkerSnapshot {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -262,6 +411,7 @@ func (c *resultCollector) snapshot() walkerSnapshot {
 		modules:        append([]ResolvedModule(nil), c.modules...),
 		sourceMappings: sourceMappings,
 		cleanups:       append([]func(){}, c.cleanups...),
+		budgetEvents:   append([]BudgetEvent(nil), c.budgetEvents...),
 	}
 }
 
@@ -291,6 +441,23 @@ func (c *moduleParseCache) set(key string, mods map[string]tfmodules.ParsedModul
 	c.entries[key] = mods
 }
 
+func (c *pendingTraversalCollector) add(traversal pendingTraversal) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[visitKey(traversal.seed, traversal.packageRoot)] = traversal
+}
+
+func (c *pendingTraversalCollector) drain() []pendingTraversal {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entries := make([]pendingTraversal, 0, len(c.entries))
+	for _, traversal := range c.entries {
+		entries = append(entries, traversal)
+	}
+	clear(c.entries)
+	return entries
+}
+
 func (w *walker) resolveRemote(
 	ctx context.Context, mod *tfmodules.ParsedModule,
 ) (resolver.Resolution, bool, error) {
@@ -309,6 +476,15 @@ func (w *walker) resolveRemote(
 		if resolveErr == nil && resolution.PackageRoot == "" && resolution.LocalPath != "" {
 			resolution.PackageRoot = resolution.LocalPath
 		}
+		if resolveErr != nil {
+			var budgetErr *resolver.BudgetExceededError
+			if errors.As(resolveErr, &budgetErr) {
+				w.results.addBudgetEvent(mod.Source, budgetErr)
+			}
+		}
+		if resolveErr == nil {
+			resolveErr = w.accountPackage(ctx, mod.Source, resolution)
+		}
 		w.resolutions.set(resolveID, resolvedEntry{res: resolution, err: resolveErr})
 		return resolution, resolveErr
 	})
@@ -316,6 +492,47 @@ func (w *walker) resolveRemote(
 		return resolver.Resolution{}, shared, err
 	}
 	return value.(resolver.Resolution), shared, nil
+}
+
+func (w *walker) accountPackage(
+	ctx context.Context, source string, resolution resolver.Resolution,
+) error {
+	if resolution.PackageRoot == "" || !w.measurePackages {
+		return nil
+	}
+	if err := w.measurePackage(ctx, resolution.PackageRoot); err != nil {
+		if resolution.Cleanup != nil {
+			resolution.Cleanup()
+		}
+		var budgetErr *resolver.BudgetExceededError
+		if errors.As(err, &budgetErr) {
+			w.results.addBudgetEvent(source, budgetErr)
+		}
+		return &tfmodules.UnresolvedError{Reason: "module package rejected: " + err.Error()}
+	}
+	return nil
+}
+
+// measurePackage charges a package root to the budget, collapsing the walks of
+// modules that share a root. The flight is forgotten as soon as it starts, so
+// only callers whose content was already on disk when the walk began reuse its
+// result; later callers, whose extraction may still have been running, measure
+// the root again.
+func (w *walker) measurePackage(ctx context.Context, root string) error {
+	key := filepath.Clean(root)
+	_, err, _ := w.measureSF.Do(key, func() (interface{}, error) {
+		w.measureSF.Forget(key)
+		limits := w.budget.Limits()
+		if scoped := resolver.ResourceBudgetFromContext(ctx); scoped != nil {
+			limits = scoped.Limits()
+		}
+		usage, measureErr := resolver.MeasurePackage(ctx, root, limits)
+		if measureErr != nil {
+			return nil, measureErr
+		}
+		return nil, w.budget.AdmitPackage(root, usage)
+	})
+	return err
 }
 
 var parseSem = make(chan struct{}, max(1, runtime.GOMAXPROCS(0)))
@@ -452,7 +669,7 @@ func (w *walker) traverse(
 		w.traverse(ctx, localDir, childAllowedFiles, repoAllowedDirs, depth+1, packageRoot)
 	}
 
-	w.traverseRemoteModules(ctx, mods, repoAllowedDirs, depth)
+	w.traverseRemoteModules(ctx, mods, repoAllowedDirs, depth, packageRoot)
 }
 
 func (w *walker) traverseRemoteModules(
@@ -460,6 +677,7 @@ func (w *walker) traverseRemoteModules(
 	mods map[string]tfmodules.ParsedModule,
 	repoAllowedDirs map[string]map[string]bool,
 	depth int,
+	parentPackageRoot string,
 ) {
 	groups := make(map[string]*remoteModuleGroup)
 	for key := range mods {
@@ -472,7 +690,7 @@ func (w *walker) traverseRemoteModules(
 		cached, hit := w.resolutions.get(id)
 		if hit {
 			if cached.err == nil && cached.res.LocalPath != "" {
-				w.results.addResolvedModule(&mod, cached.res)
+				w.results.addResolvedModule(&mod, cached.res, parentPackageRoot, depth+1)
 			}
 			continue
 		}
@@ -481,24 +699,114 @@ func (w *walker) traverseRemoteModules(
 			group.callers = append(group.callers, &mod)
 		} else {
 			groups[id] = &remoteModuleGroup{
-				representative: &mod,
-				callers:        []*tfmodules.ParsedModule{&mod},
+				representative:    &mod,
+				callers:           []*tfmodules.ParsedModule{&mod},
+				parentPackageRoot: parentPackageRoot,
 			}
 		}
 	}
 	if len(groups) == 0 {
 		return
 	}
+	w.acquireRemoteModuleGroups(ctx, groups, repoAllowedDirs, depth)
+}
 
-	g, gCtx := errgroup.WithContext(ctx)
-	g.SetLimit(max(1, resolver.FetchConcurrency))
-	for _, group := range groups {
-		g.Go(func() error {
-			w.traverseRemoteModuleGroup(gCtx, group, repoAllowedDirs, depth)
-			return nil
+// acquisitionOvershootFactor bounds how far one frontier may fetch past the
+// aggregate admission limit. Package sizes are only known once the package is on
+// disk, so a frontier has to be oversampled for shedding to have anything to
+// choose between; capping the overshoot keeps a module that declares thousands
+// of remote children from materializing all of them before admission runs.
+const acquisitionOvershootFactor = 2
+
+func acquisitionAllowance(maximum int64) int64 {
+	if maximum > math.MaxInt64/acquisitionOvershootFactor {
+		return math.MaxInt64
+	}
+	return maximum * acquisitionOvershootFactor
+}
+
+// acquireRemoteModuleGroups fetches a frontier in deterministically ordered
+// batches, stopping once the frontier has fetched past its allowance. Without
+// this the whole frontier is fetched before admission gets to reject anything,
+// so the bytes on disk are bounded only by how many modules a caller declares.
+func (w *walker) acquireRemoteModuleGroups(
+	ctx context.Context,
+	groups map[string]*remoteModuleGroup,
+	repoAllowedDirs map[string]map[string]bool,
+	depth int,
+) {
+	ids := orderedGroupIDs(groups)
+	size := max(1, resolver.FetchConcurrency)
+	for start := 0; start < len(ids); {
+		type acquisition struct {
+			group       *remoteModuleGroup
+			reservation int64
+		}
+		batch := make([]acquisition, 0, size)
+		end := min(start+size, len(ids))
+		for _, id := range ids[start:end] {
+			reservation, ok := w.reserveAcquisition()
+			if !ok {
+				break
+			}
+			batch = append(batch, acquisition{group: groups[id], reservation: reservation})
+		}
+		if len(batch) == 0 {
+			w.recordUnacquiredGroups(groups, ids[start:])
+			return
+		}
+		g, gCtx := errgroup.WithContext(ctx)
+		g.SetLimit(size)
+		for _, item := range batch {
+			g.Go(func() error {
+				w.traverseRemoteModuleGroup(
+					gCtx, item.group, repoAllowedDirs, depth, item.reservation,
+				)
+				return nil
+			})
+		}
+		_ = g.Wait()
+		start += len(batch)
+	}
+}
+
+// orderedGroupIDs gives the frontier a stable order so that when acquisition
+// stops early, which modules were fetched does not depend on map iteration.
+func orderedGroupIDs(groups map[string]*remoteModuleGroup) []string {
+	ids := make([]string, 0, len(groups))
+	for id := range groups {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		left := groups[ids[i]].representative
+		right := groups[ids[j]].representative
+		if left.Source != right.Source {
+			return left.Source < right.Source
+		}
+		return ids[i] < ids[j]
+	})
+	return ids
+}
+
+func (w *walker) reserveAcquisition() (int64, bool) {
+	if !w.deferExpansion {
+		return 0, true
+	}
+	return w.budget.ReserveAcquisition(
+		w.acquisitionBytes, w.budget.Limits().MaxPackageBytes,
+	)
+}
+
+func (w *walker) recordUnacquiredGroups(groups map[string]*remoteModuleGroup, ids []string) {
+	measured := w.budget.TotalUsage().Bytes
+	for _, id := range ids {
+		w.results.addBudgetEvent(groups[id].representative.Source, &resolver.BudgetExceededError{
+			Gate:     "acquisition",
+			Limit:    "module_bytes_total",
+			Maximum:  w.admissionBytes,
+			Measured: measured,
 		})
 	}
-	_ = g.Wait()
 }
 
 func (w *walker) traverseRemoteModuleGroup(
@@ -506,7 +814,14 @@ func (w *walker) traverseRemoteModuleGroup(
 	group *remoteModuleGroup,
 	repoAllowedDirs map[string]map[string]bool,
 	depth int,
+	reservation int64,
 ) {
+	if reservation > 0 {
+		defer w.budget.ReleaseAcquisition(reservation)
+		limits := w.budget.Limits()
+		limits.MaxPackageBytes = reservation
+		ctx = resolver.WithResourceBudget(ctx, resolver.NewResourceBudget(limits))
+	}
 	contextLogger := logger.FromContext(ctx)
 	representative := group.representative
 	contextLogger.Debug().Msgf("Fetching remote Terraform module %q", representative.Source)
@@ -530,7 +845,7 @@ func (w *walker) traverseRemoteModuleGroup(
 	}
 
 	for _, mod := range group.callers {
-		w.results.addResolvedModule(mod, resolution)
+		w.results.addResolvedModule(mod, resolution, group.parentPackageRoot, depth+1)
 	}
 	if !w.visited.tryAdd(resolution.LocalPath, resolution.PackageRoot) {
 		return
@@ -543,7 +858,16 @@ func (w *walker) traverseRemoteModuleGroup(
 		resolution.LocalPath,
 		canonicalModuleURL(representative.Source, representative.Version),
 	)
-	w.traverse(ctx, resolution.LocalPath, nil, repoAllowedDirs, depth+1, resolution.PackageRoot)
+	if !w.deferExpansion {
+		w.traverse(ctx, resolution.LocalPath, nil, repoAllowedDirs, depth+1, resolution.PackageRoot)
+		return
+	}
+	w.pending.add(pendingTraversal{
+		seed:            resolution.LocalPath,
+		repoAllowedDirs: repoAllowedDirs,
+		depth:           depth + 1,
+		packageRoot:     resolution.PackageRoot,
+	})
 }
 
 func moduleCallRoot(mod *tfmodules.ParsedModule) string {

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
@@ -2,8 +2,10 @@ package modulegraph
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -11,6 +13,46 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
 	"github.com/stretchr/testify/require"
 )
+
+func BenchmarkShedToTotalLimit1000Modules(b *testing.B) {
+	const count = 1000
+	budget := resolver.NewResourceBudget(resolver.ResourceLimits{MaxTotalBytes: count / 2})
+	modules := make([]ResolvedModule, 0, count)
+	paths := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		root := filepath.Join("packages", fmt.Sprintf("%04d", i))
+		parent := ""
+		depth := i%benchmarkDepth + 1
+		if depth > 1 {
+			parent = filepath.Join("packages", fmt.Sprintf("%04d", i-1))
+		}
+		require.NoError(b, budget.AdmitPackage(root, resolver.PackageUsage{Bytes: 1, Files: 1}))
+		modules = append(modules, ResolvedModule{
+			Source:            fmt.Sprintf("example.com/acme/module-%04d/aws", i),
+			CanonicalSource:   fmt.Sprintf("example.com/acme/module-%04d/aws", i),
+			PackageRoot:       root,
+			ParentPackageRoot: parent,
+			Depth:             depth,
+		})
+		paths = append(paths, filepath.Join(root, "main.tf"))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		snapshot := walkerSnapshot{
+			paths:          paths,
+			modules:        modules,
+			sourceMappings: make(map[string]string),
+		}
+		shedToTotalLimit(&snapshot, budget, count/2, true)
+		if len(snapshot.modules) != count/2 {
+			b.Fatalf("admitted %d modules", len(snapshot.modules))
+		}
+	}
+}
+
+const benchmarkDepth = 8
 
 type stubResolver struct {
 	resolution resolver.Resolution
@@ -36,6 +78,41 @@ func (r mapResolver) Resolve(
 	return res, nil
 }
 
+type errorResolver struct {
+	err error
+}
+
+func (r errorResolver) Resolve(
+	_ context.Context, _ *tfmodules.ParsedModule,
+) (resolver.Resolution, error) {
+	return resolver.Resolution{}, r.err
+}
+
+type trackingResolver struct {
+	mu       sync.Mutex
+	bySource map[string]resolver.Resolution
+	calls    map[string]int
+}
+
+func (r *trackingResolver) Resolve(
+	_ context.Context, mod *tfmodules.ParsedModule,
+) (resolver.Resolution, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls[mod.Source]++
+	res, ok := r.bySource[mod.Source]
+	if !ok {
+		return resolver.Resolution{}, &tfmodules.UnresolvedError{Reason: "unknown source " + mod.Source}
+	}
+	return res, nil
+}
+
+func (r *trackingResolver) callCount(source string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls[source]
+}
+
 func TestResolveAssemblesModuleMetadataAndPaths(t *testing.T) {
 	root, moduleDir := writeModuleGraphFixture(t)
 
@@ -59,6 +136,7 @@ func TestResolveAssemblesModuleMetadataAndPaths(t *testing.T) {
 		Name:            "network",
 		LocalPath:       moduleDir,
 		PackageRoot:     moduleDir,
+		Depth:           1,
 		CanonicalSource: "git::https://github.com/acme/network//modules/vpc?ref=v1@1.2.3",
 	}}, result.Modules)
 }
@@ -84,6 +162,83 @@ func TestResolveCleanupIsIdempotent(t *testing.T) {
 	require.Equal(t, int32(1), cleanupCalls.Load())
 }
 
+func TestResolveRejectsOversizedPackageAndReportsBudget(t *testing.T) {
+	root, moduleDir := writeModuleGraphFixture(t)
+	var cleanupCalls atomic.Int32
+
+	result := Resolve(context.Background(), &Request{
+		RootPaths:      []string{root},
+		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
+		Resolver: stubResolver{resolution: resolver.Resolution{
+			LocalPath:   moduleDir,
+			PackageRoot: moduleDir,
+			Cleanup: func() {
+				cleanupCalls.Add(1)
+			},
+		}},
+		MaxDepth: 2,
+		ResourceLimits: resolver.ResourceLimits{
+			MaxPackageBytes: 1,
+		},
+	})
+
+	require.Empty(t, result.ScanPaths)
+	require.Empty(t, result.Modules)
+	require.Equal(t, int32(1), cleanupCalls.Load())
+	require.Len(t, result.BudgetEvents, 1)
+	event := result.BudgetEvents[0]
+	require.Equal(t, "git::https://git@github.com/acme/network.git//modules/vpc?ref=v1", event.Source)
+	require.Equal(t, "stream", event.Gate)
+	require.Equal(t, "package_bytes", event.Limit)
+	require.Equal(t, int64(1), event.Maximum)
+	require.Greater(t, event.Measured, int64(1))
+}
+
+func TestResolveAdmitsOnDiskPackageDespitePerFileLimit(t *testing.T) {
+	root, moduleDir := writeModuleGraphFixture(t)
+
+	result := Resolve(context.Background(), &Request{
+		RootPaths:      []string{root},
+		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
+		Resolver: stubResolver{resolution: resolver.Resolution{
+			LocalPath:   moduleDir,
+			PackageRoot: moduleDir,
+		}},
+		MaxDepth: 2,
+		ResourceLimits: resolver.ResourceLimits{
+			MaxFileBytes: 1,
+		},
+	})
+
+	require.NotEmpty(t, result.ScanPaths)
+	require.Len(t, result.Modules, 1)
+	require.Empty(t, result.BudgetEvents)
+}
+
+func TestResolveReportsStreamingBudgetFailure(t *testing.T) {
+	root, _ := writeModuleGraphFixture(t)
+
+	result := Resolve(t.Context(), &Request{
+		RootPaths:      []string{root},
+		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
+		Resolver: errorResolver{err: &resolver.BudgetExceededError{
+			Gate:     "stream",
+			Limit:    "package_bytes",
+			Maximum:  10,
+			Measured: 11,
+		}},
+		MaxDepth: 2,
+	})
+
+	require.Equal(t, []BudgetEvent{{
+		Source:   "git::https://git@github.com/acme/network.git//modules/vpc?ref=v1",
+		Gate:     "stream",
+		Limit:    "package_bytes",
+		Maximum:  10,
+		Measured: 11,
+	}}, result.BudgetEvents)
+}
+
 func TestResolveTraversesLocalModuleToRemoteModule(t *testing.T) {
 	root, wrapperDir, remoteDir := writeNestedModuleGraphFixture(t)
 
@@ -103,6 +258,267 @@ func TestResolveTraversesLocalModuleToRemoteModule(t *testing.T) {
 	require.Len(t, result.Modules, 1)
 	require.Equal(t, "registry.example.com/acme/network/aws", result.Modules[0].Source)
 	require.Equal(t, wrapperDir, result.Modules[0].CallerRoot)
+}
+
+func TestResolveShedsTransitiveSubtreeBeforeDirectModule(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	direct := filepath.Join(base, "direct")
+	transitive := filepath.Join(base, "transitive")
+	for _, dir := range []string{root, direct, transitive} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(`
+module "direct" {
+  source = "example.com/acme/direct/aws"
+}
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(direct, "main.tf"), []byte(`
+resource "aws_vpc" "direct" {}
+module "transitive" {
+  source = "example.com/acme/transitive/aws"
+}
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(transitive, "main.tf"), []byte(`
+resource "aws_vpc" "transitive" {}
+`), 0o600))
+	directUsage, err := resolver.MeasurePackage(t.Context(), direct, resolver.ResourceLimits{})
+	require.NoError(t, err)
+
+	result := Resolve(t.Context(), &Request{
+		RootPaths:      []string{root},
+		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
+		Resolver: mapResolver{bySource: map[string]resolver.Resolution{
+			"example.com/acme/direct/aws": {
+				LocalPath: direct,
+			},
+			"example.com/acme/transitive/aws": {
+				LocalPath: transitive,
+			},
+		}},
+		MaxDepth: 3,
+		ResourceLimits: resolver.ResourceLimits{
+			MaxTotalBytes: directUsage.Bytes,
+		},
+	})
+
+	require.Len(t, result.Modules, 1)
+	require.Equal(t, "example.com/acme/direct/aws", result.Modules[0].Source)
+	require.Equal(t, []string{filepath.Join(direct, "main.tf")}, result.ScanPaths)
+	require.Len(t, result.BudgetEvents, 1)
+	require.Equal(t, "example.com/acme/transitive/aws", result.BudgetEvents[0].Source)
+	require.Equal(t, "pre_parse_admission", result.BudgetEvents[0].Gate)
+	require.Equal(t, 1, result.BudgetEvents[0].SheddingRank)
+}
+
+func TestResolveDoesNotTraverseDescendantsOfShedPackage(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	small := filepath.Join(base, "small")
+	large := filepath.Join(base, "large")
+	child := filepath.Join(base, "child")
+	for _, dir := range []string{root, small, large, child} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(`
+module "small" {
+  source = "example.com/acme/small/aws"
+}
+module "large" {
+  source = "example.com/acme/large/aws"
+}
+`), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(small, "main.tf"),
+		[]byte(`resource "aws_vpc" "small" {}`),
+		0o600,
+	))
+	require.NoError(t, os.WriteFile(filepath.Join(large, "main.tf"), []byte(`
+resource "aws_vpc" "large" {
+  tags = { padding = "make this package larger than the admitted sibling" }
+}
+module "child" {
+  source = "example.com/acme/child/aws"
+}
+`), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(child, "main.tf"),
+		[]byte(`resource "aws_vpc" "child" {}`),
+		0o600,
+	))
+	smallUsage, err := resolver.MeasurePackage(t.Context(), small, resolver.ResourceLimits{})
+	require.NoError(t, err)
+	tracker := &trackingResolver{
+		bySource: map[string]resolver.Resolution{
+			"example.com/acme/small/aws": {LocalPath: small},
+			"example.com/acme/large/aws": {LocalPath: large},
+			"example.com/acme/child/aws": {LocalPath: child},
+		},
+		calls: make(map[string]int),
+	}
+
+	result := Resolve(t.Context(), &Request{
+		RootPaths:      []string{root},
+		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
+		Resolver:       tracker,
+		MaxDepth:       3,
+		ResourceLimits: resolver.ResourceLimits{
+			MaxTotalBytes: smallUsage.Bytes,
+		},
+	})
+
+	require.Zero(t, tracker.callCount("example.com/acme/child/aws"))
+	require.Len(t, result.Modules, 1)
+	require.Equal(t, "example.com/acme/small/aws", result.Modules[0].Source)
+	require.Equal(t, []string{filepath.Join(small, "main.tf")}, result.ScanPaths)
+}
+
+func TestResolveStopsDeferredTraversalAtAcquisitionLimit(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	moduleA := filepath.Join(base, "module-a")
+	moduleB := filepath.Join(base, "module-b")
+	childA := filepath.Join(base, "child-a")
+	childB := filepath.Join(base, "child-b")
+	for _, dir := range []string{root, moduleA, moduleB, childA, childB} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(`
+module "a" {
+  source = "example.com/acme/a/aws"
+}
+module "b" {
+  source = "example.com/acme/b/aws"
+}
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleA, "main.tf"), []byte(`
+module "child_a" {
+  source = "example.com/acme/child-a/aws"
+}
+resource "aws_vpc" "padding" {
+  tags = { padding = "module a starts larger than module b" }
+}
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleB, "main.tf"), []byte(`
+module "child_b" {
+  source = "example.com/acme/child-b/aws"
+}
+`), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(childA, "main.tf"),
+		[]byte(`resource "aws_vpc" "child_a" {}`),
+		0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(childB, "main.tf"),
+		make([]byte, 1024),
+		0o600,
+	))
+	moduleAUsage, err := resolver.MeasurePackage(t.Context(), moduleA, resolver.ResourceLimits{})
+	require.NoError(t, err)
+	tracker := &trackingResolver{
+		bySource: map[string]resolver.Resolution{
+			"example.com/acme/a/aws":       {LocalPath: moduleA},
+			"example.com/acme/b/aws":       {LocalPath: moduleB},
+			"example.com/acme/child-a/aws": {LocalPath: childA},
+			"example.com/acme/child-b/aws": {LocalPath: childB},
+		},
+		calls: make(map[string]int),
+	}
+
+	result := Resolve(t.Context(), &Request{
+		RootPaths:      []string{root},
+		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
+		Resolver:       tracker,
+		MaxDepth:       3,
+		ResourceLimits: resolver.ResourceLimits{
+			MaxTotalBytes: moduleAUsage.Bytes,
+		},
+	})
+
+	require.Zero(t, tracker.callCount("example.com/acme/child-a/aws"))
+	require.Equal(t, 1, tracker.callCount("example.com/acme/child-b/aws"))
+	require.Len(t, result.Modules, 1)
+	require.Equal(t, "example.com/acme/b/aws", result.Modules[0].Source)
+}
+
+func TestShedToTotalLimitFiltersNestedPackagePathsByOwner(t *testing.T) {
+	t.Parallel()
+
+	parent := filepath.Join("packages", "parent")
+	child := filepath.Join(parent, "nested")
+	budget := resolver.NewResourceBudget(resolver.ResourceLimits{MaxTotalBytes: 1})
+	require.NoError(t, budget.AdmitPackage(parent, resolver.PackageUsage{Bytes: 1, Files: 1}))
+	require.NoError(t, budget.AdmitPackage(child, resolver.PackageUsage{Bytes: 2, Files: 1}))
+	snapshot := walkerSnapshot{
+		paths: []string{
+			filepath.Join(parent, "main.tf"),
+			filepath.Join(child, "main.tf"),
+		},
+		modules: []ResolvedModule{
+			{
+				CanonicalSource: "example.com/acme/parent/aws",
+				PackageRoot:     parent,
+				Depth:           1,
+			},
+			{
+				CanonicalSource:   "example.com/acme/child/aws",
+				PackageRoot:       child,
+				ParentPackageRoot: parent,
+				Depth:             2,
+			},
+		},
+		sourceMappings: map[string]string{
+			parent: "example.com/acme/parent/aws",
+			child:  "example.com/acme/child/aws",
+		},
+	}
+
+	shedToTotalLimit(&snapshot, budget, 1, true)
+
+	require.Equal(t, []string{filepath.Join(parent, "main.tf")}, snapshot.paths)
+	require.Equal(t, map[string]string{parent: "example.com/acme/parent/aws"}, snapshot.sourceMappings)
+	require.Len(t, snapshot.modules, 1)
+	require.Equal(t, parent, snapshot.modules[0].PackageRoot)
+}
+
+func TestResolveDerivesModuleAdmissionFromBaseline(t *testing.T) {
+	t.Parallel()
+
+	root, moduleDir := writeModuleGraphFixture(t)
+	rootFile := filepath.Join(root, "main.tf")
+	info, err := os.Stat(rootFile)
+	require.NoError(t, err)
+
+	source := "git::https://git@github.com/acme/network.git//modules/vpc?ref=v1"
+	tracker := &trackingResolver{
+		bySource: map[string]resolver.Resolution{
+			source: {LocalPath: moduleDir},
+		},
+		calls: make(map[string]int),
+	}
+	result := Resolve(t.Context(), &Request{
+		RootPaths:       []string{root},
+		DiscoveryPaths:  []string{rootFile},
+		BaselinePaths:   []string{rootFile},
+		TotalParseBytes: info.Size(),
+		Resolver:        tracker,
+		MaxDepth:        2,
+	})
+
+	require.Equal(t, info.Size(), result.BaselineParseBytes)
+	require.Zero(t, result.ModuleAdmissionBytes)
+	require.Empty(t, result.Modules)
+	require.Empty(t, result.ScanPaths)
+	require.Len(t, result.BudgetEvents, 1)
+	require.Equal(t, int64(0), result.BudgetEvents[0].Maximum)
+	require.Zero(t, tracker.callCount(source))
 }
 
 func TestResolveConfinesRemoteLocalModulesToPackageRoot(t *testing.T) {
@@ -258,4 +674,83 @@ module "network" {
 resource "aws_vpc" "this" {}
 `), 0o644))
 	return root, wrapperDir, remoteDir
+}
+
+func TestResolveStopsAcquiringFrontierPastAllowance(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+
+	batch := max(1, resolver.FetchConcurrency)
+	count := batch + 2
+	sources := make([]string, 0, count)
+	resolutions := make(map[string]resolver.Resolution, count)
+	calls := ""
+	for i := range count {
+		source := fmt.Sprintf("example.com/acme/m%04d/aws", i)
+		sources = append(sources, source)
+		dir := filepath.Join(base, fmt.Sprintf("m%04d", i))
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), make([]byte, 100), 0o600))
+		resolutions[source] = resolver.Resolution{LocalPath: dir}
+		calls += fmt.Sprintf("module \"m%04d\" {\n  source = %q\n}\n", i, source)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(calls), 0o600))
+	tracker := &trackingResolver{bySource: resolutions, calls: make(map[string]int)}
+
+	result := Resolve(t.Context(), &Request{
+		RootPaths:      []string{root},
+		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
+		Resolver:       tracker,
+		MaxDepth:       2,
+		ResourceLimits: resolver.ResourceLimits{MaxTotalBytes: 100},
+	})
+
+	const expectedFetched = 2
+	for index, source := range sources {
+		if index < expectedFetched {
+			require.Equal(t, 1, tracker.callCount(source), source)
+		} else {
+			require.Zero(t, tracker.callCount(source), source)
+		}
+	}
+	unacquired := 0
+	for _, event := range result.BudgetEvents {
+		if event.Gate == "acquisition" {
+			unacquired++
+			require.Equal(t, "module_bytes_total", event.Limit)
+		}
+	}
+	require.Equal(t, count-expectedFetched, unacquired)
+}
+
+func TestShedToTotalLimitBreaksTiesDeterministically(t *testing.T) {
+	t.Parallel()
+
+	build := func() (walkerSnapshot, *resolver.ResourceBudget) {
+		budget := resolver.NewResourceBudget(resolver.ResourceLimits{MaxTotalBytes: 1})
+		snapshot := walkerSnapshot{sourceMappings: make(map[string]string)}
+		for i := range 6 {
+			root := filepath.Join("packages", fmt.Sprintf("%02d", i))
+			require.NoError(t, budget.AdmitPackage(root, resolver.PackageUsage{Bytes: 1, Files: 1}))
+			snapshot.paths = append(snapshot.paths, filepath.Join(root, "main.tf"))
+			snapshot.modules = append(snapshot.modules, ResolvedModule{
+				CanonicalSource: "example.com/acme/shared/aws",
+				PackageRoot:     root,
+				Depth:           1,
+			})
+			snapshot.sourceMappings[root] = "example.com/acme/shared/aws"
+		}
+		return snapshot, budget
+	}
+
+	snapshot, budget := build()
+	shedToTotalLimit(&snapshot, budget, 2, true)
+	for range 20 {
+		other, otherBudget := build()
+		shedToTotalLimit(&other, otherBudget, 2, true)
+		require.Equal(t, snapshot.paths, other.paths)
+		require.Equal(t, snapshot.modules, other.modules)
+		require.Equal(t, snapshot.budgetEvents, other.budgetEvents)
+	}
 }

--- a/pkg/parser/terraform/modules/modulegraph/performance_benchmark_test.go
+++ b/pkg/parser/terraform/modules/modulegraph/performance_benchmark_test.go
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package modulegraph
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+)
+
+type benchmarkResolver struct {
+	bySource map[string]resolver.Resolution
+}
+
+func (r benchmarkResolver) Resolve(
+	_ context.Context, mod *tfmodules.ParsedModule,
+) (resolver.Resolution, error) {
+	return r.bySource[mod.Source], nil
+}
+
+func BenchmarkResolve100RemoteModules(b *testing.B) {
+	const count = 100
+	root := b.TempDir()
+	var config strings.Builder
+	resolutions := make(map[string]resolver.Resolution, count)
+	for i := 0; i < count; i++ {
+		source := fmt.Sprintf("example.com/acme/module-%03d/aws", i)
+		fmt.Fprintf(&config, "module \"m%03d\" { source = %q }\n", i, source)
+		moduleDir := filepath.Join(root, "modules", fmt.Sprintf("%03d", i))
+		if err := os.MkdirAll(moduleDir, 0o755); err != nil {
+			b.Fatal(err)
+		}
+		if err := os.WriteFile(
+			filepath.Join(moduleDir, "main.tf"),
+			[]byte(fmt.Sprintf("resource \"aws_vpc\" \"m%03d\" {}\n", i)),
+			0o600,
+		); err != nil {
+			b.Fatal(err)
+		}
+		resolutions[source] = resolver.Resolution{LocalPath: moduleDir}
+	}
+	rootFile := filepath.Join(root, "main.tf")
+	if err := os.WriteFile(rootFile, []byte(config.String()), 0o600); err != nil {
+		b.Fatal(err)
+	}
+	request := &Request{
+		RootPaths:      []string{root},
+		DiscoveryPaths: []string{rootFile},
+		Resolver:       benchmarkResolver{bySource: resolutions},
+		MaxDepth:       2,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		result := Resolve(b.Context(), request)
+		if len(result.Modules) != count {
+			b.Fatalf("resolved %d modules", len(result.Modules))
+		}
+		result.Cleanup()
+	}
+}

--- a/pkg/parser/terraform/modules/resolver/archive_extract_test.go
+++ b/pkg/parser/terraform/modules/resolver/archive_extract_test.go
@@ -26,7 +26,7 @@ type tarEntry struct {
 
 func extractTestArchive(r *bytes.Reader, dest string) error {
 	extracted := int64(0)
-	return extractRegularFilesWithBudget(r, dest, &extracted)
+	return extractRegularFilesWithResourceBudget(r, dest, &extracted, nil)
 }
 
 func tarBytes(t *testing.T, entries ...tarEntry) []byte {
@@ -96,6 +96,44 @@ func TestExtractRegularFilesRejectsEscapingPaths(t *testing.T) {
 	}
 }
 
+func TestExtractRegularFilesEnforcesResourceBudgetBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		limits ResourceLimits
+	}{
+		{name: "file size", limits: ResourceLimits{MaxFileBytes: 3}},
+		{name: "package size", limits: ResourceLimits{MaxPackageBytes: 3}},
+		{name: "file count", limits: ResourceLimits{MaxPackageFiles: 0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			archive := tarBytes(t, tarEntry{name: "main.tf", typeflag: tar.TypeReg, body: "content"})
+			counter := NewResourceBudget(tt.limits).NewPackageCounter()
+			if tt.name == "file count" {
+				counter = NewResourceBudget(ResourceLimits{MaxPackageFiles: 1}).NewPackageCounter()
+				archive = tarBytes(t,
+					tarEntry{name: "one.tf", typeflag: tar.TypeReg, body: "a"},
+					tarEntry{name: "two.tf", typeflag: tar.TypeReg, body: "b"},
+				)
+			}
+			dest := t.TempDir()
+			extracted := int64(0)
+
+			err := extractRegularFilesWithResourceBudget(bytes.NewReader(archive), dest, &extracted, counter)
+
+			var budgetErr *BudgetExceededError
+			require.ErrorAs(t, err, &budgetErr)
+			if tt.name != "file count" {
+				_, statErr := os.Stat(filepath.Join(dest, "main.tf"))
+				require.ErrorIs(t, statErr, os.ErrNotExist)
+			}
+		})
+	}
+}
+
 func TestExtractArchiveCommandStreamsOutput(t *testing.T) {
 	archive := tarBytes(t, tarEntry{name: "main.tf", typeflag: tar.TypeReg, body: "content"})
 	archivePath := filepath.Join(t.TempDir(), "archive.tar")
@@ -103,8 +141,9 @@ func TestExtractArchiveCommandStreamsOutput(t *testing.T) {
 	dest := t.TempDir()
 	extracted := int64(0)
 
-	require.NoError(t, extractArchiveCommandWithLimit(
-		archiveHelperCommand(t, archivePath), dest, &extracted, int64(len(archive)),
+	require.NoError(t, extractArchiveCommandWithResourceBudget(
+		t.Context(), archiveHelperCommand(t, archivePath), dest, &extracted,
+		int64(len(archive)), nil, nil,
 	))
 	data, err := os.ReadFile(filepath.Join(dest, "main.tf"))
 	require.NoError(t, err)
@@ -117,8 +156,9 @@ func TestExtractArchiveCommandBoundsStreamBeforeExtraction(t *testing.T) {
 	require.NoError(t, os.WriteFile(archivePath, archive, 0o600))
 	extracted := int64(0)
 
-	err := extractArchiveCommandWithLimit(
-		archiveHelperCommand(t, archivePath), t.TempDir(), &extracted, int64(len(archive)-1),
+	err := extractArchiveCommandWithResourceBudget(
+		t.Context(), archiveHelperCommand(t, archivePath), t.TempDir(), &extracted,
+		int64(len(archive)-1), nil, nil,
 	)
 
 	require.ErrorContains(t, err, "git archive exceeds")

--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -11,12 +11,14 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -59,6 +61,7 @@ type bareRepo struct {
 	cloneOK   atomic.Bool
 	cloneMu   sync.Mutex       // serializes clone attempts against barePath
 	cloneErrs map[string]error // transport → clone failure, guarded by cloneMu
+	networkMu sync.RWMutex     // isolates transactional fetches from lazy object writes
 
 	fetchSF   singleflight.Group
 	extractSF singleflight.Group
@@ -217,7 +220,36 @@ func (rem *bareRemote) runNetworkGitWith(
 }
 
 func (rem *bareRemote) runNetworkGit(ctx context.Context, command gitNetworkCommand) ([]byte, error) {
-	return rem.runNetworkGitWith(ctx, command, gitCombinedOutput)
+	rem.networkMu.Lock()
+	defer rem.networkMu.Unlock()
+
+	var terminalBudgetErr error
+	output := func(cmd *exec.Cmd) ([]byte, error) {
+		if terminalBudgetErr != nil {
+			return nil, terminalBudgetErr
+		}
+		objectsDir := filepath.Join(rem.barePath, "objects")
+		existing, err := snapshotPackageTree(objectsDir)
+		if err != nil {
+			return nil, err
+		}
+		out, err := runGitCommandWithResourceBudget(
+			ctx, cmd, rem.barePath, ResourceBudgetFromContext(ctx),
+		)
+		if err != nil {
+			rollbackPackageTree(objectsDir, existing)
+			var budgetErr *BudgetExceededError
+			if errors.As(err, &budgetErr) {
+				terminalBudgetErr = err
+			}
+		}
+		return out, err
+	}
+	out, err := rem.runNetworkGitWith(ctx, command, output)
+	if terminalBudgetErr != nil {
+		return out, terminalBudgetErr
+	}
+	return out, err
 }
 
 func (rem *bareRemote) archiveGitCommand(ctx context.Context, remote string, extraConfig, args []string) *exec.Cmd {
@@ -337,6 +369,10 @@ func (rem *bareRemote) doClone(ctx context.Context) error {
 func gitCloneRetryable(out []byte, err error) bool {
 	if err == nil {
 		return true
+	}
+	var budgetErr *BudgetExceededError
+	if errors.As(err, &budgetErr) {
+		return false
 	}
 	blob := strings.ToLower(string(out) + "\n" + err.Error())
 	return !strings.Contains(blob, "could not read username") &&
@@ -467,6 +503,10 @@ func (rem *bareRemote) fetchNamedRef(ctx context.Context, ref string) (string, e
 			return gitInDir(ctx, rem.barePath, args...)
 		})
 		if err != nil {
+			var budgetErr *BudgetExceededError
+			if errors.As(err, &budgetErr) {
+				return "", fmt.Errorf("git fetch %s %s: %w\n%s", rem.cloneURL, ref, err, bytes.TrimSpace(out))
+			}
 			// Retry without --depth in case the server rejects shallow fetches.
 			out2, err2 := rem.runNetworkGit(ctx, func(remote string, extraConfig []string) *exec.Cmd {
 				args := append(append([]string{}, extraConfig...),
@@ -561,6 +601,7 @@ func localCloneArchiveCommand(gitDir string) archiveCommandFunc {
 // into a sparse directory whose layout matches the repository at the given SHA.
 func archiveExtract(
 	ctx context.Context, gitDir, extractBase, sha, subdir string, runArchive archiveCommandFunc,
+	objectMu *sync.RWMutex,
 ) error {
 	cleanSubdir, err := cleanArchiveSubdir(subdir)
 	if err != nil {
@@ -580,10 +621,33 @@ func archiveExtract(
 		return err
 	}
 
+	budget := ResourceBudgetFromContext(ctx)
+	usage, err := MeasurePackage(ctx, dest, budget.Limits())
+	if err != nil {
+		return err
+	}
+	existing, err := snapshotPackageTree(dest)
+	if err != nil {
+		return err
+	}
+	stateRoot := filepath.Dir(archiveMarkerPath(extractBase, sha, "."))
+	existingState, err := snapshotPackageTree(stateRoot)
+	if err != nil {
+		return err
+	}
+	guard, err := newGitObjectGuard(ctx, gitDir, budget)
+	if err != nil {
+		return err
+	}
 	extracted := int64(0)
+	counter := &PackageCounter{limits: budget.Limits(), usage: usage}
+	visited := map[string]bool{}
 	if err := materializeModuleClosure(
-		ctx, runArchive, sha, dest, extractBase, cleanSubdir, map[string]bool{}, &extracted,
+		ctx, runArchive, sha, dest, extractBase, cleanSubdir, visited, &extracted, counter,
+		objectMu, guard,
 	); err != nil {
+		rollbackPackageTree(dest, existing)
+		rollbackPackageTree(stateRoot, existingState)
 		return err
 	}
 	return nil
@@ -606,6 +670,9 @@ func materializeModuleClosure(
 	sha, packageRoot, extractBase, subdir string,
 	visited map[string]bool,
 	extracted *int64,
+	counter *PackageCounter,
+	objectMu *sync.RWMutex,
+	guard *gitObjectGuard,
 ) error {
 	if visited[subdir] {
 		return nil
@@ -616,7 +683,9 @@ func materializeModuleClosure(
 	if _, err := os.Stat(marker); err == nil {
 		return nil
 	}
-	if err := extractArchiveSubdir(ctx, runArchive, sha, packageRoot, subdir, extracted); err != nil {
+	if err := extractArchiveSubdir(
+		ctx, runArchive, sha, packageRoot, subdir, extracted, counter, objectMu, guard,
+	); err != nil {
 		return err
 	}
 
@@ -630,7 +699,8 @@ func materializeModuleClosure(
 	}
 	for _, child := range children {
 		if err := materializeModuleClosure(
-			ctx, runArchive, sha, packageRoot, extractBase, child, visited, extracted,
+			ctx, runArchive, sha, packageRoot, extractBase, child, visited, extracted, counter,
+			objectMu, guard,
 		); err != nil {
 			return err
 		}
@@ -645,7 +715,8 @@ func materializeModuleClosure(
 }
 
 func extractArchiveSubdir(
-	ctx context.Context, runArchive archiveCommandFunc, sha, dest, subdir string, extracted *int64,
+	ctx context.Context, runArchive archiveCommandFunc, sha, dest, subdir string,
+	extracted *int64, counter *PackageCounter, objectMu *sync.RWMutex, guard *gitObjectGuard,
 ) error {
 	release, err := acquireGitProc(ctx)
 	if err != nil {
@@ -667,11 +738,33 @@ func extractArchiveSubdir(
 	}
 	var lastErr error
 	for _, prep := range preps {
-		err := extractArchiveCommand(prep.cmd, dest, extracted)
+		existing, snapshotErr := snapshotPackageTree(dest)
+		if snapshotErr != nil {
+			prep.close()
+			return snapshotErr
+		}
+		usageBefore := counter.Usage()
+		extractedBefore := *extracted
+		if objectMu != nil {
+			objectMu.RLock()
+		}
+		err := extractArchiveCommandWithResourceBudget(
+			ctx, prep.cmd, dest, extracted, maxArchiveExtractBytes, counter, guard,
+		)
+		if objectMu != nil {
+			objectMu.RUnlock()
+		}
 		prep.close()
 		if err == nil {
 			return nil
 		}
+		rollbackPackageTree(dest, existing)
+		var budgetErr *BudgetExceededError
+		if errors.As(err, &budgetErr) && budgetErr.Limit == limitPackageBytes {
+			rollbackGitObjects(guard, objectMu)
+		}
+		counter.usage = usageBefore
+		*extracted = extractedBefore
 		lastErr = err
 	}
 	if lastErr == nil {
@@ -680,11 +773,24 @@ func extractArchiveSubdir(
 	return fmt.Errorf("extracting git archive %s: %w", archiveArg, lastErr)
 }
 
-func extractArchiveCommand(cmd *exec.Cmd, dest string, extracted *int64) error {
-	return extractArchiveCommandWithLimit(cmd, dest, extracted, maxArchiveExtractBytes)
+// rollbackGitObjects undoes objects fetched lazily by an aborted `git archive`.
+// It upgrades to the clone's write lock so no concurrent reader is relying on
+// the objects being removed.
+func rollbackGitObjects(guard *gitObjectGuard, objectMu *sync.RWMutex) {
+	if guard == nil {
+		return
+	}
+	if objectMu != nil {
+		objectMu.Lock()
+		defer objectMu.Unlock()
+	}
+	guard.rollback()
 }
 
-func extractArchiveCommandWithLimit(cmd *exec.Cmd, dest string, extracted *int64, maxBytes int64) error {
+func extractArchiveCommandWithResourceBudget(
+	ctx context.Context, cmd *exec.Cmd, dest string, extracted *int64, maxBytes int64,
+	counter *PackageCounter, guard *gitObjectGuard,
+) error {
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("opening git archive stream: %w", err)
@@ -692,9 +798,10 @@ func extractArchiveCommandWithLimit(cmd *exec.Cmd, dest string, extracted *int64
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("starting git archive: %w", err)
 	}
+	stopGuard := guard.watch(ctx, func() { _ = cmd.Process.Kill() })
 
 	stream := &io.LimitedReader{R: stdout, N: maxBytes + 1}
-	extractErr := extractRegularFilesWithBudget(stream, dest, extracted)
+	extractErr := extractRegularFilesWithResourceBudget(stream, dest, extracted, counter)
 	if extractErr == nil {
 		_, extractErr = io.Copy(io.Discard, stream)
 	}
@@ -702,18 +809,68 @@ func extractArchiveCommandWithLimit(cmd *exec.Cmd, dest string, extracted *int64
 		_ = stdout.Close()
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
+		if budgetErr := stopGuard(); budgetErr != nil {
+			return budgetErr
+		}
 		if stream.N == 0 {
 			return fmt.Errorf("git archive exceeds %d byte limit", maxBytes)
 		}
 		return extractErr
 	}
-	if err := cmd.Wait(); err != nil {
-		return fmt.Errorf("running git archive: %w", err)
+	waitErr := cmd.Wait()
+	if budgetErr := stopGuard(); budgetErr != nil {
+		return budgetErr
+	}
+	if waitErr != nil {
+		return fmt.Errorf("running git archive: %w", waitErr)
 	}
 	return nil
 }
 
-func extractRegularFilesWithBudget(r io.Reader, dest string, extracted *int64) error {
+func snapshotPackageTree(root string) (map[string]bool, error) {
+	paths := make(map[string]bool)
+	err := filepath.WalkDir(root, func(path string, _ os.DirEntry, walkErr error) error {
+		if errors.Is(walkErr, os.ErrNotExist) {
+			return nil
+		}
+		if walkErr != nil {
+			return walkErr
+		}
+		paths[filepath.Clean(path)] = true
+		return nil
+	})
+	return paths, err
+}
+
+func rollbackPackageTree(root string, existing map[string]bool) {
+	var added []string
+	err := filepath.WalkDir(root, func(path string, _ os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !existing[filepath.Clean(path)] {
+			added = append(added, path)
+		}
+		return nil
+	})
+	if err != nil {
+		_ = os.RemoveAll(root)
+		return
+	}
+	sort.Slice(added, func(i, j int) bool {
+		return len(added[i]) > len(added[j])
+	})
+	for _, path := range added {
+		if err := os.RemoveAll(path); err != nil {
+			_ = os.RemoveAll(root)
+			return
+		}
+	}
+}
+
+func extractRegularFilesWithResourceBudget(
+	r io.Reader, dest string, extracted *int64, counter *PackageCounter,
+) error {
 	tr := tar.NewReader(r)
 	for {
 		header, err := tr.Next()
@@ -727,54 +884,113 @@ func extractRegularFilesWithBudget(r io.Reader, dest string, extracted *int64) e
 			return fmt.Errorf("git archive exceeds %d byte limit", maxArchiveExtractBytes)
 		}
 		name := filepath.Clean(header.Name)
-		if name == "." || !filepath.IsLocal(name) {
+		if !filepath.IsLocal(name) {
 			return fmt.Errorf("tar entry %q is not a local path", header.Name)
 		}
-		if err := extractTarEntry(tr, header, dest, name, extracted); err != nil {
+		if err := extractTarEntry(tr, header, dest, name, extracted, counter); err != nil {
 			return err
 		}
 	}
 }
 
 func extractTarEntry(
-	tr *tar.Reader, header *tar.Header, dest, name string, extracted *int64,
+	tr *tar.Reader, header *tar.Header, dest, name string, extracted *int64, counter *PackageCounter,
 ) error {
 	switch header.Typeflag {
 	case tar.TypeXHeader, tar.TypeXGlobalHeader:
-		return nil
+		return countArchiveMetadataEntry(counter)
 	case tar.TypeDir:
-		if err := os.MkdirAll(filepath.Join(dest, name), dirPerm); err != nil {
+		path := filepath.Join(dest, name)
+		if err := countImplicitParentDirs(dest, name, counter); err != nil {
+			return err
+		}
+		if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
+			if err := countArchiveMetadataEntry(counter); err != nil {
+				return err
+			}
+		} else if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(path, dirPerm); err != nil {
 			return fmt.Errorf("creating directory for tar entry %q: %w", header.Name, err)
 		}
 		return nil
 	case tar.TypeReg:
-		return extractTarRegularFile(tr, header, filepath.Join(dest, name), extracted)
+		return extractTarRegularFile(tr, header, dest, name, extracted, counter)
 	case tar.TypeSymlink, tar.TypeLink, tar.TypeChar, tar.TypeBlock, tar.TypeFifo, tar.TypeCont:
-		return nil
+		return countArchiveMetadataEntry(counter)
 	default:
 		return fmt.Errorf("tar entry %q has unsupported type %d", header.Name, header.Typeflag)
 	}
 }
 
+func countArchiveMetadataEntry(counter *PackageCounter) error {
+	if counter == nil {
+		return nil
+	}
+	return counter.AddEntry(0)
+}
+
+// countImplicitParentDirs charges directories that only exist because a nested
+// entry needs them. Archives may omit explicit directory entries, so without
+// this the file count would understate what is written to disk.
+func countImplicitParentDirs(dest, name string, counter *PackageCounter) error {
+	if counter == nil {
+		return nil
+	}
+	parent := filepath.Dir(name)
+	if parent == "." || parent == name {
+		return nil
+	}
+	if err := countImplicitParentDirs(dest, parent, counter); err != nil {
+		return err
+	}
+	_, err := os.Lstat(filepath.Join(dest, parent))
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return counter.AddEntry(0)
+}
+
 func extractTarRegularFile(
-	tr *tar.Reader, header *tar.Header, path string, extracted *int64,
+	tr *tar.Reader, header *tar.Header, dest, name string, extracted *int64, counter *PackageCounter,
 ) error {
+	path := filepath.Join(dest, name)
 	if header.Size > maxArchiveExtractBytes-*extracted {
 		return fmt.Errorf("git archive exceeds %d byte limit", maxArchiveExtractBytes)
+	}
+	if _, err := os.Lstat(path); err == nil {
+		_, discardErr := io.CopyN(io.Discard, tr, header.Size)
+		return discardErr
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := countImplicitParentDirs(dest, name, counter); err != nil {
+		return err
+	}
+	if counter != nil {
+		if err := counter.AddEntry(header.Size); err != nil {
+			return err
+		}
 	}
 	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
 		return fmt.Errorf("creating parent for tar entry %q: %w", header.Name, err)
 	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, header.FileInfo().Mode().Perm()) //nolint:gosec
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, header.FileInfo().Mode().Perm()) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("creating tar entry %q: %w", header.Name, err)
 	}
 	_, copyErr := io.CopyN(file, tr, header.Size)
 	closeErr := file.Close()
 	if copyErr != nil {
+		_ = os.Remove(path)
 		return fmt.Errorf("writing tar entry %q: %w", header.Name, copyErr)
 	}
 	if closeErr != nil {
+		_ = os.Remove(path)
 		return fmt.Errorf("closing tar entry %q: %w", header.Name, closeErr)
 	}
 	*extracted += header.Size
@@ -854,6 +1070,7 @@ func (rem *bareRemote) extract(ctx context.Context, sha, subdir string) (string,
 	_, err, _ := rem.extractSF.Do(rem.sfKey(key), func() (interface{}, error) {
 		return nil, archiveExtract(
 			ctx, rem.barePath, rem.extractBase, sha, subdir, rem.archiveCommand,
+			&rem.networkMu,
 		)
 	})
 	if err != nil {
@@ -904,19 +1121,19 @@ func (r *BareGitResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedModu
 	}
 
 	if err := remote.ensureClone(ctx); err != nil {
-		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
+		return Resolution{}, unresolvedResourceError(err)
 	}
 
 	sha, err := remote.fetchRef(ctx, ref)
 	if err != nil {
 		contextLogger.Warn().Err(err).Msgf("BareGitResolver: ref %q not reachable from %s", ref, repoURL)
-		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
+		return Resolution{}, unresolvedResourceError(err)
 	}
 
 	packageRoot, err := remote.extract(ctx, sha, subdir)
 	if err != nil {
 		contextLogger.Warn().Err(err).Msgf("BareGitResolver: archive %s:%s failed", sha, subdir)
-		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
+		return Resolution{}, unresolvedResourceError(err)
 	}
 
 	return ConfineResolution(ctx, Resolution{

--- a/pkg/parser/terraform/modules/resolver/baregit_test.go
+++ b/pkg/parser/terraform/modules/resolver/baregit_test.go
@@ -6,6 +6,8 @@
 package resolver
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"errors"
 	"net"
@@ -16,6 +18,61 @@ import (
 
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
+
+func TestSparseArchiveAcceptsRootDirectoryEntry(t *testing.T) {
+	var archive bytes.Buffer
+	tw := tar.NewWriter(&archive)
+	if err := tw.WriteHeader(&tar.Header{Name: "./", Typeflag: tar.TypeDir, Mode: 0o755}); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("resource \"test\" \"example\" {}")
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "main.tf", Typeflag: tar.TypeReg, Mode: 0o600, Size: int64(len(content)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := t.TempDir()
+	var extracted int64
+	counter := NewResourceBudget(ResourceLimits{MaxPackageFiles: 2}).NewPackageCounter()
+	if err := extractRegularFilesWithResourceBudget(&archive, dest, &extracted, counter); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "main.tf")); err != nil {
+		t.Fatal(err)
+	}
+	if counter.Usage().Files != 1 {
+		t.Fatalf("expected only the materialized file to be counted, got %+v", counter.Usage())
+	}
+}
+
+func TestSparseArchiveCountsIgnoredEntryTypes(t *testing.T) {
+	var archive bytes.Buffer
+	tw := tar.NewWriter(&archive)
+	if err := tw.WriteHeader(&tar.Header{Name: "ignored", Typeflag: tar.TypeSymlink, Linkname: "target"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.WriteHeader(&tar.Header{Name: "also-ignored", Typeflag: tar.TypeSymlink, Linkname: "target"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var extracted int64
+	counter := NewResourceBudget(ResourceLimits{MaxPackageFiles: 1}).NewPackageCounter()
+	err := extractRegularFilesWithResourceBudget(&archive, t.TempDir(), &extracted, counter)
+	var budgetErr *BudgetExceededError
+	if !errors.As(err, &budgetErr) || budgetErr.Limit != "package_file_count" {
+		t.Fatalf("expected package file-count error, got %v", err)
+	}
+}
 
 func TestResolveUsesCachedSHAArchiveWithoutDNS(t *testing.T) {
 	const sha = "0123456789abcdef0123456789abcdef01234567"

--- a/pkg/parser/terraform/modules/resolver/chain.go
+++ b/pkg/parser/terraform/modules/resolver/chain.go
@@ -31,6 +31,10 @@ func (c *ChainResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedModule
 		if err == nil {
 			return res, nil
 		}
+		var budgetErr *BudgetExceededError
+		if errors.As(err, &budgetErr) {
+			return Resolution{}, budgetErr
+		}
 		errs = append(errs, err)
 	}
 	return Resolution{}, &tfmodules.UnresolvedError{Reason: errors.Join(errs...).Error()}

--- a/pkg/parser/terraform/modules/resolver/decompressor_budget.go
+++ b/pkg/parser/terraform/modules/resolver/decompressor_budget.go
@@ -1,0 +1,188 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+
+	getter "github.com/hashicorp/go-getter"
+)
+
+const (
+	maxArchiveExpansionRatio = 20
+	maxEntryExpansionRatio   = 100
+	// minStreamRatioBytes is the amount of output that must be produced before a
+	// streaming ratio check is trusted. Decompressors buffer input ahead of the
+	// bytes they emit, so a short prefix of a well-formed archive can look far
+	// more compressed than the archive as a whole.
+	minStreamRatioBytes = 1 << 20
+)
+
+type zipBudgetDecompressor struct {
+	inner  getter.Decompressor
+	limits ResourceLimits
+}
+
+func limitedDecompressors(limits ResourceLimits, maxPackageBytes int64) map[string]getter.Decompressor {
+	decompressors := getter.LimitedDecompressors(limits.MaxPackageFiles, maxPackageBytes)
+	maxFileBytes := limits.MaxFileBytes
+	singleFileLimit := "file_bytes"
+	if maxPackageBytes > 0 && (maxFileBytes <= 0 || maxPackageBytes < maxFileBytes) {
+		maxFileBytes = maxPackageBytes
+		singleFileLimit = limitPackageBytes
+	}
+	singleFormats := map[string]archiveReaderFunc{
+		"bz2": bzip2ArchiveReader,
+		"gz":  gzipArchiveReader,
+		"xz":  xzArchiveReader,
+		"zst": zstdArchiveReader,
+	}
+	for name, open := range singleFormats {
+		decompressors[name] = &singleFileBudgetDecompressor{
+			maxFileBytes: maxFileBytes,
+			limitName:    singleFileLimit,
+			open:         open,
+		}
+	}
+	tarFormats := map[string]archiveReaderFunc{
+		"tar":     rawArchiveReader,
+		"tar.bz2": bzip2ArchiveReader,
+		"tar.gz":  gzipArchiveReader,
+		"tar.xz":  xzArchiveReader,
+		"tar.zst": zstdArchiveReader,
+		"tbz2":    bzip2ArchiveReader,
+		"tgz":     gzipArchiveReader,
+		"txz":     xzArchiveReader,
+		"tzst":    zstdArchiveReader,
+	}
+	for name, open := range tarFormats {
+		decompressors[name] = &tarBudgetDecompressor{limits: limits, open: open}
+	}
+	if zipDecompressor := decompressors["zip"]; zipDecompressor != nil {
+		decompressors["zip"] = &zipBudgetDecompressor{
+			inner:  zipDecompressor,
+			limits: limits,
+		}
+	}
+	return decompressors
+}
+
+func (d *zipBudgetDecompressor) Decompress(
+	dst, src string, dir bool, umask os.FileMode,
+) error {
+	compressed, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if err := d.checkEntries(src); err != nil {
+		return err
+	}
+	if err := d.inner.Decompress(dst, src, dir, umask); err != nil {
+		return err
+	}
+	usage, err := MeasurePackage(context.Background(), dst, d.limits)
+	if err != nil {
+		_ = os.RemoveAll(dst)
+		return err
+	}
+	if exceedsExpansionRatio(usage.Bytes, compressed.Size(), maxArchiveExpansionRatio) {
+		_ = os.RemoveAll(dst)
+		return expansionRatioError("archive_expansion_ratio", usage.Bytes, compressed.Size(), maxArchiveExpansionRatio)
+	}
+	return nil
+}
+
+func (d *zipBudgetDecompressor) checkEntries(path string) error {
+	archive, err := zip.OpenReader(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = archive.Close() }()
+
+	tree := newPackageTreeCounter(NewResourceBudget(d.limits).NewPackageCounter())
+	for _, file := range archive.File {
+		name := filepath.Clean(file.Name)
+		if file.FileInfo().IsDir() {
+			if name == "." {
+				if err := tree.counter.AddEntry(0); err != nil {
+					return err
+				}
+				continue
+			}
+			if !filepath.IsLocal(name) {
+				return fmt.Errorf("zip entry %q is not a local path", file.Name)
+			}
+			if err := tree.addDir(name); err != nil {
+				return err
+			}
+			continue
+		}
+		if !filepath.IsLocal(name) {
+			return fmt.Errorf("zip entry %q is not a local path", file.Name)
+		}
+		if err := tree.addDir(filepath.Dir(name)); err != nil {
+			return err
+		}
+		if file.UncompressedSize64 > math.MaxInt64 {
+			return fmt.Errorf("zip entry %q is too large", file.Name)
+		}
+		size := int64(file.UncompressedSize64)
+		if err := tree.counter.AddEntry(size); err != nil {
+			return err
+		}
+		if exceedsExpansionRatio(size, int64(file.CompressedSize64), maxEntryExpansionRatio) {
+			return fmt.Errorf(
+				"zip entry %q: %w",
+				file.Name,
+				expansionRatioError(
+					"entry_expansion_ratio", size, int64(file.CompressedSize64), maxEntryExpansionRatio,
+				),
+			)
+		}
+	}
+	return nil
+}
+
+func expansionRatioError(limit string, expanded, compressed, maximum int64) error {
+	measured := expanded
+	if compressed > 0 {
+		measured = (expanded + compressed - 1) / compressed
+	}
+	return &BudgetExceededError{
+		Gate:     "stream",
+		Limit:    limit,
+		Maximum:  maximum,
+		Measured: measured,
+	}
+}
+
+// exceedsStreamExpansionRatio applies the ratio check mid-stream, once enough
+// output has been produced for the measurement to be meaningful. The final,
+// unconditional check still runs when the stream ends.
+func exceedsStreamExpansionRatio(expanded, compressed, ratio int64) bool {
+	if expanded < minStreamRatioBytes {
+		return false
+	}
+	return exceedsExpansionRatio(expanded, compressed, ratio)
+}
+
+func exceedsExpansionRatio(expanded, compressed, ratio int64) bool {
+	if expanded <= 0 {
+		return false
+	}
+	if compressed <= 0 {
+		return true
+	}
+	if compressed > math.MaxInt64/ratio {
+		return false
+	}
+	return expanded > compressed*ratio
+}

--- a/pkg/parser/terraform/modules/resolver/decompressor_budget_test.go
+++ b/pkg/parser/terraform/modules/resolver/decompressor_budget_test.go
@@ -1,0 +1,265 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/rand"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopySingleFileAcceptsMaxInt64Limit(t *testing.T) {
+	t.Parallel()
+
+	var dst bytes.Buffer
+	src := bytes.NewBufferString("content")
+	compressed := &countingReader{reader: src}
+
+	written, err := copySingleFileWithBudget(
+		&dst, compressed, compressed, math.MaxInt64, "file_bytes",
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(len("content")), written)
+	require.Equal(t, "content", dst.String())
+}
+
+func TestBudgetedZipRejectsEntryBeforeExtraction(t *testing.T) {
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "module.zip")
+	file, err := os.Create(src)
+	require.NoError(t, err)
+	writer := zip.NewWriter(file)
+	entry, err := writer.Create("main.tf")
+	require.NoError(t, err)
+	_, err = entry.Write(bytes.Repeat([]byte("0"), 64*1024))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	require.NoError(t, file.Close())
+
+	decompressor := limitedDecompressors(ResourceLimits{
+		MaxPackageBytes: 128 * 1024,
+		MaxFileBytes:    128 * 1024,
+		MaxPackageFiles: 10,
+	}, 128*1024)["zip"]
+	dst := filepath.Join(t.TempDir(), "module")
+
+	err = decompressor.Decompress(dst, src, true, 0)
+
+	require.ErrorContains(t, err, "entry")
+	require.ErrorContains(t, err, "entry_expansion_ratio")
+	_, statErr := os.Stat(dst)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestBudgetedZipCountsImplicitDirectories(t *testing.T) {
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "module.zip")
+	file, err := os.Create(src)
+	require.NoError(t, err)
+	writer := zip.NewWriter(file)
+	entry, err := writer.Create("one/two/three/main.tf")
+	require.NoError(t, err)
+	_, err = entry.Write([]byte("content"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	require.NoError(t, file.Close())
+
+	decompressor := limitedDecompressors(ResourceLimits{
+		MaxPackageBytes: 128,
+		MaxFileBytes:    128,
+		MaxPackageFiles: 3,
+	}, 128)["zip"]
+	dst := filepath.Join(t.TempDir(), "module")
+
+	err = decompressor.Decompress(dst, src, true, 0)
+
+	require.ErrorContains(t, err, "package_file_count")
+	_, statErr := os.Stat(dst)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestBudgetedTarRejectsFileBeforeWritingPastLimit(t *testing.T) {
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "module.tgz")
+	file, err := os.Create(src)
+	require.NoError(t, err)
+	compressed := gzip.NewWriter(file)
+	archive := tar.NewWriter(compressed)
+	require.NoError(t, archive.WriteHeader(&tar.Header{
+		Name:     "./",
+		Mode:     0o755,
+		Typeflag: tar.TypeDir,
+	}))
+	require.NoError(t, archive.WriteHeader(&tar.Header{
+		Name: "main.tf",
+		Mode: 0o600,
+		Size: 7,
+	}))
+	_, err = archive.Write([]byte("content"))
+	require.NoError(t, err)
+	require.NoError(t, archive.Close())
+	require.NoError(t, compressed.Close())
+	require.NoError(t, file.Close())
+
+	decompressor := limitedDecompressors(ResourceLimits{
+		MaxPackageBytes: 128,
+		MaxFileBytes:    3,
+		MaxPackageFiles: 10,
+	}, 128)["tgz"]
+	dst := filepath.Join(t.TempDir(), "module")
+
+	err = decompressor.Decompress(dst, src, true, 0)
+
+	var budgetErr *BudgetExceededError
+	require.ErrorAs(t, err, &budgetErr)
+	require.Equal(t, "file_bytes", budgetErr.Limit)
+	_, statErr := os.Stat(filepath.Join(dst, "main.tf"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestBudgetedSingleFileReportsPackageLimit(t *testing.T) {
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "module.gz")
+	file, err := os.Create(src)
+	require.NoError(t, err)
+	compressed := gzip.NewWriter(file)
+	_, err = compressed.Write([]byte("content"))
+	require.NoError(t, err)
+	require.NoError(t, compressed.Close())
+	require.NoError(t, file.Close())
+	dst := filepath.Join(t.TempDir(), "module.tf")
+	decompressor := limitedDecompressors(ResourceLimits{
+		MaxPackageBytes: 3,
+		MaxFileBytes:    10,
+	}, 3)["gz"]
+
+	err = decompressor.Decompress(dst, src, false, 0)
+
+	var budgetErr *BudgetExceededError
+	require.ErrorAs(t, err, &budgetErr)
+	require.Equal(t, "package_bytes", budgetErr.Limit)
+	require.Equal(t, int64(3), budgetErr.Maximum)
+	_, statErr := os.Stat(dst)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestBudgetedTarCountsImplicitParentDirectories(t *testing.T) {
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "module.tgz")
+	file, err := os.Create(src)
+	require.NoError(t, err)
+	compressed := gzip.NewWriter(file)
+	archive := tar.NewWriter(compressed)
+	// Only the leaf entries are present; the three directories holding them are
+	// created implicitly and must still be charged to the file count.
+	for _, name := range []string{"a/b/c/one.tf", "a/b/c/two.tf"} {
+		require.NoError(t, archive.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: 1}))
+		_, err = archive.Write([]byte("x"))
+		require.NoError(t, err)
+	}
+	require.NoError(t, archive.Close())
+	require.NoError(t, compressed.Close())
+	require.NoError(t, file.Close())
+
+	decompressor := limitedDecompressors(ResourceLimits{
+		MaxPackageBytes: 128,
+		MaxFileBytes:    128,
+		MaxPackageFiles: 4,
+	}, 128)["tgz"]
+
+	err = decompressor.Decompress(filepath.Join(t.TempDir(), "module"), src, true, 0)
+
+	var budgetErr *BudgetExceededError
+	require.ErrorAs(t, err, &budgetErr)
+	require.Equal(t, "package_file_count", budgetErr.Limit)
+	require.Equal(t, int64(4), budgetErr.Maximum)
+}
+
+func TestBudgetedTarAcceptsArchiveWithHighlyCompressedPrefix(t *testing.T) {
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "module.tgz")
+	file, err := os.Create(src)
+	require.NoError(t, err)
+	compressed := gzip.NewWriter(file)
+	archive := tar.NewWriter(compressed)
+	// Zero-filled leading entries compress far better than the ratio limit, but
+	// the archive as a whole stays well inside it.
+	require.NoError(t, archive.WriteHeader(&tar.Header{Name: "zeros.bin", Mode: 0o600, Size: 4096}))
+	_, err = archive.Write(make([]byte, 4096))
+	require.NoError(t, err)
+	body := make([]byte, 256*1024)
+	_, err = rand.Read(body)
+	require.NoError(t, err)
+	require.NoError(t, archive.WriteHeader(&tar.Header{
+		Name: "main.tf", Mode: 0o600, Size: int64(len(body)),
+	}))
+	_, err = archive.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, archive.Close())
+	require.NoError(t, compressed.Close())
+	require.NoError(t, file.Close())
+
+	decompressor := limitedDecompressors(ResourceLimits{
+		MaxPackageBytes: 1024 * 1024,
+		MaxFileBytes:    1024 * 1024,
+		MaxPackageFiles: 10,
+	}, 1024*1024)["tgz"]
+	dst := filepath.Join(t.TempDir(), "module")
+
+	require.NoError(t, decompressor.Decompress(dst, src, true, 0))
+	extracted, err := os.ReadFile(filepath.Join(dst, "main.tf"))
+	require.NoError(t, err)
+	require.Equal(t, body, extracted)
+}
+
+func TestBudgetedTarRejectsRatioAtEndOfSmallArchive(t *testing.T) {
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "module.tgz")
+	file, err := os.Create(src)
+	require.NoError(t, err)
+	compressed := gzip.NewWriter(file)
+	archive := tar.NewWriter(compressed)
+	// The archive expands well past the ratio limit, but stays small enough
+	// that the mid-stream check never runs, so only the check at the end of the
+	// stream can catch it.
+	for i := range 64 {
+		require.NoError(t, archive.WriteHeader(&tar.Header{
+			Name: fmt.Sprintf("file%02d.tf", i), Mode: 0o600, Size: 1024,
+		}))
+		_, err = archive.Write(make([]byte, 1024))
+		require.NoError(t, err)
+	}
+	require.NoError(t, archive.Close())
+	require.NoError(t, compressed.Close())
+	require.NoError(t, file.Close())
+
+	decompressor := limitedDecompressors(ResourceLimits{
+		MaxPackageBytes: 1024 * 1024,
+		MaxFileBytes:    1024 * 1024,
+		MaxPackageFiles: 128,
+	}, 1024*1024)["tgz"]
+
+	err = decompressor.Decompress(filepath.Join(t.TempDir(), "module"), src, true, 0)
+
+	require.ErrorContains(t, err, "archive_expansion_ratio")
+}

--- a/pkg/parser/terraform/modules/resolver/git_resource_budget.go
+++ b/pkg/parser/terraform/modules/resolver/git_resource_budget.go
@@ -1,0 +1,307 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	gitBudgetSampleInterval    = 25 * time.Millisecond
+	gitBudgetMaxSampleInterval = 500 * time.Millisecond
+)
+
+func runGitCommandWithResourceBudget(
+	ctx context.Context, cmd *exec.Cmd, path string, budget *ResourceBudget,
+) ([]byte, error) {
+	maximum := budget.Limits().MaxPackageBytes
+	if budget == nil || maximum <= 0 {
+		return cmd.CombinedOutput()
+	}
+	baselineTotal, err := gitDirectoryBytes(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	objectMonitor, err := newGitObjectMonitor(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		return output.Bytes(), err
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	timer := time.NewTimer(objectMonitor.samplingInterval())
+	defer timer.Stop()
+	for {
+		select {
+		case err := <-done:
+			if err != nil {
+				return output.Bytes(), err
+			}
+			if budgetErr := gitDirectoryBudgetError(ctx, path, baselineTotal, maximum); budgetErr != nil {
+				return output.Bytes(), budgetErr
+			}
+			return output.Bytes(), nil
+		case <-timer.C:
+			if budgetErr := objectMonitor.budgetError(ctx, maximum); budgetErr != nil {
+				_ = cmd.Process.Kill()
+				<-done
+				return output.Bytes(), budgetErr
+			}
+			timer.Reset(objectMonitor.samplingInterval())
+		case <-ctx.Done():
+			_ = cmd.Process.Kill()
+			<-done
+			return output.Bytes(), ctx.Err()
+		}
+	}
+}
+
+// gitObjectGuard watches a clone's object store while a command that may fetch
+// objects lazily runs. `git archive` against a partial clone downloads missing
+// blobs on demand, which grows the store without going through a fetch, so the
+// guard aborts the command on breach and can undo the objects it pulled in.
+type gitObjectGuard struct {
+	gitDir   string
+	monitor  *gitObjectMonitor
+	existing map[string]bool
+	maximum  int64
+
+	mu     sync.Mutex
+	breach error
+}
+
+func newGitObjectGuard(ctx context.Context, gitDir string, budget *ResourceBudget) (*gitObjectGuard, error) {
+	maximum := budget.Limits().MaxPackageBytes
+	if maximum <= 0 {
+		return nil, nil //nolint:nilnil
+	}
+	monitor, err := newGitObjectMonitor(ctx, gitDir)
+	if err != nil {
+		return nil, err
+	}
+	existing, err := snapshotPackageTree(monitor.objectsDir)
+	if err != nil {
+		return nil, err
+	}
+	return &gitObjectGuard{
+		gitDir:   gitDir,
+		monitor:  monitor,
+		existing: existing,
+		maximum:  maximum,
+	}, nil
+}
+
+// watch polls the object store until the returned stop function is called,
+// aborting the running command as soon as the growth limit is breached. stop
+// returns the breach error, if any.
+func (g *gitObjectGuard) watch(ctx context.Context, abort func()) (stop func() error) {
+	if g == nil {
+		return func() error { return nil }
+	}
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		timer := time.NewTimer(g.monitor.samplingInterval())
+		defer timer.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-timer.C:
+				if err := g.monitor.budgetError(ctx, g.maximum); err != nil {
+					g.mu.Lock()
+					if g.breach == nil {
+						g.breach = err
+					}
+					g.mu.Unlock()
+					abort()
+					return
+				}
+				timer.Reset(g.monitor.samplingInterval())
+			}
+		}
+	}()
+	return func() error {
+		close(done)
+		<-finished
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		return g.breach
+	}
+}
+
+// rollback removes object files that appeared since the guard was created. The
+// caller must hold the clone's object write lock so no reader observes the
+// partially fetched objects being removed.
+func (g *gitObjectGuard) rollback() {
+	if g == nil {
+		return
+	}
+	rollbackPackageTree(g.monitor.objectsDir, g.existing)
+}
+
+func gitDirectoryBudgetError(ctx context.Context, path string, baseline, maximum int64) error {
+	measured, err := gitDirectoryBytes(ctx, path)
+	if err != nil {
+		return err
+	}
+	return gitGrowthBudgetError(measured-baseline, maximum)
+}
+
+func gitGrowthBudgetError(growth, maximum int64) error {
+	if growth <= maximum {
+		return nil
+	}
+	return &BudgetExceededError{
+		Gate:     "stream",
+		Limit:    limitPackageBytes,
+		Maximum:  maximum,
+		Measured: growth,
+	}
+}
+
+type gitObjectMonitor struct {
+	objectsDir string
+	baseline   int64
+
+	interval   time.Duration
+	lastGrowth int64
+	lastSample time.Time
+}
+
+func newGitObjectMonitor(ctx context.Context, path string) (*gitObjectMonitor, error) {
+	monitor := &gitObjectMonitor{
+		objectsDir: filepath.Join(path, "objects"),
+		interval:   gitBudgetSampleInterval,
+	}
+	total, err := monitor.currentBytes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	monitor.baseline = total
+	return monitor, nil
+}
+
+func (m *gitObjectMonitor) budgetError(ctx context.Context, maximum int64) error {
+	measured, err := m.currentBytes(ctx)
+	if err != nil {
+		return err
+	}
+	growth := measured - m.baseline
+	m.recordSample(growth, maximum, time.Now())
+	return gitGrowthBudgetError(growth, maximum)
+}
+
+// samplingInterval is how long to wait before measuring the object store again.
+// A full scan is not cheap on a large clone, so the wait is spaced out by how
+// long the observed download rate would need to consume the remaining headroom.
+// A clone that is barely growing is scanned rarely, while a fast one is still
+// sampled often enough to stop close to the limit.
+func (m *gitObjectMonitor) samplingInterval() time.Duration {
+	return m.interval
+}
+
+func (m *gitObjectMonitor) recordSample(growth, maximum int64, now time.Time) {
+	previousGrowth, previousSample := m.lastGrowth, m.lastSample
+	m.lastGrowth, m.lastSample = growth, now
+	if previousSample.IsZero() {
+		return
+	}
+	elapsed := now.Sub(previousSample)
+	added := growth - previousGrowth
+	headroom := maximum - growth
+	if elapsed <= 0 || added <= 0 || headroom <= 0 {
+		m.interval = gitBudgetSampleInterval
+		return
+	}
+	rate := float64(added) / elapsed.Seconds()
+	untilLimit := time.Duration(float64(headroom) / rate / 2 * float64(time.Second))
+	m.interval = min(max(untilLimit, gitBudgetSampleInterval), gitBudgetMaxSampleInterval)
+}
+
+func (m *gitObjectMonitor) currentBytes(ctx context.Context) (int64, error) {
+	entries, err := os.ReadDir(m.objectsDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		if name := entry.Name(); name != "pack" && !isLooseObjectDir(name) {
+			continue
+		}
+		size, err := regularFilesBytes(ctx, filepath.Join(m.objectsDir, entry.Name()))
+		if err != nil {
+			return 0, err
+		}
+		total += size
+	}
+	return total, nil
+}
+
+func regularFilesBytes(ctx context.Context, path string) (int64, error) {
+	entries, err := os.ReadDir(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return 0, err
+		}
+		if info.Mode().IsRegular() {
+			total += info.Size()
+		}
+	}
+	return total, nil
+}
+
+func isLooseObjectDir(name string) bool {
+	return len(name) == 2 && strings.IndexFunc(name, func(r rune) bool {
+		return !strings.ContainsRune("0123456789abcdef", r)
+	}) == -1
+}
+
+func gitDirectoryBytes(ctx context.Context, path string) (int64, error) {
+	usage, err := MeasurePackage(ctx, path, ResourceLimits{})
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	return usage.Bytes, err
+}

--- a/pkg/parser/terraform/modules/resolver/git_resource_budget_test.go
+++ b/pkg/parser/terraform/modules/resolver/git_resource_budget_test.go
@@ -1,0 +1,149 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunGitCommandStopsAtResourceBudget(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cmd := exec.Command(os.Args[0], "-test.run=TestGitResourceBudgetHelper", "--", dir)
+	cmd.Env = append(os.Environ(), "GO_WANT_GIT_BUDGET_HELPER=1")
+	budget := NewResourceBudget(ResourceLimits{MaxPackageBytes: 512})
+
+	_, err := runGitCommandWithResourceBudget(t.Context(), cmd, dir, budget)
+
+	var budgetErr *BudgetExceededError
+	require.True(t, errors.As(err, &budgetErr))
+	require.Equal(t, "package_bytes", budgetErr.Limit)
+	info, statErr := os.Stat(filepath.Join(dir, "objects", "pack", "incoming.pack"))
+	require.NoError(t, statErr)
+	require.LessOrEqual(t, info.Size(), int64(1536))
+}
+
+func TestGitObjectMonitorCountsLooseObjects(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	monitor, err := newGitObjectMonitor(t.Context(), dir)
+	require.NoError(t, err)
+	objectDir := filepath.Join(dir, "objects", "aa")
+	require.NoError(t, os.MkdirAll(objectDir, 0o755))
+	objectPath := filepath.Join(objectDir, "object")
+	require.NoError(t, os.WriteFile(objectPath, make([]byte, 256), 0o600))
+	require.NoError(t, monitor.budgetError(t.Context(), 512))
+	file, err := os.OpenFile(objectPath, os.O_APPEND|os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	_, err = file.Write(make([]byte, 257))
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	err = monitor.budgetError(t.Context(), 512)
+
+	var budgetErr *BudgetExceededError
+	require.ErrorAs(t, err, &budgetErr)
+	require.Equal(t, int64(513), budgetErr.Measured)
+}
+
+func TestGitObjectMonitorFindsLooseObjectsWhenDirectoryTimestampIsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	objectDir := filepath.Join(dir, "objects", "aa")
+	require.NoError(t, os.MkdirAll(objectDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(objectDir, "existing"), []byte("x"), 0o600))
+	info, err := os.Stat(objectDir)
+	require.NoError(t, err)
+	monitor, err := newGitObjectMonitor(t.Context(), dir)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(objectDir, "new"), make([]byte, 513), 0o600))
+	require.NoError(t, os.Chtimes(objectDir, info.ModTime(), info.ModTime()))
+
+	err = monitor.budgetError(t.Context(), 512)
+	var budgetErr *BudgetExceededError
+	require.ErrorAs(t, err, &budgetErr)
+	require.Equal(t, int64(513), budgetErr.Measured)
+}
+
+func TestGitResourceBudgetHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_GIT_BUDGET_HELPER") != "1" {
+		return
+	}
+	dir := os.Args[len(os.Args)-1]
+	packDir := filepath.Join(dir, "objects", "pack")
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		os.Exit(1)
+	}
+	file, err := os.Create(filepath.Join(packDir, "incoming.pack"))
+	if err != nil {
+		os.Exit(1)
+	}
+	defer func() { _ = file.Close() }()
+	chunk := make([]byte, 256)
+	for {
+		if _, err := file.Write(chunk); err != nil {
+			os.Exit(1)
+		}
+		if err := file.Sync(); err != nil {
+			os.Exit(1)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestGitObjectMonitorSpacesSamplesByGrowthRate(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now()
+	monitor := &gitObjectMonitor{interval: gitBudgetSampleInterval}
+	monitor.recordSample(0, 10<<20, start)
+
+	// A trickle of objects leaves plenty of headroom, so the next scan waits.
+	monitor.recordSample(1024, 10<<20, start.Add(time.Second))
+	require.Equal(t, gitBudgetMaxSampleInterval, monitor.samplingInterval())
+
+	// A download that would consume the headroom in milliseconds is sampled at
+	// the tightest interval.
+	monitor.recordSample(10<<20-1024, 10<<20, start.Add(2*time.Second))
+	require.Equal(t, gitBudgetSampleInterval, monitor.samplingInterval())
+}
+
+func TestGitObjectGuardAbortsAndRollsBackLazyObjectFetch(t *testing.T) {
+	t.Parallel()
+
+	gitDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(gitDir, "objects"), 0o755))
+	guard, err := newGitObjectGuard(
+		t.Context(), gitDir, NewResourceBudget(ResourceLimits{MaxPackageBytes: 512}),
+	)
+	require.NoError(t, err)
+	cmd := exec.Command(os.Args[0], "-test.run=TestGitResourceBudgetHelper", "--", gitDir)
+	cmd.Env = append(os.Environ(), "GO_WANT_GIT_BUDGET_HELPER=1")
+	extracted := int64(0)
+
+	err = extractArchiveCommandWithResourceBudget(
+		t.Context(), cmd, t.TempDir(), &extracted, 1024, nil, guard,
+	)
+
+	var budgetErr *BudgetExceededError
+	require.ErrorAs(t, err, &budgetErr)
+	require.Equal(t, "package_bytes", budgetErr.Limit)
+
+	rollbackGitObjects(guard, nil)
+	_, statErr := os.Stat(filepath.Join(gitDir, "objects", "pack", "incoming.pack"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}

--- a/pkg/parser/terraform/modules/resolver/git_ssh_transport_test.go
+++ b/pkg/parser/terraform/modules/resolver/git_ssh_transport_test.go
@@ -17,6 +17,10 @@ import (
 	"testing"
 )
 
+func gitCombinedOutput(cmd *exec.Cmd) ([]byte, error) {
+	return cmd.CombinedOutput()
+}
+
 // writeKnownHosts writes content to a temporary known_hosts file and returns its path.
 func writeKnownHosts(t *testing.T, content string) string {
 	t.Helper()

--- a/pkg/parser/terraform/modules/resolver/git_transport.go
+++ b/pkg/parser/terraform/modules/resolver/git_transport.go
@@ -22,12 +22,6 @@ type gitNetworkCommand func(remote string, extraConfig []string) *exec.Cmd
 // gitOutputFunc captures the output of a git command built by a gitNetworkCommand.
 type gitOutputFunc func(cmd *exec.Cmd) ([]byte, error)
 
-// gitCombinedOutput folds stderr into the result, which suits commands whose output is
-// only ever read for diagnostics.
-func gitCombinedOutput(cmd *exec.Cmd) ([]byte, error) {
-	return cmd.CombinedOutput()
-}
-
 // gitInheritedEnvBlockedPrefixes lists environment prefixes that let the caller
 // redirect a git subprocess to an unvalidated destination.
 var gitInheritedEnvBlockedPrefixes = []string{

--- a/pkg/parser/terraform/modules/resolver/gogetter.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter.go
@@ -7,8 +7,8 @@ package resolver
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"io/fs"
 	"math/rand"
 	"net"
 	"net/http"
@@ -30,8 +30,8 @@ import (
 
 const (
 	DefaultFetchTimeout   = 30 * time.Second
-	DefaultMaxModuleBytes = 0                 // no per-module cap; use MaxTotalBytes only
-	DefaultMaxTotalBytes  = 200 * 1024 * 1024 // 200 MiB
+	DefaultMaxModuleBytes = 0
+	DefaultMaxTotalBytes  = 200 * 1024 * 1024
 	mib                   = 1024 * 1024
 
 	sourceTypeRegistry = "registry"
@@ -71,10 +71,10 @@ type GoGetterConfig struct {
 	Disabled bool
 
 	FetchTimeout time.Duration
-	// MaxModuleBytes caps each individual module fetch (programmatic knob; not exposed via CLI).
-	// Defaults to 0 (no per-module cap); the scan-level cap MaxTotalBytes applies instead.
+	// MaxModuleBytes caps each individual module fetch when no graph budget is attached.
 	MaxModuleBytes int64
-	MaxTotalBytes  int64
+	// MaxTotalBytes is retained for standalone resolver compatibility.
+	MaxTotalBytes int64
 
 	HostAllowlist []string
 	Cache         *moduleCache
@@ -114,6 +114,7 @@ func NewGoGetterResolver(cfg *GoGetterConfig) *GoGetterResolver {
 	if cfg.httpClient == nil {
 		cfg.httpClient = newPolicyHTTPClient(cfg.FetchTimeout, cfg.HostAllowlist)
 	}
+	cfg.httpClient = withResourceBudgetTransport(cfg.httpClient, cfg.MaxModuleBytes)
 	if cfg.RegistryCache == nil {
 		cfg.RegistryCache = NewRegistryCache(cfg.FetchTimeout, cfg.HostAllowlist...)
 	}
@@ -266,14 +267,48 @@ func (r *GoGetterResolver) lookupCache(
 	if !ok {
 		return Resolution{}, false, nil
 	}
-	if err := r.reserveDirBytes(packageRoot); err != nil {
-		return Resolution{}, false, err
+	if ResourceBudgetFromContext(ctx) == nil {
+		if err := r.reserveDirBytes(ctx, packageRoot); err != nil {
+			return Resolution{}, false, err
+		}
 	}
 	resolution, err := resolutionForPackage(ctx, packageRoot, selectedSubdir)
 	if err != nil {
 		return Resolution{}, false, &tfmodules.UnresolvedError{Reason: "invalid cached module package: " + err.Error()}
 	}
 	return resolution, true, nil
+}
+
+func (r *GoGetterResolver) checkByteLimits(size int64) error {
+	if r.cfg.MaxModuleBytes > 0 && size > r.cfg.MaxModuleBytes {
+		return &tfmodules.UnresolvedError{
+			Reason: fmt.Sprintf("module exceeds per-module limit of %d MiB", r.cfg.MaxModuleBytes/mib),
+		}
+	}
+	if r.cfg.MaxTotalBytes > 0 {
+		if used := r.cfg.totalBytesUsed.Add(size); used > r.cfg.MaxTotalBytes {
+			r.cfg.totalBytesUsed.Add(-size)
+			return &tfmodules.UnresolvedError{Reason: "scan-level remote module byte cap exceeded"}
+		}
+	}
+	return nil
+}
+
+func (r *GoGetterResolver) reserveDirBytes(ctx context.Context, dir string) error {
+	cleanDir := filepath.Clean(dir)
+	if _, loaded := r.cfg.accountedDirs.LoadOrStore(cleanDir, struct{}{}); loaded {
+		return nil
+	}
+	usage, err := MeasurePackage(ctx, dir, ResourceLimits{})
+	if err != nil {
+		r.cfg.accountedDirs.Delete(cleanDir)
+		return &tfmodules.UnresolvedError{Reason: "measuring cached module: " + err.Error()}
+	}
+	if err := r.checkByteLimits(usage.Bytes); err != nil {
+		r.cfg.accountedDirs.Delete(cleanDir)
+		return err
+	}
+	return nil
 }
 
 func (r *GoGetterResolver) acquireFetchSlot(ctx context.Context) error {
@@ -309,57 +344,27 @@ func (r *GoGetterResolver) acquireHostSlot(ctx context.Context, host string) (fu
 	}
 }
 
-// checkByteLimits returns an error if size exceeds per-module or scan-level caps.
-// On a total-bytes overflow it rolls back the atomic counter before returning.
-func (r *GoGetterResolver) checkByteLimits(size int64) error {
-	if r.cfg.MaxModuleBytes > 0 && size > r.cfg.MaxModuleBytes {
-		return &tfmodules.UnresolvedError{
-			Reason: fmt.Sprintf("module exceeds per-module limit of %d MiB", r.cfg.MaxModuleBytes/mib),
-		}
-	}
-	if r.cfg.MaxTotalBytes > 0 {
-		if n := r.cfg.totalBytesUsed.Add(size); n > r.cfg.MaxTotalBytes {
-			r.cfg.totalBytesUsed.Add(-size)
-			return &tfmodules.UnresolvedError{Reason: "scan-level remote module byte cap exceeded"}
-		}
-	}
-	return nil
-}
-
-func (r *GoGetterResolver) reserveDirBytes(dir string) error {
-	cleanDir := filepath.Clean(dir)
-	if _, loaded := r.cfg.accountedDirs.LoadOrStore(cleanDir, struct{}{}); loaded {
-		return nil
-	}
-	size, err := measureDir(dir)
-	if err != nil {
-		r.cfg.accountedDirs.Delete(cleanDir)
-		return &tfmodules.UnresolvedError{Reason: "measuring cached module: " + err.Error()}
-	}
-	if err := r.checkByteLimits(size); err != nil {
-		r.cfg.accountedDirs.Delete(cleanDir)
-		return err
-	}
-	return nil
-}
-
-// commitFetchedDir enforces size limits, caches, returns Resolution.
+// commitFetchedDir caches the fetched package and returns its selected module.
 func (r *GoGetterResolver) commitFetchedDir(
 	ctx context.Context, source, version, tmpDir, selectedSubdir string, useCache bool,
 ) (Resolution, error) {
-	size, err := measureDir(tmpDir)
-	if err != nil {
-		_ = os.RemoveAll(tmpDir)
-		return Resolution{}, &tfmodules.UnresolvedError{Reason: "measuring module size: " + err.Error()}
-	}
-	if err := r.checkByteLimits(size); err != nil {
-		_ = os.RemoveAll(tmpDir)
-		return Resolution{}, err
+	if ResourceBudgetFromContext(ctx) == nil {
+		usage, err := MeasurePackage(ctx, tmpDir, ResourceLimits{})
+		if err != nil {
+			_ = os.RemoveAll(tmpDir)
+			return Resolution{}, &tfmodules.UnresolvedError{Reason: "measuring module size: " + err.Error()}
+		}
+		if err := r.checkByteLimits(usage.Bytes); err != nil {
+			_ = os.RemoveAll(tmpDir)
+			return Resolution{}, err
+		}
 	}
 	if useCache {
 		if cached, storeErr := r.cfg.Cache.store(source, version, tmpDir, selectedSubdir); storeErr == nil {
 			_ = os.RemoveAll(tmpDir)
-			r.cfg.accountedDirs.Store(filepath.Clean(cached), struct{}{})
+			if ResourceBudgetFromContext(ctx) == nil {
+				r.cfg.accountedDirs.Store(filepath.Clean(cached), struct{}{})
+			}
 			resolution, err := resolutionForPackage(ctx, cached, selectedSubdir)
 			if err != nil {
 				return Resolution{}, &tfmodules.UnresolvedError{Reason: "invalid cached module package: " + err.Error()}
@@ -528,17 +533,23 @@ func (r *GoGetterResolver) fetchOnce(ctx context.Context, getterSrc string) (str
 	defer cancel()
 
 	client := &getter.Client{
-		Ctx:  fetchCtx,
-		Src:  getterSrc,
-		Dst:  tmpDir,
-		Pwd:  tmpDir,
-		Mode: getter.ClientModeDir,
+		Ctx:             fetchCtx,
+		Src:             getterSrc,
+		Dst:             tmpDir,
+		Pwd:             tmpDir,
+		Mode:            getter.ClientModeDir,
+		DisableSymlinks: true,
+		Decompressors:   r.decompressors(fetchCtx),
 		Options: []getter.ClientOption{
 			getter.WithGetters(r.getters(getterSrc)),
 		},
 	}
 	if err := client.Get(); err != nil {
 		_ = os.RemoveAll(tmpDir)
+		var budgetErr *BudgetExceededError
+		if errors.As(err, &budgetErr) {
+			return "", budgetErr
+		}
 		return "", &tfmodules.UnresolvedError{Reason: "fetch failed: " + err.Error()}
 	}
 	return tmpDir, nil
@@ -557,6 +568,20 @@ func (r *GoGetterResolver) getters(source string) map[string]getter.Getter {
 	getters["http"] = httpGetter
 	getters["https"] = httpGetter
 	return getters
+}
+
+func (r *GoGetterResolver) decompressors(ctx context.Context) map[string]getter.Decompressor {
+	limits := ResourceBudgetFromContext(ctx).Limits()
+	return limitedDecompressors(limits, r.maxPackageBytes(ctx))
+}
+
+func (r *GoGetterResolver) maxPackageBytes(ctx context.Context) int64 {
+	maxBytes := r.cfg.MaxModuleBytes
+	if budgetMax := ResourceBudgetFromContext(ctx).Limits().MaxPackageBytes; budgetMax > 0 &&
+		(maxBytes <= 0 || budgetMax < maxBytes) {
+		maxBytes = budgetMax
+	}
+	return maxBytes
 }
 
 func validateGetterSourceTransport(source string) error {
@@ -693,28 +718,4 @@ func stripPort(host string) string {
 		return h
 	}
 	return host
-}
-
-func measureDir(path string) (int64, error) {
-	root, err := os.OpenRoot(path)
-	if err != nil {
-		return 0, err
-	}
-	defer func() { _ = root.Close() }()
-	var total int64
-	err = fs.WalkDir(root.FS(), ".", func(_ string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil || d.IsDir() {
-			return walkErr
-		}
-		info, infoErr := d.Info()
-		if infoErr != nil {
-			return infoErr
-		}
-		if !info.Mode().IsRegular() {
-			return nil
-		}
-		total += info.Size()
-		return nil
-	})
-	return total, err
 }

--- a/pkg/parser/terraform/modules/resolver/gogetter_test.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter_test.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 	"time"
 
+	getter "github.com/hashicorp/go-getter"
+	"github.com/stretchr/testify/require"
+
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
 
@@ -125,6 +128,30 @@ func TestGetterSourceForPreservesHTTPSGit(t *testing.T) {
 	if strings.Contains(got, "ssh://") {
 		t.Fatalf("getter source must not rewrite to SSH, got %q", got)
 	}
+}
+
+func TestGoGetterUsesGraphResourceLimits(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewGoGetterConfig()
+	resolver := NewGoGetterResolver(cfg)
+	ctx := WithResourceBudget(t.Context(), NewResourceBudget(ResourceLimits{
+		MaxPackageBytes: 1234,
+		MaxPackageFiles: 7,
+	}))
+
+	httpGetter, ok := resolver.getters("https://example.com/module.zip")["https"].(*getter.HttpGetter)
+	require.True(t, ok)
+	require.Zero(t, httpGetter.MaxBytes)
+	require.Equal(t, int64(1234), resolver.maxPackageBytes(ctx))
+
+	decompressors := resolver.decompressors(ctx)
+	budgeted, ok := decompressors["zip"].(*zipBudgetDecompressor)
+	require.True(t, ok)
+	zipper, ok := budgeted.inner.(*getter.ZipDecompressor)
+	require.True(t, ok)
+	require.Equal(t, int64(1234), zipper.FileSizeLimit)
+	require.Equal(t, 7, zipper.FilesLimit)
 }
 
 func TestGoGetterDisablesUnpinnedNetworkTransports(t *testing.T) {

--- a/pkg/parser/terraform/modules/resolver/http_resource_budget.go
+++ b/pkg/parser/terraform/modules/resolver/http_resource_budget.go
@@ -1,0 +1,80 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"io"
+	"net/http"
+)
+
+type resourceBudgetRoundTripper struct {
+	base            http.RoundTripper
+	fallbackMaximum int64
+}
+
+func (t *resourceBudgetRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	response, err := t.base.RoundTrip(request)
+	if err != nil || response.Body == nil {
+		return response, err
+	}
+	maximum := ResourceBudgetFromContext(request.Context()).Limits().MaxPackageBytes
+	if t.fallbackMaximum > 0 && (maximum <= 0 || t.fallbackMaximum < maximum) {
+		maximum = t.fallbackMaximum
+	}
+	if maximum > 0 {
+		response.Body = &resourceBudgetBody{
+			ReadCloser: response.Body,
+			maximum:    maximum,
+		}
+	}
+	return response, nil
+}
+
+type resourceBudgetBody struct {
+	io.ReadCloser
+	maximum int64
+	read    int64
+}
+
+func (r *resourceBudgetBody) Read(buffer []byte) (int, error) {
+	remaining := r.maximum - r.read
+	if remaining > 0 {
+		if int64(len(buffer)) > remaining {
+			buffer = buffer[:remaining]
+		}
+		n, err := r.ReadCloser.Read(buffer)
+		r.read += int64(n)
+		return n, err
+	}
+	var probe [1]byte
+	n, err := r.ReadCloser.Read(probe[:])
+	if n > 0 {
+		return 0, &BudgetExceededError{
+			Gate:     "stream",
+			Limit:    limitPackageBytes,
+			Maximum:  r.maximum,
+			Measured: r.read + int64(n),
+		}
+	}
+	return 0, err
+}
+
+func withResourceBudgetTransport(client *http.Client, fallbackMaximum int64) *http.Client {
+	if client == nil {
+		return nil
+	}
+	if existing, ok := client.Transport.(*resourceBudgetRoundTripper); ok {
+		existing.fallbackMaximum = fallbackMaximum
+		return client
+	}
+	transport := client.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	cloned := *client
+	cloned.Transport = &resourceBudgetRoundTripper{base: transport, fallbackMaximum: fallbackMaximum}
+	return &cloned
+}

--- a/pkg/parser/terraform/modules/resolver/http_resource_budget_test.go
+++ b/pkg/parser/terraform/modules/resolver/http_resource_budget_test.go
@@ -1,0 +1,68 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type budgetRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f budgetRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestResourceBudgetBodyStopsBeforeReturningExcessByte(t *testing.T) {
+	t.Parallel()
+
+	body := &resourceBudgetBody{
+		ReadCloser: io.NopCloser(bytes.NewReader([]byte("1234"))),
+		maximum:    3,
+	}
+	buffer := make([]byte, 8)
+
+	n, err := body.Read(buffer)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+	require.Equal(t, "123", string(buffer[:n]))
+
+	n, err = body.Read(buffer)
+	require.Zero(t, n)
+	var budgetErr *BudgetExceededError
+	require.True(t, errors.As(err, &budgetErr))
+	require.Equal(t, int64(4), budgetErr.Measured)
+}
+
+func TestResourceBudgetTransportUsesStandaloneLimit(t *testing.T) {
+	t.Parallel()
+
+	transport := &resourceBudgetRoundTripper{
+		base: budgetRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte("1234"))),
+			}, nil
+		}),
+		fallbackMaximum: 3,
+	}
+	ctx := WithResourceBudget(t.Context(), NewResourceBudget(ResourceLimits{MaxPackageBytes: 10}))
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+	response, err := transport.RoundTrip(request)
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(response.Body)
+
+	var budgetErr *BudgetExceededError
+	require.True(t, errors.As(err, &budgetErr))
+	require.Equal(t, int64(3), budgetErr.Maximum)
+}

--- a/pkg/parser/terraform/modules/resolver/localref.go
+++ b/pkg/parser/terraform/modules/resolver/localref.go
@@ -249,7 +249,7 @@ func (r *LocalGitRefResolver) Resolve(ctx context.Context, mod *tfmodules.Parsed
 	_, err, _ := r.extractSF.Do(key, func() (interface{}, error) {
 		return nil, archiveExtract(
 			ctx, info.gitDir, info.extractBase, sha, subdir,
-			localCloneArchiveCommand(info.gitDir),
+			localCloneArchiveCommand(info.gitDir), nil,
 		)
 	})
 	if err != nil {

--- a/pkg/parser/terraform/modules/resolver/localref_test.go
+++ b/pkg/parser/terraform/modules/resolver/localref_test.go
@@ -102,7 +102,7 @@ func TestArchiveExtractMaterializesLocalModuleClosure(t *testing.T) {
 	gitDir := filepath.Join(workTree, ".git")
 	if err := archiveExtract(
 		t.Context(), gitDir, extractBase, sha, "modules/selected",
-		localCloneArchiveCommand(gitDir),
+		localCloneArchiveCommand(gitDir), nil,
 	); err != nil {
 		t.Fatalf("archiveExtract: %v", err)
 	}

--- a/pkg/parser/terraform/modules/resolver/registry_test.go
+++ b/pkg/parser/terraform/modules/resolver/registry_test.go
@@ -396,15 +396,14 @@ func TestDotTerraformResolverUnpinnedCallUsesModuleNameWhenPinnedRecordSharesSou
 
 func TestGoGetterCacheHitCountsTotalBytes(t *testing.T) {
 	cacheDir := t.TempDir()
-	err := os.WriteFile(filepath.Join(cacheDir, "main.tf"), []byte("0123456789"), 0o644)
-	if err != nil {
+	if err := os.WriteFile(filepath.Join(cacheDir, "main.tf"), []byte("0123456789"), 0o644); err != nil {
 		t.Fatalf("write cached module: %v", err)
 	}
 	cfg := NewGoGetterConfig()
 	cfg.MaxTotalBytes = 5
 	r := NewGoGetterResolver(cfg)
 
-	err = r.reserveDirBytes(cacheDir)
+	err := r.reserveDirBytes(t.Context(), cacheDir)
 
 	if err == nil || !strings.Contains(err.Error(), "scan-level remote module byte cap exceeded") {
 		t.Fatalf("expected total byte cap error, got %v", err)
@@ -413,18 +412,17 @@ func TestGoGetterCacheHitCountsTotalBytes(t *testing.T) {
 
 func TestGoGetterCacheHitCountsDirectoryOnce(t *testing.T) {
 	cacheDir := t.TempDir()
-	err := os.WriteFile(filepath.Join(cacheDir, "main.tf"), []byte("0123456789"), 0o644)
-	if err != nil {
+	if err := os.WriteFile(filepath.Join(cacheDir, "main.tf"), []byte("0123456789"), 0o644); err != nil {
 		t.Fatalf("write cached module: %v", err)
 	}
 	cfg := NewGoGetterConfig()
 	cfg.MaxTotalBytes = 15
 	r := NewGoGetterResolver(cfg)
 
-	if err := r.reserveDirBytes(cacheDir); err != nil {
+	if err := r.reserveDirBytes(t.Context(), cacheDir); err != nil {
 		t.Fatalf("first reserveDirBytes: %v", err)
 	}
-	if err := r.reserveDirBytes(cacheDir); err != nil {
+	if err := r.reserveDirBytes(t.Context(), cacheDir); err != nil {
 		t.Fatalf("second reserveDirBytes should not double-count: %v", err)
 	}
 }

--- a/pkg/parser/terraform/modules/resolver/resource_budget.go
+++ b/pkg/parser/terraform/modules/resolver/resource_budget.go
@@ -1,0 +1,280 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sync"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+)
+
+// limitPackageBytes names the per-package byte limit in budget events.
+const limitPackageBytes = "package_bytes"
+
+const (
+	DefaultMaxPackageBytes = 128 * 1024 * 1024
+	DefaultMaxFileBytes    = 5 * 1024 * 1024
+	DefaultMaxPackageFiles = 10_000
+)
+
+type ResourceLimits struct {
+	MaxPackageBytes int64
+	MaxFileBytes    int64
+	MaxPackageFiles int
+	MaxTotalBytes   int64
+}
+
+func (l ResourceLimits) Enabled() bool {
+	return l.MaxPackageBytes > 0 || l.MaxFileBytes > 0 || l.MaxPackageFiles > 0 || l.MaxTotalBytes > 0
+}
+
+type PackageUsage struct {
+	Bytes int64
+	Files int
+}
+
+type BudgetExceededError struct {
+	Gate     string
+	Limit    string
+	Maximum  int64
+	Measured int64
+}
+
+func (e *BudgetExceededError) Error() string {
+	return fmt.Sprintf(
+		"module resource budget exceeded at %s: %s limit %d, measured %d",
+		e.Gate, e.Limit, e.Maximum, e.Measured,
+	)
+}
+
+func unresolvedResourceError(err error) error {
+	var budgetErr *BudgetExceededError
+	if errors.As(err, &budgetErr) {
+		return budgetErr
+	}
+	return &tfmodules.UnresolvedError{Reason: err.Error()}
+}
+
+type resourceBudgetContextKey struct{}
+
+type ResourceBudget struct {
+	limits ResourceLimits
+
+	mu                  sync.Mutex
+	packages            map[string]PackageUsage
+	total               PackageUsage
+	acquisitionReserved int64
+}
+
+func NewResourceBudget(limits ResourceLimits) *ResourceBudget {
+	return &ResourceBudget{
+		limits:   limits,
+		packages: make(map[string]PackageUsage),
+	}
+}
+
+func WithResourceBudget(ctx context.Context, budget *ResourceBudget) context.Context {
+	if budget == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, resourceBudgetContextKey{}, budget)
+}
+
+func ResourceBudgetFromContext(ctx context.Context) *ResourceBudget {
+	if ctx == nil {
+		return nil
+	}
+	budget, _ := ctx.Value(resourceBudgetContextKey{}).(*ResourceBudget)
+	return budget
+}
+
+func (b *ResourceBudget) Limits() ResourceLimits {
+	if b == nil {
+		return ResourceLimits{}
+	}
+	return b.limits
+}
+
+func (b *ResourceBudget) NewPackageCounter() *PackageCounter {
+	if b == nil {
+		return &PackageCounter{}
+	}
+	return &PackageCounter{limits: b.limits}
+}
+
+func (b *ResourceBudget) AdmitPackage(identity string, usage PackageUsage) error {
+	if b == nil {
+		return nil
+	}
+	identity = filepath.Clean(identity)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if previous, exists := b.packages[identity]; exists {
+		b.total.Bytes -= previous.Bytes
+		b.total.Files -= previous.Files
+		usage.Bytes = max(usage.Bytes, previous.Bytes)
+		usage.Files = max(usage.Files, previous.Files)
+	}
+	b.packages[identity] = usage
+	b.total.Bytes += usage.Bytes
+	b.total.Files += usage.Files
+	return nil
+}
+
+func (b *ResourceBudget) ReserveAcquisition(maximum, requested int64) (int64, bool) {
+	if b == nil || maximum <= 0 {
+		return 0, false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	available := maximum - b.total.Bytes - b.acquisitionReserved
+	if available <= 0 {
+		return 0, false
+	}
+	if requested <= 0 || requested > available {
+		requested = available
+	}
+	b.acquisitionReserved += requested
+	return requested, true
+}
+
+func (b *ResourceBudget) ReleaseAcquisition(reserved int64) {
+	if b == nil || reserved <= 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.acquisitionReserved -= reserved
+}
+
+func (b *ResourceBudget) Usage(identity string) (PackageUsage, bool) {
+	if b == nil {
+		return PackageUsage{}, false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	usage, ok := b.packages[filepath.Clean(identity)]
+	return usage, ok
+}
+
+func (b *ResourceBudget) TotalUsage() PackageUsage {
+	if b == nil {
+		return PackageUsage{}
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.total
+}
+
+type PackageCounter struct {
+	limits ResourceLimits
+	usage  PackageUsage
+}
+
+type packageTreeCounter struct {
+	counter *PackageCounter
+	dirs    map[string]bool
+}
+
+func newPackageTreeCounter(counter *PackageCounter) *packageTreeCounter {
+	return &packageTreeCounter{counter: counter, dirs: make(map[string]bool)}
+}
+
+func (c *packageTreeCounter) addDir(name string) error {
+	name = filepath.Clean(name)
+	if name == "." || name == string(filepath.Separator) || c.dirs[name] {
+		return nil
+	}
+	if parent := filepath.Dir(name); parent != name {
+		if err := c.addDir(parent); err != nil {
+			return err
+		}
+	}
+	c.dirs[name] = true
+	return c.counter.AddEntry(0)
+}
+
+func (c *PackageCounter) AddEntry(size int64) error {
+	if size < 0 {
+		return errors.New("module file size cannot be negative")
+	}
+	if c.limits.MaxFileBytes > 0 && size > c.limits.MaxFileBytes {
+		return &BudgetExceededError{
+			Gate:     "stream",
+			Limit:    "file_bytes",
+			Maximum:  c.limits.MaxFileBytes,
+			Measured: size,
+		}
+	}
+	files := c.usage.Files + 1
+	if c.limits.MaxPackageFiles > 0 && files > c.limits.MaxPackageFiles {
+		return &BudgetExceededError{
+			Gate:     "stream",
+			Limit:    "package_file_count",
+			Maximum:  int64(c.limits.MaxPackageFiles),
+			Measured: int64(files),
+		}
+	}
+	bytes := c.usage.Bytes + size
+	if c.limits.MaxPackageBytes > 0 && bytes > c.limits.MaxPackageBytes {
+		return &BudgetExceededError{
+			Gate:     "stream",
+			Limit:    limitPackageBytes,
+			Maximum:  c.limits.MaxPackageBytes,
+			Measured: bytes,
+		}
+	}
+	c.usage = PackageUsage{Bytes: bytes, Files: files}
+	return nil
+}
+
+func (c *PackageCounter) Usage() PackageUsage {
+	if c == nil {
+		return PackageUsage{}
+	}
+	return c.usage
+}
+
+func MeasurePackage(ctx context.Context, root string, limits ResourceLimits) (PackageUsage, error) {
+	// Per-file limits apply while bytes are streaming; packages already on disk may
+	// contain large artifacts such as lambda zips or generated policies.
+	measureLimits := limits
+	measureLimits.MaxFileBytes = 0
+
+	counter := (&ResourceBudget{limits: measureLimits}).NewPackageCounter()
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if filepath.Clean(path) != filepath.Clean(root) {
+				return counter.AddEntry(0)
+			}
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		return counter.AddEntry(info.Size())
+	})
+	if err != nil {
+		return PackageUsage{}, err
+	}
+	return counter.Usage(), nil
+}

--- a/pkg/parser/terraform/modules/resolver/resource_budget_test.go
+++ b/pkg/parser/terraform/modules/resolver/resource_budget_test.go
@@ -1,0 +1,118 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageCounterEnforcesLimitsBeforeAccounting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		limits ResourceLimits
+		sizes  []int64
+		limit  string
+	}{
+		{
+			name:   "file bytes",
+			limits: ResourceLimits{MaxFileBytes: 3},
+			sizes:  []int64{4},
+			limit:  "file_bytes",
+		},
+		{
+			name:   "file count",
+			limits: ResourceLimits{MaxPackageFiles: 1},
+			sizes:  []int64{1, 1},
+			limit:  "package_file_count",
+		},
+		{
+			name:   "package bytes",
+			limits: ResourceLimits{MaxPackageBytes: 3},
+			sizes:  []int64{2, 2},
+			limit:  "package_bytes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			counter := NewResourceBudget(tt.limits).NewPackageCounter()
+			var err error
+			for _, size := range tt.sizes {
+				err = counter.AddEntry(size)
+				if err != nil {
+					break
+				}
+			}
+			var budgetErr *BudgetExceededError
+			require.ErrorAs(t, err, &budgetErr)
+			require.Equal(t, tt.limit, budgetErr.Limit)
+		})
+	}
+}
+
+func TestResourceBudgetReconcilesPackages(t *testing.T) {
+	t.Parallel()
+
+	budget := NewResourceBudget(ResourceLimits{MaxTotalBytes: 5})
+	require.NoError(t, budget.AdmitPackage("/tmp/a", PackageUsage{Bytes: 4, Files: 1}))
+	require.NoError(t, budget.AdmitPackage("/tmp/a", PackageUsage{Bytes: 6, Files: 2}))
+	require.NoError(t, budget.AdmitPackage("/tmp/b", PackageUsage{Bytes: 2, Files: 1}))
+	require.NoError(t, budget.AdmitPackage("/tmp/a", PackageUsage{Bytes: 4, Files: 1}))
+	require.Equal(t, PackageUsage{Bytes: 8, Files: 3}, budget.TotalUsage())
+}
+
+func TestResourceBudgetReservesAcquisitionAgainstUsage(t *testing.T) {
+	t.Parallel()
+
+	budget := NewResourceBudget(ResourceLimits{})
+	require.NoError(t, budget.AdmitPackage("/tmp/a", PackageUsage{Bytes: 4}))
+
+	reserved, ok := budget.ReserveAcquisition(10, 8)
+	require.True(t, ok)
+	require.Equal(t, int64(6), reserved)
+
+	_, ok = budget.ReserveAcquisition(10, 1)
+	require.False(t, ok)
+	budget.ReleaseAcquisition(reserved)
+
+	reserved, ok = budget.ReserveAcquisition(10, 3)
+	require.True(t, ok)
+	require.Equal(t, int64(3), reserved)
+}
+
+func TestMeasurePackageStopsAtConfiguredLimit(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "one.tf"), []byte("123"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "two.tf"), []byte("456"), 0o600))
+
+	_, err := MeasurePackage(t.Context(), root, ResourceLimits{MaxPackageBytes: 5})
+	var budgetErr *BudgetExceededError
+	require.True(t, errors.As(err, &budgetErr))
+	require.Equal(t, int64(6), budgetErr.Measured)
+}
+
+func TestMeasurePackageIgnoresPerFileLimit(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte("x"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "large.zip"), make([]byte, 8), 0o600))
+
+	usage, err := MeasurePackage(t.Context(), root, ResourceLimits{MaxFileBytes: 5})
+	require.NoError(t, err)
+	require.Equal(t, int64(9), usage.Bytes)
+	require.Equal(t, 2, usage.Files)
+}

--- a/pkg/parser/terraform/modules/resolver/tar_decompressor_budget.go
+++ b/pkg/parser/terraform/modules/resolver/tar_decompressor_budget.go
@@ -1,0 +1,286 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/bzip2"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/ulikunitz/xz"
+)
+
+type archiveReaderFunc func(io.Reader) (io.Reader, func(), error)
+
+type tarBudgetDecompressor struct {
+	limits ResourceLimits
+	open   archiveReaderFunc
+}
+
+type singleFileBudgetDecompressor struct {
+	maxFileBytes int64
+	limitName    string
+	open         archiveReaderFunc
+}
+
+const (
+	decompressionCopyBufferSize = 32 * 1024
+	decompressedFilePerm        = 0o622
+)
+
+func (d *singleFileBudgetDecompressor) Decompress(
+	dst, src string, _ bool, umask os.FileMode,
+) error {
+	source, err := os.Open(src) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	defer func() { _ = source.Close() }()
+	compressed := &countingReader{reader: source}
+	reader, closeReader, err := d.open(compressed)
+	if err != nil {
+		return err
+	}
+	defer closeReader()
+
+	if err := os.MkdirAll(filepath.Dir(dst), dirPerm&^umask); err != nil {
+		return err
+	}
+	file, err := os.OpenFile( //nolint:gosec
+		dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, decompressedFilePerm&^umask,
+	)
+	if err != nil {
+		return err
+	}
+	written, copyErr := copySingleFileWithBudget(
+		file, reader, compressed, d.maxFileBytes, d.limitName,
+	)
+	closeErr := file.Close()
+	if copyErr != nil {
+		_ = os.Remove(dst)
+		return copyErr
+	}
+	if closeErr != nil {
+		_ = os.Remove(dst)
+		return closeErr
+	}
+	if exceedsExpansionRatio(written, compressed.read, maxArchiveExpansionRatio) {
+		_ = os.Remove(dst)
+		return expansionRatioError(
+			"archive_expansion_ratio", written, compressed.read, maxArchiveExpansionRatio,
+		)
+	}
+	return nil
+}
+
+func copySingleFileWithBudget(
+	dst io.Writer, src io.Reader, compressed *countingReader, maximum int64, limitName string,
+) (int64, error) {
+	buffer := make([]byte, decompressionCopyBufferSize)
+	var written int64
+	for {
+		readBuffer := buffer
+		if maximum > 0 {
+			remaining := maximum - written
+			if remaining < int64(len(readBuffer)) {
+				readBuffer = readBuffer[:remaining+1]
+			}
+		}
+		n, err := src.Read(readBuffer)
+		if maximum > 0 && written+int64(n) > maximum {
+			return written, &BudgetExceededError{
+				Gate:     "stream",
+				Limit:    limitName,
+				Maximum:  maximum,
+				Measured: written + int64(n),
+			}
+		}
+		if n > 0 {
+			count, writeErr := dst.Write(readBuffer[:n])
+			written += int64(count)
+			if writeErr != nil {
+				return written, writeErr
+			}
+			if count != n {
+				return written, io.ErrShortWrite
+			}
+			if exceedsStreamExpansionRatio(written, compressed.read, maxArchiveExpansionRatio) {
+				return written, expansionRatioError(
+					"archive_expansion_ratio", written, compressed.read, maxArchiveExpansionRatio,
+				)
+			}
+		}
+		if err == io.EOF {
+			return written, nil
+		}
+		if err != nil {
+			return written, err
+		}
+	}
+}
+
+func (d *tarBudgetDecompressor) Decompress(dst, src string, dir bool, umask os.FileMode) error {
+	if !dir {
+		return fmt.Errorf("tar module archive requires a directory destination")
+	}
+	source, err := os.Open(src) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	defer func() { _ = source.Close() }()
+
+	compressed := &countingReader{reader: source}
+	reader, closeReader, err := d.open(compressed)
+	if err != nil {
+		return err
+	}
+	defer closeReader()
+
+	if err := os.MkdirAll(dst, dirPerm&^umask); err != nil {
+		return err
+	}
+	state := newPackageTreeCounter(NewResourceBudget(d.limits).NewPackageCounter())
+	archive := tar.NewReader(reader)
+	for {
+		header, nextErr := archive.Next()
+		if nextErr == io.EOF {
+			return tarFinalRatioError(state.counter, compressed)
+		}
+		if nextErr != nil {
+			return nextErr
+		}
+		if err := extractTarBudgetEntry(archive, header, dst, umask, state, compressed); err != nil {
+			return err
+		}
+	}
+}
+
+func tarFinalRatioError(counter *PackageCounter, compressed *countingReader) error {
+	if !exceedsExpansionRatio(counter.Usage().Bytes, compressed.read, maxArchiveExpansionRatio) {
+		return nil
+	}
+	return expansionRatioError(
+		"archive_expansion_ratio", counter.Usage().Bytes, compressed.read, maxArchiveExpansionRatio,
+	)
+}
+
+func extractTarBudgetEntry(
+	archive *tar.Reader,
+	header *tar.Header,
+	dst string,
+	umask os.FileMode,
+	state *packageTreeCounter,
+	compressed *countingReader,
+) error {
+	name := filepath.Clean(header.Name)
+	if name == "." && header.Typeflag == tar.TypeDir {
+		return state.counter.AddEntry(0)
+	}
+	if name == "." || !filepath.IsLocal(name) {
+		return fmt.Errorf("tar entry %q is not a local path", header.Name)
+	}
+	path := filepath.Join(dst, name)
+	switch header.Typeflag {
+	case tar.TypeDir:
+		if err := state.addDir(name); err != nil {
+			return err
+		}
+		return os.MkdirAll(path, header.FileInfo().Mode().Perm()&^umask)
+	case tar.TypeReg, 0:
+		if err := state.addDir(filepath.Dir(name)); err != nil {
+			return err
+		}
+		if err := state.counter.AddEntry(header.Size); err != nil {
+			return err
+		}
+		if err := writeTarBudgetFile(archive, path, header, umask); err != nil {
+			return err
+		}
+		if exceedsStreamExpansionRatio(
+			state.counter.Usage().Bytes, compressed.read, maxArchiveExpansionRatio,
+		) {
+			return expansionRatioError(
+				"archive_expansion_ratio",
+				state.counter.Usage().Bytes,
+				compressed.read,
+				maxArchiveExpansionRatio,
+			)
+		}
+		return nil
+	case tar.TypeXHeader, tar.TypeXGlobalHeader:
+		return nil
+	default:
+		return fmt.Errorf("tar entry %q has unsupported type %d", header.Name, header.Typeflag)
+	}
+}
+
+func writeTarBudgetFile(
+	archive *tar.Reader, path string, header *tar.Header, umask os.FileMode,
+) error {
+	if err := os.MkdirAll(filepath.Dir(path), dirPerm&^umask); err != nil {
+		return err
+	}
+	file, err := os.OpenFile( //nolint:gosec
+		path,
+		os.O_CREATE|os.O_EXCL|os.O_WRONLY,
+		header.FileInfo().Mode().Perm()&^umask,
+	)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.CopyN(file, archive, header.Size)
+	closeErr := file.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}
+
+type countingReader struct {
+	reader io.Reader
+	read   int64
+}
+
+func (r *countingReader) Read(buffer []byte) (int, error) {
+	n, err := r.reader.Read(buffer)
+	r.read += int64(n)
+	return n, err
+}
+
+func rawArchiveReader(reader io.Reader) (io.Reader, func(), error) {
+	return reader, func() {}, nil
+}
+
+func gzipArchiveReader(reader io.Reader) (io.Reader, func(), error) {
+	archive, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return archive, func() { _ = archive.Close() }, nil
+}
+
+func bzip2ArchiveReader(reader io.Reader) (io.Reader, func(), error) {
+	return bzip2.NewReader(reader), func() {}, nil
+}
+
+func xzArchiveReader(reader io.Reader) (io.Reader, func(), error) {
+	archive, err := xz.NewReader(bufio.NewReader(reader))
+	return archive, func() {}, err
+}
+
+func zstdArchiveReader(reader io.Reader) (io.Reader, func(), error) {
+	archive, err := zstd.NewReader(reader)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return archive, archive.Close, nil
+}

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -16,14 +16,20 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	tfresolver "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
 	"github.com/DataDog/datadog-iac-scanner/pkg/platforms"
 	consolePrinter "github.com/DataDog/datadog-iac-scanner/pkg/printer"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/rs/zerolog/log"
 )
 
-// DefaultRemoteModuleMaxDepth bounds network work while covering typical nested module stacks.
-const DefaultRemoteModuleMaxDepth = 8
+const (
+	DefaultRemoteModuleMaxDepth        = 8
+	DefaultRemoteModuleMaxTotalBytes   = tfresolver.DefaultMaxTotalBytes
+	DefaultRemoteModuleMaxPackageBytes = tfresolver.DefaultMaxPackageBytes
+	DefaultRemoteModuleMaxFileBytes    = tfresolver.DefaultMaxFileBytes
+	DefaultRemoteModuleMaxPackageFiles = tfresolver.DefaultMaxPackageFiles
+)
 
 // Parameters represents all available scan parameters
 type Parameters struct {
@@ -65,9 +71,13 @@ type Parameters struct {
 	RemoteModulesManifestPath   string
 	RemoteModulesHostAllowlist  []string
 	// ModuleMaxDepth caps the BFS depth of the remote-module graph walker (0 disables traversal entirely).
-	ModuleMaxDepth      int
-	ModuleFetchTimeout  time.Duration
-	MaxModuleBytesTotal int64
+	ModuleMaxDepth        int
+	ModuleFetchTimeout    time.Duration
+	MaxModuleBytesTotal   int64
+	MaxModulePackageBytes int64
+	MaxModuleFileBytes    int64
+	MaxModulePackageFiles int
+	MaxModuleParseBytes   int64
 }
 
 func (p *Parameters) GetEffectivePlatforms() []string {
@@ -170,7 +180,10 @@ func GetDefaultParameters(ctx context.Context, rootPath string) (*Parameters, co
 		MaxResolverDepth:            15,
 		ModuleMaxDepth:              DefaultRemoteModuleMaxDepth,
 		ModuleFetchTimeout:          30 * time.Second,
-		MaxModuleBytesTotal:         200 * 1024 * 1024,
+		MaxModuleBytesTotal:         DefaultRemoteModuleMaxTotalBytes,
+		MaxModulePackageBytes:       DefaultRemoteModuleMaxPackageBytes,
+		MaxModuleFileBytes:          DefaultRemoteModuleMaxFileBytes,
+		MaxModulePackageFiles:       DefaultRemoteModuleMaxPackageFiles,
 	}, logCtx
 }
 

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -23,6 +23,7 @@ func (c *Client) resolveTerraformModulesForScan(
 	ctx context.Context,
 	paramsPlatforms []string,
 	extractedPaths *provider.ExtractedPath,
+	baselinePaths []string,
 ) (
 	moduleCleanup func(),
 	remoteModulePaths []string,
@@ -50,13 +51,43 @@ func (c *Client) resolveTerraformModulesForScan(
 		contextLogger.Debug().Msg("Resolving Terraform modules from local, manifest, or .terraform/modules sources only")
 	}
 
+	packageBytes := c.ScanParams.MaxModulePackageBytes
+	if packageBytes == 0 {
+		packageBytes = DefaultRemoteModuleMaxPackageBytes
+	}
+	fileBytes := c.ScanParams.MaxModuleFileBytes
+	if fileBytes == 0 {
+		fileBytes = DefaultRemoteModuleMaxFileBytes
+	}
+	packageFiles := c.ScanParams.MaxModulePackageFiles
+	if packageFiles == 0 {
+		packageFiles = DefaultRemoteModuleMaxPackageFiles
+	}
 	result := modulegraph.Resolve(ctx, &modulegraph.Request{
 		RootPaths:      extractedPaths.Path,
 		DiscoveryPaths: moduleDiscoveryPaths,
 		Resolver:       chain,
 		MaxDepth:       c.ScanParams.ModuleMaxDepth,
-		FS:             c.fsys,
+		ResourceLimits: tfresolver.ResourceLimits{
+			MaxPackageBytes: packageBytes,
+			MaxFileBytes:    fileBytes,
+			MaxPackageFiles: packageFiles,
+			MaxTotalBytes:   c.ScanParams.MaxModuleBytesTotal,
+		},
+		BaselinePaths:   baselinePaths,
+		TotalParseBytes: c.ScanParams.MaxModuleParseBytes,
+		FS:              c.fsys,
 	})
+	for _, event := range result.BudgetEvents {
+		contextLogger.Warn().
+			Str("module_source", event.Source).
+			Str("gate", event.Gate).
+			Str("limit_name", event.Limit).
+			Int64("limit", event.Maximum).
+			Int64("measured", event.Measured).
+			Int("shedding_rank", event.SheddingRank).
+			Msg("Terraform module excluded by resource budget")
+	}
 	if len(result.ScanPaths) > 0 {
 		contextLogger.Info().Msgf("Adding %d remote module file(s) to scan", len(result.ScanPaths))
 	}
@@ -67,7 +98,8 @@ func (c *Client) resolveTerraformModulesForScan(
 		}
 	}
 	remoteSourceDirs = make(map[string]engine.RemoteModuleDirectory, len(result.Modules)*3)
-	for _, module := range result.Modules {
+	for i := range result.Modules {
+		module := &result.Modules[i]
 		directory := engine.RemoteModuleDirectory{
 			Path:        module.LocalPath,
 			PackageRoot: module.PackageRoot,
@@ -124,7 +156,6 @@ func (c *Client) buildModuleResolverChain(ctx context.Context, moduleDiscoveryPa
 	if t := c.ScanParams.ModuleFetchTimeout; t > 0 {
 		ggCfg.FetchTimeout = t
 	}
-	ggCfg.MaxTotalBytes = c.ScanParams.MaxModuleBytesTotal
 	ggCfg.HostAllowlist = c.ScanParams.RemoteModulesHostAllowlist
 
 	if c.ScanParams.EnableRemoteModules {

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -78,7 +78,16 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 
 	paramsPlatforms := c.ScanParams.GetEffectivePlatforms()
 
-	moduleCleanup, remoteModulePaths, remoteSourceDirs, err := c.resolveTerraformModulesForScan(ctx, paramsPlatforms, &extractedPaths)
+	baselinePaths := extractedPaths.Path
+	if len(filePlatform) > 0 {
+		baselinePaths = make([]string, 0, len(filePlatform))
+		for path := range filePlatform {
+			baselinePaths = append(baselinePaths, path)
+		}
+	}
+	moduleCleanup, remoteModulePaths, remoteSourceDirs, err := c.resolveTerraformModulesForScan(
+		ctx, paramsPlatforms, &extractedPaths, baselinePaths,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Motivation

Remote Terraform module resolution could still download and materialize oversized packages before any graph-level limit applied. After [#310](https://github.com/DataDog/datadog-iac-scanner/pull/310) tightened transport policy, this change adds graph-owned streaming budgets so acquisition, extraction, and pre-parse admission stay within configured byte and file limits under concurrency.

Related ticket: [K9CODESEC-5288](https://datadoghq.atlassian.net/browse/K9CODESEC-5288)

## Changes

**Resource budget core**

Introduce a shared graph-owned budget consulted by every resolver through request context. Limits cover per-package bytes, file count, and aggregate module bytes for admission. Per-file size limits apply only while bytes are streaming; packages already on disk are measured without rejecting the whole module for a single oversized file.

**Streaming enforcement**

Bound HTTP downloads, archive decompression (tar and zip), and git subprocess growth while data is still streaming. Failed transfers roll back partial extraction and object-store writes so oversized packages never become visible to admission.

**Module graph admission**

After resolution, measure package usage and apply deterministic subtree shedding when aggregate module bytes exceed the configured ceiling. Frontier acquisition is capped at 2× the aggregate limit so a wide graph cannot fetch unboundedly before shedding runs. Emit structured budget events (gate, limit, measured value, shedding rank) as warnings before parse.

**Scan wiring**

Plumb new experimental CLI limits for package bytes, file bytes, file count, and parse admission into the module graph request. Existing `--x-remote-modules-max-bytes` continues to cap total module bytes.

## QA Instruction

1. `go test -race ./pkg/parser/terraform/modules/resolver ./pkg/parser/terraform/modules/modulegraph ./pkg/scan -count=1`
2. `make build && ./bin/datadog-iac-scanner scan -p <fixture> -t Terraform --x-remote-modules`
3. Confirm oversized remote modules are rejected or shed with budget warnings in logs instead of being parsed.
4. Scan a repo with `.terraform/modules` containing a file larger than 5 MiB (without `--x-remote-modules`) and confirm findings are still reported.

## Impact

Affects remote Terraform module resolution when `--x-remote-modules` is enabled. Per-file rejection applies to streaming acquisition paths only. Local, manifest, and `.terraform/modules` paths inherit package measurement for aggregate admission but remain scannable when they contain oversized files.

[K9CODESEC-5288]: https://datadoghq.atlassian.net/browse/K9CODESEC-5288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ