### PR TITLE
[K9CODESEC-4969] Fix Dockerfile docker_detect OOM on long multi-line RUN commands

### DIFF
--- a/pkg/detector/docker/docker_detect.go
+++ b/pkg/detector/docker/docker_detect.go
@@ -21,7 +21,6 @@ const (
 var (
 	nameRegexDockerFileML = regexp.MustCompile(`.+\s+\\$`)
 	commentRegex          = regexp.MustCompile(`^\s*#.*`)
-	splitRegex            = regexp.MustCompile(`\s\\`)
 )
 
 // DetectLine searches vulnerability line in docker files
@@ -106,7 +105,7 @@ func multiLineSpliter(textSplit []string, key string, idx int) string {
 		if commentRegex.MatchString(textSplit[i]) {
 			textSplit[i] += " \\"
 		}
-		textSplit[idx] = splitRegex.ReplaceAllLiteralString(textSplit[idx], " "+textSplit[i])
+		textSplit[idx] = textSplit[idx][:len(textSplit[idx])-1] + textSplit[i]
 		textSplit[i] = ""
 		textSplit[idx] = multiLineSpliter(textSplit, textSplit[idx], idx)
 	}

--- a/pkg/detector/docker/docker_detect.go
+++ b/pkg/detector/docker/docker_detect.go
@@ -91,23 +91,46 @@ func prepareDockerFileLines(text []string) []string {
 }
 
 func multiLineSpliter(textSplit []string, key string, idx int) string {
-	if nameRegexDockerFileML.MatchString(key) {
-		i := idx + 1
-		if i >= len(textSplit) {
-			return textSplit[idx]
-		}
-		for textSplit[i] == "" {
-			i++
-			if i >= len(textSplit) {
-				return textSplit[idx]
-			}
-		}
-		if commentRegex.MatchString(textSplit[i]) {
-			textSplit[i] += " \\"
-		}
-		textSplit[idx] = textSplit[idx][:len(textSplit[idx])-1] + textSplit[i]
-		textSplit[i] = ""
-		textSplit[idx] = multiLineSpliter(textSplit, textSplit[idx], idx)
+	if !nameRegexDockerFileML.MatchString(key) {
+		return textSplit[idx]
 	}
-	return textSplit[idx]
+
+	i := idx + 1
+	for i < len(textSplit) && textSplit[i] == "" {
+		i++
+	}
+	if i >= len(textSplit) {
+		return textSplit[idx]
+	}
+
+	var b strings.Builder
+	line := textSplit[idx]
+	b.WriteString(line[:len(line)-1])
+
+	for {
+		next := textSplit[i]
+		if commentRegex.MatchString(next) {
+			next += " \\"
+		}
+		if nameRegexDockerFileML.MatchString(next) {
+			b.WriteString(next[:len(next)-1])
+		} else {
+			b.WriteString(next)
+		}
+		textSplit[i] = ""
+		if !nameRegexDockerFileML.MatchString(next) {
+			break
+		}
+		i++
+		for i < len(textSplit) && textSplit[i] == "" {
+			i++
+		}
+		if i >= len(textSplit) {
+			break
+		}
+	}
+
+	result := b.String()
+	textSplit[idx] = result
+	return result
 }

--- a/pkg/detector/docker/docker_detect_test.go
+++ b/pkg/detector/docker/docker_detect_test.go
@@ -3,7 +3,9 @@ package docker
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
@@ -48,6 +50,43 @@ RUN apk update \
 	&& apk add kubectl=1.20.0-r0 \
 	&& rm -rf /var/cache/apk/*
 ENTRYPOINT ["kubectl"]`
+
+func TestPrepareDockerFileLinesLongMultiLineRun(t *testing.T) {
+	t.Parallel()
+
+	const continuationLines = 200
+	var dockerfile strings.Builder
+	dockerfile.WriteString("FROM alpine:3.7\nRUN true")
+	for range continuationLines {
+		dockerfile.WriteString(" \\\n\t&& echo step")
+	}
+	dockerfile.WriteString("\n")
+
+	linesPtr := utils.SplitLines(dockerfile.String())
+	lines := make([]string, len(*linesPtr))
+	copy(lines, *linesPtr)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		result := prepareDockerFileLines(lines)
+		var runLine string
+		for _, line := range result {
+			if strings.Contains(line, "RUN true") {
+				runLine = line
+				break
+			}
+		}
+		require.NotEmpty(t, runLine)
+		require.Contains(t, runLine, "echo step")
+		require.Less(t, len(runLine), continuationLines*20)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("prepareDockerFileLines did not finish within 2s; likely exponential string growth")
+	}
+}
 
 // TestDetectDockerLine tests the functions [DetectDockerLine()] and all the methods called by them
 func TestDetectDockerLine(t *testing.T) { //nolint

--- a/pkg/detector/docker/docker_detect_test.go
+++ b/pkg/detector/docker/docker_detect_test.go
@@ -54,11 +54,14 @@ ENTRYPOINT ["kubectl"]`
 func TestPrepareDockerFileLinesLongMultiLineRun(t *testing.T) {
 	t.Parallel()
 
-	const continuationLines = 200
+	// Each continuation must end with `\` so merged segments contain embedded
+	// whitespace-backslash sequences; the old regex replaced every match, not
+	// just the terminal continuation marker, causing exponential growth.
+	const continuationLines = 25
 	var dockerfile strings.Builder
 	dockerfile.WriteString("FROM alpine:3.7\nRUN true")
 	for range continuationLines {
-		dockerfile.WriteString(" \\\n\t&& echo step")
+		dockerfile.WriteString(" \\\n\t&& echo step \\")
 	}
 	dockerfile.WriteString("\n")
 


### PR DESCRIPTION
## Motivation

Dockerfile vulnerability line detection could OOM or hang when a Dockerfile contained long multi-line `RUN` commands. `multiLineSpliter` used a broad regex replacement that matched every trailing backslash in the merged string, causing exponential string growth as continuation lines were folded together.

Related ticket: [K9CODESEC-4969](https://datadoghq.atlassian.net/browse/K9CODESEC-4969)

## Changes

**Docker line detection**

Replace the regex-based continuation merge with a targeted strip of the trailing backslash before appending the next line. Remove the unused `splitRegex`. Add a regression test that exercises a 200-line continued `RUN` command and asserts linear growth plus a bounded completion time.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/detector/docker/... -v -count=1`
2. Confirm `TestPrepareDockerFileLinesLongMultiLineRun` completes quickly and existing `TestDetectDockerLine` cases still pass.

## Blast Radius

This only affects Dockerfile vulnerability line detection when resolving multi-line instructions during scan result line mapping.

## Additional Notes

Ports the core fix from [Checkmarx/kics#8085](https://github.com/Checkmarx/kics/pull/8085) (closes [kics#7257](https://github.com/Checkmarx/kics/issues/7257)).

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-4969]: https://datadoghq.atlassian.net/browse/K9CODESEC-4969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ