### PR TITLE
[K9CODESEC-5292] Make resolver concurrency and caches deterministic

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -153,6 +153,17 @@ var scanAction = &cli.Command{
 			Hidden: true,
 			Usage:  "(experimental) target bytes admitted for repository and remote module parsing (default disabled)",
 		},
+		&cli.StringFlag{
+			Name:   "x-remote-modules-cache-dir",
+			Hidden: true,
+			Usage:  "(experimental) directory for fetched Terraform module caches",
+		},
+		&cli.Int64Flag{
+			Name:   "x-remote-modules-cache-max-bytes",
+			Hidden: true,
+			Usage:  "(experimental) maximum on-disk size of the fetched Terraform module cache (default 2GiB)",
+			Value:  scan.DefaultRemoteModuleMaxCacheBytes,
+		},
 		&cli.BoolFlag{
 			Name:   "x-terraform-plan",
 			Hidden: true,
@@ -348,7 +359,8 @@ func runScan(ctx context.Context, c *cli.Command) error {
 	}
 	if !c.Bool("x-remote-modules") &&
 		(c.String("x-remote-modules-manifest") != "" ||
-			len(c.StringSlice("x-remote-modules-allowed-host")) > 0) {
+			len(c.StringSlice("x-remote-modules-allowed-host")) > 0 ||
+			c.String("x-remote-modules-cache-dir") != "") {
 		return errorWithExitCode(
 			errors.New("remote module resolver options require --x-remote-modules"),
 			constants.InvalidConfigErrorCode,
@@ -410,6 +422,8 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		MaxModuleFileBytes:          c.Int64("x-remote-modules-max-file-bytes"),
 		MaxModulePackageFiles:       c.Int("x-remote-modules-max-package-files"),
 		MaxModuleParseBytes:         c.Int64("x-remote-modules-max-parse-bytes"),
+		RemoteModulesCacheDir:       c.String("x-remote-modules-cache-dir"),
+		MaxModuleCacheBytes:         c.Int64("x-remote-modules-cache-max-bytes"),
 	}
 
 	var opts []scan.ClientOption

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -864,11 +864,11 @@ func (w *walker) traverseRemoteModuleGroup(
 	for _, mod := range group.callers {
 		w.results.addResolvedModule(mod, resolution, group.parentPackageRoot, depth+1)
 	}
-	if !w.visited.tryAdd(resolution.LocalPath, resolution.PackageRoot) {
-		return
-	}
 	if resolution.Cleanup != nil {
 		w.results.addCleanup(resolution.Cleanup)
+	}
+	if !w.visited.tryAdd(resolution.LocalPath, resolution.PackageRoot) {
+		return
 	}
 	w.results.addPaths(flatTerraformFilePaths(ctx, resolution.LocalPath, resolution.PackageRoot)...)
 	w.results.addSourceMapping(

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -132,6 +132,7 @@ type walker struct {
 	results          resultCollector
 	parseCache       moduleParseCache
 	pending          pendingTraversalCollector
+	parseSem         chan struct{}
 	sf               singleflight.Group
 	measureSF        singleflight.Group
 	resolver         resolver.Resolver
@@ -173,6 +174,7 @@ func Resolve(ctx context.Context, request *Request) Result {
 		pending: pendingTraversalCollector{
 			entries: make(map[string]pendingTraversal),
 		},
+		parseSem:         make(chan struct{}, max(1, runtime.GOMAXPROCS(0))),
 		resolver:         request.Resolver,
 		budget:           budget,
 		measurePackages:  request.ResourceLimits.Enabled() || request.TotalParseBytes > 0,
@@ -305,20 +307,34 @@ func (w *walker) parseModulesInDir(
 	if mods, ok := w.parseCache.get(key); ok {
 		return mods
 	}
-
-	var mods map[string]tfmodules.ParsedModule
-	files, err := tfmodules.LoadTFFilesFromDir(dir, packageRoot)
-	if err == nil && len(files) > 0 {
-		withParseSlot(ctx, func() {
-			parsed, parseErr := tfmodules.ParseTerraformModulesFromFiles(ctx, w.fsys, files, allowedFiles)
-			if parseErr == nil {
-				mods = parsed
-			}
-		})
+	if err := ctx.Err(); err != nil {
+		return nil
 	}
 
-	w.parseCache.set(key, mods)
-	return mods
+	files, err := tfmodules.LoadTFFilesFromDir(dir, packageRoot)
+	if err != nil {
+		return nil
+	}
+	if len(files) == 0 {
+		empty := map[string]tfmodules.ParsedModule{}
+		w.parseCache.set(key, empty)
+		return empty
+	}
+
+	var parsed map[string]tfmodules.ParsedModule
+	parseErr := w.withParseSlot(ctx, func() error {
+		var slotErr error
+		parsed, slotErr = tfmodules.ParseTerraformModulesFromFiles(ctx, w.fsys, files, allowedFiles)
+		return slotErr
+	})
+	if parseErr != nil || ctx.Err() != nil {
+		return nil
+	}
+	if parsed == nil {
+		parsed = map[string]tfmodules.ParsedModule{}
+	}
+	w.parseCache.set(key, parsed)
+	return parsed
 }
 
 func allowedFilesCacheKey(allowed map[string]bool) string {
@@ -485,7 +501,9 @@ func (w *walker) resolveRemote(
 		if resolveErr == nil {
 			resolveErr = w.accountPackage(ctx, mod.Source, resolution)
 		}
-		w.resolutions.set(resolveID, resolvedEntry{res: resolution, err: resolveErr})
+		if ctx.Err() == nil {
+			w.resolutions.set(resolveID, resolvedEntry{res: resolution, err: resolveErr})
+		}
 		return resolution, resolveErr
 	})
 	if err != nil {
@@ -535,14 +553,13 @@ func (w *walker) measurePackage(ctx context.Context, root string) error {
 	return err
 }
 
-var parseSem = make(chan struct{}, max(1, runtime.GOMAXPROCS(0)))
-
-func withParseSlot(ctx context.Context, fn func()) {
+func (w *walker) withParseSlot(ctx context.Context, fn func() error) error {
 	select {
-	case parseSem <- struct{}{}:
-		defer func() { <-parseSem }()
-		fn()
+	case w.parseSem <- struct{}{}:
+		defer func() { <-w.parseSem }()
+		return fn()
 	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
@@ -754,3 +754,37 @@ func TestShedToTotalLimitBreaksTiesDeterministically(t *testing.T) {
 		require.Equal(t, snapshot.budgetEvents, other.budgetEvents)
 	}
 }
+
+func TestParseModulesInDirDoesNotCacheCanceledParse(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+module "child" {
+  source = "./child"
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w := &walker{
+		parseCache: moduleParseCache{entries: make(map[string]map[string]tfmodules.ParsedModule)},
+		parseSem:   make(chan struct{}, 1),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if mods := w.parseModulesInDir(ctx, dir, nil, dir); len(mods) != 0 {
+		t.Fatalf("canceled parse returned %d modules", len(mods))
+	}
+	if _, ok := w.parseCache.get(filepath.Clean(dir) + "\x00" + filepath.Clean(dir) + "\x00all"); ok {
+		t.Fatal("canceled parse must not be cached")
+	}
+	mods := w.parseModulesInDir(context.Background(), dir, nil, dir)
+	found := false
+	for _, mod := range mods {
+		if mod.Name == "child" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("live parse missing child module: %#v", mods)
+	}
+}

--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -43,7 +43,7 @@ const maxArchiveExtractBytes = 200 * 1024 * 1024
 type BareGitResolver struct {
 	// Defaults to <user-cache-dir>/datadog-iac-scanner/git-bare.
 	CacheDir string
-	MaxBytes int64
+	Budget   *ModuleCacheBudget
 
 	hostAllowlist []string
 	policy        *httpDestinationPolicy
@@ -1081,17 +1081,80 @@ func (rem *bareRemote) extract(ctx context.Context, sha, subdir string) (string,
 	return dest, nil
 }
 
-func (r *BareGitResolver) evictGitCache() {
-	if r == nil || r.MaxBytes <= 0 {
-		return
+func (r *BareGitResolver) admitGitEntry(repoEntry string) error {
+	if r == nil || r.Budget == nil {
+		return nil
 	}
-	r.mu.Lock()
-	retained := make(map[string]bool, len(r.repos))
-	for _, repo := range r.repos {
-		retained[filepath.Clean(filepath.Dir(repo.barePath))] = true
+	if err := r.Budget.EnsureEntryFits(repoEntry); err != nil {
+		return err
 	}
-	r.mu.Unlock()
-	evictUnretainedDirs(r.effectiveCacheDir(), r.MaxBytes, retained)
+	r.Budget.Admit(repoEntry)
+	return nil
+}
+
+func (r *BareGitResolver) resolveCachedSHAArchive(
+	ctx context.Context, remote *bareRemote, repoEntry, ref, subdir string,
+) (Resolution, bool, error) {
+	if !looksLikeSHA(ref) {
+		return Resolution{}, false, nil
+	}
+	packageRoot, ok := cachedArchiveDir(remote.extractBase, ref, subdir)
+	if !ok {
+		return Resolution{}, false, nil
+	}
+	release := r.Budget.Lease(repoEntry)
+	if err := r.Budget.EnsureEntryFits(repoEntry); err != nil {
+		release()
+		return Resolution{}, true, unresolvedResourceError(err)
+	}
+	resolution, err := ConfineResolution(ctx, Resolution{
+		LocalPath:   filepath.Join(packageRoot, filepath.FromSlash(subdir)),
+		PackageRoot: packageRoot,
+	})
+	if err != nil {
+		release()
+		return Resolution{}, true, err
+	}
+	return withResolutionCleanup(resolution, release), true, nil
+}
+
+func (r *BareGitResolver) resolveRemoteArchive(
+	ctx context.Context, remote *bareRemote, repoEntry, repoURL, ref, subdir string,
+) (Resolution, error) {
+	contextLogger := logger.FromContext(ctx)
+	release := r.Budget.Lease(repoEntry)
+	if err := remote.ensureClone(ctx); err != nil {
+		release()
+		return Resolution{}, unresolvedResourceError(err)
+	}
+
+	sha, err := remote.fetchRef(ctx, ref)
+	if err != nil {
+		release()
+		contextLogger.Warn().Err(err).Msgf("BareGitResolver: ref %q not reachable from %s", ref, repoURL)
+		return Resolution{}, unresolvedResourceError(err)
+	}
+
+	packageRoot, err := remote.extract(ctx, sha, subdir)
+	if err != nil {
+		release()
+		contextLogger.Warn().Err(err).Msgf("BareGitResolver: archive %s:%s failed", sha, subdir)
+		return Resolution{}, unresolvedResourceError(err)
+	}
+	if err := r.admitGitEntry(repoEntry); err != nil {
+		release()
+		return Resolution{}, unresolvedResourceError(err)
+	}
+
+	resolution, err := ConfineResolution(ctx, Resolution{
+		LocalPath:   filepath.Join(packageRoot, filepath.FromSlash(subdir)),
+		PackageRoot: packageRoot,
+	})
+	if err != nil {
+		release()
+		return Resolution{}, err
+	}
+	return withResolutionCleanup(resolution, release), nil
 }
 
 // Resolve implements Resolver for pinnable git:: sources. A missing ref uses HEAD.
@@ -1118,44 +1181,18 @@ func (r *BareGitResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedModu
 		return Resolution{}, err
 	}
 
-	contextLogger := logger.FromContext(ctx)
 	remote := r.getOrInitRemote(repoURL)
+	repoEntry := filepath.Dir(remote.barePath)
 
-	// SHA refs have stable extraction keys; branch/tag refs must be re-resolved.
-	if looksLikeSHA(ref) {
-		if packageRoot, ok := cachedArchiveDir(remote.extractBase, ref, subdir); ok {
-			return ConfineResolution(ctx, Resolution{
-				LocalPath:   filepath.Join(packageRoot, filepath.FromSlash(subdir)),
-				PackageRoot: packageRoot,
-			})
-		}
+	if resolution, ok, err := r.resolveCachedSHAArchive(ctx, remote, repoEntry, ref, subdir); ok {
+		return resolution, err
 	}
 
 	if _, err := r.policy.resolveHost(ctx, parsedRepo.Hostname()); err != nil {
 		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
 	}
 
-	if err := remote.ensureClone(ctx); err != nil {
-		return Resolution{}, unresolvedResourceError(err)
-	}
-	defer r.evictGitCache()
-
-	sha, err := remote.fetchRef(ctx, ref)
-	if err != nil {
-		contextLogger.Warn().Err(err).Msgf("BareGitResolver: ref %q not reachable from %s", ref, repoURL)
-		return Resolution{}, unresolvedResourceError(err)
-	}
-
-	packageRoot, err := remote.extract(ctx, sha, subdir)
-	if err != nil {
-		contextLogger.Warn().Err(err).Msgf("BareGitResolver: archive %s:%s failed", sha, subdir)
-		return Resolution{}, unresolvedResourceError(err)
-	}
-
-	return ConfineResolution(ctx, Resolution{
-		LocalPath:   filepath.Join(packageRoot, filepath.FromSlash(subdir)),
-		PackageRoot: packageRoot,
-	})
+	return r.resolveRemoteArchive(ctx, remote, repoEntry, repoURL, ref, subdir)
 }
 
 // checkGitTransportAllowed accepts only the transports whose destination the

--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -43,6 +43,7 @@ const maxArchiveExtractBytes = 200 * 1024 * 1024
 type BareGitResolver struct {
 	// Defaults to <user-cache-dir>/datadog-iac-scanner/git-bare.
 	CacheDir string
+	MaxBytes int64
 
 	hostAllowlist []string
 	policy        *httpDestinationPolicy
@@ -1076,7 +1077,21 @@ func (rem *bareRemote) extract(ctx context.Context, sha, subdir string) (string,
 	if err != nil {
 		return "", err
 	}
-	return archiveCacheDir(rem.extractBase, sha), nil
+	dest := archiveCacheDir(rem.extractBase, sha)
+	return dest, nil
+}
+
+func (r *BareGitResolver) evictGitCache() {
+	if r == nil || r.MaxBytes <= 0 {
+		return
+	}
+	r.mu.Lock()
+	retained := make(map[string]bool, len(r.repos))
+	for _, repo := range r.repos {
+		retained[filepath.Clean(filepath.Dir(repo.barePath))] = true
+	}
+	r.mu.Unlock()
+	evictUnretainedDirs(r.effectiveCacheDir(), r.MaxBytes, retained)
 }
 
 // Resolve implements Resolver for pinnable git:: sources. A missing ref uses HEAD.
@@ -1123,6 +1138,7 @@ func (r *BareGitResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedModu
 	if err := remote.ensureClone(ctx); err != nil {
 		return Resolution{}, unresolvedResourceError(err)
 	}
+	defer r.evictGitCache()
 
 	sha, err := remote.fetchRef(ctx, ref)
 	if err != nil {

--- a/pkg/parser/terraform/modules/resolver/cache.go
+++ b/pkg/parser/terraform/modules/resolver/cache.go
@@ -14,10 +14,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"golang.org/x/sync/singleflight"
@@ -36,42 +34,54 @@ const (
 	CacheSubdirGitLocal = "git-local"
 )
 
-var errCacheEntryTooLarge = errors.New("module package exceeds cache size limit")
+var errCacheEntryTooLarge = errors.New("cache entry exceeds cache size limit")
 
 // moduleCache is a content-addressed on-disk module store.
 type moduleCache struct {
-	dir      string
-	maxBytes int64
-	sf       singleflight.Group
-	evictMu  sync.Mutex
-	total    int64
-	sized    bool
-	inUse    map[string]bool
+	dir    string
+	budget *ModuleCacheBudget
+	sf     singleflight.Group
 }
 
 func NewModuleCache() (*moduleCache, error) {
-	return NewModuleCacheWithDir("", DefaultMaxCacheBytes)
+	root, err := DefaultModuleCacheRoot()
+	if err != nil {
+		return nil, err
+	}
+	budget, err := NewModuleCacheBudget(root, DefaultMaxCacheBytes)
+	if err != nil {
+		return nil, err
+	}
+	return NewModuleCacheWithDir("", budget)
 }
 
-func NewModuleCacheWithDir(dir string, maxBytes int64) (*moduleCache, error) {
+func NewModuleCacheWithDir(dir string, budget *ModuleCacheBudget) (*moduleCache, error) {
 	if dir == "" {
-		root, err := defaultModuleCacheRoot()
-		if err != nil {
-			return nil, err
+		if budget != nil && budget.Root() != "" {
+			dir = filepath.Join(budget.Root(), CacheSubdirModules)
+		} else {
+			root, err := DefaultModuleCacheRoot()
+			if err != nil {
+				return nil, err
+			}
+			dir = filepath.Join(root, CacheSubdirModules)
+			if budget == nil {
+				var budgetErr error
+				budget, budgetErr = NewModuleCacheBudget(root, DefaultMaxCacheBytes)
+				if budgetErr != nil {
+					return nil, budgetErr
+				}
+			}
 		}
-		dir = filepath.Join(root, CacheSubdirModules)
-	}
-	if maxBytes <= 0 {
-		maxBytes = DefaultMaxCacheBytes
 	}
 	dir = filepath.Clean(dir)
 	if err := os.MkdirAll(dir, cacheDirPerms); err != nil {
 		return nil, fmt.Errorf("creating module cache: %w", err)
 	}
-	return &moduleCache{dir: dir, maxBytes: maxBytes}, nil
+	return &moduleCache{dir: dir, budget: budget}, nil
 }
 
-func defaultModuleCacheRoot() (string, error) {
+func DefaultModuleCacheRoot() (string, error) {
 	base := os.Getenv("XDG_CACHE_HOME")
 	if base == "" {
 		home, err := os.UserHomeDir()
@@ -125,18 +135,46 @@ func (c *moduleCache) lookup(source, version string) (packageRoot string, ok boo
 	if _, err := os.ReadFile(filepath.Join(dir, cacheSelectionFile)); err != nil { //nolint:gosec
 		return "", false
 	}
-	c.retain(dir)
 	return dir, true
 }
 
-func (c *moduleCache) store(source, version, srcDir, subdir string) (string, error) {
+func (c *moduleCache) lookupLease(source, version string) (packageRoot string, release func(), ok bool) {
+	path := filepath.Join(c.dir, moduleCacheKey(source, version))
+	release = c.lease(path)
+	packageRoot, ok = c.lookup(source, version)
+	if !ok {
+		release()
+		return "", func() {}, false
+	}
+	return packageRoot, release, true
+}
+
+func (c *moduleCache) lease(path string) func() {
+	if c == nil || c.budget == nil || path == "" {
+		return func() {}
+	}
+	return c.budget.Lease(path)
+}
+
+func (c *moduleCache) admitStored(path string) error {
+	if c == nil || c.budget == nil {
+		return nil
+	}
+	if err := c.budget.EnsureEntryFits(path); err != nil {
+		return err
+	}
+	c.budget.Admit(path)
+	return nil
+}
+
+func (c *moduleCache) store(source, version, srcDir, subdir string) (stored string, release func(), err error) {
 	key := moduleCacheKey(source, version)
 	dst := filepath.Join(c.dir, key)
+	release = c.lease(dst)
 	if cached, ok := c.lookup(source, version); ok {
-		return cached, nil
+		return cached, release, nil
 	}
 	var published bool
-	var added int64
 	v, err, _ := c.sf.Do(key, func() (interface{}, error) {
 		if cached, ok := c.lookup(source, version); ok {
 			return cached, nil
@@ -158,7 +196,7 @@ func (c *moduleCache) store(source, version, srcDir, subdir string) (string, err
 			return "", fmt.Errorf("writing cache selection: %w", err)
 		}
 		size := copied + int64(len(subdir))
-		if c.maxBytes > 0 && size > c.maxBytes {
+		if c.budget != nil && size > c.budget.MaxBytes() {
 			_ = os.RemoveAll(tmp)
 			return "", errCacheEntryTooLarge
 		}
@@ -174,71 +212,20 @@ func (c *moduleCache) store(source, version, srcDir, subdir string) (string, err
 			return "", fmt.Errorf("publishing cache entry: %w", err)
 		}
 		published = true
-		added = size
 		return dst, nil
 	})
 	if err != nil {
-		return "", err
+		release()
+		return "", func() {}, err
 	}
-	stored := v.(string)
-	c.retain(stored)
+	stored = v.(string)
 	if published {
-		c.accountAndEvict(stored, added)
-	}
-	return stored, nil
-}
-
-func (c *moduleCache) retain(path string) {
-	if c == nil || path == "" {
-		return
-	}
-	c.evictMu.Lock()
-	defer c.evictMu.Unlock()
-	if c.inUse == nil {
-		c.inUse = make(map[string]bool)
-	}
-	c.inUse[filepath.Clean(path)] = true
-}
-
-func (c *moduleCache) accountAndEvict(keep string, added int64) {
-	if c == nil || c.maxBytes <= 0 {
-		return
-	}
-	c.evictMu.Lock()
-	defer c.evictMu.Unlock()
-
-	if !c.sized {
-		_, c.total = listCacheEntries(c.dir)
-		c.sized = true
-	} else {
-		c.total += added
-	}
-	if c.total <= c.maxBytes {
-		return
-	}
-
-	entries, total := listCacheEntries(c.dir)
-	sort.Slice(entries, func(i, j int) bool {
-		if entries[i].modTime.Equal(entries[j].modTime) {
-			return entries[i].path < entries[j].path
+		if fitErr := c.admitStored(stored); fitErr != nil {
+			release()
+			return "", func() {}, fitErr
 		}
-		return entries[i].modTime.Before(entries[j].modTime)
-	})
-	keep = filepath.Clean(keep)
-	for _, entry := range entries {
-		if total <= c.maxBytes {
-			break
-		}
-		path := filepath.Clean(entry.path)
-		if path == keep || c.inUse[path] {
-			continue
-		}
-		if err := os.RemoveAll(entry.path); err != nil {
-			continue
-		}
-		total -= entry.size
 	}
-	c.total = max(total, 0)
+	return stored, release, nil
 }
 
 type cacheEntry struct {
@@ -273,35 +260,6 @@ func listCacheEntries(dir string) (entries []cacheEntry, total int64) {
 		entries = append(entries, cacheEntry{path: path, size: size, modTime: info.ModTime()})
 	}
 	return entries, total
-}
-
-func evictUnretainedDirs(dir string, maxBytes int64, retained map[string]bool) {
-	if maxBytes <= 0 || dir == "" {
-		return
-	}
-	entries, total := listCacheEntries(dir)
-	if total <= maxBytes {
-		return
-	}
-	sort.Slice(entries, func(i, j int) bool {
-		if entries[i].modTime.Equal(entries[j].modTime) {
-			return entries[i].path < entries[j].path
-		}
-		return entries[i].modTime.Before(entries[j].modTime)
-	})
-	for _, entry := range entries {
-		if total <= maxBytes {
-			return
-		}
-		path := filepath.Clean(entry.path)
-		if retained[path] {
-			continue
-		}
-		if err := os.RemoveAll(entry.path); err != nil {
-			continue
-		}
-		total -= entry.size
-	}
 }
 
 func readCacheSize(dir string) (int64, bool) {

--- a/pkg/parser/terraform/modules/resolver/cache.go
+++ b/pkg/parser/terraform/modules/resolver/cache.go
@@ -13,53 +13,106 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	"golang.org/x/sync/singleflight"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
 
-const cacheDirPerms = 0o700
-const cacheSelectionFile = ".module-subdir"
+const (
+	cacheDirPerms        = 0o700
+	cacheSelectionFile   = ".module-subdir"
+	cacheSizeFile        = ".module-bytes"
+	DefaultMaxCacheBytes = 2 * 1024 * 1024 * 1024
 
-// moduleCache is a content-addressed on-disk module store ($XDG_CACHE_HOME/.../modules).
+	CacheSubdirModules  = "modules"
+	CacheSubdirGitBare  = "git-bare"
+	CacheSubdirGitLocal = "git-local"
+)
+
+// moduleCache is a content-addressed on-disk module store.
 type moduleCache struct {
-	dir string
-	sf  singleflight.Group
+	dir      string
+	maxBytes int64
+	sf       singleflight.Group
+	evictMu  sync.Mutex
+	total    int64
+	sized    bool
 }
 
-// NewModuleCache creates ~/.cache/.../modules (or XDG_CACHE_HOME) and returns it.
 func NewModuleCache() (*moduleCache, error) {
+	return NewModuleCacheWithDir("", DefaultMaxCacheBytes)
+}
+
+func NewModuleCacheWithDir(dir string, maxBytes int64) (*moduleCache, error) {
+	if dir == "" {
+		root, err := defaultModuleCacheRoot()
+		if err != nil {
+			return nil, err
+		}
+		dir = filepath.Join(root, CacheSubdirModules)
+	}
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxCacheBytes
+	}
+	dir = filepath.Clean(dir)
+	if err := os.MkdirAll(dir, cacheDirPerms); err != nil {
+		return nil, fmt.Errorf("creating module cache: %w", err)
+	}
+	return &moduleCache{dir: dir, maxBytes: maxBytes}, nil
+}
+
+func defaultModuleCacheRoot() (string, error) {
 	base := os.Getenv("XDG_CACHE_HOME")
 	if base == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return nil, fmt.Errorf("determining home dir for module cache: %w", err)
+			return "", fmt.Errorf("determining home dir for module cache: %w", err)
 		}
 		base = filepath.Join(home, ".cache")
 	}
-	dir := filepath.Join(filepath.Clean(base), "datadog-iac-scanner", "modules")
-	if err := os.MkdirAll(dir, cacheDirPerms); err != nil {
-		return nil, fmt.Errorf("creating module cache: %w", err)
-	}
-	return &moduleCache{dir: dir}, nil
+	return filepath.Join(filepath.Clean(base), "datadog-iac-scanner"), nil
 }
 
-// moduleCacheKey is sha256(packageSource + NUL + version) hex.
+func ModuleCacheSubdir(root, name string) string {
+	if strings.TrimSpace(root) == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Clean(root), name)
+}
+
 func moduleCacheKey(source, version string) string {
 	h := sha256.New()
-	_, _ = h.Write([]byte("package-v1"))
+	_, _ = h.Write([]byte("package-v2"))
 	_, _ = h.Write([]byte{0})
-	_, _ = h.Write([]byte(moduleCachePackageSource(source)))
+	_, _ = h.Write([]byte(canonicalizeModuleCacheSource(source)))
 	_, _ = h.Write([]byte{0})
-	_, _ = h.Write([]byte(version))
+	_, _ = h.Write([]byte(strings.TrimSpace(version)))
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func moduleCachePackageSource(source string) string {
+func canonicalizeModuleCacheSource(source string) string {
 	packageSource, _ := splitGetterSubdir(source)
+	st, _ := tfmodules.DetectModuleSourceType(packageSource)
+	switch st {
+	case sourceTypeRegistry:
+		host, namespace, name, provider, err := parseRegistrySource(packageSource)
+		if err == nil {
+			return strings.ToLower(host) + "/" + namespace + "/" + name + "/" + provider
+		}
+	case sourceTypeGit:
+		if key, ok := GitModuleResolveKey(packageSource, ""); ok {
+			return key
+		}
+	}
 	return packageSource
 }
 
-// lookup returns a cached package root when the entry is complete.
 func (c *moduleCache) lookup(source, version string) (packageRoot string, ok bool) {
 	dir := filepath.Join(c.dir, moduleCacheKey(source, version))
 	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
@@ -71,19 +124,15 @@ func (c *moduleCache) lookup(source, version string) (packageRoot string, ok boo
 	return dir, true
 }
 
-// store copies srcDir into the cache key path via temp dir + rename (concurrent-safe).
-// A singleflight ensures that only one goroutine performs the copy+rename per key;
-// concurrent callers with the same key wait and share the result, which avoids the
-// Windows file-locking errors that arise when multiple goroutines race to rename
-// different temp dirs onto the same destination directory.
 func (c *moduleCache) store(source, version, srcDir, subdir string) (string, error) {
 	key := moduleCacheKey(source, version)
 	dst := filepath.Join(c.dir, key)
 	if cached, ok := c.lookup(source, version); ok {
 		return cached, nil
 	}
+	var published bool
+	var added int64
 	v, err, _ := c.sf.Do(key, func() (interface{}, error) {
-		// Re-check after acquiring the singleflight slot.
 		if cached, ok := c.lookup(source, version); ok {
 			return cached, nil
 		}
@@ -94,13 +143,19 @@ func (c *moduleCache) store(source, version, srcDir, subdir string) (string, err
 		if err != nil {
 			return "", fmt.Errorf("creating cache temp dir: %w", err)
 		}
-		if err := copyRegularFiles(tmp, srcDir); err != nil {
+		copied, err := copyRegularFiles(tmp, srcDir)
+		if err != nil {
 			_ = os.RemoveAll(tmp)
 			return "", fmt.Errorf("copying to cache: %w", err)
 		}
 		if err := os.WriteFile(filepath.Join(tmp, cacheSelectionFile), []byte(subdir), cacheFilePerms); err != nil {
 			_ = os.RemoveAll(tmp)
 			return "", fmt.Errorf("writing cache selection: %w", err)
+		}
+		size := copied + int64(len(subdir))
+		if err := os.WriteFile(filepath.Join(tmp, cacheSizeFile), []byte(strconv.FormatInt(size, 10)), cacheFilePerms); err != nil {
+			_ = os.RemoveAll(tmp)
+			return "", fmt.Errorf("writing cache size: %w", err)
 		}
 		if err := os.Rename(tmp, dst); err != nil {
 			_ = os.RemoveAll(tmp)
@@ -109,16 +164,120 @@ func (c *moduleCache) store(source, version, srcDir, subdir string) (string, err
 			}
 			return "", fmt.Errorf("publishing cache entry: %w", err)
 		}
+		published = true
+		added = size
 		return dst, nil
 	})
 	if err != nil {
 		return "", err
 	}
-	return v.(string), nil
+	stored := v.(string)
+	if published {
+		c.accountAndEvict(stored, added)
+	}
+	return stored, nil
 }
 
-func copyRegularFiles(dest, source string) error {
-	return fs.WalkDir(os.DirFS(source), ".", func(path string, entry fs.DirEntry, walkErr error) error {
+func (c *moduleCache) accountAndEvict(keep string, added int64) {
+	if c == nil || c.maxBytes <= 0 {
+		return
+	}
+	c.evictMu.Lock()
+	defer c.evictMu.Unlock()
+
+	if !c.sized {
+		_, c.total = listCacheEntries(c.dir)
+		c.sized = true
+	} else {
+		c.total += added
+	}
+	if c.total <= c.maxBytes {
+		return
+	}
+
+	entries, total := listCacheEntries(c.dir)
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].modTime.Equal(entries[j].modTime) {
+			return entries[i].path < entries[j].path
+		}
+		return entries[i].modTime.Before(entries[j].modTime)
+	})
+	keep = filepath.Clean(keep)
+	for _, entry := range entries {
+		if total <= c.maxBytes {
+			break
+		}
+		if filepath.Clean(entry.path) == keep {
+			continue
+		}
+		if err := os.RemoveAll(entry.path); err != nil {
+			continue
+		}
+		total -= entry.size
+	}
+	c.total = max(total, 0)
+}
+
+type cacheEntry struct {
+	path    string
+	size    int64
+	modTime time.Time
+}
+
+func listCacheEntries(dir string) (entries []cacheEntry, total int64) {
+	items, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, 0
+	}
+	entries = make([]cacheEntry, 0, len(items))
+	for _, item := range items {
+		path := filepath.Join(dir, item.Name())
+		info, infoErr := item.Info()
+		if infoErr != nil {
+			continue
+		}
+		if !item.IsDir() {
+			total += info.Size()
+			continue
+		}
+		size, ok := readCacheSize(path)
+		if !ok {
+			size = directorySize(path)
+		}
+		total += size
+		entries = append(entries, cacheEntry{path: path, size: size, modTime: info.ModTime()})
+	}
+	return entries, total
+}
+
+func readCacheSize(dir string) (int64, bool) {
+	data, err := os.ReadFile(filepath.Join(dir, cacheSizeFile)) //nolint:gosec
+	if err != nil {
+		return 0, false
+	}
+	size, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	return size, err == nil && size >= 0
+}
+
+func directorySize(path string) int64 {
+	var total int64
+	_ = fs.WalkDir(os.DirFS(path), ".", func(_ string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return nil
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil || !info.Mode().IsRegular() {
+			return nil
+		}
+		total += info.Size()
+		return nil
+	})
+	return total
+}
+
+func copyRegularFiles(dest, source string) (int64, error) {
+	var written int64
+	err := fs.WalkDir(os.DirFS(source), ".", func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -145,7 +304,7 @@ func copyRegularFiles(dest, source string) error {
 			_ = sourceFile.Close()
 			return err
 		}
-		_, copyErr := io.Copy(destFile, sourceFile)
+		n, copyErr := io.Copy(destFile, sourceFile)
 		sourceCloseErr := sourceFile.Close()
 		destCloseErr := destFile.Close()
 		if copyErr != nil {
@@ -154,6 +313,11 @@ func copyRegularFiles(dest, source string) error {
 		if sourceCloseErr != nil {
 			return sourceCloseErr
 		}
-		return destCloseErr
+		if destCloseErr != nil {
+			return destCloseErr
+		}
+		written += n
+		return nil
 	})
+	return written, err
 }

--- a/pkg/parser/terraform/modules/resolver/cache.go
+++ b/pkg/parser/terraform/modules/resolver/cache.go
@@ -8,6 +8,7 @@ package resolver
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -35,6 +36,8 @@ const (
 	CacheSubdirGitLocal = "git-local"
 )
 
+var errCacheEntryTooLarge = errors.New("module package exceeds cache size limit")
+
 // moduleCache is a content-addressed on-disk module store.
 type moduleCache struct {
 	dir      string
@@ -43,6 +46,7 @@ type moduleCache struct {
 	evictMu  sync.Mutex
 	total    int64
 	sized    bool
+	inUse    map[string]bool
 }
 
 func NewModuleCache() (*moduleCache, error) {
@@ -121,6 +125,7 @@ func (c *moduleCache) lookup(source, version string) (packageRoot string, ok boo
 	if _, err := os.ReadFile(filepath.Join(dir, cacheSelectionFile)); err != nil { //nolint:gosec
 		return "", false
 	}
+	c.retain(dir)
 	return dir, true
 }
 
@@ -153,6 +158,10 @@ func (c *moduleCache) store(source, version, srcDir, subdir string) (string, err
 			return "", fmt.Errorf("writing cache selection: %w", err)
 		}
 		size := copied + int64(len(subdir))
+		if c.maxBytes > 0 && size > c.maxBytes {
+			_ = os.RemoveAll(tmp)
+			return "", errCacheEntryTooLarge
+		}
 		if err := os.WriteFile(filepath.Join(tmp, cacheSizeFile), []byte(strconv.FormatInt(size, 10)), cacheFilePerms); err != nil {
 			_ = os.RemoveAll(tmp)
 			return "", fmt.Errorf("writing cache size: %w", err)
@@ -172,10 +181,23 @@ func (c *moduleCache) store(source, version, srcDir, subdir string) (string, err
 		return "", err
 	}
 	stored := v.(string)
+	c.retain(stored)
 	if published {
 		c.accountAndEvict(stored, added)
 	}
 	return stored, nil
+}
+
+func (c *moduleCache) retain(path string) {
+	if c == nil || path == "" {
+		return
+	}
+	c.evictMu.Lock()
+	defer c.evictMu.Unlock()
+	if c.inUse == nil {
+		c.inUse = make(map[string]bool)
+	}
+	c.inUse[filepath.Clean(path)] = true
 }
 
 func (c *moduleCache) accountAndEvict(keep string, added int64) {
@@ -207,7 +229,8 @@ func (c *moduleCache) accountAndEvict(keep string, added int64) {
 		if total <= c.maxBytes {
 			break
 		}
-		if filepath.Clean(entry.path) == keep {
+		path := filepath.Clean(entry.path)
+		if path == keep || c.inUse[path] {
 			continue
 		}
 		if err := os.RemoveAll(entry.path); err != nil {
@@ -236,8 +259,10 @@ func listCacheEntries(dir string) (entries []cacheEntry, total int64) {
 		if infoErr != nil {
 			continue
 		}
-		if !item.IsDir() {
-			total += info.Size()
+		if !item.IsDir() || strings.HasPrefix(item.Name(), ".") {
+			if !item.IsDir() {
+				total += info.Size()
+			}
 			continue
 		}
 		size, ok := readCacheSize(path)
@@ -248,6 +273,35 @@ func listCacheEntries(dir string) (entries []cacheEntry, total int64) {
 		entries = append(entries, cacheEntry{path: path, size: size, modTime: info.ModTime()})
 	}
 	return entries, total
+}
+
+func evictUnretainedDirs(dir string, maxBytes int64, retained map[string]bool) {
+	if maxBytes <= 0 || dir == "" {
+		return
+	}
+	entries, total := listCacheEntries(dir)
+	if total <= maxBytes {
+		return
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].modTime.Equal(entries[j].modTime) {
+			return entries[i].path < entries[j].path
+		}
+		return entries[i].modTime.Before(entries[j].modTime)
+	})
+	for _, entry := range entries {
+		if total <= maxBytes {
+			return
+		}
+		path := filepath.Clean(entry.path)
+		if retained[path] {
+			continue
+		}
+		if err := os.RemoveAll(entry.path); err != nil {
+			continue
+		}
+		total -= entry.size
+	}
 }
 
 func readCacheSize(dir string) (int64, bool) {

--- a/pkg/parser/terraform/modules/resolver/cache_budget.go
+++ b/pkg/parser/terraform/modules/resolver/cache_budget.go
@@ -1,0 +1,188 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+// ModuleCacheBudget tracks one byte limit shared across modules/, git-bare/, and git-local/.
+type ModuleCacheBudget struct {
+	root     string
+	maxBytes int64
+
+	mu                 sync.Mutex
+	pins               map[string]int
+	removeWhenUnpinned map[string]bool
+	evictOnUnpin       bool
+}
+
+func NewModuleCacheBudget(root string, maxBytes int64) (*ModuleCacheBudget, error) {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxCacheBytes
+	}
+	root = filepath.Clean(root)
+	for _, sub := range []string{CacheSubdirModules, CacheSubdirGitBare, CacheSubdirGitLocal} {
+		if err := os.MkdirAll(filepath.Join(root, sub), cacheDirPerms); err != nil {
+			return nil, err
+		}
+	}
+	return &ModuleCacheBudget{root: root, maxBytes: maxBytes}, nil
+}
+
+func (b *ModuleCacheBudget) MaxBytes() int64 {
+	if b == nil {
+		return 0
+	}
+	return b.maxBytes
+}
+
+func (b *ModuleCacheBudget) Root() string {
+	if b == nil {
+		return ""
+	}
+	return b.root
+}
+
+func (b *ModuleCacheBudget) Pin(path string) {
+	if b == nil || path == "" {
+		return
+	}
+	path = filepath.Clean(path)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.pins == nil {
+		b.pins = make(map[string]int)
+	}
+	b.pins[path]++
+}
+
+func (b *ModuleCacheBudget) Unpin(path string) {
+	if b == nil || path == "" {
+		return
+	}
+	path = filepath.Clean(path)
+	b.mu.Lock()
+	if b.pins[path] > 1 {
+		b.pins[path]--
+		b.mu.Unlock()
+		return
+	}
+	delete(b.pins, path)
+	if b.removeWhenUnpinned[path] {
+		_ = os.RemoveAll(path)
+		delete(b.removeWhenUnpinned, path)
+	}
+	shouldEvict := b.evictOnUnpin
+	b.mu.Unlock()
+	if shouldEvict {
+		b.Admit("")
+	}
+}
+
+func (b *ModuleCacheBudget) Lease(path string) func() {
+	if b == nil || path == "" {
+		return func() {}
+	}
+	b.Pin(path)
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			b.Unpin(path)
+		})
+	}
+}
+
+func (b *ModuleCacheBudget) WithPin(path string, fn func() error) error {
+	release := b.Lease(path)
+	defer release()
+	return fn()
+}
+
+func (b *ModuleCacheBudget) EnsureEntryFits(path string) error {
+	if b == nil || path == "" {
+		return nil
+	}
+	path = filepath.Clean(path)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if cacheEntrySize(path) <= b.maxBytes {
+		return nil
+	}
+	if b.removeWhenUnpinned == nil {
+		b.removeWhenUnpinned = make(map[string]bool)
+	}
+	b.removeWhenUnpinned[path] = true
+	if b.pins[path] == 0 {
+		_ = os.RemoveAll(path)
+		delete(b.removeWhenUnpinned, path)
+	}
+	return errCacheEntryTooLarge
+}
+
+func (b *ModuleCacheBudget) Admit(keep string) {
+	if b == nil || b.maxBytes <= 0 {
+		return
+	}
+	if keep != "" {
+		keep = filepath.Clean(keep)
+		if b.EnsureEntryFits(keep) != nil {
+			keep = ""
+		}
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	entries, total := listAggregateCacheEntries(b.root)
+	if total <= b.maxBytes {
+		b.evictOnUnpin = false
+		return
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].modTime.Equal(entries[j].modTime) {
+			return entries[i].path < entries[j].path
+		}
+		return entries[i].modTime.Before(entries[j].modTime)
+	})
+	for _, entry := range entries {
+		if total <= b.maxBytes {
+			break
+		}
+		path := filepath.Clean(entry.path)
+		if keep != "" && path == keep {
+			continue
+		}
+		if b.pins[path] > 0 {
+			continue
+		}
+		if err := os.RemoveAll(entry.path); err != nil {
+			continue
+		}
+		total -= entry.size
+	}
+	b.evictOnUnpin = total > b.maxBytes
+}
+
+func cacheEntrySize(path string) int64 {
+	size, ok := readCacheSize(path)
+	if ok {
+		return size
+	}
+	return directorySize(path)
+}
+
+func listAggregateCacheEntries(root string) (entries []cacheEntry, total int64) {
+	for _, sub := range []string{CacheSubdirModules, CacheSubdirGitBare, CacheSubdirGitLocal} {
+		subEntries, subTotal := listCacheEntries(filepath.Join(root, sub))
+		entries = append(entries, subEntries...)
+		total += subTotal
+	}
+	return entries, total
+}

--- a/pkg/parser/terraform/modules/resolver/cache_budget_test.go
+++ b/pkg/parser/terraform/modules/resolver/cache_budget_test.go
@@ -1,0 +1,185 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testCacheRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, sub := range []string{CacheSubdirModules, CacheSubdirGitBare, CacheSubdirGitLocal} {
+		if err := os.MkdirAll(filepath.Join(root, sub), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func writeCacheEntry(t *testing.T, dir, name string, size int, age time.Duration) string {
+	t.Helper()
+	entry := filepath.Join(dir, name)
+	if err := os.MkdirAll(entry, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(entry, "blob"), []byte(strings.Repeat("a", size)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	when := time.Now().Add(-age)
+	if err := os.Chtimes(entry, when, when); err != nil {
+		t.Fatal(err)
+	}
+	return entry
+}
+
+func TestModuleCacheBudgetEvictsAcrossSubdirs(t *testing.T) {
+	root := testCacheRoot(t)
+	budget, err := NewModuleCacheBudget(root, 150)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	modulesDir := filepath.Join(root, CacheSubdirModules)
+	gitDir := filepath.Join(root, CacheSubdirGitBare)
+	stale := writeCacheEntry(t, modulesDir, "stale", 80, 2*time.Hour)
+	writeCacheEntry(t, gitDir, "git", 80, time.Hour)
+
+	budget.Admit("")
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("oldest aggregate entry should have been evicted, stat: %v", err)
+	}
+	if _, total := listAggregateCacheEntries(root); total > budget.MaxBytes() {
+		t.Fatalf("aggregate cache size %d exceeds max %d", total, budget.MaxBytes())
+	}
+}
+
+func TestModuleCacheBudgetRemovesOversizedEntryAfterLease(t *testing.T) {
+	root := testCacheRoot(t)
+	budget, err := NewModuleCacheBudget(root, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oversized := writeCacheEntry(t, filepath.Join(root, CacheSubdirGitBare), "huge", 150, time.Hour)
+	release := budget.Lease(oversized)
+	if err := budget.EnsureEntryFits(oversized); !errors.Is(err, errCacheEntryTooLarge) {
+		t.Fatalf("checking oversized entry: %v", err)
+	}
+	if _, err := os.Stat(oversized); err != nil {
+		t.Fatalf("leased oversized entry was removed early: %v", err)
+	}
+	release()
+	if _, err := os.Stat(oversized); !os.IsNotExist(err) {
+		t.Fatalf("oversized entry should be removed after its final lease, stat: %v", err)
+	}
+}
+
+func TestModuleCacheStoreLeaseProtectsEntryDuringUse(t *testing.T) {
+	cache, _ := newTestModuleCache(t, 150)
+	write := func(name string, size int) string {
+		t.Helper()
+		src := t.TempDir()
+		if err := os.WriteFile(filepath.Join(src, name+".tf"), []byte(strings.Repeat("a", size)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return src
+	}
+
+	for i := 0; i < 2; i++ {
+		name := fmt.Sprintf("seed%d", i)
+		dir, release, err := cache.store("example/"+name+"/aws", "1.0.0", write(name, 80), "")
+		release()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(dir, time.Now().Add(-time.Duration(i+1)*time.Hour), time.Now().Add(-time.Duration(i+1)*time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	live, liveRelease, err := cache.store("example/live/aws", "1.0.0", write("live", 80), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer liveRelease()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, release, storeErr := cache.store("example/newer/aws", "1.0.0", write("newer", 80), "")
+		if storeErr != nil {
+			t.Error(storeErr)
+			return
+		}
+		release()
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	if _, statErr := os.Stat(live); statErr != nil {
+		t.Fatalf("leased cache entry was evicted during concurrent admit: %v", statErr)
+	}
+	<-done
+}
+
+func TestModuleCacheBudgetDoesNotEvictPinnedEntries(t *testing.T) {
+	root := testCacheRoot(t)
+	budget, err := NewModuleCacheBudget(root, 150)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modulesDir := filepath.Join(root, CacheSubdirModules)
+	stale := writeCacheEntry(t, modulesDir, "stale", 80, 2*time.Hour)
+	live := writeCacheEntry(t, modulesDir, "live", 80, time.Hour)
+
+	err = budget.WithPin(live, func() error {
+		writeCacheEntry(t, modulesDir, "newer", 80, 0)
+		budget.Admit(live)
+		if _, statErr := os.Stat(live); statErr != nil {
+			t.Fatalf("pinned entry was evicted during pin: %v", statErr)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale entry should have been evicted after pin released, stat: %v", err)
+	}
+}
+
+func TestModuleCacheBudgetEvictsWhenLeaseEnds(t *testing.T) {
+	root := testCacheRoot(t)
+	budget, err := NewModuleCacheBudget(root, 150)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modulesDir := filepath.Join(root, CacheSubdirModules)
+	first := writeCacheEntry(t, modulesDir, "first", 80, time.Hour)
+	second := writeCacheEntry(t, modulesDir, "second", 80, 0)
+	releaseFirst := budget.Lease(first)
+	releaseSecond := budget.Lease(second)
+
+	budget.Admit(second)
+	if _, total := listAggregateCacheEntries(root); total <= budget.MaxBytes() {
+		t.Fatal("expected active leases to allow a temporary cache overage")
+	}
+
+	releaseFirst()
+	if _, err := os.Stat(first); !os.IsNotExist(err) {
+		t.Fatalf("released entry should be evicted to restore the cache limit: %v", err)
+	}
+	if _, total := listAggregateCacheEntries(root); total > budget.MaxBytes() {
+		t.Fatalf("cache size %d exceeds max %d after lease release", total, budget.MaxBytes())
+	}
+	releaseSecond()
+}

--- a/pkg/parser/terraform/modules/resolver/cache_test.go
+++ b/pkg/parser/terraform/modules/resolver/cache_test.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func writeModuleSrc(t *testing.T, nFiles int) string {
@@ -146,5 +148,107 @@ func TestModuleCacheSharesPackageAcrossSubdirs(t *testing.T) {
 	}
 	if vpcDir != ec2Dir {
 		t.Fatalf("expected one shared package cache dir, got %q and %q", vpcDir, ec2Dir)
+	}
+}
+
+func TestModuleCacheKeyAliasesEquivalentSources(t *testing.T) {
+	registryA := moduleCacheKey("terraform-aws-modules/vpc/aws", "1.0.0")
+	registryB := moduleCacheKey("registry.terraform.io/terraform-aws-modules/vpc/aws", "1.0.0")
+	if registryA != registryB {
+		t.Fatalf("registry prefix aliases must share a cache key")
+	}
+	if moduleCacheKey("terraform-aws-modules/vpc/aws", "2.0.0") == registryA {
+		t.Fatal("different versions must not share a cache key")
+	}
+
+	gitA := moduleCacheKey("git::https://github.com/org/repo.git?ref=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "")
+	gitB := moduleCacheKey("git::https://github.com/org/repo?ref=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "")
+	if gitA != gitB {
+		t.Fatalf("git .git suffix aliases must share a cache key")
+	}
+	gitOther := moduleCacheKey("git::https://github.com/org/repo.git?ref=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "")
+	if gitA == gitOther {
+		t.Fatal("different git refs must not share a cache key")
+	}
+}
+
+func TestModuleCacheEvictsOldestEntries(t *testing.T) {
+	cache, err := NewModuleCacheWithDir(t.TempDir(), 150)
+	if err != nil {
+		t.Fatal(err)
+	}
+	write := func(name string, size int) string {
+		t.Helper()
+		src := t.TempDir()
+		payload := strings.Repeat("a", size)
+		if err := os.WriteFile(filepath.Join(src, name+".tf"), []byte(payload), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return src
+	}
+
+	first, err := cache.store("example/one/aws", "1.0.0", write("one", 80), "")
+	if err != nil {
+		t.Fatalf("store one: %v", err)
+	}
+	past := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(first, past, past); err != nil {
+		t.Fatal(err)
+	}
+	second, err := cache.store("example/two/aws", "1.0.0", write("two", 80), "")
+	if err != nil {
+		t.Fatalf("store two: %v", err)
+	}
+	older := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(second, older, older); err != nil {
+		t.Fatal(err)
+	}
+	third, err := cache.store("example/three/aws", "1.0.0", write("three", 80), "")
+	if err != nil {
+		t.Fatalf("store three: %v", err)
+	}
+
+	if _, err := os.Stat(first); !os.IsNotExist(err) {
+		t.Fatalf("oldest cache entry should have been evicted, stat: %v", err)
+	}
+	if _, err := os.Stat(second); !os.IsNotExist(err) {
+		t.Fatalf("second cache entry should have been evicted, stat: %v", err)
+	}
+	if _, err := os.Stat(third); err != nil {
+		t.Fatalf("kept cache entry missing: %v", err)
+	}
+	if _, total := listCacheEntries(cache.dir); total > cache.maxBytes {
+		t.Fatalf("cache size %d exceeds max %d", total, cache.maxBytes)
+	}
+}
+
+func TestModuleCacheHitsDoNotEvictSiblings(t *testing.T) {
+	cache, err := NewModuleCacheWithDir(t.TempDir(), 10*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := writeModuleSrc(t, 2)
+	first, err := cache.store("example/one/aws", "1.0.0", src, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := cache.store("example/two/aws", "1.0.0", src, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		got, storeErr := cache.store("example/one/aws", "1.0.0", src, "")
+		if storeErr != nil {
+			t.Fatal(storeErr)
+		}
+		if got != first {
+			t.Fatalf("hit returned %q, want %q", got, first)
+		}
+	}
+	if _, err := os.Stat(first); err != nil {
+		t.Fatalf("cached module missing after hits: %v", err)
+	}
+	if _, err := os.Stat(second); err != nil {
+		t.Fatalf("sibling evicted on cache hit: %v", err)
 	}
 }

--- a/pkg/parser/terraform/modules/resolver/cache_test.go
+++ b/pkg/parser/terraform/modules/resolver/cache_test.go
@@ -6,6 +6,7 @@
 package resolver
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -173,7 +174,8 @@ func TestModuleCacheKeyAliasesEquivalentSources(t *testing.T) {
 }
 
 func TestModuleCacheEvictsOldestEntries(t *testing.T) {
-	cache, err := NewModuleCacheWithDir(t.TempDir(), 150)
+	dir := t.TempDir()
+	previous, err := NewModuleCacheWithDir(dir, 150)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +189,7 @@ func TestModuleCacheEvictsOldestEntries(t *testing.T) {
 		return src
 	}
 
-	first, err := cache.store("example/one/aws", "1.0.0", write("one", 80), "")
+	first, err := previous.store("example/one/aws", "1.0.0", write("one", 80), "")
 	if err != nil {
 		t.Fatalf("store one: %v", err)
 	}
@@ -195,12 +197,17 @@ func TestModuleCacheEvictsOldestEntries(t *testing.T) {
 	if err := os.Chtimes(first, past, past); err != nil {
 		t.Fatal(err)
 	}
-	second, err := cache.store("example/two/aws", "1.0.0", write("two", 80), "")
+	second, err := previous.store("example/two/aws", "1.0.0", write("two", 80), "")
 	if err != nil {
 		t.Fatalf("store two: %v", err)
 	}
 	older := time.Now().Add(-time.Hour)
 	if err := os.Chtimes(second, older, older); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := NewModuleCacheWithDir(dir, 150)
+	if err != nil {
 		t.Fatal(err)
 	}
 	third, err := cache.store("example/three/aws", "1.0.0", write("three", 80), "")
@@ -250,5 +257,102 @@ func TestModuleCacheHitsDoNotEvictSiblings(t *testing.T) {
 	}
 	if _, err := os.Stat(second); err != nil {
 		t.Fatalf("sibling evicted on cache hit: %v", err)
+	}
+}
+
+func TestModuleCacheDoesNotEvictInUseEntries(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string, size int) string {
+		t.Helper()
+		src := t.TempDir()
+		if err := os.WriteFile(filepath.Join(src, name+".tf"), []byte(strings.Repeat("a", size)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return src
+	}
+
+	previous, err := NewModuleCacheWithDir(dir, 150)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale, err := previous.store("example/stale/aws", "1.0.0", write("stale", 80), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(stale, time.Now().Add(-2*time.Hour), time.Now().Add(-2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := NewModuleCacheWithDir(dir, 150)
+	if err != nil {
+		t.Fatal(err)
+	}
+	live, err := cache.store("example/live/aws", "1.0.0", write("live", 80), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cache.lookup("example/live/aws", "1.0.0"); !ok {
+		t.Fatal("expected live cache hit")
+	}
+	if _, err := cache.store("example/newer/aws", "1.0.0", write("newer", 80), ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("unused previous-scan entry should have been evicted, stat: %v", err)
+	}
+	if _, err := os.Stat(live); err != nil {
+		t.Fatalf("in-use cache entry was evicted: %v", err)
+	}
+}
+
+func TestModuleCacheRejectsEntryLargerThanLimit(t *testing.T) {
+	cache, err := NewModuleCacheWithDir(t.TempDir(), 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "main.tf"), []byte(strings.Repeat("a", 80)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cache.store("example/huge/aws", "1.0.0", src, ""); !errors.Is(err, errCacheEntryTooLarge) {
+		t.Fatalf("store oversized package: %v", err)
+	}
+	entries, err := os.ReadDir(cache.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && !strings.HasPrefix(entry.Name(), ".") {
+			t.Fatalf("oversized package was published as %s", entry.Name())
+		}
+	}
+}
+
+func TestEvictUnretainedDirsSkipsRetained(t *testing.T) {
+	root := t.TempDir()
+	writeDir := func(name string, size int, age time.Duration) string {
+		t.Helper()
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "blob"), []byte(strings.Repeat("a", size)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		when := time.Now().Add(-age)
+		if err := os.Chtimes(dir, when, when); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+	stale := writeDir("stale", 80, 2*time.Hour)
+	live := writeDir("live", 80, time.Hour)
+	evictUnretainedDirs(root, 100, map[string]bool{filepath.Clean(live): true})
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("unretained dir should have been evicted, stat: %v", err)
+	}
+	if _, err := os.Stat(live); err != nil {
+		t.Fatalf("retained dir was evicted: %v", err)
 	}
 }

--- a/pkg/parser/terraform/modules/resolver/cache_test.go
+++ b/pkg/parser/terraform/modules/resolver/cache_test.go
@@ -58,8 +58,10 @@ func TestModuleCacheConcurrentStoreLookupNeverPartial(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if _, err := c.store(source, version, src, ""); err != nil {
+			if _, release, err := c.store(source, version, src, ""); err != nil {
 				errCh <- fmt.Errorf("store: %w", err)
+			} else {
+				release()
 			}
 		}()
 		wg.Add(1)
@@ -109,7 +111,8 @@ func TestModuleCacheSkipsSymlinks(t *testing.T) {
 	}
 
 	cache := &moduleCache{dir: t.TempDir()}
-	dir, err := cache.store("example/module/aws", "1.0.0", src, "modules/selected")
+	dir, release, err := cache.store("example/module/aws", "1.0.0", src, "modules/selected")
+	release()
 	if err != nil {
 		t.Fatalf("store: %v", err)
 	}
@@ -139,11 +142,13 @@ func TestModuleCacheSharesPackageAcrossSubdirs(t *testing.T) {
 	vpcSource := "git::https://github.com/acme/modules.git//modules/vpc?ref=abc"
 	ec2Source := "git::https://github.com/acme/modules.git//modules/ec2?ref=abc"
 
-	vpcDir, err := cache.store(vpcSource, version, src, "modules/vpc")
+	vpcDir, vpcRelease, err := cache.store(vpcSource, version, src, "modules/vpc")
+	vpcRelease()
 	if err != nil {
 		t.Fatalf("store vpc: %v", err)
 	}
-	ec2Dir, err := cache.store(ec2Source, version, src, "modules/ec2")
+	ec2Dir, ec2Release, err := cache.store(ec2Source, version, src, "modules/ec2")
+	ec2Release()
 	if err != nil {
 		t.Fatalf("store ec2: %v", err)
 	}
@@ -173,9 +178,28 @@ func TestModuleCacheKeyAliasesEquivalentSources(t *testing.T) {
 	}
 }
 
+func newTestModuleCache(t *testing.T, maxBytes int64) (*moduleCache, *ModuleCacheBudget) {
+	t.Helper()
+	root := testCacheRoot(t)
+	budget, err := NewModuleCacheBudget(root, maxBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache, err := NewModuleCacheWithDir(filepath.Join(root, CacheSubdirModules), budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cache, budget
+}
+
 func TestModuleCacheEvictsOldestEntries(t *testing.T) {
-	dir := t.TempDir()
-	previous, err := NewModuleCacheWithDir(dir, 150)
+	root := testCacheRoot(t)
+	budget, err := NewModuleCacheBudget(root, 150)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modulesDir := filepath.Join(root, CacheSubdirModules)
+	previous, err := NewModuleCacheWithDir(modulesDir, budget)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +213,8 @@ func TestModuleCacheEvictsOldestEntries(t *testing.T) {
 		return src
 	}
 
-	first, err := previous.store("example/one/aws", "1.0.0", write("one", 80), "")
+	first, firstRelease, err := previous.store("example/one/aws", "1.0.0", write("one", 80), "")
+	firstRelease()
 	if err != nil {
 		t.Fatalf("store one: %v", err)
 	}
@@ -197,7 +222,8 @@ func TestModuleCacheEvictsOldestEntries(t *testing.T) {
 	if err := os.Chtimes(first, past, past); err != nil {
 		t.Fatal(err)
 	}
-	second, err := previous.store("example/two/aws", "1.0.0", write("two", 80), "")
+	second, secondRelease, err := previous.store("example/two/aws", "1.0.0", write("two", 80), "")
+	secondRelease()
 	if err != nil {
 		t.Fatalf("store two: %v", err)
 	}
@@ -206,11 +232,12 @@ func TestModuleCacheEvictsOldestEntries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cache, err := NewModuleCacheWithDir(dir, 150)
+	cache, err := NewModuleCacheWithDir(modulesDir, budget)
 	if err != nil {
 		t.Fatal(err)
 	}
-	third, err := cache.store("example/three/aws", "1.0.0", write("three", 80), "")
+	third, thirdRelease, err := cache.store("example/three/aws", "1.0.0", write("three", 80), "")
+	thirdRelease()
 	if err != nil {
 		t.Fatalf("store three: %v", err)
 	}
@@ -224,27 +251,27 @@ func TestModuleCacheEvictsOldestEntries(t *testing.T) {
 	if _, err := os.Stat(third); err != nil {
 		t.Fatalf("kept cache entry missing: %v", err)
 	}
-	if _, total := listCacheEntries(cache.dir); total > cache.maxBytes {
-		t.Fatalf("cache size %d exceeds max %d", total, cache.maxBytes)
+	if _, total := listCacheEntries(cache.dir); total > budget.MaxBytes() {
+		t.Fatalf("cache size %d exceeds max %d", total, budget.MaxBytes())
 	}
 }
 
 func TestModuleCacheHitsDoNotEvictSiblings(t *testing.T) {
-	cache, err := NewModuleCacheWithDir(t.TempDir(), 10*1024)
-	if err != nil {
-		t.Fatal(err)
-	}
+	cache, _ := newTestModuleCache(t, 10*1024)
 	src := writeModuleSrc(t, 2)
-	first, err := cache.store("example/one/aws", "1.0.0", src, "")
+	first, firstRelease, err := cache.store("example/one/aws", "1.0.0", src, "")
+	firstRelease()
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := cache.store("example/two/aws", "1.0.0", src, "")
+	second, secondRelease, err := cache.store("example/two/aws", "1.0.0", src, "")
+	secondRelease()
 	if err != nil {
 		t.Fatal(err)
 	}
 	for i := 0; i < 20; i++ {
-		got, storeErr := cache.store("example/one/aws", "1.0.0", src, "")
+		got, release, storeErr := cache.store("example/one/aws", "1.0.0", src, "")
+		release()
 		if storeErr != nil {
 			t.Fatal(storeErr)
 		}
@@ -260,8 +287,13 @@ func TestModuleCacheHitsDoNotEvictSiblings(t *testing.T) {
 	}
 }
 
-func TestModuleCacheDoesNotEvictInUseEntries(t *testing.T) {
-	dir := t.TempDir()
+func TestModuleCacheDoesNotEvictPinnedEntries(t *testing.T) {
+	root := testCacheRoot(t)
+	budget, err := NewModuleCacheBudget(root, 150)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modulesDir := filepath.Join(root, CacheSubdirModules)
 	write := func(name string, size int) string {
 		t.Helper()
 		src := t.TempDir()
@@ -271,11 +303,12 @@ func TestModuleCacheDoesNotEvictInUseEntries(t *testing.T) {
 		return src
 	}
 
-	previous, err := NewModuleCacheWithDir(dir, 150)
+	previous, err := NewModuleCacheWithDir(modulesDir, budget)
 	if err != nil {
 		t.Fatal(err)
 	}
-	stale, err := previous.store("example/stale/aws", "1.0.0", write("stale", 80), "")
+	stale, staleRelease, err := previous.store("example/stale/aws", "1.0.0", write("stale", 80), "")
+	staleRelease()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,39 +316,39 @@ func TestModuleCacheDoesNotEvictInUseEntries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cache, err := NewModuleCacheWithDir(dir, 150)
+	cache, err := NewModuleCacheWithDir(modulesDir, budget)
 	if err != nil {
 		t.Fatal(err)
 	}
-	live, err := cache.store("example/live/aws", "1.0.0", write("live", 80), "")
+	live, liveRelease, err := cache.store("example/live/aws", "1.0.0", write("live", 80), "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := cache.lookup("example/live/aws", "1.0.0"); !ok {
-		t.Fatal("expected live cache hit")
+	defer liveRelease()
+	_, newerRelease, storeErr := cache.store("example/newer/aws", "1.0.0", write("newer", 80), "")
+	newerRelease()
+	if storeErr != nil {
+		t.Fatal(storeErr)
 	}
-	if _, err := cache.store("example/newer/aws", "1.0.0", write("newer", 80), ""); err != nil {
-		t.Fatal(err)
+	if _, statErr := os.Stat(live); statErr != nil {
+		t.Fatalf("pinned cache entry was evicted: %v", statErr)
 	}
 
 	if _, err := os.Stat(stale); !os.IsNotExist(err) {
 		t.Fatalf("unused previous-scan entry should have been evicted, stat: %v", err)
 	}
 	if _, err := os.Stat(live); err != nil {
-		t.Fatalf("in-use cache entry was evicted: %v", err)
+		t.Fatalf("pinned cache entry was evicted: %v", err)
 	}
 }
 
 func TestModuleCacheRejectsEntryLargerThanLimit(t *testing.T) {
-	cache, err := NewModuleCacheWithDir(t.TempDir(), 50)
-	if err != nil {
-		t.Fatal(err)
-	}
+	cache, _ := newTestModuleCache(t, 50)
 	src := t.TempDir()
 	if err := os.WriteFile(filepath.Join(src, "main.tf"), []byte(strings.Repeat("a", 80)), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := cache.store("example/huge/aws", "1.0.0", src, ""); !errors.Is(err, errCacheEntryTooLarge) {
+	if _, _, err := cache.store("example/huge/aws", "1.0.0", src, ""); !errors.Is(err, errCacheEntryTooLarge) {
 		t.Fatalf("store oversized package: %v", err)
 	}
 	entries, err := os.ReadDir(cache.dir)
@@ -326,33 +359,5 @@ func TestModuleCacheRejectsEntryLargerThanLimit(t *testing.T) {
 		if entry.IsDir() && !strings.HasPrefix(entry.Name(), ".") {
 			t.Fatalf("oversized package was published as %s", entry.Name())
 		}
-	}
-}
-
-func TestEvictUnretainedDirsSkipsRetained(t *testing.T) {
-	root := t.TempDir()
-	writeDir := func(name string, size int, age time.Duration) string {
-		t.Helper()
-		dir := filepath.Join(root, name)
-		if err := os.MkdirAll(dir, 0o700); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(dir, "blob"), []byte(strings.Repeat("a", size)), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		when := time.Now().Add(-age)
-		if err := os.Chtimes(dir, when, when); err != nil {
-			t.Fatal(err)
-		}
-		return dir
-	}
-	stale := writeDir("stale", 80, 2*time.Hour)
-	live := writeDir("live", 80, time.Hour)
-	evictUnretainedDirs(root, 100, map[string]bool{filepath.Clean(live): true})
-	if _, err := os.Stat(stale); !os.IsNotExist(err) {
-		t.Fatalf("unretained dir should have been evicted, stat: %v", err)
-	}
-	if _, err := os.Stat(live); err != nil {
-		t.Fatalf("retained dir was evicted: %v", err)
 	}
 }

--- a/pkg/parser/terraform/modules/resolver/gogetter.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter.go
@@ -270,20 +270,22 @@ func (r *GoGetterResolver) lookupCache(
 	if !useCache {
 		return Resolution{}, false, nil
 	}
-	packageRoot, ok := r.cfg.Cache.lookup(mod.Source, cacheVersion)
+	packageRoot, release, ok := r.cfg.Cache.lookupLease(mod.Source, cacheVersion)
 	if !ok {
 		return Resolution{}, false, nil
 	}
 	if ResourceBudgetFromContext(ctx) == nil {
 		if err := r.reserveDirBytes(ctx, packageRoot); err != nil {
+			release()
 			return Resolution{}, false, err
 		}
 	}
 	resolution, err := resolutionForPackage(ctx, packageRoot, selectedSubdir)
 	if err != nil {
+		release()
 		return Resolution{}, false, &tfmodules.UnresolvedError{Reason: "invalid cached module package: " + err.Error()}
 	}
-	return resolution, true, nil
+	return withResolutionCleanup(resolution, release), true, nil
 }
 
 func (r *GoGetterResolver) checkByteLimits(size int64) error {
@@ -368,16 +370,17 @@ func (r *GoGetterResolver) commitFetchedDir(
 		}
 	}
 	if useCache {
-		if cached, storeErr := r.cfg.Cache.store(source, version, tmpDir, selectedSubdir); storeErr == nil {
+		if cached, release, storeErr := r.cfg.Cache.store(source, version, tmpDir, selectedSubdir); storeErr == nil {
 			_ = os.RemoveAll(tmpDir)
 			if ResourceBudgetFromContext(ctx) == nil {
 				r.cfg.accountedDirs.Store(filepath.Clean(cached), struct{}{})
 			}
 			resolution, err := resolutionForPackage(ctx, cached, selectedSubdir)
 			if err != nil {
+				release()
 				return Resolution{}, &tfmodules.UnresolvedError{Reason: "invalid cached module package: " + err.Error()}
 			}
-			return resolution, nil
+			return withResolutionCleanup(resolution, release), nil
 		}
 	}
 	cleanup := func() { _ = os.RemoveAll(tmpDir) }

--- a/pkg/parser/terraform/modules/resolver/gogetter.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter.go
@@ -58,9 +58,16 @@ var HostFetchConcurrency = hostFetchConcurrencyFromEnv()
 
 func hostFetchConcurrencyFromEnv() int {
 	if v := os.Getenv("IAC_MODULE_HOST_FETCH_CONCURRENCY"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			return n
 		}
+	}
+	return defaultHostFetchConcurrency
+}
+
+func hostFetchLimit() int {
+	if HostFetchConcurrency > 0 {
+		return HostFetchConcurrency
 	}
 	return defaultHostFetchConcurrency
 }
@@ -331,10 +338,11 @@ func (r *GoGetterResolver) releaseFetchSlot() {
 }
 
 func (r *GoGetterResolver) acquireHostSlot(ctx context.Context, host string) (func(), error) {
-	if HostFetchConcurrency <= 0 || host == "" {
+	if host == "" {
 		return func() {}, nil
 	}
-	v, _ := r.cfg.hostSems.LoadOrStore(host, make(chan struct{}, HostFetchConcurrency))
+	limit := hostFetchLimit()
+	v, _ := r.cfg.hostSems.LoadOrStore(host, make(chan struct{}, limit))
 	sem := v.(chan struct{})
 	select {
 	case sem <- struct{}{}:
@@ -541,7 +549,7 @@ func (r *GoGetterResolver) fetchOnce(ctx context.Context, getterSrc string) (str
 		DisableSymlinks: true,
 		Decompressors:   r.decompressors(fetchCtx),
 		Options: []getter.ClientOption{
-			getter.WithGetters(r.getters(getterSrc)),
+			getter.WithGetters(r.getters(fetchCtx, getterSrc)),
 		},
 	}
 	if err := client.Get(); err != nil {
@@ -555,15 +563,16 @@ func (r *GoGetterResolver) fetchOnce(ctx context.Context, getterSrc string) (str
 	return tmpDir, nil
 }
 
-func (r *GoGetterResolver) getters(source string) map[string]getter.Getter {
+func (r *GoGetterResolver) getters(ctx context.Context, source string) map[string]getter.Getter {
 	getters := make(map[string]getter.Getter)
 	if !isHTTPGetterSource(source) {
-		getters["file"] = getter.Getters["file"]
+		getters["file"] = &getter.FileGetter{}
 	}
 	httpGetter := &getter.HttpGetter{
 		Netrc:              true,
 		Client:             r.cfg.httpClient,
 		XTerraformGetLimit: maxHTTPRedirects,
+		MaxBytes:           r.maxPackageBytes(ctx),
 	}
 	getters["http"] = httpGetter
 	getters["https"] = httpGetter

--- a/pkg/parser/terraform/modules/resolver/gogetter_test.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter_test.go
@@ -140,9 +140,9 @@ func TestGoGetterUsesGraphResourceLimits(t *testing.T) {
 		MaxPackageFiles: 7,
 	}))
 
-	httpGetter, ok := resolver.getters("https://example.com/module.zip")["https"].(*getter.HttpGetter)
+	httpGetter, ok := resolver.getters(ctx, "https://example.com/module.zip")["https"].(*getter.HttpGetter)
 	require.True(t, ok)
-	require.Zero(t, httpGetter.MaxBytes)
+	require.Equal(t, int64(1234), httpGetter.MaxBytes)
 	require.Equal(t, int64(1234), resolver.maxPackageBytes(ctx))
 
 	decompressors := resolver.decompressors(ctx)
@@ -157,7 +157,7 @@ func TestGoGetterUsesGraphResourceLimits(t *testing.T) {
 func TestGoGetterDisablesUnpinnedNetworkTransports(t *testing.T) {
 	r := NewGoGetterResolver(NewGoGetterConfig())
 	for _, scheme := range []string{"s3", "gcs", "hg"} {
-		if _, ok := r.getters(scheme + "::https://modules.example/package")[scheme]; ok {
+		if _, ok := r.getters(t.Context(), scheme+"::https://modules.example/package")[scheme]; ok {
 			t.Fatalf("getter %q must be disabled", scheme)
 		}
 	}
@@ -263,13 +263,34 @@ func TestAcquireHostSlotCapsConcurrencyPerHost(t *testing.T) {
 	measure("github.com", 3)
 	measure("gitlab.com", 3)
 
-	// Disabled cap is a no-op.
 	HostFetchConcurrency = 0
-	release, err := r.acquireHostSlot(context.Background(), "github.com")
-	if err != nil {
-		t.Fatalf("disabled cap should not error: %v", err)
+	var inFlight, maxInFlight atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < 40; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release, err := r.acquireHostSlot(context.Background(), "example.com")
+			if err != nil {
+				t.Errorf("acquireHostSlot: %v", err)
+				return
+			}
+			defer release()
+			n := inFlight.Add(1)
+			for {
+				m := maxInFlight.Load()
+				if n <= m || maxInFlight.CompareAndSwap(m, n) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond)
+			inFlight.Add(-1)
+		}()
 	}
-	release()
+	wg.Wait()
+	if got := maxInFlight.Load(); got > int64(defaultHostFetchConcurrency) {
+		t.Fatalf("zero host concurrency must fall back to default cap %d, got %d", defaultHostFetchConcurrency, got)
+	}
 }
 
 func TestGoGetterResolveCoalescesConcurrentFetches(t *testing.T) {
@@ -380,5 +401,81 @@ func TestFetchAndCommitDelegatesPinnableGit(t *testing.T) {
 	}
 	if stub.last.Source != "git::https://github.com/terraform-aws-modules/terraform-aws-vpc//modules/vpc?ref=abc123" {
 		t.Fatalf("delegated source = %q", stub.last.Source)
+	}
+}
+
+func TestGoGetterUsesIsolatedGetterInstances(t *testing.T) {
+	r := NewGoGetterResolver(NewGoGetterConfig())
+	first := r.getters(t.Context(), "file:///tmp/module-a")
+	second := r.getters(t.Context(), "file:///tmp/module-b")
+	if first["file"] == getter.Getters["file"] || second["file"] == getter.Getters["file"] {
+		t.Fatal("file getter must not reuse go-getter package globals")
+	}
+	if first["file"] == second["file"] {
+		t.Fatal("each fetch must receive its own file getter")
+	}
+	if first["https"] == second["https"] {
+		t.Fatal("each fetch must receive its own HTTP getter")
+	}
+}
+
+func TestGoGetterResolveRaceWith32ConcurrentFetches(t *testing.T) {
+	var moduleArchive bytes.Buffer
+	zipWriter := zip.NewWriter(&moduleArchive)
+	file, err := zipWriter.Create("main.tf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Write([]byte(`resource "r" "n" {}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := zipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(moduleArchive.Bytes())
+	}))
+	defer server.Close()
+	_, port, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := newHTTPDestinationPolicy(nil)
+	policy.lookupNetIP = func(context.Context, string, string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	policy.dial = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
+	}
+
+	cfg := NewGoGetterConfig()
+	cfg.TmpDir = t.TempDir()
+	cfg.httpClient = newPolicyHTTPClientWithPolicy(time.Second, policy)
+	r := NewGoGetterResolver(cfg)
+
+	const n = 32
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mod := &tfmodules.ParsedModule{
+				Source:   fmt.Sprintf("http://modules.example:%s/module-%d.zip", port, i),
+				Name:     fmt.Sprintf("m%d", i),
+				FileName: "main.tf",
+			}
+			_, errs[i] = r.Resolve(context.Background(), mod)
+		}()
+	}
+	wg.Wait()
+	for i := 0; i < n; i++ {
+		if errs[i] != nil {
+			t.Fatalf("resolve %d failed: %v", i, errs[i])
+		}
+	}
+	if got := cfg.fetchCount.Load(); got != int64(n) {
+		t.Fatalf("expected %d independent fetches, got %d", n, got)
 	}
 }

--- a/pkg/parser/terraform/modules/resolver/gogetter_test.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter_test.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -290,6 +291,55 @@ func TestAcquireHostSlotCapsConcurrencyPerHost(t *testing.T) {
 	wg.Wait()
 	if got := maxInFlight.Load(); got > int64(defaultHostFetchConcurrency) {
 		t.Fatalf("zero host concurrency must fall back to default cap %d, got %d", defaultHostFetchConcurrency, got)
+	}
+}
+
+func TestCachedResolutionKeepsLeaseUntilCleanup(t *testing.T) {
+	cache, budget := newTestModuleCache(t, 150)
+	source := "example/live/aws"
+	packageRoot, release, err := cache.store(source, "1.0.0", writeModuleSrc(t, 5), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	release()
+
+	cfg := NewGoGetterConfig()
+	cfg.Cache = cache
+	resolver := NewGoGetterResolver(cfg)
+	resolution, ok, err := resolver.lookupCache(
+		t.Context(),
+		&tfmodules.ParsedModule{Source: source},
+		"1.0.0",
+		"",
+		true,
+	)
+	if err != nil || !ok {
+		t.Fatalf("lookup cache: ok=%v err=%v", ok, err)
+	}
+	if resolution.Cleanup == nil {
+		t.Fatal("cached resolution did not retain its lease")
+	}
+
+	_, newerRelease, err := cache.store("example/newer/aws", "1.0.0", writeModuleSrc(t, 5), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	newerRelease()
+	if _, err := os.Stat(packageRoot); err != nil {
+		t.Fatalf("active resolution was evicted before cleanup: %v", err)
+	}
+
+	resolution.Cleanup()
+	_, finalRelease, err := cache.store("example/final/aws", "1.0.0", writeModuleSrc(t, 5), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalRelease()
+	if _, err := os.Stat(packageRoot); !os.IsNotExist(err) {
+		t.Fatalf("released resolution remained protected from eviction: %v", err)
+	}
+	if _, total := listAggregateCacheEntries(budget.Root()); total > budget.MaxBytes() {
+		t.Fatalf("cache size %d exceeds max %d", total, budget.MaxBytes())
 	}
 }
 

--- a/pkg/parser/terraform/modules/resolver/localref.go
+++ b/pkg/parser/terraform/modules/resolver/localref.go
@@ -25,6 +25,7 @@ type LocalGitRefResolver struct {
 
 	// Defaults to <user-cache-dir>/datadog-iac-scanner/git-local.
 	CacheDir string
+	MaxBytes int64
 
 	initOnce sync.Once
 	repos    []*localRepoInfo // scan roots that are git repos
@@ -258,8 +259,20 @@ func (r *LocalGitRefResolver) Resolve(ctx context.Context, mod *tfmodules.Parsed
 	}
 
 	packageRoot := archiveCacheDir(info.extractBase, sha)
+	r.evictGitCache()
 	return ConfineResolution(ctx, Resolution{
 		LocalPath:   filepath.Join(packageRoot, filepath.FromSlash(subdir)),
 		PackageRoot: packageRoot,
 	})
+}
+
+func (r *LocalGitRefResolver) evictGitCache() {
+	if r == nil || r.MaxBytes <= 0 {
+		return
+	}
+	retained := make(map[string]bool, len(r.repos))
+	for _, info := range r.repos {
+		retained[filepath.Clean(info.extractBase)] = true
+	}
+	evictUnretainedDirs(r.effectiveCacheDir(), r.MaxBytes, retained)
 }

--- a/pkg/parser/terraform/modules/resolver/localref.go
+++ b/pkg/parser/terraform/modules/resolver/localref.go
@@ -25,7 +25,7 @@ type LocalGitRefResolver struct {
 
 	// Defaults to <user-cache-dir>/datadog-iac-scanner/git-local.
 	CacheDir string
-	MaxBytes int64
+	Budget   *ModuleCacheBudget
 
 	initOnce sync.Once
 	repos    []*localRepoInfo // scan roots that are git repos
@@ -230,16 +230,28 @@ func (r *LocalGitRefResolver) Resolve(ctx context.Context, mod *tfmodules.Parsed
 	// Warm-cache fast path for pinned SHA refs.
 	if looksLikeSHA(ref) {
 		if packageRoot, ok := cachedArchiveDir(info.extractBase, ref, subdir); ok {
-			return ConfineResolution(ctx, Resolution{
+			release := r.Budget.Lease(info.extractBase)
+			if err := r.Budget.EnsureEntryFits(info.extractBase); err != nil {
+				release()
+				return Resolution{}, unresolvedResourceError(err)
+			}
+			resolution, err := ConfineResolution(ctx, Resolution{
 				LocalPath:   filepath.Join(packageRoot, filepath.FromSlash(subdir)),
 				PackageRoot: packageRoot,
 			})
+			if err != nil {
+				release()
+				return Resolution{}, err
+			}
+			return withResolutionCleanup(resolution, release), nil
 		}
 	}
 
 	contextLogger := logger.FromContext(ctx)
+	release := r.Budget.Lease(info.extractBase)
 	sha, present := resolveLocalRef(ctx, info, ref)
 	if !present {
+		release()
 		contextLogger.Debug().Msgf("LocalGitRefResolver: ref %q not in local clone %s (shallow checkout?)", ref, info.gitDir)
 		return Resolution{}, &tfmodules.UnresolvedError{
 			Reason: fmt.Sprintf("LocalGitRefResolver: ref %q not present locally", ref),
@@ -254,25 +266,26 @@ func (r *LocalGitRefResolver) Resolve(ctx context.Context, mod *tfmodules.Parsed
 		)
 	})
 	if err != nil {
+		release()
 		contextLogger.Warn().Err(err).Msgf("LocalGitRefResolver: archive %s:%s failed", sha, subdir)
 		return Resolution{}, &tfmodules.UnresolvedError{Reason: err.Error()}
 	}
 
+	if r.Budget != nil {
+		if err := r.Budget.EnsureEntryFits(info.extractBase); err != nil {
+			release()
+			return Resolution{}, unresolvedResourceError(err)
+		}
+		r.Budget.Admit(info.extractBase)
+	}
 	packageRoot := archiveCacheDir(info.extractBase, sha)
-	r.evictGitCache()
-	return ConfineResolution(ctx, Resolution{
+	resolution, err := ConfineResolution(ctx, Resolution{
 		LocalPath:   filepath.Join(packageRoot, filepath.FromSlash(subdir)),
 		PackageRoot: packageRoot,
 	})
-}
-
-func (r *LocalGitRefResolver) evictGitCache() {
-	if r == nil || r.MaxBytes <= 0 {
-		return
+	if err != nil {
+		release()
+		return Resolution{}, err
 	}
-	retained := make(map[string]bool, len(r.repos))
-	for _, info := range r.repos {
-		retained[filepath.Clean(info.extractBase)] = true
-	}
-	evictUnretainedDirs(r.effectiveCacheDir(), r.MaxBytes, retained)
+	return withResolutionCleanup(resolution, release), nil
 }

--- a/pkg/parser/terraform/modules/resolver/localref_test.go
+++ b/pkg/parser/terraform/modules/resolver/localref_test.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
 
 func runGit(t *testing.T, dir string, args ...string) string {
@@ -75,6 +77,36 @@ func TestResolveLocalRefSHAAndMissing(t *testing.T) {
 	}
 	if _, ok := resolveLocalRef(context.Background(), info, "does-not-exist"); ok {
 		t.Fatal("expected missing ref to be unresolved")
+	}
+}
+
+func TestLocalGitResolverRejectsAndRemovesOversizedCacheEntry(t *testing.T) {
+	workTree, gitDir := initRepoWithRefs(t)
+	root := testCacheRoot(t)
+	budget, err := NewModuleCacheBudget(root, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoURL := "https://example.com/acme/repo.git"
+	extractBase := filepath.Join(root, CacheSubdirGitLocal, "repo")
+	resolver := NewLocalGitRefResolver(nil, filepath.Join(root, CacheSubdirGitLocal))
+	resolver.Budget = budget
+	resolver.repos = []*localRepoInfo{{
+		gitDir:      gitDir,
+		normalURLs:  map[string]bool{normalizeGitRepoURL(repoURL): true},
+		extractBase: extractBase,
+		refSHA:      loadRefMap(t.Context(), gitDir),
+	}}
+
+	sha := runGit(t, workTree, "rev-parse", "HEAD")
+	_, err = resolver.Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source: "git::" + repoURL + "?ref=" + sha,
+	})
+	if !tfmodules.IsUnresolved(err) || !strings.Contains(err.Error(), errCacheEntryTooLarge.Error()) {
+		t.Fatalf("resolving oversized local git module: %v", err)
+	}
+	if _, err := os.Stat(extractBase); !os.IsNotExist(err) {
+		t.Fatalf("oversized local git cache entry remained on disk: %v", err)
 	}
 }
 

--- a/pkg/parser/terraform/modules/resolver/registry_cache.go
+++ b/pkg/parser/terraform/modules/resolver/registry_cache.go
@@ -7,13 +7,9 @@ package resolver
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -23,123 +19,87 @@ import (
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
 
-// deadHostTTL is how long a registry discovery failure is remembered across runs.
-const deadHostTTL = 24 * time.Hour
+const defaultRegistryFailureBackoff = 30 * time.Second
 
-// isNetworkUnreachable reports whether err represents a genuine network-level
-// failure (DNS, connection refused, timeout) as opposed to an HTTP-level error
-// like 401/403/500, which means the host is reachable and should not be cached
-// as dead across runs.
-func isNetworkUnreachable(err error) bool {
-	var netErr net.Error
-	if errors.As(err, &netErr) {
-		return true
-	}
-	var dnsErr *net.DNSError
-	return errors.As(err, &dnsErr)
+type cachedFailure struct {
+	err    error
+	expiry time.Time
 }
 
-func deadHostsFilePath() string {
-	base := os.Getenv("XDG_CACHE_HOME")
-	if base == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		base = filepath.Join(home, ".cache")
-	}
-	return filepath.Join(base, "datadog-iac-scanner", "dead-registry-hosts.json")
-}
-
-// loadDeadHosts reads hosts whose registry discovery has previously failed.
-// Entries older than deadHostTTL are ignored.
-func loadDeadHosts() map[string]int64 {
-	p := deadHostsFilePath()
-	if p == "" {
-		return nil
-	}
-	data, err := os.ReadFile(filepath.Clean(p)) //nolint:gosec
-	if err != nil {
-		return nil
-	}
-	var m map[string]int64
-	if err := json.Unmarshal(data, &m); err != nil {
-		return nil
-	}
-	return m
-}
-
-// persistDeadHost records host as unreachable, pruning entries older than deadHostTTL.
-// Runs in a goroutine so it never blocks the hot path.
-func persistDeadHost(host string) {
-	p := deadHostsFilePath()
-	if p == "" {
-		return
-	}
-	p = filepath.Clean(p)
-	existing := make(map[string]int64)
-	if data, err := os.ReadFile(p); err == nil { //nolint:gosec
-		_ = json.Unmarshal(data, &existing)
-	}
-	now := time.Now().Unix()
-	cutoff := now - int64(deadHostTTL.Seconds())
-	for h, ts := range existing {
-		if ts < cutoff {
-			delete(existing, h)
-		}
-	}
-	existing[host] = now
-	data, err := json.Marshal(existing)
-	if err != nil {
-		return
-	}
-	tmp := p + ".tmp"
-	if err := os.WriteFile(tmp, data, cacheFilePerms); err != nil {
-		return
-	}
-	_ = os.Rename(tmp, p)
-}
-
-// registryCache caches per-scan registry API calls (including failures).
 type registryCache struct {
 	client *http.Client
 
+	now     func() time.Time
+	backoff time.Duration
+
 	discMu     sync.RWMutex
-	discMap    map[string]string // host → modulesV1 URL
-	discErrMap map[string]error  // host → discovery failure
+	discMap    map[string]string
+	discErrMap map[string]cachedFailure
 	discSF     singleflight.Group
 
 	verMu     sync.RWMutex
-	verMap    map[string]string // cacheKey(source, constraint) → resolved bare version
-	verErrMap map[string]error  // cacheKey(source, constraint) → resolution failure
+	verMap    map[string]string
+	verErrMap map[string]cachedFailure
 	verSF     singleflight.Group
 
 	dlMu     sync.RWMutex
-	dlMap    map[string]string // cacheKey(source, version) → X-Terraform-Get getter URL
-	dlErrMap map[string]error  // cacheKey(source, version) → download failure
+	dlMap    map[string]string
+	dlErrMap map[string]cachedFailure
 	dlSF     singleflight.Group
 }
 
 func NewRegistryCache(timeout time.Duration, hostAllowlist ...string) *registryCache {
-	c := &registryCache{
+	return &registryCache{
 		client:     newPolicyHTTPClient(timeout, hostAllowlist),
 		discMap:    make(map[string]string),
-		discErrMap: make(map[string]error),
+		discErrMap: make(map[string]cachedFailure),
 		verMap:     make(map[string]string),
-		verErrMap:  make(map[string]error),
+		verErrMap:  make(map[string]cachedFailure),
 		dlMap:      make(map[string]string),
-		dlErrMap:   make(map[string]error),
+		dlErrMap:   make(map[string]cachedFailure),
+		backoff:    defaultRegistryFailureBackoff,
 	}
-	// Pre-populate known-dead hosts from previous runs so we skip DNS lookups
-	// for registries that were unreachable last time (within deadHostTTL).
-	now := time.Now().Unix()
-	cutoff := now - int64(deadHostTTL.Seconds())
-	for host, ts := range loadDeadHosts() {
-		if ts >= cutoff {
-			c.discErrMap[host] = fmt.Errorf("registry host unreachable (cached from previous run; clear %s to retry)", deadHostsFilePath())
+}
+
+func (c *registryCache) clock() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+func (c *registryCache) failureBackoff() time.Duration {
+	if c.backoff > 0 {
+		return c.backoff
+	}
+	return defaultRegistryFailureBackoff
+}
+
+func (c *registryCache) lookupFailure(mu *sync.RWMutex, failures map[string]cachedFailure, key string) (error, bool) {
+	mu.RLock()
+	cached, ok := failures[key]
+	mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if c.clock().After(cached.expiry) {
+		mu.Lock()
+		if current, still := failures[key]; still && current.expiry.Equal(cached.expiry) {
+			delete(failures, key)
 		}
+		mu.Unlock()
+		return nil, false
 	}
-	return c
+	return cached.err, true
+}
+
+func (c *registryCache) rememberFailure(mu *sync.RWMutex, failures map[string]cachedFailure, key string, err error) {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+	mu.Lock()
+	failures[key] = cachedFailure{err: err, expiry: c.clock().Add(c.failureBackoff())}
+	mu.Unlock()
 }
 
 func (c *registryCache) modulesV1(ctx context.Context, host string) (string, error) {
@@ -148,29 +108,20 @@ func (c *registryCache) modulesV1(ctx context.Context, host string) (string, err
 		c.discMu.RUnlock()
 		return ep, nil
 	}
-	if cachedErr, ok := c.discErrMap[host]; ok {
-		c.discMu.RUnlock()
+	c.discMu.RUnlock()
+	if cachedErr, ok := c.lookupFailure(&c.discMu, c.discErrMap, host); ok {
 		return "", cachedErr
 	}
-	c.discMu.RUnlock()
 
 	v, err, _ := c.discSF.Do(host, func() (interface{}, error) {
 		ep, err := discoverModulesEndpoint(ctx, c.client, "https://"+host)
 		if err != nil {
-			c.discMu.Lock()
-			c.discErrMap[host] = err
-			c.discMu.Unlock()
-			// Only persist hosts that are network-unreachable (DNS failures, connection
-			// refused, timeouts). HTTP-level errors (401, 500, etc.) mean the host is
-			// reachable — persisting those would ban the registry for 24 h even after
-			// fixing credentials or waiting for a recovery.
-			if isNetworkUnreachable(err) {
-				go persistDeadHost(host)
-			}
+			c.rememberFailure(&c.discMu, c.discErrMap, host, err)
 			return "", err
 		}
 		c.discMu.Lock()
 		c.discMap[host] = ep
+		delete(c.discErrMap, host)
 		c.discMu.Unlock()
 		return ep, nil
 	})
@@ -188,22 +139,20 @@ func (c *registryCache) resolvedVersion(ctx context.Context, ep, host, namespace
 		c.verMu.RUnlock()
 		return v, nil
 	}
-	if cachedErr, ok := c.verErrMap[key]; ok {
-		c.verMu.RUnlock()
+	c.verMu.RUnlock()
+	if cachedErr, ok := c.lookupFailure(&c.verMu, c.verErrMap, key); ok {
 		return "", cachedErr
 	}
-	c.verMu.RUnlock()
 
 	v, err, _ := c.verSF.Do(key, func() (interface{}, error) {
 		resolved, err := resolveRegistryVersion(ctx, c.client, ep, namespace, name, provider, constraint)
 		if err != nil {
-			c.verMu.Lock()
-			c.verErrMap[key] = err
-			c.verMu.Unlock()
+			c.rememberFailure(&c.verMu, c.verErrMap, key, err)
 			return "", err
 		}
 		c.verMu.Lock()
 		c.verMap[key] = resolved
+		delete(c.verErrMap, key)
 		c.verMu.Unlock()
 		return resolved, nil
 	})
@@ -221,22 +170,20 @@ func (c *registryCache) downloadURL(ctx context.Context, ep, host, namespace, na
 		c.dlMu.RUnlock()
 		return v, nil
 	}
-	if cachedErr, ok := c.dlErrMap[key]; ok {
-		c.dlMu.RUnlock()
+	c.dlMu.RUnlock()
+	if cachedErr, ok := c.lookupFailure(&c.dlMu, c.dlErrMap, key); ok {
 		return "", cachedErr
 	}
-	c.dlMu.RUnlock()
 
 	v, err, _ := c.dlSF.Do(key, func() (interface{}, error) {
 		dlURL, err := registryDownloadURL(ctx, c.client, ep, namespace, name, provider, version, host)
 		if err != nil {
-			c.dlMu.Lock()
-			c.dlErrMap[key] = err
-			c.dlMu.Unlock()
+			c.rememberFailure(&c.dlMu, c.dlErrMap, key, err)
 			return "", err
 		}
 		c.dlMu.Lock()
 		c.dlMap[key] = dlURL
+		delete(c.dlErrMap, key)
 		c.dlMu.Unlock()
 		return dlURL, nil
 	})

--- a/pkg/parser/terraform/modules/resolver/registry_test.go
+++ b/pkg/parser/terraform/modules/resolver/registry_test.go
@@ -9,10 +9,12 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -490,4 +492,71 @@ func writeModulesJSONRecords(t *testing.T, records []dotTerraformModuleRecord) s
 		t.Fatalf("write modules.json: %v", err)
 	}
 	return root
+}
+
+func TestRegistryDiscoveryFailureBackoffExpires(t *testing.T) {
+	var calls atomic.Int64
+	now := time.Now()
+	cache := NewRegistryCache(time.Second)
+	cache.now = func() time.Time { return now }
+	cache.backoff = time.Second
+	cache.client = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return nil, &net.DNSError{Err: "no such host", Name: "registry.example", IsNotFound: true}
+		}),
+	}
+
+	if _, err := cache.modulesV1(context.Background(), "registry.example"); err == nil {
+		t.Fatal("expected discovery failure")
+	}
+	if _, err := cache.modulesV1(context.Background(), "registry.example"); err == nil {
+		t.Fatal("expected cached discovery failure")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("cached DNS failure retried immediately: %d calls", got)
+	}
+	now = now.Add(2 * time.Second)
+	if _, err := cache.modulesV1(context.Background(), "registry.example"); err == nil {
+		t.Fatal("expected retry to fail")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expired DNS failure was not retried: %d calls", got)
+	}
+}
+
+func TestRegistryDiscoveryDoesNotCacheCanceledContext(t *testing.T) {
+	var calls atomic.Int64
+	cache := NewRegistryCache(time.Second)
+	cache.client = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return nil, context.Canceled
+		}),
+	}
+	if _, err := cache.modulesV1(context.Background(), "registry.example"); err == nil {
+		t.Fatal("expected canceled discovery")
+	}
+	if _, err := cache.modulesV1(context.Background(), "registry.example"); err == nil {
+		t.Fatal("expected second canceled discovery")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("canceled discovery must not be cached, calls=%d", got)
+	}
+}
+
+func TestRegistryCacheDoesNotWriteDeadHostFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", home)
+	cache := NewRegistryCache(time.Second)
+	cache.client = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, &net.DNSError{Err: "no such host", Name: "registry.example", IsNotFound: true}
+		}),
+	}
+	_, _ = cache.modulesV1(context.Background(), "registry.example")
+	path := filepath.Join(home, "datadog-iac-scanner", "dead-registry-hosts.json")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("dead-host file should not exist, stat: %v", err)
+	}
 }

--- a/pkg/parser/terraform/modules/resolver/resolver.go
+++ b/pkg/parser/terraform/modules/resolver/resolver.go
@@ -9,6 +9,7 @@ package resolver
 
 import (
 	"context"
+	"sync"
 
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
@@ -18,6 +19,22 @@ type Resolution struct {
 	LocalPath   string
 	PackageRoot string
 	Cleanup     func() // optional post-scan cleanup
+}
+
+func withResolutionCleanup(res Resolution, cleanup func()) Resolution {
+	previous := res.Cleanup
+	var once sync.Once
+	res.Cleanup = func() {
+		once.Do(func() {
+			if previous != nil {
+				previous()
+			}
+			if cleanup != nil {
+				cleanup()
+			}
+		})
+	}
+	return res
 }
 
 // Resolver maps one module call to disk; errors should wrap *tfmodules.UnresolvedError when appropriate.

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -29,6 +29,7 @@ const (
 	DefaultRemoteModuleMaxPackageBytes = tfresolver.DefaultMaxPackageBytes
 	DefaultRemoteModuleMaxFileBytes    = tfresolver.DefaultMaxFileBytes
 	DefaultRemoteModuleMaxPackageFiles = tfresolver.DefaultMaxPackageFiles
+	DefaultRemoteModuleMaxCacheBytes   = tfresolver.DefaultMaxCacheBytes
 )
 
 // Parameters represents all available scan parameters
@@ -78,6 +79,8 @@ type Parameters struct {
 	MaxModuleFileBytes    int64
 	MaxModulePackageFiles int
 	MaxModuleParseBytes   int64
+	RemoteModulesCacheDir string
+	MaxModuleCacheBytes   int64
 }
 
 func (p *Parameters) GetEffectivePlatforms() []string {
@@ -184,6 +187,7 @@ func GetDefaultParameters(ctx context.Context, rootPath string) (*Parameters, co
 		MaxModulePackageBytes:       DefaultRemoteModuleMaxPackageBytes,
 		MaxModuleFileBytes:          DefaultRemoteModuleMaxFileBytes,
 		MaxModulePackageFiles:       DefaultRemoteModuleMaxPackageFiles,
+		MaxModuleCacheBytes:         DefaultRemoteModuleMaxCacheBytes,
 	}, logCtx
 }
 

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -158,23 +158,24 @@ func (c *Client) buildModuleResolverChain(ctx context.Context, moduleDiscoveryPa
 	}
 	ggCfg.HostAllowlist = c.ScanParams.RemoteModulesHostAllowlist
 
+	cacheBytes := c.ScanParams.MaxModuleCacheBytes
+	if cacheBytes == 0 {
+		cacheBytes = DefaultRemoteModuleMaxCacheBytes
+	}
+
 	if c.ScanParams.EnableRemoteModules {
 		gitCacheDir := tfresolver.ModuleCacheSubdir(c.ScanParams.RemoteModulesCacheDir, tfresolver.CacheSubdirGitBare)
 		localCacheDir := tfresolver.ModuleCacheSubdir(c.ScanParams.RemoteModulesCacheDir, tfresolver.CacheSubdirGitLocal)
 		git := tfresolver.NewBareGitResolver(gitCacheDir, c.ScanParams.RemoteModulesHostAllowlist...)
+		git.MaxBytes = cacheBytes
 		ggCfg.Git = git
-		resolvers = append(resolvers,
-			tfresolver.NewLocalGitRefResolver(dotTerraformRootDirs(moduleDiscoveryPaths), localCacheDir),
-			git,
-		)
+		localGit := tfresolver.NewLocalGitRefResolver(dotTerraformRootDirs(moduleDiscoveryPaths), localCacheDir)
+		localGit.MaxBytes = cacheBytes
+		resolvers = append(resolvers, localGit, git)
 	}
 
 	if !ggCfg.Disabled {
 		moduleCacheDir := tfresolver.ModuleCacheSubdir(c.ScanParams.RemoteModulesCacheDir, tfresolver.CacheSubdirModules)
-		cacheBytes := c.ScanParams.MaxModuleCacheBytes
-		if cacheBytes == 0 {
-			cacheBytes = DefaultRemoteModuleMaxCacheBytes
-		}
 		cache, err := tfresolver.NewModuleCacheWithDir(moduleCacheDir, cacheBytes)
 		if err != nil {
 			contextLogger.Warn().Err(err).Msg("Module disk cache unavailable; fetched modules will not be cached")

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -163,20 +163,42 @@ func (c *Client) buildModuleResolverChain(ctx context.Context, moduleDiscoveryPa
 		cacheBytes = DefaultRemoteModuleMaxCacheBytes
 	}
 
+	var (
+		cacheRoot string
+		budget    *tfresolver.ModuleCacheBudget
+	)
+	if !ggCfg.Disabled {
+		cacheRoot = strings.TrimSpace(c.ScanParams.RemoteModulesCacheDir)
+		if cacheRoot == "" {
+			var rootErr error
+			cacheRoot, rootErr = tfresolver.DefaultModuleCacheRoot()
+			if rootErr != nil {
+				contextLogger.Warn().Err(rootErr).Msg("Remote module cache root unavailable; cache limits will not be enforced")
+			}
+		}
+		if cacheRoot != "" {
+			var budgetErr error
+			budget, budgetErr = tfresolver.NewModuleCacheBudget(cacheRoot, cacheBytes)
+			if budgetErr != nil {
+				contextLogger.Warn().Err(budgetErr).Msg("Remote module cache budget unavailable; cache limits will not be enforced")
+			}
+		}
+	}
+
 	if c.ScanParams.EnableRemoteModules {
-		gitCacheDir := tfresolver.ModuleCacheSubdir(c.ScanParams.RemoteModulesCacheDir, tfresolver.CacheSubdirGitBare)
-		localCacheDir := tfresolver.ModuleCacheSubdir(c.ScanParams.RemoteModulesCacheDir, tfresolver.CacheSubdirGitLocal)
+		gitCacheDir := tfresolver.ModuleCacheSubdir(cacheRoot, tfresolver.CacheSubdirGitBare)
+		localCacheDir := tfresolver.ModuleCacheSubdir(cacheRoot, tfresolver.CacheSubdirGitLocal)
 		git := tfresolver.NewBareGitResolver(gitCacheDir, c.ScanParams.RemoteModulesHostAllowlist...)
-		git.MaxBytes = cacheBytes
+		git.Budget = budget
 		ggCfg.Git = git
 		localGit := tfresolver.NewLocalGitRefResolver(dotTerraformRootDirs(moduleDiscoveryPaths), localCacheDir)
-		localGit.MaxBytes = cacheBytes
+		localGit.Budget = budget
 		resolvers = append(resolvers, localGit, git)
 	}
 
 	if !ggCfg.Disabled {
-		moduleCacheDir := tfresolver.ModuleCacheSubdir(c.ScanParams.RemoteModulesCacheDir, tfresolver.CacheSubdirModules)
-		cache, err := tfresolver.NewModuleCacheWithDir(moduleCacheDir, cacheBytes)
+		moduleCacheDir := tfresolver.ModuleCacheSubdir(cacheRoot, tfresolver.CacheSubdirModules)
+		cache, err := tfresolver.NewModuleCacheWithDir(moduleCacheDir, budget)
 		if err != nil {
 			contextLogger.Warn().Err(err).Msg("Module disk cache unavailable; fetched modules will not be cached")
 		} else {

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -159,16 +159,23 @@ func (c *Client) buildModuleResolverChain(ctx context.Context, moduleDiscoveryPa
 	ggCfg.HostAllowlist = c.ScanParams.RemoteModulesHostAllowlist
 
 	if c.ScanParams.EnableRemoteModules {
-		git := tfresolver.NewBareGitResolver("", c.ScanParams.RemoteModulesHostAllowlist...)
+		gitCacheDir := tfresolver.ModuleCacheSubdir(c.ScanParams.RemoteModulesCacheDir, tfresolver.CacheSubdirGitBare)
+		localCacheDir := tfresolver.ModuleCacheSubdir(c.ScanParams.RemoteModulesCacheDir, tfresolver.CacheSubdirGitLocal)
+		git := tfresolver.NewBareGitResolver(gitCacheDir, c.ScanParams.RemoteModulesHostAllowlist...)
 		ggCfg.Git = git
 		resolvers = append(resolvers,
-			tfresolver.NewLocalGitRefResolver(dotTerraformRootDirs(moduleDiscoveryPaths), ""),
+			tfresolver.NewLocalGitRefResolver(dotTerraformRootDirs(moduleDiscoveryPaths), localCacheDir),
 			git,
 		)
 	}
 
 	if !ggCfg.Disabled {
-		cache, err := tfresolver.NewModuleCache()
+		moduleCacheDir := tfresolver.ModuleCacheSubdir(c.ScanParams.RemoteModulesCacheDir, tfresolver.CacheSubdirModules)
+		cacheBytes := c.ScanParams.MaxModuleCacheBytes
+		if cacheBytes == 0 {
+			cacheBytes = DefaultRemoteModuleMaxCacheBytes
+		}
+		cache, err := tfresolver.NewModuleCacheWithDir(moduleCacheDir, cacheBytes)
 		if err != nil {
 			contextLogger.Warn().Err(err).Msg("Module disk cache unavailable; fetched modules will not be cached")
 		} else {


### PR DESCRIPTION
## Motivation

Shared go-getter instances could steal another fetch's deadline, canceled parses could be cached as empty, and module caches grew without a size bound while a single DNS blip banned a registry for 24 hours.

Related ticket: [K9CODESEC-5292](https://datadoghq.atlassian.net/browse/K9CODESEC-5292)

## Changes

**Resolver concurrency**

Each fetch now builds its own go-getter map instead of mutating package globals, HTTP getters honor the package byte ceiling in flight, and a zero or negative per-host concurrency setting falls back to the default cap of 6.

**Parse and resolution caches**

Canceled module parses and canceled remote resolutions are not stored, and the parse semaphore is scoped to one scan so a later retry can still discover modules.

**On-disk and registry caches**

Equivalent registry and git source spellings share a cache key while different versions do not. New package stores record size metadata and only reconcile or evict when the running total exceeds the limit, so cache hits do not walk the tree. Registry discovery failures stay in-process with a short backoff and are no longer written to `dead-registry-hosts.json`.

**CLI**

`--x-remote-modules-cache-dir` and `--x-remote-modules-cache-max-bytes` (default 2GiB) select the cache root and bound its size.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test -race ./pkg/parser/terraform/modules/resolver ./pkg/parser/terraform/modules/modulegraph -count=1`
2. `go test ./pkg/scan ./cmd/scanner -count=1`
3. Confirm `TestGoGetterResolveRaceWith32ConcurrentFetches` and `TestModuleCacheHitsDoNotEvictSiblings` pass.

## Blast Radius

This PR only changes Terraform remote-module fetching, caching, and experimental CLI flags. Scan results for repositories that do not enable `--x-remote-modules` are unchanged.

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-5292]: https://datadoghq.atlassian.net/browse/K9CODESEC-5292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ