### PR TITLE
[K9CODESEC-5293] Correct Terraform module source and version identity

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -467,6 +467,7 @@ core,github.com/hashicorp/hcl/v2/hcldec,MPL-2.0,"Copyright © 2014-2018 HashiCor
 core,github.com/hashicorp/hcl/v2/hclsyntax,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/hcl/v2/hclwrite,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/terraform-json,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
+core,github.com/hashicorp/terraform-svchost,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/huandu/xstrings,MIT,Copyright (c) 2015 Huan Du
 core,github.com/inconshreveable/mousetrap,Apache-2.0,Copyright 2022 Alan Shreve (@inconshreveable)
 core,github.com/jbenet/go-context/io,MIT,Copyright (c) 2014 Juan Batiz-Benet
@@ -666,6 +667,7 @@ core,github.com/open-policy-agent/regal/pkg/rules,Apache-2.0,Copyright The Regal
 core,github.com/opencontainers/go-digest,Apache-2.0,"Copyright 2016 Docker, Inc | Copyright 2019, 2020 OCI Contributors | Copyright © 2016 Docker, Inc | Copyright © 2019, 2020 OCI Contributors"
 core,github.com/opencontainers/image-spec/specs-go,Apache-2.0,Copyright 2016 The Linux Foundation
 core,github.com/opencontainers/image-spec/specs-go/v1,Apache-2.0,Copyright 2016 The Linux Foundation
+core,github.com/opentofu/registry-address,MPL-2.0,"Copyright (c) 2021 HashiCorp, Inc | copyright doctrines of fair use, fair dealing, or other equivalents"
 core,github.com/pelletier/go-toml/v2,MIT,Copyright (c) 2021 - 2023 Thomas Pelletier
 core,github.com/pelletier/go-toml/v2/internal/characters,MIT,Copyright (c) 2021 - 2023 Thomas Pelletier
 core,github.com/pelletier/go-toml/v2/internal/danger,MIT,Copyright (c) 2021 - 2023 Thomas Pelletier

--- a/go.mod
+++ b/go.mod
@@ -20,10 +20,12 @@ require (
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/terraform-json v0.27.2
+	github.com/hashicorp/terraform-svchost v0.1.1
 	github.com/johnfercher/maroto v1.0.0
 	github.com/moby/buildkit v0.27.1
 	github.com/open-policy-agent/opa v1.13.2
 	github.com/open-policy-agent/regal v0.38.1
+	github.com/opentofu/registry-address v0.0.0-20230922120653-901b9ae4061a
 	github.com/pkg/errors v0.9.1
 	github.com/relex/aini v1.6.0
 	github.com/rmuir/tree-sitter-ghactions v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -370,6 +370,8 @@ github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQx
 github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
 github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoKST/tRDBJKU=
 github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
+github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
+github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -472,6 +474,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/opentofu/registry-address v0.0.0-20230922120653-901b9ae4061a h1:NyM/PPbc+kxxv2d4OKfE32C5fLtVTLceyg4YKKCYO9Y=
+github.com/opentofu/registry-address v0.0.0-20230922120653-901b9ae4061a/go.mod h1:HzQhpVo/NJnGmN+7FPECCVCA5ijU7AUcvf39enBKYOc=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -143,6 +143,8 @@ type walker struct {
 	deferExpansion   bool
 	admissionBytes   int64
 	acquisitionBytes int64
+	acquisitionBase  int64
+	acquisitionMu    sync.Mutex
 	maxDepth         int
 	fsys             vfs.FS
 }
@@ -185,6 +187,9 @@ func Resolve(ctx context.Context, request *Request) Result {
 		acquisitionBytes: acquisitionAllowance(moduleMaximum),
 		maxDepth:         request.MaxDepth,
 		fsys:             request.FS,
+	}
+	if enforceAdmission {
+		w.acquisitionBase = budget.TotalUsage().Bytes
 	}
 	seedGroups, repositoryGroups := w.seedGroups(ctx, request.RootPaths, request.DiscoveryPaths)
 
@@ -762,26 +767,31 @@ func (w *walker) acquireRemoteModuleGroups(
 		return
 	}
 	size := max(1, resolver.FetchConcurrency)
-	baseline := w.budget.TotalUsage().Bytes
 	for start := 0; start < len(ids); {
-		if start > 0 && w.acquisitionExhausted(baseline) {
+		w.acquisitionMu.Lock()
+		if start > 0 && w.acquisitionExhausted() {
+			w.acquisitionMu.Unlock()
 			w.recordUnacquiredGroups(groups, ids[start:])
 			return
 		}
 		end := start
 		for end < len(ids) && end-start < size {
-			if end > start && w.acquisitionExhausted(baseline) {
+			if end > start && w.acquisitionExhausted() {
 				break
 			}
 			end++
 		}
 		if end == start {
+			w.acquisitionMu.Unlock()
 			w.recordUnacquiredGroups(groups, ids[start:])
 			return
 		}
+		batchIDs := ids[start:end]
+		w.acquisitionMu.Unlock()
+
 		g, gCtx := errgroup.WithContext(ctx)
 		g.SetLimit(size)
-		for _, id := range ids[start:end] {
+		for _, id := range batchIDs {
 			group := groups[id]
 			g.Go(func() error {
 				w.traverseRemoteModuleGroup(gCtx, group, repoAllowedDirs, depth)
@@ -811,11 +821,11 @@ func orderedGroupIDs(groups map[string]*remoteModuleGroup) []string {
 	return ids
 }
 
-func (w *walker) acquisitionExhausted(baseline int64) bool {
+func (w *walker) acquisitionExhausted() bool {
 	if !w.deferExpansion || w.acquisitionBytes <= 0 {
 		return false
 	}
-	return w.budget.TotalUsage().Bytes-baseline >= w.acquisitionBytes
+	return w.budget.TotalUsage().Bytes-w.acquisitionBase >= w.acquisitionBytes
 }
 
 func (w *walker) recordUnacquiredGroups(groups map[string]*remoteModuleGroup, ids []string) {
@@ -836,6 +846,16 @@ func (w *walker) traverseRemoteModuleGroup(
 	repoAllowedDirs map[string]map[string]bool,
 	depth int,
 ) {
+	if w.deferExpansion && w.acquisitionBytes > 0 {
+		limits := w.budget.Limits()
+		remaining := w.acquisitionBytes - (w.budget.TotalUsage().Bytes - w.acquisitionBase)
+		if remaining > 0 {
+			if limits.MaxPackageBytes <= 0 || remaining < limits.MaxPackageBytes {
+				limits.MaxPackageBytes = remaining
+			}
+			ctx = resolver.WithResourceBudget(ctx, resolver.NewResourceBudget(limits))
+		}
+	}
 	contextLogger := logger.FromContext(ctx)
 	representative := group.representative
 	contextLogger.Debug().Msgf("Fetching remote Terraform module %q", representative.Source)

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -144,7 +144,6 @@ type walker struct {
 	admissionBytes   int64
 	acquisitionBytes int64
 	acquisitionBase  int64
-	acquisitionMu    sync.Mutex
 	maxDepth         int
 	fsys             vfs.FS
 }
@@ -768,38 +767,39 @@ func (w *walker) acquireRemoteModuleGroups(
 	}
 	size := max(1, resolver.FetchConcurrency)
 	for start := 0; start < len(ids); {
-		w.acquisitionMu.Lock()
-		if start > 0 && w.acquisitionExhausted() {
-			w.acquisitionMu.Unlock()
-			w.recordUnacquiredGroups(groups, ids[start:])
-			return
+		type acquisition struct {
+			group *remoteModuleGroup
+			lease *resolver.AcquisitionLease
 		}
-		end := start
-		for end < len(ids) && end-start < size {
-			if end > start && w.acquisitionExhausted() {
+		batch := make([]acquisition, 0, size)
+		end := min(start+size, len(ids))
+		for _, id := range ids[start:end] {
+			lease, ok := w.acquireAcquisition(ctx, len(batch) == 0)
+			if !ok {
 				break
 			}
-			end++
+			batch = append(batch, acquisition{group: groups[id], lease: lease})
 		}
-		if end == start {
-			w.acquisitionMu.Unlock()
-			w.recordUnacquiredGroups(groups, ids[start:])
+		if len(batch) == 0 {
+			if ctx.Err() == nil {
+				w.recordUnacquiredGroups(groups, ids[start:])
+			}
 			return
 		}
-		batchIDs := ids[start:end]
-		w.acquisitionMu.Unlock()
 
 		g, gCtx := errgroup.WithContext(ctx)
 		g.SetLimit(size)
-		for _, id := range batchIDs {
-			group := groups[id]
+		for _, item := range batch {
 			g.Go(func() error {
-				w.traverseRemoteModuleGroup(gCtx, group, repoAllowedDirs, depth)
+				defer item.lease.Release()
+				w.traverseRemoteModuleGroup(
+					gCtx, item.group, repoAllowedDirs, depth, item.lease,
+				)
 				return nil
 			})
 		}
 		_ = g.Wait()
-		start = end
+		start += len(batch)
 	}
 }
 
@@ -821,11 +821,21 @@ func orderedGroupIDs(groups map[string]*remoteModuleGroup) []string {
 	return ids
 }
 
-func (w *walker) acquisitionExhausted() bool {
-	if !w.deferExpansion || w.acquisitionBytes <= 0 {
-		return false
+func (w *walker) acquireAcquisition(
+	ctx context.Context, wait bool,
+) (*resolver.AcquisitionLease, bool) {
+	if !w.deferExpansion {
+		return nil, true
 	}
-	return w.budget.TotalUsage().Bytes-w.acquisitionBase >= w.acquisitionBytes
+	requested := w.budget.Limits().MaxPackageBytes
+	maximum := w.acquisitionBase + w.acquisitionBytes
+	if maximum < w.acquisitionBase {
+		maximum = math.MaxInt64
+	}
+	if wait {
+		return w.budget.AcquireAcquisition(ctx, maximum, requested)
+	}
+	return w.budget.TryAcquireAcquisition(maximum, requested)
 }
 
 func (w *walker) recordUnacquiredGroups(groups map[string]*remoteModuleGroup, ids []string) {
@@ -845,16 +855,14 @@ func (w *walker) traverseRemoteModuleGroup(
 	group *remoteModuleGroup,
 	repoAllowedDirs map[string]map[string]bool,
 	depth int,
+	lease *resolver.AcquisitionLease,
 ) {
-	if w.deferExpansion && w.acquisitionBytes > 0 {
+	if lease != nil {
 		limits := w.budget.Limits()
-		remaining := w.acquisitionBytes - (w.budget.TotalUsage().Bytes - w.acquisitionBase)
-		if remaining > 0 {
-			if limits.MaxPackageBytes <= 0 || remaining < limits.MaxPackageBytes {
-				limits.MaxPackageBytes = remaining
-			}
-			ctx = resolver.WithResourceBudget(ctx, resolver.NewResourceBudget(limits))
+		if limits.MaxPackageBytes <= 0 || lease.Bytes() < limits.MaxPackageBytes {
+			limits.MaxPackageBytes = lease.Bytes()
 		}
+		ctx = resolver.WithResourceBudget(ctx, resolver.NewResourceBudget(limits))
 	}
 	contextLogger := logger.FromContext(ctx)
 	representative := group.representative

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -44,6 +44,8 @@ type ResolvedModule struct {
 	CallerRoot        string
 	Source            string
 	Version           string
+	ResolvedVersion   string
+	ResolvedRef       string
 	Name              string
 	LocalPath         string
 	PackageRoot       string
@@ -382,12 +384,14 @@ func (c *resultCollector) addResolvedModule(
 		CallerRoot:        moduleCallRoot(mod),
 		Source:            mod.Source,
 		Version:           mod.Version,
+		ResolvedVersion:   resolution.ResolvedVersion,
+		ResolvedRef:       resolution.ResolvedRef,
 		Name:              mod.Name,
 		LocalPath:         resolution.LocalPath,
 		PackageRoot:       resolution.PackageRoot,
 		ParentPackageRoot: parentPackageRoot,
 		Depth:             depth,
-		CanonicalSource:   canonicalModuleURL(mod.Source, mod.Version),
+		CanonicalSource:   canonicalModuleURL(mod.Source, resolution.ResolvedVersion),
 	})
 }
 
@@ -438,10 +442,10 @@ func (c *resolutionCache) get(resolveID string) (resolvedEntry, bool) {
 	return entry, ok
 }
 
-func (c *resolutionCache) set(resolveID string, entry resolvedEntry) {
+func (c *resolutionCache) set(resolveID string, entry *resolvedEntry) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.entries[resolveID] = entry
+	c.entries[resolveID] = *entry
 }
 
 func (c *moduleParseCache) get(key string) (map[string]tfmodules.ParsedModule, bool) {
@@ -502,7 +506,7 @@ func (w *walker) resolveRemote(
 			resolveErr = w.accountPackage(ctx, mod.Source, resolution)
 		}
 		if ctx.Err() == nil {
-			w.resolutions.set(resolveID, resolvedEntry{res: resolution, err: resolveErr})
+			w.resolutions.set(resolveID, &resolvedEntry{res: resolution, err: resolveErr})
 		}
 		return resolution, resolveErr
 	})
@@ -753,37 +757,39 @@ func (w *walker) acquireRemoteModuleGroups(
 	depth int,
 ) {
 	ids := orderedGroupIDs(groups)
+	if w.deferExpansion && w.acquisitionBytes <= 0 {
+		w.recordUnacquiredGroups(groups, ids)
+		return
+	}
 	size := max(1, resolver.FetchConcurrency)
+	baseline := w.budget.TotalUsage().Bytes
 	for start := 0; start < len(ids); {
-		type acquisition struct {
-			group       *remoteModuleGroup
-			reservation int64
+		if start > 0 && w.acquisitionExhausted(baseline) {
+			w.recordUnacquiredGroups(groups, ids[start:])
+			return
 		}
-		batch := make([]acquisition, 0, size)
-		end := min(start+size, len(ids))
-		for _, id := range ids[start:end] {
-			reservation, ok := w.reserveAcquisition()
-			if !ok {
+		end := start
+		for end < len(ids) && end-start < size {
+			if end > start && w.acquisitionExhausted(baseline) {
 				break
 			}
-			batch = append(batch, acquisition{group: groups[id], reservation: reservation})
+			end++
 		}
-		if len(batch) == 0 {
+		if end == start {
 			w.recordUnacquiredGroups(groups, ids[start:])
 			return
 		}
 		g, gCtx := errgroup.WithContext(ctx)
 		g.SetLimit(size)
-		for _, item := range batch {
+		for _, id := range ids[start:end] {
+			group := groups[id]
 			g.Go(func() error {
-				w.traverseRemoteModuleGroup(
-					gCtx, item.group, repoAllowedDirs, depth, item.reservation,
-				)
+				w.traverseRemoteModuleGroup(gCtx, group, repoAllowedDirs, depth)
 				return nil
 			})
 		}
 		_ = g.Wait()
-		start += len(batch)
+		start = end
 	}
 }
 
@@ -805,13 +811,11 @@ func orderedGroupIDs(groups map[string]*remoteModuleGroup) []string {
 	return ids
 }
 
-func (w *walker) reserveAcquisition() (int64, bool) {
-	if !w.deferExpansion {
-		return 0, true
+func (w *walker) acquisitionExhausted(baseline int64) bool {
+	if !w.deferExpansion || w.acquisitionBytes <= 0 {
+		return false
 	}
-	return w.budget.ReserveAcquisition(
-		w.acquisitionBytes, w.budget.Limits().MaxPackageBytes,
-	)
+	return w.budget.TotalUsage().Bytes-baseline >= w.acquisitionBytes
 }
 
 func (w *walker) recordUnacquiredGroups(groups map[string]*remoteModuleGroup, ids []string) {
@@ -831,14 +835,7 @@ func (w *walker) traverseRemoteModuleGroup(
 	group *remoteModuleGroup,
 	repoAllowedDirs map[string]map[string]bool,
 	depth int,
-	reservation int64,
 ) {
-	if reservation > 0 {
-		defer w.budget.ReleaseAcquisition(reservation)
-		limits := w.budget.Limits()
-		limits.MaxPackageBytes = reservation
-		ctx = resolver.WithResourceBudget(ctx, resolver.NewResourceBudget(limits))
-	}
 	contextLogger := logger.FromContext(ctx)
 	representative := group.representative
 	contextLogger.Debug().Msgf("Fetching remote Terraform module %q", representative.Source)
@@ -873,7 +870,7 @@ func (w *walker) traverseRemoteModuleGroup(
 	w.results.addPaths(flatTerraformFilePaths(ctx, resolution.LocalPath, resolution.PackageRoot)...)
 	w.results.addSourceMapping(
 		resolution.LocalPath,
-		canonicalModuleURL(representative.Source, representative.Version),
+		canonicalModuleURL(representative.Source, resolution.ResolvedVersion),
 	)
 	if !w.deferExpansion {
 		w.traverse(ctx, resolution.LocalPath, nil, repoAllowedDirs, depth+1, resolution.PackageRoot)
@@ -942,20 +939,33 @@ func canonicalGitModuleSource(moduleSource string) string {
 	return source
 }
 
-func canonicalModuleURL(moduleSource, version string) string {
-	source := canonicalGitModuleSource(moduleSource)
-	sourceType, scope := tfmodules.DetectModuleSourceType(source)
-	if sourceType == sourceTypeRegistry && scope == "public" &&
-		!strings.HasPrefix(source, "registry.terraform.io/") {
-		source = "registry.terraform.io/" + source
+func canonicalModuleURL(moduleSource, resolvedVersion string) string {
+	source := strings.TrimSpace(moduleSource)
+	if addr, err := tfmodules.ParseRegistryModuleSource(source); err == nil {
+		canonical := addr.String()
+		if version := concreteRegistryVersion(resolvedVersion); version != "" {
+			canonical += "@" + version
+		}
+		return canonical
 	}
+	source = canonicalGitModuleSource(source)
 	if index := strings.Index(source, "@"); index != -1 {
 		if schemeEnd := strings.Index(source, "://"); schemeEnd != -1 && schemeEnd < index {
 			source = source[:schemeEnd+3] + source[index+1:]
 		}
 	}
-	if version != "" {
-		source += "@" + version
-	}
 	return source
+}
+
+func concreteRegistryVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" || strings.ContainsAny(version, " \t") {
+		return ""
+	}
+	for _, c := range version {
+		if c != '.' && c != '-' && c != '+' && (c < '0' || c > '9') && (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') {
+			return ""
+		}
+	}
+	return version
 }

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
@@ -127,7 +127,7 @@ func TestResolveAssemblesModuleMetadataAndPaths(t *testing.T) {
 
 	require.Equal(t, []string{filepath.Join(moduleDir, "main.tf")}, result.ScanPaths)
 	require.Equal(t, map[string]string{
-		moduleDir: "git::https://github.com/acme/network//modules/vpc?ref=v1@1.2.3",
+		moduleDir: "git::https://github.com/acme/network//modules/vpc?ref=v1",
 	}, result.SourceMappings)
 	require.Equal(t, []ResolvedModule{{
 		CallerRoot:      root,
@@ -137,8 +137,84 @@ func TestResolveAssemblesModuleMetadataAndPaths(t *testing.T) {
 		LocalPath:       moduleDir,
 		PackageRoot:     moduleDir,
 		Depth:           1,
-		CanonicalSource: "git::https://github.com/acme/network//modules/vpc?ref=v1@1.2.3",
+		CanonicalSource: "git::https://github.com/acme/network//modules/vpc?ref=v1",
 	}}, result.Modules)
+}
+
+func TestResolveThreadsRegistryIdentity(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	moduleDir := filepath.Join(base, "module")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(`
+module "bucket" {
+  source  = "cloud-inventory/bucket/aws"
+  version = "~> 9.0"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte(`
+resource "aws_s3_bucket" "this" {}
+`), 0o644))
+
+	result := Resolve(context.Background(), &Request{
+		RootPaths:      []string{root},
+		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
+		Resolver: stubResolver{resolution: resolver.Resolution{
+			LocalPath:       moduleDir,
+			ResolvedVersion: "9.1.0",
+		}},
+		MaxDepth: 2,
+	})
+
+	require.Equal(t, map[string]string{
+		moduleDir: "registry.terraform.io/cloud-inventory/bucket/aws@9.1.0",
+	}, result.SourceMappings)
+	require.Equal(t, []ResolvedModule{{
+		CallerRoot:      root,
+		Source:          "cloud-inventory/bucket/aws",
+		Version:         "~> 9.0",
+		ResolvedVersion: "9.1.0",
+		Name:            "bucket",
+		LocalPath:       moduleDir,
+		PackageRoot:     moduleDir,
+		Depth:           1,
+		CanonicalSource: "registry.terraform.io/cloud-inventory/bucket/aws@9.1.0",
+	}}, result.Modules)
+}
+
+func TestCanonicalModuleURL(t *testing.T) {
+	tests := []struct {
+		source  string
+		version string
+		want    string
+	}{
+		{
+			source:  "cloud-inventory/bucket/aws",
+			version: "9.1.0",
+			want:    "registry.terraform.io/cloud-inventory/bucket/aws@9.1.0",
+		},
+		{
+			source:  "cloud-inventory/bucket/aws",
+			version: "~> 9.0",
+			want:    "registry.terraform.io/cloud-inventory/bucket/aws",
+		},
+		{
+			source:  "registry.example.com:8443/ns/name/aws//modules/child",
+			version: "1.2.3",
+			want:    "registry.example.com:8443/ns/name/aws//modules/child@1.2.3",
+		},
+		{
+			source:  "git::https://git@github.com/acme/network.git//modules/vpc?ref=v1",
+			version: "1.2.3",
+			want:    "git::https://github.com/acme/network//modules/vpc?ref=v1",
+		},
+	}
+	for _, tt := range tests {
+		if got := canonicalModuleURL(tt.source, tt.version); got != tt.want {
+			t.Errorf("canonicalModuleURL(%q, %q) = %q, want %q", tt.source, tt.version, got, tt.want)
+		}
+	}
 }
 
 func TestResolveCleanupIsIdempotent(t *testing.T) {
@@ -377,75 +453,62 @@ module "child" {
 	require.Equal(t, []string{filepath.Join(small, "main.tf")}, result.ScanPaths)
 }
 
-func TestResolveStopsDeferredTraversalAtAcquisitionLimit(t *testing.T) {
+func TestResolveAcquiresRemoteModulesFromParallelSeeds(t *testing.T) {
 	t.Parallel()
 
 	base := t.TempDir()
-	root := filepath.Join(base, "root")
+	seedA := filepath.Join(base, "seed-a")
+	seedB := filepath.Join(base, "seed-b")
 	moduleA := filepath.Join(base, "module-a")
 	moduleB := filepath.Join(base, "module-b")
-	childA := filepath.Join(base, "child-a")
-	childB := filepath.Join(base, "child-b")
-	for _, dir := range []string{root, moduleA, moduleB, childA, childB} {
+	for _, dir := range []string{seedA, seedB, moduleA, moduleB} {
 		require.NoError(t, os.MkdirAll(dir, 0o755))
 	}
-	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(`
+	require.NoError(t, os.WriteFile(filepath.Join(seedA, "main.tf"), []byte(`
 module "a" {
   source = "example.com/acme/a/aws"
 }
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(seedB, "main.tf"), []byte(`
 module "b" {
   source = "example.com/acme/b/aws"
 }
 `), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(moduleA, "main.tf"), []byte(`
-module "child_a" {
-  source = "example.com/acme/child-a/aws"
-}
-resource "aws_vpc" "padding" {
-  tags = { padding = "module a starts larger than module b" }
-}
-`), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(moduleB, "main.tf"), []byte(`
-module "child_b" {
-  source = "example.com/acme/child-b/aws"
-}
-`), 0o600))
 	require.NoError(t, os.WriteFile(
-		filepath.Join(childA, "main.tf"),
-		[]byte(`resource "aws_vpc" "child_a" {}`),
+		filepath.Join(moduleA, "main.tf"),
+		[]byte(`resource "aws_vpc" "a" {}`),
 		0o600,
 	))
 	require.NoError(t, os.WriteFile(
-		filepath.Join(childB, "main.tf"),
-		make([]byte, 1024),
+		filepath.Join(moduleB, "main.tf"),
+		[]byte(`resource "aws_vpc" "b" {}`),
 		0o600,
 	))
-	moduleAUsage, err := resolver.MeasurePackage(t.Context(), moduleA, resolver.ResourceLimits{})
-	require.NoError(t, err)
 	tracker := &trackingResolver{
 		bySource: map[string]resolver.Resolution{
-			"example.com/acme/a/aws":       {LocalPath: moduleA},
-			"example.com/acme/b/aws":       {LocalPath: moduleB},
-			"example.com/acme/child-a/aws": {LocalPath: childA},
-			"example.com/acme/child-b/aws": {LocalPath: childB},
+			"example.com/acme/a/aws": {LocalPath: moduleA},
+			"example.com/acme/b/aws": {LocalPath: moduleB},
 		},
 		calls: make(map[string]int),
 	}
 
 	result := Resolve(t.Context(), &Request{
-		RootPaths:      []string{root},
-		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
-		Resolver:       tracker,
-		MaxDepth:       3,
+		RootPaths: []string{base},
+		DiscoveryPaths: []string{
+			filepath.Join(seedA, "main.tf"),
+			filepath.Join(seedB, "main.tf"),
+		},
+		Resolver: tracker,
+		MaxDepth: 2,
 		ResourceLimits: resolver.ResourceLimits{
-			MaxTotalBytes: moduleAUsage.Bytes,
+			MaxTotalBytes: 200 * 1024 * 1024,
 		},
 	})
 
-	require.Zero(t, tracker.callCount("example.com/acme/child-a/aws"))
-	require.Equal(t, 1, tracker.callCount("example.com/acme/child-b/aws"))
-	require.Len(t, result.Modules, 1)
-	require.Equal(t, "example.com/acme/b/aws", result.Modules[0].Source)
+	require.Equal(t, 1, tracker.callCount("example.com/acme/a/aws"))
+	require.Equal(t, 1, tracker.callCount("example.com/acme/b/aws"))
+	require.Contains(t, result.ScanPaths, filepath.Join(moduleA, "main.tf"))
+	require.Contains(t, result.ScanPaths, filepath.Join(moduleB, "main.tf"))
 }
 
 func TestShedToTotalLimitFiltersNestedPackagePathsByOwner(t *testing.T) {
@@ -698,6 +761,8 @@ func TestResolveStopsAcquiringFrontierPastAllowance(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(calls), 0o600))
 	tracker := &trackingResolver{bySource: resolutions, calls: make(map[string]int)}
 
+	// One batch alone overshoots the allowance, so the trailing sources are
+	// never fetched.
 	result := Resolve(t.Context(), &Request{
 		RootPaths:      []string{root},
 		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
@@ -706,14 +771,10 @@ func TestResolveStopsAcquiringFrontierPastAllowance(t *testing.T) {
 		ResourceLimits: resolver.ResourceLimits{MaxTotalBytes: 100},
 	})
 
-	const expectedFetched = 2
-	for index, source := range sources {
-		if index < expectedFetched {
-			require.Equal(t, 1, tracker.callCount(source), source)
-		} else {
-			require.Zero(t, tracker.callCount(source), source)
-		}
+	for _, source := range sources[batch:] {
+		require.Zero(t, tracker.callCount(source), source)
 	}
+	require.Equal(t, 1, tracker.callCount(sources[0]))
 	unacquired := 0
 	for _, event := range result.BudgetEvents {
 		if event.Gate == "acquisition" {
@@ -721,7 +782,7 @@ func TestResolveStopsAcquiringFrontierPastAllowance(t *testing.T) {
 			require.Equal(t, "module_bytes_total", event.Limit)
 		}
 	}
-	require.Equal(t, count-expectedFetched, unacquired)
+	require.Equal(t, count-batch, unacquired)
 }
 
 func TestShedToTotalLimitBreaksTiesDeterministically(t *testing.T) {

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
@@ -111,6 +112,42 @@ func (r *trackingResolver) callCount(source string) int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.calls[source]
+}
+
+type acquisitionTrackingResolver struct {
+	bySource     map[string]resolver.Resolution
+	release      chan struct{}
+	releaseOnce  sync.Once
+	entered      atomic.Int64
+	activeBytes  atomic.Int64
+	maximumBytes atomic.Int64
+}
+
+func (r *acquisitionTrackingResolver) Resolve(
+	ctx context.Context, mod *tfmodules.ParsedModule,
+) (resolver.Resolution, error) {
+	res, ok := r.bySource[mod.Source]
+	if !ok {
+		return resolver.Resolution{}, &tfmodules.UnresolvedError{Reason: "unknown source " + mod.Source}
+	}
+	reserved := resolver.ResourceBudgetFromContext(ctx).Limits().MaxPackageBytes
+	active := r.activeBytes.Add(reserved)
+	defer r.activeBytes.Add(-reserved)
+	for {
+		maximum := r.maximumBytes.Load()
+		if active <= maximum || r.maximumBytes.CompareAndSwap(maximum, active) {
+			break
+		}
+	}
+	if r.entered.Add(1) == 2 {
+		r.releaseOnce.Do(func() { close(r.release) })
+	}
+	select {
+	case <-ctx.Done():
+		return resolver.Resolution{}, ctx.Err()
+	case <-r.release:
+		return res, nil
+	}
 }
 
 func TestResolveAssemblesModuleMetadataAndPaths(t *testing.T) {
@@ -511,6 +548,133 @@ module "b" {
 	require.Contains(t, result.ScanPaths, filepath.Join(moduleB, "main.tf"))
 }
 
+func TestResolveStopsDeferredTraversalAtAcquisitionLimit(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	moduleA := filepath.Join(base, "module-a")
+	moduleB := filepath.Join(base, "module-b")
+	childA := filepath.Join(base, "child-a")
+	childB := filepath.Join(base, "child-b")
+	for _, dir := range []string{root, moduleA, moduleB, childA, childB} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(`
+module "a" {
+  source = "example.com/acme/a/aws"
+}
+module "b" {
+  source = "example.com/acme/b/aws"
+}
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleA, "main.tf"), []byte(`
+module "child_a" {
+  source = "example.com/acme/child-a/aws"
+}
+resource "aws_vpc" "padding" {
+  tags = { padding = "module a starts larger than module b" }
+}
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleB, "main.tf"), []byte(`
+module "child_b" {
+  source = "example.com/acme/child-b/aws"
+}
+`), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(childA, "main.tf"),
+		[]byte(`resource "aws_vpc" "child_a" {}`),
+		0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(childB, "main.tf"),
+		make([]byte, 1024),
+		0o600,
+	))
+	moduleAUsage, err := resolver.MeasurePackage(t.Context(), moduleA, resolver.ResourceLimits{})
+	require.NoError(t, err)
+	tracker := &trackingResolver{
+		bySource: map[string]resolver.Resolution{
+			"example.com/acme/a/aws":       {LocalPath: moduleA},
+			"example.com/acme/b/aws":       {LocalPath: moduleB},
+			"example.com/acme/child-a/aws": {LocalPath: childA},
+			"example.com/acme/child-b/aws": {LocalPath: childB},
+		},
+		calls: make(map[string]int),
+	}
+
+	result := Resolve(t.Context(), &Request{
+		RootPaths:      []string{root},
+		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
+		Resolver:       tracker,
+		MaxDepth:       3,
+		ResourceLimits: resolver.ResourceLimits{
+			MaxTotalBytes: moduleAUsage.Bytes,
+		},
+	})
+
+	require.Zero(t, tracker.callCount("example.com/acme/child-a/aws"))
+	require.Equal(t, 1, tracker.callCount("example.com/acme/child-b/aws"))
+	require.Len(t, result.Modules, 1)
+	require.Equal(t, "example.com/acme/b/aws", result.Modules[0].Source)
+}
+
+func TestResolveReservesAcquisitionAcrossConcurrentFrontiers(t *testing.T) {
+	t.Parallel()
+
+	const (
+		seedCount        = 4
+		maximumBytes     = int64(200)
+		acquisitionBytes = maximumBytes * acquisitionOvershootFactor
+	)
+	base := t.TempDir()
+	discoveryPaths := make([]string, 0, seedCount)
+	resolutions := make(map[string]resolver.Resolution, seedCount)
+	for i := range seedCount {
+		seed := filepath.Join(base, fmt.Sprintf("seed-%d", i))
+		module := filepath.Join(base, fmt.Sprintf("module-%d", i))
+		require.NoError(t, os.MkdirAll(seed, 0o755))
+		require.NoError(t, os.MkdirAll(module, 0o755))
+		source := fmt.Sprintf("example.com/acme/module-%d/aws", i)
+		require.NoError(t, os.WriteFile(
+			filepath.Join(seed, "main.tf"),
+			[]byte(fmt.Sprintf("module \"m\" {\n  source = %q\n}\n", source)),
+			0o600,
+		))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(module, "main.tf"),
+			[]byte(`resource "test" "example" {}`),
+			0o600,
+		))
+		discoveryPaths = append(discoveryPaths, filepath.Join(seed, "main.tf"))
+		resolutions[source] = resolver.Resolution{LocalPath: module}
+	}
+	tracker := &acquisitionTrackingResolver{
+		bySource: resolutions,
+		release:  make(chan struct{}),
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	result := Resolve(ctx, &Request{
+		RootPaths:      []string{base},
+		DiscoveryPaths: discoveryPaths,
+		Resolver:       tracker,
+		MaxDepth:       2,
+		ResourceLimits: resolver.ResourceLimits{
+			MaxPackageBytes: 300,
+			MaxTotalBytes:   maximumBytes,
+		},
+	})
+
+	require.NoError(t, ctx.Err())
+	require.Equal(t, int64(seedCount), tracker.entered.Load())
+	require.LessOrEqual(t, tracker.maximumBytes.Load(), acquisitionBytes)
+	for _, event := range result.BudgetEvents {
+		require.NotEqual(t, "acquisition", event.Gate)
+	}
+}
+
 func TestShedToTotalLimitFiltersNestedPackagePathsByOwner(t *testing.T) {
 	t.Parallel()
 
@@ -761,8 +925,6 @@ func TestResolveStopsAcquiringFrontierPastAllowance(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(calls), 0o600))
 	tracker := &trackingResolver{bySource: resolutions, calls: make(map[string]int)}
 
-	// One batch alone overshoots the allowance, so the trailing sources are
-	// never fetched.
 	result := Resolve(t.Context(), &Request{
 		RootPaths:      []string{root},
 		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
@@ -771,9 +933,11 @@ func TestResolveStopsAcquiringFrontierPastAllowance(t *testing.T) {
 		ResourceLimits: resolver.ResourceLimits{MaxTotalBytes: 100},
 	})
 
-	for _, source := range sources[batch:] {
-		require.Zero(t, tracker.callCount(source), source)
+	acquired := 0
+	for _, source := range sources {
+		acquired += tracker.callCount(source)
 	}
+	require.Equal(t, 2, acquired)
 	require.Equal(t, 1, tracker.callCount(sources[0]))
 	unacquired := 0
 	for _, event := range result.BudgetEvents {
@@ -782,7 +946,7 @@ func TestResolveStopsAcquiringFrontierPastAllowance(t *testing.T) {
 			require.Equal(t, "module_bytes_total", event.Limit)
 		}
 	}
-	require.Equal(t, count-batch, unacquired)
+	require.Equal(t, count-acquired, unacquired)
 }
 
 func TestShedToTotalLimitBreaksTiesDeterministically(t *testing.T) {

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -73,12 +73,6 @@ type ModuleAttributesInfo struct {
 	Inputs    map[string]string `json:"inputs"`
 }
 
-var registryPattern = regexp.MustCompile(`^[a-z0-9\-]+/[a-z0-9\-]+/[a-z0-9\-]+$`)
-
-func isValidRegistryFormat(s string) bool {
-	return registryPattern.MatchString(s)
-}
-
 func resolveModulePath(source, rootDir string) string {
 	clean := strings.TrimPrefix(source, "file://")
 	clean = strings.TrimPrefix(clean, "git::")
@@ -700,43 +694,24 @@ func LooksLikeLocalModuleSource(source string) bool {
 
 func DetectModuleSourceType(source string) (sourceType, registryScope string) {
 	source = strings.TrimSpace(source)
-
 	if source == "" {
 		return stringUnknown, ""
 	}
-	registrySource := source
-	if idx := strings.Index(registrySource, "//"); idx != -1 {
-		registrySource = registrySource[:idx]
-	}
-
 	if strings.HasPrefix(source, "data_ref:") {
 		return "data_ref", ""
 	}
-
-	// Recognize git-based sources
 	if strings.HasPrefix(source, "git::") {
 		return "git", ""
 	}
-
-	// Recognize public registry hostname
-	if strings.HasPrefix(registrySource, "registry.terraform.io/") {
-		return stringRegistry, stringPublic
-	}
-
-	// Recognize private registries by fully qualified domain with 3 parts
-	if strings.Count(registrySource, "/") == 3 && strings.Contains(registrySource, ".") {
-		return stringRegistry, stringPrivate
-	}
-
-	// Recognize implicit public registry format (namespace/name/provider)
-	if isValidRegistryFormat(registrySource) {
-		return stringRegistry, stringPublic
-	}
-
 	if LooksLikeLocalModuleSource(source) {
 		return stringLocal, ""
 	}
-
+	if addr, err := ParseRegistryModuleSource(source); err == nil {
+		if addr.Public() {
+			return stringRegistry, stringPublic
+		}
+		return stringRegistry, stringPrivate
+	}
 	return stringUnknown, ""
 }
 

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -542,6 +542,8 @@ func TestDetectModuleSourceTypeWithScope(t *testing.T) {
 		{"terraform-aws-modules/eks/aws//modules/karpenter", "registry", "public"},
 		{"company.internal.io/infra/mod/aws", "registry", "private"},
 		{"company.internal.io/infra/mod/aws//child", "registry", "private"},
+		{"registry.example.com:8443/ns/name/aws", "registry", "private"},
+		{"registry.terraform.io:443/org/vpc/aws", "registry", "public"},
 		{"https://github.com/org/repo", "unknown", ""},
 		{"data_ref:aws_s3.bucket.id", "data_ref", ""},
 		{"", "unknown", ""},

--- a/pkg/parser/terraform/modules/registry_addr.go
+++ b/pkg/parser/terraform/modules/registry_addr.go
@@ -26,13 +26,15 @@ type RegistryModuleSource struct {
 
 // ParseRegistryModuleSource parses a registry module source, including hosts
 // with ports and //subdir selections. Implicit three-part addresses use
-// registry.terraform.io rather than the OpenTofu default host.
+// registry.terraform.io rather than the OpenTofu default host; explicit
+// registry.opentofu.org sources keep their declared host.
 func ParseRegistryModuleSource(source string) (RegistryModuleSource, error) {
-	addr, err := tfaddr.ParseModuleSource(strings.TrimSpace(source))
+	source = strings.TrimSpace(source)
+	addr, err := tfaddr.ParseModuleSource(source)
 	if err != nil {
 		return RegistryModuleSource{}, err
 	}
-	if addr.Package.Host == tfaddr.DefaultModuleRegistryHost {
+	if addr.Package.Host == tfaddr.DefaultModuleRegistryHost && implicitRegistryModuleSource(source) {
 		addr.Package.Host = terraformRegistryHost
 	}
 	return RegistryModuleSource{
@@ -58,4 +60,15 @@ func (s *RegistryModuleSource) String() string {
 		src += "//" + s.Subdir
 	}
 	return src
+}
+
+func implicitRegistryModuleSource(source string) bool {
+	raw := source
+	if idx := strings.Index(raw, "?"); idx >= 0 {
+		raw = raw[:idx]
+	}
+	if idx := strings.Index(raw, "//"); idx >= 0 {
+		raw = raw[:idx]
+	}
+	return len(strings.Split(raw, "/")) == 3
 }

--- a/pkg/parser/terraform/modules/registry_addr.go
+++ b/pkg/parser/terraform/modules/registry_addr.go
@@ -1,0 +1,61 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package tfmodules
+
+import (
+	"net"
+	"strings"
+
+	svchost "github.com/hashicorp/terraform-svchost"
+	tfaddr "github.com/opentofu/registry-address"
+)
+
+const terraformRegistryHost = svchost.Hostname("registry.terraform.io")
+
+// RegistryModuleSource is a Terraform registry module address.
+type RegistryModuleSource struct {
+	Host      string
+	Namespace string
+	Name      string
+	Provider  string
+	Subdir    string
+}
+
+// ParseRegistryModuleSource parses a registry module source, including hosts
+// with ports and //subdir selections. Implicit three-part addresses use
+// registry.terraform.io rather than the OpenTofu default host.
+func ParseRegistryModuleSource(source string) (RegistryModuleSource, error) {
+	addr, err := tfaddr.ParseModuleSource(strings.TrimSpace(source))
+	if err != nil {
+		return RegistryModuleSource{}, err
+	}
+	if addr.Package.Host == tfaddr.DefaultModuleRegistryHost {
+		addr.Package.Host = terraformRegistryHost
+	}
+	return RegistryModuleSource{
+		Host:      addr.Package.Host.ForDisplay(),
+		Namespace: addr.Package.Namespace,
+		Name:      addr.Package.Name,
+		Provider:  addr.Package.TargetSystem,
+		Subdir:    addr.Subdir,
+	}, nil
+}
+
+func (s *RegistryModuleSource) Public() bool {
+	host := s.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return strings.EqualFold(host, string(terraformRegistryHost))
+}
+
+func (s *RegistryModuleSource) String() string {
+	src := s.Host + "/" + s.Namespace + "/" + s.Name + "/" + s.Provider
+	if s.Subdir != "" {
+		src += "//" + s.Subdir
+	}
+	return src
+}

--- a/pkg/parser/terraform/modules/registry_addr_test.go
+++ b/pkg/parser/terraform/modules/registry_addr_test.go
@@ -40,6 +40,25 @@ func TestParseRegistryModuleSource(t *testing.T) {
 				Provider:  "aws",
 			},
 		},
+		{
+			source: "registry.opentofu.org/org/module/aws",
+			want: RegistryModuleSource{
+				Host:      "registry.opentofu.org",
+				Namespace: "org",
+				Name:      "module",
+				Provider:  "aws",
+			},
+		},
+		{
+			source: "registry.opentofu.org/org/module/aws//modules/child",
+			want: RegistryModuleSource{
+				Host:      "registry.opentofu.org",
+				Namespace: "org",
+				Name:      "module",
+				Provider:  "aws",
+				Subdir:    "modules/child",
+			},
+		},
 	}
 	for _, tt := range tests {
 		got, err := ParseRegistryModuleSource(tt.source)

--- a/pkg/parser/terraform/modules/registry_addr_test.go
+++ b/pkg/parser/terraform/modules/registry_addr_test.go
@@ -1,0 +1,56 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package tfmodules
+
+import "testing"
+
+func TestParseRegistryModuleSource(t *testing.T) {
+	tests := []struct {
+		source string
+		want   RegistryModuleSource
+	}{
+		{
+			source: "terraform-aws-modules/vpc/aws",
+			want: RegistryModuleSource{
+				Host:      "registry.terraform.io",
+				Namespace: "terraform-aws-modules",
+				Name:      "vpc",
+				Provider:  "aws",
+			},
+		},
+		{
+			source: "registry.terraform.io/org/vpc/aws//modules/child",
+			want: RegistryModuleSource{
+				Host:      "registry.terraform.io",
+				Namespace: "org",
+				Name:      "vpc",
+				Provider:  "aws",
+				Subdir:    "modules/child",
+			},
+		},
+		{
+			source: "registry.example.com:8443/ns/name/aws",
+			want: RegistryModuleSource{
+				Host:      "registry.example.com:8443",
+				Namespace: "ns",
+				Name:      "name",
+				Provider:  "aws",
+			},
+		},
+	}
+	for _, tt := range tests {
+		got, err := ParseRegistryModuleSource(tt.source)
+		if err != nil {
+			t.Fatalf("ParseRegistryModuleSource(%q): %v", tt.source, err)
+		}
+		if got != tt.want {
+			t.Errorf("ParseRegistryModuleSource(%q) = %+v, want %+v", tt.source, got, tt.want)
+		}
+	}
+	if _, err := ParseRegistryModuleSource("git::https://github.com/org/repo"); err == nil {
+		t.Fatal("git sources must not parse as registry addresses")
+	}
+}

--- a/pkg/parser/terraform/modules/resolver/baregit.go
+++ b/pkg/parser/terraform/modules/resolver/baregit.go
@@ -1110,6 +1110,7 @@ func (r *BareGitResolver) resolveCachedSHAArchive(
 	resolution, err := ConfineResolution(ctx, Resolution{
 		LocalPath:   filepath.Join(packageRoot, filepath.FromSlash(subdir)),
 		PackageRoot: packageRoot,
+		ResolvedRef: ref,
 	})
 	if err != nil {
 		release()
@@ -1149,6 +1150,7 @@ func (r *BareGitResolver) resolveRemoteArchive(
 	resolution, err := ConfineResolution(ctx, Resolution{
 		LocalPath:   filepath.Join(packageRoot, filepath.FromSlash(subdir)),
 		PackageRoot: packageRoot,
+		ResolvedRef: sha,
 	})
 	if err != nil {
 		release()

--- a/pkg/parser/terraform/modules/resolver/git_module_test.go
+++ b/pkg/parser/terraform/modules/resolver/git_module_test.go
@@ -6,6 +6,7 @@
 package resolver
 
 import (
+	"net/url"
 	"testing"
 
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
@@ -115,6 +116,16 @@ func TestGitModuleResolveKeyDefaultsMissingRefToHEAD(t *testing.T) {
 	want := "https\x00github.com/org/repo\x00HEAD\x00"
 	if key != want {
 		t.Fatalf("key = %q, want %q", key, want)
+	}
+}
+
+func TestHTTPSGitTransportDoesNotRequireSSHHostKey(t *testing.T) {
+	repo, err := url.Parse("https://github.com/org/repo.git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkGitTransportAllowed(t.Context(), repo); err != nil {
+		t.Fatalf("pinned git::https must resolve without SSH host keys: %v", err)
 	}
 }
 

--- a/pkg/parser/terraform/modules/resolver/gogetter.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter.go
@@ -166,7 +166,7 @@ func (r *GoGetterResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedMod
 	if res, ok, cacheErr := r.lookupCache(ctx, mod, cacheVersion, selectedSubdir, useCache); cacheErr != nil {
 		return Resolution{}, cacheErr
 	} else if ok {
-		return res, nil
+		return stampRegistryVersion(res, st, cacheVersion), nil
 	}
 
 	// Coalesce cacheable fetches; non-cacheable results carry per-call Cleanup.
@@ -178,9 +178,20 @@ func (r *GoGetterResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedMod
 		if sfErr != nil {
 			return Resolution{}, sfErr
 		}
-		return v.(Resolution), nil
+		return stampRegistryVersion(v.(Resolution), st, cacheVersion), nil
 	}
-	return r.fetchAndCommit(ctx, st, mod, cacheVersion, selectedSubdir, useCache)
+	res, err := r.fetchAndCommit(ctx, st, mod, cacheVersion, selectedSubdir, useCache)
+	if err != nil {
+		return Resolution{}, err
+	}
+	return stampRegistryVersion(res, st, cacheVersion), nil
+}
+
+func stampRegistryVersion(res Resolution, sourceType, version string) Resolution {
+	if sourceType == sourceTypeRegistry && version != "" {
+		res.ResolvedVersion = version
+	}
+	return res
 }
 
 func (r *GoGetterResolver) fetchAndCommit(

--- a/pkg/parser/terraform/modules/resolver/localref.go
+++ b/pkg/parser/terraform/modules/resolver/localref.go
@@ -238,6 +238,7 @@ func (r *LocalGitRefResolver) Resolve(ctx context.Context, mod *tfmodules.Parsed
 			resolution, err := ConfineResolution(ctx, Resolution{
 				LocalPath:   filepath.Join(packageRoot, filepath.FromSlash(subdir)),
 				PackageRoot: packageRoot,
+				ResolvedRef: ref,
 			})
 			if err != nil {
 				release()
@@ -282,6 +283,7 @@ func (r *LocalGitRefResolver) Resolve(ctx context.Context, mod *tfmodules.Parsed
 	resolution, err := ConfineResolution(ctx, Resolution{
 		LocalPath:   filepath.Join(packageRoot, filepath.FromSlash(subdir)),
 		PackageRoot: packageRoot,
+		ResolvedRef: sha,
 	})
 	if err != nil {
 		release()

--- a/pkg/parser/terraform/modules/resolver/registry.go
+++ b/pkg/parser/terraform/modules/resolver/registry.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -25,9 +26,6 @@ const (
 
 	discoveryResponseLimit = 64 * 1024
 	versionsResponseLimit  = 128 * 1024
-
-	publicRegistrySourceParts  = 3 // namespace/name/provider
-	privateRegistrySourceParts = 4 // host/namespace/name/provider
 )
 
 func appendGetterSubdir(getterURL, subdir string) string {
@@ -63,24 +61,19 @@ func splitGetterSubdir(getterURL string) (packageURL, subdir string) {
 
 // parseRegistrySource splits public (ns/name/provider) or private (host/ns/name/provider) sources.
 func parseRegistrySource(source string) (host, namespace, name, provider string, err error) {
-	source, _, _ = strings.Cut(source, "//")
-	parts := strings.Split(source, "/")
-	switch len(parts) {
-	case publicRegistrySourceParts:
-		return defaultRegistryHost, parts[0], parts[1], parts[2], nil
-	case privateRegistrySourceParts:
-		return parts[0], parts[1], parts[2], parts[3], nil
-	default:
-		return "", "", "", "", fmt.Errorf("invalid registry source %q: expected namespace/name/provider", source)
+	addr, err := tfmodules.ParseRegistryModuleSource(source)
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("invalid registry source %q: %w", source, err)
 	}
+	return addr.Host, addr.Namespace, addr.Name, addr.Provider, nil
 }
 
 func registrySubdir(source string) string {
-	_, subdir, ok := strings.Cut(source, "//")
-	if !ok {
+	addr, err := tfmodules.ParseRegistryModuleSource(source)
+	if err != nil {
 		return ""
 	}
-	return strings.TrimPrefix(subdir, "/")
+	return addr.Subdir
 }
 
 type serviceDiscovery struct {
@@ -135,14 +128,14 @@ type versionsResponse struct {
 // resolveRegistryVersion picks the highest published version satisfying constraint (empty → latest).
 func resolveRegistryVersion(
 	ctx context.Context, client *http.Client,
-	modulesV1, namespace, name, provider, constraint string,
+	modulesV1, namespace, name, provider, constraint, registryHost string,
 ) (string, error) {
 	rawURL := fmt.Sprintf("%s%s/%s/%s/versions", modulesV1, namespace, name, provider)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
 	if err != nil {
 		return "", err
 	}
-	addRegistryToken(req, req.URL.Hostname())
+	addRegistryToken(req, registryHost)
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -163,8 +156,9 @@ func resolveRegistryVersion(
 		return "", fmt.Errorf("no versions published")
 	}
 
+	allowPrerelease := constraintAllowsPrerelease(constraint)
 	if constraint == "" {
-		best, ok := selectBestVersion(vr, nil)
+		best, ok := selectBestVersion(vr, nil, allowPrerelease)
 		if !ok {
 			return "", fmt.Errorf("no parseable versions published")
 		}
@@ -175,20 +169,27 @@ func resolveRegistryVersion(
 	if err != nil {
 		return "", fmt.Errorf("invalid version constraint %q: %w", constraint, err)
 	}
-	best, ok := selectBestVersion(vr, cs)
+	best, ok := selectBestVersion(vr, cs, allowPrerelease)
 	if !ok {
 		return "", fmt.Errorf("no published version satisfies constraint %q", constraint)
 	}
 	return best.Original(), nil
 }
 
+func constraintAllowsPrerelease(constraint string) bool {
+	return strings.Contains(constraint, "-")
+}
+
 // selectBestVersion returns the highest published version satisfying cs (nil = any parseable version).
-func selectBestVersion(vr versionsResponse, cs goversion.Constraints) (*goversion.Version, bool) {
+func selectBestVersion(vr versionsResponse, cs goversion.Constraints, allowPrerelease bool) (*goversion.Version, bool) {
 	var best *goversion.Version
 	for _, mod := range vr.Modules {
 		for _, v := range mod.Versions {
 			sv, err := goversion.NewVersion(v.Version)
 			if err != nil || (cs != nil && !cs.Check(sv)) {
+				continue
+			}
+			if sv.Prerelease() != "" && !allowPrerelease {
 				continue
 			}
 			if best == nil || sv.GreaterThan(best) {
@@ -242,9 +243,16 @@ func isBareVersion(s string) bool {
 	return s != ""
 }
 
+func registryCredentialHost(rawHost string) string {
+	if host, _, err := net.SplitHostPort(rawHost); err == nil {
+		return host
+	}
+	return rawHost
+}
+
 // addRegistryToken sets Authorization from TF_TOKEN_<host> (dots/hyphens → underscores).
 func addRegistryToken(req *http.Request, rawHost string) {
-	envKey := "TF_TOKEN_" + strings.NewReplacer(".", "_", "-", "_").Replace(rawHost)
+	envKey := "TF_TOKEN_" + strings.NewReplacer(".", "_", "-", "_").Replace(registryCredentialHost(rawHost))
 	if tok := os.Getenv(envKey); tok != "" {
 		req.Header.Set("Authorization", "Bearer "+tok)
 	}

--- a/pkg/parser/terraform/modules/resolver/registry_cache.go
+++ b/pkg/parser/terraform/modules/resolver/registry_cache.go
@@ -102,95 +102,60 @@ func (c *registryCache) rememberFailure(mu *sync.RWMutex, failures map[string]ca
 	mu.Unlock()
 }
 
-func (c *registryCache) modulesV1(ctx context.Context, host string) (string, error) {
-	c.discMu.RLock()
-	if ep, ok := c.discMap[host]; ok {
-		c.discMu.RUnlock()
-		return ep, nil
+func (c *registryCache) cachedString(
+	mu *sync.RWMutex,
+	values map[string]string,
+	failures map[string]cachedFailure,
+	sf *singleflight.Group,
+	key string,
+	fetch func() (string, error),
+) (string, error) {
+	mu.RLock()
+	if v, ok := values[key]; ok {
+		mu.RUnlock()
+		return v, nil
 	}
-	c.discMu.RUnlock()
-	if cachedErr, ok := c.lookupFailure(&c.discMu, c.discErrMap, host); ok {
+	mu.RUnlock()
+	if cachedErr, ok := c.lookupFailure(mu, failures, key); ok {
 		return "", cachedErr
 	}
 
-	v, err, _ := c.discSF.Do(host, func() (interface{}, error) {
-		ep, err := discoverModulesEndpoint(ctx, c.client, "https://"+host)
+	v, err, _ := sf.Do(key, func() (interface{}, error) {
+		value, err := fetch()
 		if err != nil {
-			c.rememberFailure(&c.discMu, c.discErrMap, host, err)
+			c.rememberFailure(mu, failures, key, err)
 			return "", err
 		}
-		c.discMu.Lock()
-		c.discMap[host] = ep
-		delete(c.discErrMap, host)
-		c.discMu.Unlock()
-		return ep, nil
+		mu.Lock()
+		values[key] = value
+		delete(failures, key)
+		mu.Unlock()
+		return value, nil
 	})
 	if err != nil {
 		return "", err
 	}
 	return v.(string), nil
+}
+
+func (c *registryCache) modulesV1(ctx context.Context, host string) (string, error) {
+	return c.cachedString(&c.discMu, c.discMap, c.discErrMap, &c.discSF, host, func() (string, error) {
+		return discoverModulesEndpoint(ctx, c.client, "https://"+host)
+	})
 }
 
 func (c *registryCache) resolvedVersion(ctx context.Context, ep, host, namespace, name, provider, constraint string) (string, error) {
 	key := host + "\x00" + namespace + "/" + name + "/" + provider + "\x00" + constraint
-
-	c.verMu.RLock()
-	if v, ok := c.verMap[key]; ok {
-		c.verMu.RUnlock()
-		return v, nil
-	}
-	c.verMu.RUnlock()
-	if cachedErr, ok := c.lookupFailure(&c.verMu, c.verErrMap, key); ok {
-		return "", cachedErr
-	}
-
-	v, err, _ := c.verSF.Do(key, func() (interface{}, error) {
-		resolved, err := resolveRegistryVersion(ctx, c.client, ep, namespace, name, provider, constraint, host)
-		if err != nil {
-			c.rememberFailure(&c.verMu, c.verErrMap, key, err)
-			return "", err
-		}
-		c.verMu.Lock()
-		c.verMap[key] = resolved
-		delete(c.verErrMap, key)
-		c.verMu.Unlock()
-		return resolved, nil
+	return c.cachedString(&c.verMu, c.verMap, c.verErrMap, &c.verSF, key, func() (string, error) {
+		return resolveRegistryVersion(ctx, c.client, ep, namespace, name, provider, constraint, host)
 	})
-	if err != nil {
-		return "", err
-	}
-	return v.(string), nil
 }
 
 func (c *registryCache) downloadURL(ctx context.Context, ep, host, namespace, name, provider, version string) (string, error) {
 	key := host + "\x00" + namespace + "/" + name + "/" + provider + "@" + version
-
-	c.dlMu.RLock()
-	if v, ok := c.dlMap[key]; ok {
-		c.dlMu.RUnlock()
-		return v, nil
-	}
-	c.dlMu.RUnlock()
-	if cachedErr, ok := c.lookupFailure(&c.dlMu, c.dlErrMap, key); ok {
-		return "", cachedErr
-	}
-
-	v, err, _ := c.dlSF.Do(key, func() (interface{}, error) {
-		dlURL, err := registryDownloadURL(ctx, c.client, ep, namespace, name, provider, version, host)
-		if err != nil {
-			c.rememberFailure(&c.dlMu, c.dlErrMap, key, err)
-			return "", err
-		}
-		c.dlMu.Lock()
-		c.dlMap[key] = dlURL
-		delete(c.dlErrMap, key)
-		c.dlMu.Unlock()
-		return dlURL, nil
+	return c.cachedString(&c.dlMu, c.dlMap, c.dlErrMap, &c.dlSF, key, func() (string, error) {
+		return registryDownloadURL(ctx, c.client, ep, namespace, name, provider, version, host)
 	})
-	if err != nil {
-		return "", err
-	}
-	return v.(string), nil
 }
 
 func (c *registryCache) resolveConcreteVersion(ctx context.Context, source, version string) (string, error) {

--- a/pkg/parser/terraform/modules/resolver/registry_cache.go
+++ b/pkg/parser/terraform/modules/resolver/registry_cache.go
@@ -145,7 +145,7 @@ func (c *registryCache) resolvedVersion(ctx context.Context, ep, host, namespace
 	}
 
 	v, err, _ := c.verSF.Do(key, func() (interface{}, error) {
-		resolved, err := resolveRegistryVersion(ctx, c.client, ep, namespace, name, provider, constraint)
+		resolved, err := resolveRegistryVersion(ctx, c.client, ep, namespace, name, provider, constraint, host)
 		if err != nil {
 			c.rememberFailure(&c.verMu, c.verErrMap, key, err)
 			return "", err

--- a/pkg/parser/terraform/modules/resolver/registry_test.go
+++ b/pkg/parser/terraform/modules/resolver/registry_test.go
@@ -75,6 +75,7 @@ func TestResolveRegistryVersionInvalidConstraint(t *testing.T) {
 		"vpc",
 		"aws",
 		"var.module_version",
+		defaultRegistryHost,
 	)
 
 	if err == nil || !strings.Contains(err.Error(), "invalid version constraint") {
@@ -102,6 +103,7 @@ func TestResolveRegistryVersionEmptyConstraintUsesHighestSemver(t *testing.T) {
 		"vpc",
 		"aws",
 		"",
+		defaultRegistryHost,
 	)
 
 	if err != nil {
@@ -134,6 +136,110 @@ func TestResolveConcreteVersionBareVersionSkipsDiscovery(t *testing.T) {
 	}
 }
 
+func TestResolveRegistryVersionSkipsUnrequestedPrerelease(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(
+					`{"modules":[{"versions":[{"version":"2.0.0"},{"version":"3.0.0-beta.1"}]}]}`,
+				)),
+				Header:  make(http.Header),
+				Request: req,
+			}, nil
+		}),
+	}
+
+	got, err := resolveRegistryVersion(
+		context.Background(),
+		client,
+		"https://registry.terraform.io/v1/modules/",
+		"terraform-aws-modules",
+		"vpc",
+		"aws",
+		"",
+		defaultRegistryHost,
+	)
+	if err != nil {
+		t.Fatalf("resolveRegistryVersion: %v", err)
+	}
+	if got != "2.0.0" {
+		t.Fatalf("version = %q, want 2.0.0", got)
+	}
+}
+
+func TestResolveRegistryVersionConstraintCanSelectPrerelease(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(
+					`{"modules":[{"versions":[{"version":"2.0.0"},{"version":"3.0.0-beta.1"}]}]}`,
+				)),
+				Header:  make(http.Header),
+				Request: req,
+			}, nil
+		}),
+	}
+
+	got, err := resolveRegistryVersion(
+		context.Background(),
+		client,
+		"https://registry.terraform.io/v1/modules/",
+		"terraform-aws-modules",
+		"vpc",
+		"aws",
+		">= 3.0.0-beta.1",
+		defaultRegistryHost,
+	)
+	if err != nil {
+		t.Fatalf("resolveRegistryVersion: %v", err)
+	}
+	if got != "3.0.0-beta.1" {
+		t.Fatalf("version = %q, want 3.0.0-beta.1", got)
+	}
+}
+
+func TestResolveRegistryVersionUsesRegistryHostToken(t *testing.T) {
+	t.Setenv("TF_TOKEN_registry_example_com", "secret-token")
+	var auth, requestHost string
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			auth = req.Header.Get("Authorization")
+			requestHost = req.URL.Hostname()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"modules":[{"versions":[{"version":"1.0.0"}]}]}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	got, err := resolveRegistryVersion(
+		context.Background(),
+		client,
+		"https://modules.other.example/v1/modules/",
+		"ns",
+		"name",
+		"aws",
+		"1.0.0",
+		"registry.example.com:8443",
+	)
+	if err != nil {
+		t.Fatalf("resolveRegistryVersion: %v", err)
+	}
+	if got != "1.0.0" {
+		t.Fatalf("version = %q, want 1.0.0", got)
+	}
+	if requestHost != "modules.other.example" {
+		t.Fatalf("request host = %q, want modules.other.example", requestHost)
+	}
+	if auth != "Bearer secret-token" {
+		t.Fatalf("authorization = %q, want registry-host token", auth)
+	}
+}
+
 func TestParseRegistrySourceWithSubdir(t *testing.T) {
 	host, namespace, name, provider, err := parseRegistrySource("terraform-aws-modules/eks/aws//modules/karpenter")
 	if err != nil {
@@ -144,6 +250,19 @@ func TestParseRegistrySourceWithSubdir(t *testing.T) {
 	}
 	if got := registrySubdir("terraform-aws-modules/eks/aws//modules/karpenter"); got != "modules/karpenter" {
 		t.Fatalf("subdir = %q, want modules/karpenter", got)
+	}
+}
+
+func TestParseRegistrySourceWithHostPort(t *testing.T) {
+	host, namespace, name, provider, err := parseRegistrySource("registry.example.com:8443/ns/name/aws//modules/child")
+	if err != nil {
+		t.Fatalf("parseRegistrySource: %v", err)
+	}
+	if host != "registry.example.com:8443" || namespace != "ns" || name != "name" || provider != "aws" {
+		t.Fatalf("unexpected source parts: %q %q %q %q", host, namespace, name, provider)
+	}
+	if got := registrySubdir("registry.example.com:8443/ns/name/aws//modules/child"); got != "modules/child" {
+		t.Fatalf("subdir = %q, want modules/child", got)
 	}
 }
 

--- a/pkg/parser/terraform/modules/resolver/resolver.go
+++ b/pkg/parser/terraform/modules/resolver/resolver.go
@@ -16,9 +16,11 @@ import (
 
 // Resolution holds an acquired package, its selected module directory, and optional cleanup.
 type Resolution struct {
-	LocalPath   string
-	PackageRoot string
-	Cleanup     func() // optional post-scan cleanup
+	LocalPath       string
+	PackageRoot     string
+	ResolvedVersion string
+	ResolvedRef     string
+	Cleanup         func() // optional post-scan cleanup
 }
 
 func withResolutionCleanup(res Resolution, cleanup func()) Resolution {

--- a/pkg/parser/terraform/modules/resolver/resource_budget.go
+++ b/pkg/parser/terraform/modules/resolver/resource_budget.go
@@ -72,13 +72,37 @@ type ResourceBudget struct {
 	packages            map[string]PackageUsage
 	total               PackageUsage
 	acquisitionReserved int64
+	acquisitionChanged  chan struct{}
 }
 
 func NewResourceBudget(limits ResourceLimits) *ResourceBudget {
 	return &ResourceBudget{
-		limits:   limits,
-		packages: make(map[string]PackageUsage),
+		limits:             limits,
+		packages:           make(map[string]PackageUsage),
+		acquisitionChanged: make(chan struct{}),
 	}
+}
+
+type AcquisitionLease struct {
+	budget *ResourceBudget
+	bytes  int64
+	once   sync.Once
+}
+
+func (l *AcquisitionLease) Bytes() int64 {
+	if l == nil {
+		return 0
+	}
+	return l.bytes
+}
+
+func (l *AcquisitionLease) Release() {
+	if l == nil {
+		return
+	}
+	l.once.Do(func() {
+		l.budget.releaseAcquisition(l.bytes)
+	})
 }
 
 func WithResourceBudget(ctx context.Context, budget *ResourceBudget) context.Context {
@@ -127,33 +151,80 @@ func (b *ResourceBudget) AdmitPackage(identity string, usage PackageUsage) error
 	b.packages[identity] = usage
 	b.total.Bytes += usage.Bytes
 	b.total.Files += usage.Files
+	b.notifyAcquisitionChangedLocked()
 	return nil
 }
 
-func (b *ResourceBudget) ReserveAcquisition(maximum, requested int64) (int64, bool) {
+func (b *ResourceBudget) TryAcquireAcquisition(maximum, requested int64) (*AcquisitionLease, bool) {
 	if b == nil || maximum <= 0 {
-		return 0, false
+		return nil, false
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	return b.tryAcquireAcquisitionLocked(maximum, requested)
+}
+
+func (b *ResourceBudget) AcquireAcquisition(
+	ctx context.Context, maximum, requested int64,
+) (*AcquisitionLease, bool) {
+	if b == nil || maximum <= 0 {
+		return nil, false
+	}
+	for {
+		b.mu.Lock()
+		if lease, ok := b.tryAcquireAcquisitionLocked(maximum, requested); ok {
+			b.mu.Unlock()
+			return lease, true
+		}
+		if b.total.Bytes >= maximum {
+			b.mu.Unlock()
+			return nil, false
+		}
+		if b.acquisitionChanged == nil {
+			b.acquisitionChanged = make(chan struct{})
+		}
+		changed := b.acquisitionChanged
+		b.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return nil, false
+		case <-changed:
+		}
+	}
+}
+
+func (b *ResourceBudget) tryAcquireAcquisitionLocked(
+	maximum, requested int64,
+) (*AcquisitionLease, bool) {
 	available := maximum - b.total.Bytes - b.acquisitionReserved
 	if available <= 0 {
-		return 0, false
+		return nil, false
 	}
 	if requested <= 0 || requested > available {
 		requested = available
 	}
 	b.acquisitionReserved += requested
-	return requested, true
+	return &AcquisitionLease{budget: b, bytes: requested}, true
 }
 
-func (b *ResourceBudget) ReleaseAcquisition(reserved int64) {
+func (b *ResourceBudget) releaseAcquisition(reserved int64) {
 	if b == nil || reserved <= 0 {
 		return
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.acquisitionReserved -= reserved
+	b.notifyAcquisitionChangedLocked()
+}
+
+func (b *ResourceBudget) notifyAcquisitionChangedLocked() {
+	if b.acquisitionChanged == nil {
+		b.acquisitionChanged = make(chan struct{})
+		return
+	}
+	close(b.acquisitionChanged)
+	b.acquisitionChanged = make(chan struct{})
 }
 
 func (b *ResourceBudget) Usage(identity string) (PackageUsage, bool) {

--- a/pkg/parser/terraform/modules/resolver/resource_budget_test.go
+++ b/pkg/parser/terraform/modules/resolver/resource_budget_test.go
@@ -6,10 +6,12 @@
 package resolver
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -78,17 +80,62 @@ func TestResourceBudgetReservesAcquisitionAgainstUsage(t *testing.T) {
 	budget := NewResourceBudget(ResourceLimits{})
 	require.NoError(t, budget.AdmitPackage("/tmp/a", PackageUsage{Bytes: 4}))
 
-	reserved, ok := budget.ReserveAcquisition(10, 8)
+	lease, ok := budget.TryAcquireAcquisition(10, 8)
 	require.True(t, ok)
-	require.Equal(t, int64(6), reserved)
+	require.Equal(t, int64(6), lease.Bytes())
 
-	_, ok = budget.ReserveAcquisition(10, 1)
+	_, ok = budget.TryAcquireAcquisition(10, 1)
 	require.False(t, ok)
-	budget.ReleaseAcquisition(reserved)
+	lease.Release()
+	lease.Release()
 
-	reserved, ok = budget.ReserveAcquisition(10, 3)
+	lease, ok = budget.TryAcquireAcquisition(10, 3)
 	require.True(t, ok)
-	require.Equal(t, int64(3), reserved)
+	require.Equal(t, int64(3), lease.Bytes())
+}
+
+func TestResourceBudgetWaitsForAcquisitionCapacity(t *testing.T) {
+	t.Parallel()
+
+	budget := NewResourceBudget(ResourceLimits{})
+	first, ok := budget.TryAcquireAcquisition(10, 10)
+	require.True(t, ok)
+
+	type result struct {
+		lease *AcquisitionLease
+		ok    bool
+	}
+	acquired := make(chan result, 1)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	go func() {
+		lease, acquiredOK := budget.AcquireAcquisition(ctx, 10, 5)
+		acquired <- result{lease: lease, ok: acquiredOK}
+	}()
+
+	first.Release()
+	second := <-acquired
+	require.True(t, second.ok)
+	require.Equal(t, int64(5), second.lease.Bytes())
+	second.lease.Release()
+}
+
+func TestResourceBudgetStopsWaitingWhenUsageExhaustsAcquisition(t *testing.T) {
+	t.Parallel()
+
+	budget := NewResourceBudget(ResourceLimits{})
+	first, ok := budget.TryAcquireAcquisition(10, 10)
+	require.True(t, ok)
+
+	acquired := make(chan bool, 1)
+	go func() {
+		_, acquiredOK := budget.AcquireAcquisition(t.Context(), 10, 1)
+		acquired <- acquiredOK
+	}()
+
+	require.NoError(t, budget.AdmitPackage("/tmp/a", PackageUsage{Bytes: 10}))
+	first.Release()
+	require.False(t, <-acquired)
 }
 
 func TestMeasurePackageStopsAtConfiguredLimit(t *testing.T) {


### PR DESCRIPTION
## Motivation

Requested version constraints were treated as the version that was actually fetched, and that string was appended to every module source. That leaked operators and whitespace into reported paths and made git sources carry a version Terraform ignores. Related ticket: [K9CODESEC-5293](https://datadoghq.atlassian.net/browse/K9CODESEC-5293).

## Changes

**Source classification**

Registry addresses are parsed with `opentofu/registry-address`. Implicit three-part sources still map to `registry.terraform.io`. Hosts with ports and `//subdir` selections classify correctly.

**Registry resolution**

Version-list requests authenticate with `TF_TOKEN_*` for the registry host, not the `modules.v1` hostname. Unpinned or stable constraints skip prereleases unless the constraint names one.

**Reported identity**

`ResolvedModule` keeps the requested `Version` for lookup and records `ResolvedVersion` and `ResolvedRef`. Canonical URLs append a concrete version for registry sources only. `git::https` still does not require SSH host keys.

## Author Checklist

- [ ] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/parser/terraform/modules ./pkg/parser/terraform/modules/resolver ./pkg/parser/terraform/modules/modulegraph ./pkg/engine ./pkg/scan -count=1`
2. Confirm a constrained registry fixture reports `ResolvedVersion` as a concrete semver and a canonical source without `~>` or spaces.
3. Confirm a git module with `version = "1.2.3"` keeps that constraint off `CanonicalSource`.

## Blast Radius

This PR only changes Terraform remote-module classification, registry version selection, and the identity fields recorded during resolution. Scan findings that currently embed a requested constraint in the module path will start using the resolved registry version instead.

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-5293]: https://datadoghq.atlassian.net/browse/K9CODESEC-5293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ