### PR TITLE
[K9CODESEC-5295] Emit module attribution in scanner SARIF

### DIFF
--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -229,13 +229,46 @@ type Inspector struct {
 	// fsys is the filesystem used for Terraform module resolution. Defaults to
 	// the real disk; the HTTP server injects an in-memory FS built from pushed
 	// content.
-	fsys              vfs.FS
-	remoteModuleDirs  map[string]RemoteModuleDirectory
-	externalPathRoots map[string]bool
+	fsys                   vfs.FS
+	remoteModuleDirs       map[string]RemoteModuleDirectory
+	remoteModuleProvenance map[string]RemoteModuleProvenance
+	externalPathRoots      map[string]bool
 }
 
 func (c *Inspector) SetRemoteModuleDirectories(sourceToDir map[string]RemoteModuleDirectory) {
 	c.remoteModuleDirs = sourceToDir
+}
+
+func (c *Inspector) SetRemoteModuleProvenance(sourceToProvenance map[string]RemoteModuleProvenance) {
+	c.remoteModuleProvenance = sourceToProvenance
+}
+
+func (c *Inspector) buildModuleProvenanceLookup() moduleProvenanceLookup {
+	return func(callerRoot, source, version, moduleName string) (RemoteModuleProvenance, bool) {
+		if c.remoteModuleProvenance != nil {
+			for _, key := range []string{
+				RemoteModuleCallKey(callerRoot, source, version, moduleName),
+				RemoteModuleCallKey(callerRoot, source, "", moduleName),
+				RemoteModuleKey(callerRoot, source, version),
+				RemoteModuleKey(callerRoot, source, ""),
+			} {
+				if prov, ok := c.remoteModuleProvenance[key]; ok {
+					return prov, true
+				}
+			}
+		}
+		if c.remoteModuleDirs != nil {
+			if directory, ok := lookupRemoteDir(c.remoteModuleDirs, callerRoot, source, version, moduleName); ok {
+				sourceType, _ := tfmodules.DetectModuleSourceType(source)
+				return RemoteModuleProvenance{
+					Source:     source,
+					SourceType: sourceType,
+					ModuleRoot: directory.Path,
+				}, true
+			}
+		}
+		return RemoteModuleProvenance{}, false
+	}
 }
 
 func (c *Inspector) SetExternalModulePaths(paths []string) {
@@ -608,6 +641,12 @@ func expandModuleFindings(vulns []model.Vulnerability, extras map[string][]extra
 			vCopy := vulns[i]
 			vCopy.ModuleCallChain = ex.callChain
 			vCopy.FileID = ex.docID
+			vCopy.ModuleAttribution = moduleAttributionForResource(
+				ex.attributions,
+				vCopy.ResourceType,
+				vCopy.BlockLocation.Start.Line,
+				vCopy.BlockLocation.Start.Col,
+			)
 			expanded = append(expanded, vCopy)
 		}
 	}
@@ -1025,7 +1064,8 @@ func rulePathExcluded(filePath string, ignorePaths, onlyPaths []string) bool {
 func (c *Inspector) isExternalModulePath(filePath string) bool {
 	for root := range c.externalPathRoots {
 		rel, err := filepath.Rel(root, filepath.Clean(filePath))
-		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		if err == nil && rel != parentDirectoryPath &&
+			!strings.HasPrefix(rel, parentDirectoryPath+string(os.PathSeparator)) {
 			return true
 		}
 	}

--- a/pkg/engine/module_attribution.go
+++ b/pkg/engine/module_attribution.go
@@ -1,0 +1,332 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package engine
+
+import (
+	"net/url"
+	pathpkg "path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/tfeval"
+)
+
+const (
+	moduleDependencyDirect     = "direct"
+	moduleDependencyTransitive = "transitive"
+	moduleSourceTypeGit        = "git"
+	moduleSourceTypeLocal      = "local"
+	moduleSourceTypeRegistry   = "registry"
+	moduleSourceSchemeFile     = "file"
+	parentDirectoryPath        = ".."
+)
+
+// RemoteModuleProvenance holds resolved identity for a remote module call site.
+type RemoteModuleProvenance struct {
+	Source          string
+	ResolvedVersion string
+	ResolvedRef     string
+	CanonicalSource string
+	SourceType      string
+	ModuleRoot      string
+}
+
+type moduleProvenanceLookup func(callerRoot, source, version, moduleName string) (RemoteModuleProvenance, bool)
+
+func buildModuleAttribution(
+	r *tfeval.ResolvedResource,
+	repoPath string,
+	moduleRoot string,
+	lookup moduleProvenanceLookup,
+) *model.ModuleAttribution {
+	if r == nil || len(r.CallChain) == 0 {
+		return nil
+	}
+
+	path := buildModulePath(r.CallChain, repoPath, lookup)
+	if len(path) == 0 {
+		return nil
+	}
+
+	leaf := path[len(path)-1]
+	dependencyType := moduleDependencyDirect
+	if len(path) > 1 {
+		dependencyType = moduleDependencyTransitive
+	}
+
+	bodyFile := moduleRelativePath(r.DefinedIn, moduleRoot, repoPath)
+	bodyEnd := r.DefEndLine
+	if bodyEnd < r.DefLine {
+		bodyEnd = r.DefLine
+	}
+
+	var modulePath []model.ModulePathHop
+	if len(path) > 1 {
+		modulePath = path
+	}
+	return &model.ModuleAttribution{
+		Name:           leaf.Name,
+		Source:         leaf.Source,
+		SourceType:     leaf.SourceType,
+		Version:        leaf.Version,
+		DependencyType: dependencyType,
+		CodeLocation:   path[0].CodeLocation,
+		ModuleCodeLocation: model.SourceLocation{
+			Filename:    bodyFile,
+			LineStart:   r.DefLine,
+			LineEnd:     bodyEnd,
+			ColumnStart: r.DefColumn,
+			ColumnEnd:   r.DefEndColumn,
+		},
+		ModulePath:      modulePath,
+		ModuleCodeOwned: leaf.SourceType == moduleSourceTypeLocal && pathWithinRoot(moduleRoot, repoPath),
+	}
+}
+
+func buildModulePath(
+	chain []tfeval.CallSite,
+	repoPath string,
+	lookup moduleProvenanceLookup,
+) []model.ModulePathHop {
+	path := make([]model.ModulePathHop, 0, len(chain))
+	for i, site := range chain {
+		location := declarationLocation(
+			site.CalledFrom,
+			site.CalledLine,
+			site.CalledEndLine,
+			site.CalledColumn,
+			site.CalledEndColumn,
+			repoPath,
+		)
+		if i > 0 {
+			location.Filename = filepath.ToSlash(filepath.Base(site.CalledFrom))
+		}
+		hop := model.ModulePathHop{
+			Name:         site.ModuleName,
+			CodeLocation: location,
+		}
+		enrichModuleHop(&hop, moduleCallerRoot(site.CalledFrom, repoPath), repoPath, &site, lookup)
+		path = append(path, hop)
+	}
+	return path
+}
+
+func enrichModuleHop(
+	hop *model.ModulePathHop,
+	callerRoot string,
+	repoPath string,
+	site *tfeval.CallSite,
+	lookup moduleProvenanceLookup,
+) {
+	sourceType, _ := tfmodules.DetectModuleSourceType(site.Source)
+	hop.SourceType = sourceType
+	hop.Source = normalizedModuleSource(site.Source, sourceType, callerRoot, repoPath)
+
+	if lookup != nil {
+		if prov, ok := lookup(callerRoot, site.Source, site.Version, site.ModuleName); ok {
+			if prov.SourceType != "" {
+				hop.SourceType = prov.SourceType
+			}
+			source := firstNonEmpty(prov.CanonicalSource, prov.Source, site.Source)
+			hop.Source = normalizedModuleSource(source, hop.SourceType, callerRoot, repoPath)
+			switch hop.SourceType {
+			case moduleSourceTypeRegistry:
+				hop.Version = strings.TrimSpace(prov.ResolvedVersion)
+			case moduleSourceTypeGit:
+				hop.Version = strings.TrimSpace(prov.ResolvedRef)
+			}
+			return
+		}
+	}
+}
+
+func normalizedModuleSource(source, sourceType, callerRoot, repoPath string) string {
+	source = strings.TrimSpace(source)
+	if sourceType == moduleSourceTypeRegistry {
+		source = strings.SplitN(source, "@", 2)[0]
+		if addr, err := tfmodules.ParseRegistryModuleSource(source); err == nil {
+			return addr.String()
+		}
+	}
+	if sourceType == moduleSourceTypeLocal {
+		localSource := strings.TrimPrefix(source, "git::")
+		if parsed, err := url.Parse(localSource); err == nil && parsed.Scheme == moduleSourceSchemeFile {
+			localSource = fileURLPath(parsed.Path)
+		}
+		if portablePathIsAbs(localSource) && !filepath.IsAbs(localSource) {
+			return portablePathBase(localSource)
+		}
+		target := absPath(localSource, callerRoot)
+		if pathWithinRoot(target, repoPath) {
+			rel, _ := filepath.Rel(filepath.Clean(repoPath), target)
+			return filepath.ToSlash(rel)
+		}
+		return filepath.Base(filepath.Clean(target))
+	}
+	source = strings.TrimPrefix(source, "git::")
+	source = strings.SplitN(source, "?", 2)[0]
+	if parsed, err := url.Parse(source); err == nil && parsed.Scheme != "" {
+		if parsed.Scheme == moduleSourceSchemeFile {
+			return normalizedFileModuleSource(parsed.Path)
+		}
+		parsed.User = nil
+		source = parsed.String()
+	} else if at := strings.Index(source, "@"); at > 0 && strings.Contains(source[at+1:], ":") {
+		source = source[at+1:]
+	}
+	source = strings.Replace(source, ".git//", "//", 1)
+	return strings.TrimSuffix(source, ".git")
+}
+
+func normalizedFileModuleSource(path string) string {
+	path = filepath.ToSlash(filepath.Clean(path))
+	if packageEnd := strings.Index(path, ".git/"); packageEnd >= 0 {
+		subdir := strings.TrimPrefix(path[packageEnd+len(".git/"):], "/")
+		name := filepath.Base(path[:packageEnd])
+		if subdir != "" {
+			return name + "//" + subdir
+		}
+		return name
+	}
+	return strings.TrimSuffix(filepath.Base(path), ".git")
+}
+
+func fileURLPath(value string) string {
+	if len(value) >= 3 && value[0] == '/' && value[2] == ':' {
+		value = value[1:]
+	}
+	return filepath.FromSlash(value)
+}
+
+func portablePathIsAbs(value string) bool {
+	value = strings.ReplaceAll(value, `\`, "/")
+	return strings.HasPrefix(value, "/") ||
+		(len(value) >= 3 && value[1] == ':' && value[2] == '/')
+}
+
+func portablePathBase(value string) string {
+	return pathpkg.Base(strings.ReplaceAll(value, `\`, "/"))
+}
+
+func declarationLocation(
+	filePath string,
+	startLine, endLine, startColumn, endColumn int,
+	repoPath string,
+) model.SourceLocation {
+	if endLine < startLine {
+		endLine = startLine
+	}
+	filename := repoRelativeFile(filePath, repoPath)
+	return model.SourceLocation{
+		Filename:    filename,
+		LineStart:   startLine,
+		LineEnd:     endLine,
+		ColumnStart: startColumn,
+		ColumnEnd:   endColumn,
+	}
+}
+
+func pathWithinRoot(path, root string) bool {
+	if path == "" || root == "" {
+		return false
+	}
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	return err == nil && rel != parentDirectoryPath &&
+		!strings.HasPrefix(rel, parentDirectoryPath+string(filepath.Separator))
+}
+
+func repoRelativeFile(filePath, repoPath string) string {
+	abs := absPath(filePath, repoPath)
+	rel, err := filepath.Rel(filepath.Clean(repoPath), abs)
+	if err != nil {
+		return filepath.ToSlash(filepath.Base(abs))
+	}
+	return filepath.ToSlash(rel)
+}
+
+func moduleCallerRoot(calledFrom, repoPath string) string {
+	return filepath.Clean(filepath.Dir(absPath(calledFrom, repoPath)))
+}
+
+func moduleRelativePath(definedIn, moduleRoot, repoPath string) string {
+	absDefined := absPath(definedIn, repoPath)
+	if moduleRoot != "" {
+		rel, err := filepath.Rel(filepath.Clean(moduleRoot), absDefined)
+		if err == nil && pathWithinRoot(absDefined, moduleRoot) {
+			return filepath.ToSlash(rel)
+		}
+	}
+	return repoRelativeFile(absDefined, repoPath)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func cloneModuleAttribution(attr *model.ModuleAttribution) *model.ModuleAttribution {
+	if attr == nil {
+		return nil
+	}
+	clone := *attr
+	if len(attr.ModulePath) > 0 {
+		clone.ModulePath = append([]model.ModulePathHop(nil), attr.ModulePath...)
+	}
+	return &clone
+}
+
+func moduleAttributionKey(resourceType string, definitionLine, definitionColumn int) string {
+	return resourceType + "." + strconv.Itoa(definitionLine) + "." + strconv.Itoa(definitionColumn)
+}
+
+func cloneModuleAttributions(attrs map[string]*model.ModuleAttribution) map[string]*model.ModuleAttribution {
+	if len(attrs) == 0 {
+		return nil
+	}
+	out := make(map[string]*model.ModuleAttribution, len(attrs))
+	for key, attr := range attrs {
+		out[key] = cloneModuleAttribution(attr)
+	}
+	return out
+}
+
+func moduleAttributionForResource(
+	attrs map[string]*model.ModuleAttribution,
+	resourceType string,
+	definitionLine, definitionColumn int,
+) *model.ModuleAttribution {
+	if len(attrs) > 0 {
+		if attr, ok := attrs[moduleAttributionKey(resourceType, definitionLine, definitionColumn)]; ok {
+			return cloneModuleAttribution(attr)
+		}
+	}
+	return nil
+}
+
+func moduleRootForResource(r *tfeval.ResolvedResource, repoPath string, lookup moduleProvenanceLookup) string {
+	if r == nil || len(r.CallChain) == 0 {
+		return ""
+	}
+	leaf := r.CallChain[len(r.CallChain)-1]
+	callerRoot := moduleCallerRoot(leaf.CalledFrom, repoPath)
+	if lookup != nil {
+		if prov, ok := lookup(callerRoot, leaf.Source, leaf.Version, leaf.ModuleName); ok && prov.ModuleRoot != "" {
+			return prov.ModuleRoot
+		}
+	}
+	if len(r.CallChain) > 0 &&
+		tfmodules.LooksLikeLocalModuleSource(strings.TrimPrefix(leaf.Source, "git::")) {
+		return filepath.Dir(absPath(r.DefinedIn, repoPath))
+	}
+	return ""
+}

--- a/pkg/engine/module_attribution_sarif_integration_test.go
+++ b/pkg/engine/module_attribution_sarif_integration_test.go
@@ -1,0 +1,134 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	reportModel "github.com/DataDog/datadog-iac-scanner/pkg/report/model"
+	"github.com/stretchr/testify/require"
+)
+
+const displayNameAclRule = `package datadog
+
+DatadogPolicy contains result if {
+	some label, i
+	bucket := input.document[i].resource.aws_s3_bucket[label]
+	bucket.acl == "public-read"
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_s3_bucket",
+		"resourceName": bucket.bucket,
+		"searchKey": sprintf("aws_s3_bucket[%s].acl", [label]),
+	}
+}
+`
+
+func TestInspect_ModuleAttribution_EndToEndSARIF(t *testing.T) {
+	root := t.TempDir()
+
+	rootDir := filepath.Join(root, "stack")
+	modDir := filepath.Join(root, "modules", "bucket")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+
+	rootPath := filepath.Join(rootDir, "main.tf")
+	modPath := filepath.Join(modDir, "main.tf")
+
+	require.NoError(t, os.WriteFile(rootPath, []byte(`
+module "bucket" {
+  source = "../modules/bucket"
+  acl    = "public-read"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(modPath, []byte(`
+variable "acl" {
+  type = string
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = "customer-bucket"
+  acl    = var.acl
+}
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, rootPath)...)
+	files = append(files, parseTerraform(t, modPath)...)
+
+	queries := []model.QueryMetadata{{
+		Query:       "acl_rule",
+		Content:     displayNameAclRule,
+		InputData:   "{}",
+		Platform:    "terraform",
+		Metadata:    map[string]interface{}{"id": "acl-rule"},
+		Aggregation: 1,
+	}}
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries:       queries,
+		repoPath:      root,
+		vb:            DefaultVulnerabilityBuilder,
+		flagEvaluator: moduleEvalEnabled(),
+	})
+
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
+	require.NoError(t, err)
+	require.Len(t, vulns, 1)
+	require.Equal(t, "customer-bucket", vulns[0].ResourceName)
+
+	summary := model.CreateSummary(context.Background(), model.Counters{}, vulns, "test", nil, root, model.SCIInfo{})
+	require.Len(t, summary.Queries, 1)
+	require.Len(t, summary.Queries[0].Files, 1)
+	require.NotNil(t, summary.Queries[0].Files[0].ModuleAttribution)
+
+	report := reportModel.NewSarifReport()
+	_, err = report.BuildSarifIssue(context.Background(), &summary.Queries[0], model.SCIInfo{})
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(report)
+	require.NoError(t, err)
+
+	var doc struct {
+		Runs []struct {
+			Results []struct {
+				Locations []struct {
+					PhysicalLocation struct {
+						ArtifactLocation struct {
+							URI string `json:"uri"`
+						} `json:"artifactLocation"`
+						Region struct {
+							StartLine int `json:"startLine"`
+							EndLine   int `json:"endLine"`
+						} `json:"region"`
+					} `json:"physicalLocation"`
+				} `json:"locations"`
+				Properties map[string]json.RawMessage `json:"properties"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.Len(t, doc.Runs, 1)
+	require.Len(t, doc.Runs[0].Results, 1)
+
+	result := doc.Runs[0].Results[0]
+	require.Equal(t, "stack/main.tf", result.Locations[0].PhysicalLocation.ArtifactLocation.URI)
+	require.Equal(t, 2, result.Locations[0].PhysicalLocation.Region.StartLine)
+	require.GreaterOrEqual(t, result.Locations[0].PhysicalLocation.Region.EndLine, 2)
+
+	moduleRaw, ok := result.Properties["module"]
+	require.True(t, ok)
+	require.Contains(t, string(moduleRaw), `"name":"bucket"`)
+	require.Contains(t, string(moduleRaw), `"source":"modules/bucket"`)
+	require.Contains(t, string(moduleRaw), `"code_location"`)
+	require.NotContains(t, string(moduleRaw), `"module_path"`)
+}

--- a/pkg/engine/module_attribution_test.go
+++ b/pkg/engine/module_attribution_test.go
@@ -1,0 +1,335 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/tfeval"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildModuleAttributionDirectLocalModule(t *testing.T) {
+	repo := t.TempDir()
+	moduleDir := writeLocalModuleFixture(t, repo, "modules/bucket", `
+resource "aws_s3_bucket" "this" {
+  acl = var.acl
+}
+`)
+	callerPath := writeCallerFixture(t, repo, "stack/main.tf", `
+module "bucket" {
+  source = "../modules/bucket"
+  acl    = "public-read"
+}
+`)
+
+	resource := tfeval.ResolvedResource{
+		Type:          "aws_s3_bucket",
+		Name:          "this",
+		DefinedIn:     filepath.Join(moduleDir, "main.tf"),
+		DefLine:       2,
+		DefEndLine:    4,
+		DefColumn:     1,
+		DefEndColumn:  2,
+		ModuleAddress: "module.bucket",
+		CallChain: []tfeval.CallSite{{
+			ModuleName:      "bucket",
+			Source:          "../modules/bucket",
+			CalledFrom:      callerPath,
+			CalledLine:      2,
+			CalledEndLine:   5,
+			CalledColumn:    1,
+			CalledEndColumn: 2,
+		}},
+	}
+
+	attr := buildModuleAttribution(&resource, repo, moduleDir, nil)
+	require.NotNil(t, attr)
+	require.Equal(t, "direct", attr.DependencyType)
+	require.Equal(t, "stack/main.tf", attr.CodeLocation.Filename)
+	require.Equal(t, 2, attr.CodeLocation.LineStart)
+	require.Equal(t, 5, attr.CodeLocation.LineEnd)
+	require.Equal(t, 1, attr.CodeLocation.ColumnStart)
+	require.Equal(t, 2, attr.CodeLocation.ColumnEnd)
+	require.Equal(t, "bucket", attr.Name)
+	require.Equal(t, "modules/bucket", attr.Source)
+	require.Equal(t, "local", attr.SourceType)
+	require.Equal(t, "main.tf", attr.ModuleCodeLocation.Filename)
+	require.Equal(t, 2, attr.ModuleCodeLocation.LineStart)
+	require.Equal(t, 1, attr.ModuleCodeLocation.ColumnStart)
+	require.Equal(t, 2, attr.ModuleCodeLocation.ColumnEnd)
+	require.True(t, attr.ModuleCodeOwned)
+	require.Empty(t, attr.ModulePath)
+}
+
+func TestBuildModuleAttributionRemoteModuleUsesProvenance(t *testing.T) {
+	repo := t.TempDir()
+	callerPath := writeCallerFixture(t, repo, "stack/main.tf", `
+module "bucket" {
+  source  = "registry.example.com/acme/bucket/aws"
+  version = "1.0.0"
+  acl     = "public-read"
+}
+`)
+	moduleBody := filepath.Join(repo, "cache", "main.tf")
+	resource := tfeval.ResolvedResource{
+		Type:          "aws_s3_bucket",
+		Name:          "this",
+		DefinedIn:     moduleBody,
+		DefLine:       8,
+		DefEndLine:    10,
+		ModuleAddress: "module.bucket",
+		CallChain: []tfeval.CallSite{{
+			ModuleName:    "bucket",
+			Source:        "registry.example.com/acme/bucket/aws",
+			Version:       "1.0.0",
+			CalledFrom:    callerPath,
+			CalledLine:    2,
+			CalledEndLine: 6,
+		}},
+	}
+	lookup := moduleProvenanceLookup(func(_, _, _, _ string) (RemoteModuleProvenance, bool) {
+		return RemoteModuleProvenance{
+			Source:          "registry.example.com/acme/bucket/aws",
+			ResolvedVersion: "1.0.0",
+			CanonicalSource: "registry.example.com/acme/bucket/aws",
+			SourceType:      "registry",
+			ModuleRoot:      filepath.Join(repo, "cache"),
+		}, true
+	})
+
+	attr := buildModuleAttribution(&resource, repo, filepath.Join(repo, "cache"), lookup)
+	require.NotNil(t, attr)
+	require.Equal(t, "bucket", attr.Name)
+	require.Equal(t, "registry.example.com/acme/bucket/aws", attr.Source)
+	require.Equal(t, "registry", attr.SourceType)
+	require.Equal(t, "1.0.0", attr.Version)
+	require.Equal(t, "main.tf", attr.ModuleCodeLocation.Filename)
+	require.Equal(t, "stack/main.tf", attr.CodeLocation.Filename)
+	require.Empty(t, attr.ModulePath)
+	require.False(t, attr.ModuleCodeOwned)
+}
+
+func TestBuildModuleAttributionUsesSelectedRemoteModuleRoot(t *testing.T) {
+	repo := t.TempDir()
+	callerPath := writeCallerFixture(t, repo, "stack/main.tf", `
+module "vpc" {
+  source = "git::https://example.com/acme/network.git//modules/vpc?ref=v1.0.0"
+}
+`)
+	moduleRoot := filepath.Join(repo, "cache", "modules", "vpc")
+	resource := tfeval.ResolvedResource{
+		Type:      "aws_vpc",
+		Name:      "this",
+		DefinedIn: filepath.Join(moduleRoot, "main.tf"),
+		DefLine:   3,
+		CallChain: []tfeval.CallSite{{
+			ModuleName: "vpc",
+			Source:     "git::https://example.com/acme/network.git//modules/vpc?ref=v1.0.0",
+			CalledFrom: callerPath,
+			CalledLine: 2,
+		}},
+	}
+	lookup := moduleProvenanceLookup(func(_, _, _, _ string) (RemoteModuleProvenance, bool) {
+		return RemoteModuleProvenance{
+			Source:     resource.CallChain[0].Source,
+			SourceType: "git",
+			ModuleRoot: moduleRoot,
+		}, true
+	})
+
+	attr := buildModuleAttribution(
+		&resource, repo, moduleRootForResource(&resource, repo, lookup), lookup,
+	)
+	require.NotNil(t, attr)
+	require.Equal(t, "main.tf", attr.ModuleCodeLocation.Filename)
+}
+
+func TestBuildModuleAttributionUsesOnlyConcreteResolvedVersion(t *testing.T) {
+	repo := t.TempDir()
+	callerPath := writeCallerFixture(t, repo, "stack/main.tf", `
+module "bucket" {
+  source  = "registry.example.com/acme/bucket/aws"
+  version = "~> 1.0"
+}
+`)
+	resource := tfeval.ResolvedResource{
+		Type:      "aws_s3_bucket",
+		Name:      "this",
+		DefinedIn: filepath.Join(repo, "cache", "main.tf"),
+		DefLine:   2,
+		CallChain: []tfeval.CallSite{{
+			ModuleName: "bucket",
+			Source:     "registry.example.com/acme/bucket/aws",
+			Version:    "~> 1.0",
+			CalledFrom: callerPath,
+			CalledLine: 2,
+		}},
+	}
+
+	attr := buildModuleAttribution(&resource, repo, filepath.Join(repo, "cache"), nil)
+	require.NotNil(t, attr)
+	require.Empty(t, attr.Version)
+}
+
+func TestBuildModuleAttributionUsesResolvedGitRefAsVersion(t *testing.T) {
+	repo := t.TempDir()
+	callerPath := writeCallerFixture(t, repo, "stack/main.tf", `
+module "vpc" {
+  source = "git::https://user:token@example.com/acme/network.git//modules/vpc?ref=v3.2.0"
+}
+`)
+	resource := tfeval.ResolvedResource{
+		Type:      "aws_vpc",
+		Name:      "this",
+		DefinedIn: filepath.Join(repo, "cache", "main.tf"),
+		DefLine:   2,
+		CallChain: []tfeval.CallSite{{
+			ModuleName: "vpc",
+			Source:     "git::https://user:token@example.com/acme/network.git//modules/vpc?ref=v3.2.0",
+			CalledFrom: callerPath,
+			CalledLine: 2,
+		}},
+	}
+	lookup := moduleProvenanceLookup(func(_, _, _, _ string) (RemoteModuleProvenance, bool) {
+		return RemoteModuleProvenance{
+			Source:          resource.CallChain[0].Source,
+			ResolvedRef:     "45ea6a143c2d",
+			CanonicalSource: resource.CallChain[0].Source,
+			SourceType:      "git",
+			ModuleRoot:      filepath.Join(repo, "cache"),
+		}, true
+	})
+
+	attr := buildModuleAttribution(&resource, repo, filepath.Join(repo, "cache"), lookup)
+	require.NotNil(t, attr)
+	require.Equal(t, "https://example.com/acme/network//modules/vpc", attr.Source)
+	require.Equal(t, "45ea6a143c2d", attr.Version)
+}
+
+func TestNormalizedModuleSourceDoesNotExposeExternalLocalPaths(t *testing.T) {
+	repo := t.TempDir()
+
+	require.Equal(t, "shared", normalizedModuleSource("/Users/example/shared", "local", repo, repo))
+	require.Equal(t, "shared", normalizedModuleSource("../../../Users/example/shared", "local", repo, repo))
+	require.Equal(t, "shared", normalizedModuleSource("file:///Users/example/shared", "local", repo, repo))
+	require.Equal(t, "shared", normalizedModuleSource(`C:\Users\example\shared`, "local", repo, repo))
+	require.Equal(
+		t,
+		"network//modules/vpc",
+		normalizedModuleSource(
+			"git::file:///Users/example/network.git//modules/vpc?ref=v1.0.0",
+			"git",
+			repo,
+			repo,
+		),
+	)
+	require.Equal(
+		t,
+		"github.com:acme/network",
+		normalizedModuleSource("token@github.com:acme/network.git?ref=v1.0.0", "git", repo, repo),
+	)
+}
+
+func TestBuildModuleAttributionTransitiveHopUsesCallerDirectory(t *testing.T) {
+	repo := t.TempDir()
+	rootCaller := writeCallerFixture(t, repo, "stack/main.tf", `
+module "wrapper" {
+  source = "../modules/wrapper"
+}
+`)
+	wrapperCaller := writeCallerFixture(t, repo, "modules/wrapper/main.tf", `
+module "bucket" {
+  source  = "registry.example.com/acme/bucket/aws"
+  version = "1.0.0"
+}
+`)
+	_ = wrapperCaller
+	moduleBody := filepath.Join(repo, "cache", "main.tf")
+	wrapperRoot := filepath.Join(repo, "modules", "wrapper")
+	lookup := moduleProvenanceLookup(func(callerRoot, _, _, moduleName string) (RemoteModuleProvenance, bool) {
+		if callerRoot == wrapperRoot && moduleName == "bucket" {
+			return RemoteModuleProvenance{
+				Source:          "registry.example.com/acme/bucket/aws",
+				ResolvedVersion: "1.0.0",
+				CanonicalSource: "registry.example.com/acme/bucket/aws",
+				SourceType:      "registry",
+				ModuleRoot:      filepath.Join(repo, "cache"),
+			}, true
+		}
+		return RemoteModuleProvenance{}, false
+	})
+	resource := tfeval.ResolvedResource{
+		Type:          "aws_s3_bucket",
+		Name:          "this",
+		DefinedIn:     moduleBody,
+		DefLine:       2,
+		ModuleAddress: "module.wrapper.module.bucket",
+		CallChain: []tfeval.CallSite{
+			{
+				ModuleName: "wrapper",
+				Source:     "../modules/wrapper",
+				CalledFrom: rootCaller,
+				CalledLine: 2,
+			},
+			{
+				ModuleName: "bucket",
+				Source:     "registry.example.com/acme/bucket/aws",
+				Version:    "1.0.0",
+				CalledFrom: wrapperCaller,
+				CalledLine: 2,
+			},
+		},
+	}
+
+	attr := buildModuleAttribution(&resource, repo, filepath.Join(repo, "cache"), lookup)
+	require.NotNil(t, attr)
+	require.Equal(t, "transitive", attr.DependencyType)
+	require.Len(t, attr.ModulePath, 2)
+	require.Equal(t, "modules/wrapper", attr.ModulePath[0].Source)
+	require.Equal(t, "stack/main.tf", attr.ModulePath[0].CodeLocation.Filename)
+	require.Equal(t, "registry.example.com/acme/bucket/aws", attr.ModulePath[1].Source)
+	require.Equal(t, "1.0.0", attr.ModulePath[1].Version)
+	require.Equal(t, "main.tf", attr.ModulePath[1].CodeLocation.Filename)
+	require.Equal(t, "main.tf", attr.ModuleCodeLocation.Filename)
+}
+
+func TestModuleAttributionForResourceSelectsMatchingResource(t *testing.T) {
+	attrs := map[string]*model.ModuleAttribution{
+		"aws_s3_bucket.5.1": {
+			Name:               "a",
+			ModuleCodeLocation: model.SourceLocation{Filename: "a.tf", LineStart: 5},
+		},
+		"aws_s3_bucket.5.3": {
+			Name:               "b",
+			ModuleCodeLocation: model.SourceLocation{Filename: "b.tf", LineStart: 5},
+		},
+	}
+
+	got := moduleAttributionForResource(attrs, "aws_s3_bucket", 5, 3)
+	require.NotNil(t, got)
+	require.Equal(t, "b", got.Name)
+	require.Equal(t, 5, got.ModuleCodeLocation.LineStart)
+}
+
+func writeLocalModuleFixture(t *testing.T, repo, relDir, body string) string {
+	t.Helper()
+	dir := filepath.Join(repo, relDir)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(body), 0o644))
+	return dir
+}
+
+func writeCallerFixture(t *testing.T, repo, relPath, body string) string {
+	t.Helper()
+	path := filepath.Join(repo, relPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+	return path
+}

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -26,8 +26,9 @@ import (
 // extraCallerInfo records a deduplicated module caller so its findings can be
 // cloned from the primary OPA doc after eval without adding a separate doc to input.document.
 type extraCallerInfo struct {
-	callChain string
-	docID     string
+	callChain    string
+	docID        string
+	attributions map[string]*model.ModuleAttribution
 }
 
 // moduleResolutionResult bundles all outputs of resolveModuleDocuments.
@@ -301,7 +302,7 @@ func (c *Inspector) resolveModulesSafely(
 			res = moduleResolutionResult{}
 		}
 	}()
-	return resolveModuleDocuments(ctx, files, c.repoPath, resolver, targets)
+	return resolveModuleDocuments(ctx, files, c.repoPath, resolver, targets, c.buildModuleProvenanceLookup())
 }
 
 // resolveModuleDocuments instantiates all local modules referenced by the
@@ -321,6 +322,7 @@ func evaluateRootModules(
 	repoPath string,
 	resolver tfeval.RemoteResolver,
 	targets *ruleTargets,
+	lookup moduleProvenanceLookup,
 	byAbsPath map[string]*model.FileMetadata,
 	seen map[docContentKey]string,
 	extras map[string][]extraCallerInfo,
@@ -352,7 +354,7 @@ func evaluateRootModules(
 			actualCalledDirs[d] = true
 		}
 		docs, syn, count := instantiatedDocs(
-			resources, byAbsPath, repoPath, targets, seen, extras, instantiated)
+			resources, byAbsPath, repoPath, targets, seen, extras, instantiated, lookup)
 		*extra = append(*extra, docs...)
 		*syntheticFiles = append(*syntheticFiles, syn...)
 		*resourceCount += count
@@ -433,6 +435,7 @@ func resolveModuleDocuments(
 	repoPath string,
 	resolver tfeval.RemoteResolver,
 	targets *ruleTargets,
+	lookup moduleProvenanceLookup,
 ) moduleResolutionResult {
 	byAbsPath, filesByDir, dirsWithTf := indexTerraformFiles(ctx, files, repoPath)
 	if len(dirsWithTf) == 0 {
@@ -486,7 +489,7 @@ func resolveModuleDocuments(
 	sort.Strings(roots)
 
 	evaluateRootModules(
-		ctx, evaluator, roots, filesByDir, repoPath, resolver, targets,
+		ctx, evaluator, roots, filesByDir, repoPath, resolver, targets, lookup,
 		byAbsPath, seen, extras, instantiated,
 		successfulRoots, unresolvedModuleDirs, actualCalledDirs,
 		&extra, &syntheticFiles, &resourceCount, &rootEvalOK,
@@ -557,6 +560,7 @@ type docGroup struct {
 	moduleAddress string
 	layer         int
 	entries       []instantiatedResource
+	attributions  map[string]*model.ModuleAttribution
 }
 
 // docContentKey identifies a document by its content. Two independent digests
@@ -593,6 +597,7 @@ func instantiatedDocs(
 	seen map[docContentKey]string,
 	extras map[string][]extraCallerInfo,
 	instantiated instantiatedIndex,
+	lookup moduleProvenanceLookup,
 ) (docs []model.Document, synthetic []*model.FileMetadata, resourceCount int) {
 	groups := make(map[string]*docGroup)
 	var order []string
@@ -636,10 +641,16 @@ func instantiatedDocs(
 		key := cck + "\x00" + fm.ID + "\x00" + strconv.Itoa(layer)
 		g, exists := groups[key]
 		if !exists {
-			g = &docGroup{fm: fm, callChain: cck, moduleAddress: r.ModuleAddress, layer: layer}
+			g = &docGroup{
+				fm: fm, callChain: cck, moduleAddress: r.ModuleAddress, layer: layer,
+				attributions: make(map[string]*model.ModuleAttribution),
+			}
 			groups[key] = g
 			order = append(order, key)
 		}
+		moduleRoot := moduleRootForResource(r, repoPath, lookup)
+		g.attributions[moduleAttributionKey(r.Type, r.DefLine, r.DefColumn)] =
+			buildModuleAttribution(r, repoPath, moduleRoot, lookup)
 		g.entries = append(g.entries, entry)
 		// Recorded before deduplication: a document that dedupes away still
 		// covers its resource, through a finding cloned onto its call site.
@@ -656,8 +667,9 @@ func instantiatedDocs(
 		contentKey := groupContentKey(g)
 		if primaryDocID, dup := seen[contentKey]; dup {
 			extras[primaryDocID] = append(extras[primaryDocID], extraCallerInfo{
-				callChain: g.callChain,
-				docID:     docID,
+				callChain:    g.callChain,
+				docID:        docID,
+				attributions: cloneModuleAttributions(g.attributions),
 			})
 			continue
 		}
@@ -679,7 +691,7 @@ func instantiatedDocs(
 			"file":     g.fm.FilePath,
 			"resource": resource,
 		})
-		synthetic = append(synthetic, newInstanceFileMetadata(g.fm, docID, g.callChain))
+		synthetic = append(synthetic, newInstanceFileMetadata(g.fm, docID, g.callChain, g.attributions))
 	}
 	return docs, synthetic, resourceCount
 }
@@ -759,11 +771,14 @@ func (h contentHasher) key() docContentKey {
 }
 
 // newInstanceFileMetadata clones fm for a synthetic doc (empty Document so Combine skips it).
-func newInstanceFileMetadata(fm *model.FileMetadata, id, callChain string) *model.FileMetadata {
+func newInstanceFileMetadata(
+	fm *model.FileMetadata, id, callChain string, attributions map[string]*model.ModuleAttribution,
+) *model.FileMetadata {
 	clone := fm.ShallowCopy()
 	clone.ID = id
 	clone.Document = model.Document{}
 	clone.ModuleCallChain = callChain
+	clone.ModuleAttributions = cloneModuleAttributions(attributions)
 	if fm.LineInfoDocument != nil {
 		// Already materialized: shallow-clone so later mutations on the
 		// parent (e.g. deleting a suppressed "resource" key) don't alias

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -131,6 +131,13 @@ resource "aws_s3_bucket" "this" {
 	require.Equal(t, "main.tf", filepath.Base(v.FileName))
 	require.Equal(t, modPath, v.FileName, "finding should be reported at the module resource definition")
 	require.Greater(t, v.Line, 0, "line should be detected in the module file")
+	require.NotNil(t, v.ModuleAttribution)
+	require.Equal(t, "stack/main.tf", v.ModuleAttribution.CodeLocation.Filename)
+	require.Equal(t, "direct", v.ModuleAttribution.DependencyType)
+	require.Equal(t, "bucket", v.ModuleAttribution.Name)
+	require.Equal(t, "modules/bucket", v.ModuleAttribution.Source)
+	require.Equal(t, "main.tf", v.ModuleAttribution.ModuleCodeLocation.Filename)
+	require.Empty(t, v.ModuleAttribution.ModulePath)
 }
 
 // Two roots call the same module with the same inputs: expect two findings and two distinct ModuleCallChain values.

--- a/pkg/engine/module_resolve_nesting_test.go
+++ b/pkg/engine/module_resolve_nesting_test.go
@@ -81,7 +81,7 @@ func TestResolveModuleDocuments_DeepFanOutStaysAffordable(t *testing.T) {
 	const depth, branch = 12, 2
 	root, files := writeDeepFanOut(t, depth, branch)
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 
 	if res.resourceCount == 0 {
 		t.Fatal("expected the nested module tree to instantiate resources, got none")
@@ -106,7 +106,7 @@ func TestResolveModuleDocuments_DeepFanOutStaysAffordable(t *testing.T) {
 func TestResolveModuleDocuments_NoDirectorySuppressedWithoutReplacement(t *testing.T) {
 	root, files := writeBudgetFanOut(t, 6, 4)
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 
 	if res.resourceCount == 0 {
 		t.Fatal("expected resources to be instantiated")
@@ -178,7 +178,7 @@ func TestResolveModuleDocuments_PartiallyResolvedModuleKeepsItsBody(t *testing.T
 	// Comfortably past the evaluator's depth cap, so the chain is cut short.
 	root, files := writePartiallyResolvedShare(t, 25)
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 
 	if !res.ok {
 		t.Fatal("expected module resolution to succeed for the shallow call")

--- a/pkg/engine/module_resolve_remote_integration_test.go
+++ b/pkg/engine/module_resolve_remote_integration_test.go
@@ -82,9 +82,27 @@ func remoteModuleKey(callerRoot string) string {
 }
 
 func registerRemoteBucket(ins *Inspector, callerRoot, cacheDir string) {
-	ins.SetRemoteModuleDirectories(map[string]RemoteModuleDirectory{
-		remoteModuleKey(callerRoot): {Path: cacheDir, PackageRoot: cacheDir},
-	})
+	directory := RemoteModuleDirectory{Path: cacheDir, PackageRoot: cacheDir}
+	provenance := RemoteModuleProvenance{
+		Source:          remoteBucketSource,
+		ResolvedVersion: remoteBucketVersion,
+		CanonicalSource: remoteBucketSource,
+		SourceType:      "registry",
+		ModuleRoot:      cacheDir,
+	}
+	keys := []string{
+		RemoteModuleKey(callerRoot, remoteBucketSource, remoteBucketVersion),
+		RemoteModuleCallKey(callerRoot, remoteBucketSource, remoteBucketVersion, "bucket"),
+		RemoteModuleCallKey(callerRoot, remoteBucketSource, "", "bucket"),
+	}
+	dirs := make(map[string]RemoteModuleDirectory, len(keys))
+	provs := make(map[string]RemoteModuleProvenance, len(keys))
+	for _, key := range keys {
+		dirs[key] = directory
+		provs[key] = provenance
+	}
+	ins.SetRemoteModuleDirectories(dirs)
+	ins.SetRemoteModuleProvenance(provs)
 }
 
 func inspectRemoteBucket(t *testing.T, fx remoteBucketFixture, callerPaths []string, rule string) []model.Vulnerability {
@@ -124,6 +142,11 @@ module "bucket" {
 	require.Len(t, vulns, 1)
 	require.Equal(t, fx.modPath, vulns[0].FileName)
 	require.NotEmpty(t, vulns[0].ModuleCallChain)
+	require.NotNil(t, vulns[0].ModuleAttribution)
+	require.Equal(t, "stack/main.tf", vulns[0].ModuleAttribution.CodeLocation.Filename)
+	require.Equal(t, remoteBucketSource, vulns[0].ModuleAttribution.Source)
+	require.Equal(t, remoteBucketVersion, vulns[0].ModuleAttribution.Version)
+	require.Equal(t, "main.tf", vulns[0].ModuleAttribution.ModuleCodeLocation.Filename)
 }
 
 func TestInspect_RemoteModule_SecureCallerOverridesInsecureDefault(t *testing.T) {

--- a/pkg/engine/module_resolve_test.go
+++ b/pkg/engine/module_resolve_test.go
@@ -194,6 +194,7 @@ resource "aws_s3_bucket" "replica" {
 		make(map[docContentKey]string),
 		make(map[string][]extraCallerInfo),
 		make(instantiatedIndex),
+		nil,
 	)
 
 	if len(docs) != 2 {
@@ -267,7 +268,7 @@ resource "aws_s3_bucket" "this" { bucket = var.name }
 		t.Fatalf("remove stack-b: %v", err)
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 	if !res.ok {
 		t.Fatal("expected partial module resolution to succeed")
 	}
@@ -322,7 +323,7 @@ resource "aws_s3_bucket" "this" {
 		t.Fatalf("remove failed root: %v", err)
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 	if !res.ok {
 		t.Fatal("expected the other root to evaluate successfully")
 	}
@@ -353,7 +354,7 @@ resource "aws_s3_bucket" "replica" {
 		fileMeta("mod-id", modFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 	if !res.ok {
 		t.Fatal("expected module resolution to succeed")
 	}
@@ -392,7 +393,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", modFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -532,7 +533,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", filepath.Join("modules", "bucket", "main.tf")),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -603,7 +604,7 @@ func TestResolveModuleDocuments_DocumentsDoNotGrowWithCallSites(t *testing.T) {
 
 	for _, roots := range []int{1, 4, 32} {
 		repo, files := writeFanOut(t, roots, false)
-		res := resolveModuleDocuments(context.Background(), files, repo, nil, nil)
+		res := resolveModuleDocuments(context.Background(), files, repo, nil, nil, nil)
 		if !res.ok {
 			t.Fatalf("roots=%d: resolveModuleDocuments ok = false", roots)
 		}
@@ -622,7 +623,7 @@ func TestResolveModuleDocuments_DocumentsDoNotGrowWithCallSites(t *testing.T) {
 
 	// Different inputs genuinely produce different content, so those do scale.
 	repo, files := writeFanOut(t, 8, true)
-	res := resolveModuleDocuments(context.Background(), files, repo, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, repo, nil, nil, nil)
 	if len(res.docs) != 8*modFiles {
 		t.Fatalf("%d documents for 8 differing roots, want %d", len(res.docs), 8*modFiles)
 	}
@@ -632,7 +633,7 @@ func TestResolveModuleDocuments_DocumentsDoNotGrowWithCallSites(t *testing.T) {
 // document holding that file's resources, and nothing else.
 func TestResolveModuleDocuments_DocumentMirrorsItsFile(t *testing.T) {
 	repo, files := writeFanOut(t, 1, false)
-	res := resolveModuleDocuments(context.Background(), files, repo, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, repo, nil, nil, nil)
 	if !res.ok {
 		t.Fatal("resolveModuleDocuments ok = false")
 	}
@@ -671,7 +672,7 @@ func TestResolveModuleDocuments_DocumentIDsAreStable(t *testing.T) {
 	repo, files := writeFanOut(t, 8, false)
 
 	snapshot := func() ([]string, map[string][]string) {
-		res := resolveModuleDocuments(context.Background(), files, repo, nil, nil)
+		res := resolveModuleDocuments(context.Background(), files, repo, nil, nil, nil)
 		ids := make([]string, 0, len(res.docs))
 		for _, doc := range res.docs {
 			ids = append(ids, doc["id"].(string))
@@ -739,7 +740,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", modFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -822,7 +823,7 @@ resource "aws_s3_bucket" "this" {
 		fileMeta("mod-id", modFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -867,7 +868,7 @@ func TestNewInstanceFileMetadata_LineInfoDocumentNotAliased(t *testing.T) {
 			},
 		},
 	}
-	synth := newInstanceFileMetadata(fm, "synth-id", "stack|module.x")
+	synth := newInstanceFileMetadata(fm, "synth-id", "stack|module.x", nil)
 	delete(fm.LineInfoDocument, "resource")
 	if _, ok := synth.LineInfoDocument["resource"]; !ok {
 		t.Fatal("synthetic LineInfoDocument must keep resource after suppression on parent")
@@ -919,7 +920,7 @@ resource "aws_s3_bucket" "this" { bucket = var.name }
 		fileMeta("mod-b", modBFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}
@@ -957,7 +958,7 @@ module "bucket" {
 		fileMeta("root-id", filepath.Join("stack", "main.tf")),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 	if res.ok {
 		t.Fatalf("resolveModuleDocuments ok = true, want false when all roots fail")
 	}
@@ -984,7 +985,7 @@ resource "aws_s3_bucket" "this" {
 
 	files := model.FileMetadatas{fileMeta("orphan-id", orphanFile)}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true for orphan root")
 	}
@@ -1027,7 +1028,7 @@ resource "aws_s3_bucket" "leaf" {
 		fileMeta("leaf-id", leafFile),
 	}
 
-	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil, nil)
 	if !res.ok {
 		t.Fatalf("resolveModuleDocuments ok = false, want true")
 	}

--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -222,6 +222,12 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 		FileSource:            linesVulne.FileSource,
 		BlockLocation:         linesVulne.BlockLocation,
 		ModuleCallChain:       file.ModuleCallChain,
+		ModuleAttribution: moduleAttributionForResource(
+			file.ModuleAttributions,
+			resourceType,
+			linesVulne.BlockLocation.Start.Line,
+			linesVulne.BlockLocation.Start.Col,
+		),
 		Frameworks: append(extractDefaultFrameworks(ctx, qCtx.Query.Metadata.Metadata, qCtx.FlagEvaluator),
 			extractCustomFrameworks(ctx, qCtx.Query.Metadata.Metadata, qCtx.FlagEvaluator)...),
 	}, nil

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -167,6 +167,9 @@ type FileMetadata struct {
 	IsMinified        bool
 	// ModuleCallChain: synthetic rows for instantiated local modules; used in SARIF fingerprint (Terraform only).
 	ModuleCallChain string
+	// ModuleAttributions maps resourceType.resourceName to attribution when a synthetic
+	// document groups multiple module resources from the same file.
+	ModuleAttributions map[string]*ModuleAttribution
 	// Platform is the lowercased platform the file was classified as (e.g.
 	// "ansible", "kubernetes", "terraform"); "" when undetermined. Used by the
 	// engine to evaluate each query only against documents of its own platform.
@@ -292,6 +295,8 @@ type Vulnerability struct {
 	SuppressionJustification string `json:"suppressionJustification,omitempty"`
 	// ModuleCallChain: local-module instantiation path; empty for root resources; folded into fingerprint.
 	ModuleCallChain string `json:"moduleCallChain,omitempty"`
+	// ModuleAttribution: declaration and body locations for instantiated module findings.
+	ModuleAttribution *ModuleAttribution `json:"-"`
 }
 
 // Framework represents a framework mapping for a query

--- a/pkg/model/module_attribution.go
+++ b/pkg/model/module_attribution.go
@@ -1,0 +1,38 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package model
+
+// SourceLocation is a filename plus an inclusive line range.
+type SourceLocation struct {
+	Filename    string `json:"filename,omitempty"`
+	LineStart   int    `json:"line_start,omitempty"`
+	LineEnd     int    `json:"line_end,omitempty"`
+	ColumnStart int    `json:"-"`
+	ColumnEnd   int    `json:"-"`
+}
+
+// ModulePathHop is one module call on the path to a finding.
+type ModulePathHop struct {
+	Name         string         `json:"name,omitempty"`
+	Source       string         `json:"source,omitempty"`
+	SourceType   string         `json:"source_type,omitempty"`
+	Version      string         `json:"version,omitempty"`
+	CodeLocation SourceLocation `json:"code_location,omitempty"`
+}
+
+// ModuleAttribution carries module provenance for instantiated Terraform findings.
+// CodeLocation is repo-relative on the customer-owned root module declaration.
+type ModuleAttribution struct {
+	Name               string          `json:"name,omitempty"`
+	Source             string          `json:"source,omitempty"`
+	SourceType         string          `json:"source_type,omitempty"`
+	Version            string          `json:"version,omitempty"`
+	DependencyType     string          `json:"dependency_type,omitempty"`
+	CodeLocation       SourceLocation  `json:"-"`
+	ModuleCodeLocation SourceLocation  `json:"code_location,omitempty"`
+	ModulePath         []ModulePathHop `json:"module_path,omitempty"`
+	ModuleCodeOwned    bool            `json:"-"`
+}

--- a/pkg/model/module_attribution_sarif.go
+++ b/pkg/model/module_attribution_sarif.go
@@ -1,0 +1,50 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package model
+
+// ModuleAttributionSARIF is the properties.module payload emitted for instantiated findings.
+type ModuleAttributionSARIF struct {
+	Name               string          `json:"name,omitempty"`
+	Source             string          `json:"source,omitempty"`
+	SourceType         string          `json:"source_type,omitempty"`
+	Version            string          `json:"version,omitempty"`
+	DependencyType     string          `json:"dependency_type,omitempty"`
+	ModuleCodeLocation SourceLocation  `json:"code_location,omitempty"`
+	ModulePath         []ModulePathHop `json:"module_path,omitempty"`
+}
+
+func ModuleAttributionForSARIF(attr *ModuleAttribution) *ModuleAttributionSARIF {
+	if attr == nil {
+		return nil
+	}
+	return &ModuleAttributionSARIF{
+		Name:               attr.Name,
+		Source:             sanitizeModuleSource(attr.Source),
+		SourceType:         attr.SourceType,
+		Version:            attr.Version,
+		DependencyType:     attr.DependencyType,
+		ModuleCodeLocation: attr.ModuleCodeLocation,
+		ModulePath:         sanitizeModulePath(attr.ModulePath),
+	}
+}
+
+func sanitizeModuleSource(source string) string {
+	if source == "" {
+		return ""
+	}
+	return removeURLCredentials(source)
+}
+
+func sanitizeModulePath(path []ModulePathHop) []ModulePathHop {
+	if len(path) == 0 {
+		return nil
+	}
+	out := append([]ModulePathHop(nil), path...)
+	for i := range out {
+		out[i].Source = sanitizeModuleSource(out[i].Source)
+	}
+	return out
+}

--- a/pkg/model/module_attribution_sarif_test.go
+++ b/pkg/model/module_attribution_sarif_test.go
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestModuleAttributionForSARIF_RedactsCredentials(t *testing.T) {
+	attr := &ModuleAttribution{
+		Source: "https://user:token@example.com/modules/bucket",
+		ModulePath: []ModulePathHop{{
+			Source: "https://user:token@example.com/modules/bucket",
+		}},
+	}
+
+	payload := ModuleAttributionForSARIF(attr)
+	require.NotContains(t, payload.Source, "user:token@")
+	require.NotContains(t, payload.ModulePath[0].Source, "user:token@")
+	require.Contains(t, payload.Source, "example.com/modules/bucket")
+}

--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -51,6 +51,8 @@ type VulnerableFile struct {
 	SuppressionJustification string `json:"suppression_justification,omitempty"`
 	// ModuleCallChain: local-module call path; empty for root; included in fingerprint.
 	ModuleCallChain string `json:"module_call_chain,omitempty"`
+	// ModuleAttribution: declaration and body locations for instantiated module findings.
+	ModuleAttribution *ModuleAttribution `json:"-"`
 }
 
 // QueryResult contains a query that tested positive ID, name, severity and a list of files that tested vulnerable
@@ -231,6 +233,17 @@ func removeURLCredentials(url string) string {
 	return strings.Replace(url, authGroup, "", 1)
 }
 
+func cloneModuleAttributionSummary(attr *ModuleAttribution) *ModuleAttribution {
+	if attr == nil {
+		return nil
+	}
+	clone := *attr
+	if len(attr.ModulePath) > 0 {
+		clone.ModulePath = append([]ModulePathHop(nil), attr.ModulePath...)
+	}
+	return &clone
+}
+
 func resolvePath(filePath string, pathExtractionMap map[string]ExtractedPathObject, repoDir string) string {
 	var returnPath string
 	returnPath = replaceIfTemporaryPath(filepath.FromSlash(filePath), pathExtractionMap)
@@ -313,6 +326,7 @@ func CreateSummary(ctx context.Context, counters Counters, vulnerabilities []Vul
 			SuppressionKind:          item.SuppressionKind,
 			SuppressionJustification: item.SuppressionJustification,
 			ModuleCallChain:          item.ModuleCallChain,
+			ModuleAttribution:        cloneModuleAttributionSummary(item.ModuleAttribution),
 		})
 
 		filePaths[resolvedPath] = item.FileName

--- a/pkg/model/summary_test.go
+++ b/pkg/model/summary_test.go
@@ -7,12 +7,25 @@ package model
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestModuleAttributionIsNotPartOfJSONReports(t *testing.T) {
+	attribution := &ModuleAttribution{Name: "bucket"}
+
+	vulnerabilityJSON, err := json.Marshal(Vulnerability{ModuleAttribution: attribution})
+	require.NoError(t, err)
+	require.NotContains(t, string(vulnerabilityJSON), "moduleAttribution")
+
+	summaryFileJSON, err := json.Marshal(VulnerableFile{ModuleAttribution: attribution})
+	require.NoError(t, err)
+	require.NotContains(t, string(summaryFileJSON), "module_attribution")
+}
 
 // TestCreateSummary tests the functions [CreateSummary()] and all the methods called by them
 func TestCreateSummary(t *testing.T) {

--- a/pkg/parser/terraform/modules/resolver/dotterraform.go
+++ b/pkg/parser/terraform/modules/resolver/dotterraform.go
@@ -35,6 +35,7 @@ type installedModulePath struct {
 	localPath   string
 	packageRoot string
 	scanRoot    string
+	version     string
 }
 
 // DotTerraformResolver reads terraform init output: .terraform/modules/modules.json.
@@ -70,6 +71,7 @@ func (r *DotTerraformResolver) load() {
 			if !ok {
 				continue
 			}
+			resolvedPath.version = strings.TrimSpace(rec.Version)
 			r.index[dotTerraformKey(root, rec.Source, rec.Version)] = resolvedPath
 			if rec.Key != "" {
 				for _, key := range dotTerraformLoadCallKeys(root, rec.Source, rec.Version, moduleNameFromKey(rec.Key)) {
@@ -132,8 +134,9 @@ func (r *DotTerraformResolver) Resolve(ctx context.Context, mod *tfmodules.Parse
 		}
 	}
 	resolution, err := ConfineResolution(ctx, Resolution{
-		LocalPath:   path.localPath,
-		PackageRoot: packageRoot,
+		LocalPath:       path.localPath,
+		PackageRoot:     packageRoot,
+		ResolvedVersion: path.version,
 	})
 	if err != nil {
 		return Resolution{}, &tfmodules.UnresolvedError{

--- a/pkg/parser/terraform/modules/resolver/prefetched.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
@@ -116,8 +117,9 @@ func (r *PrefetchedResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedM
 		}
 	}
 	return ConfineResolution(ctx, Resolution{
-		LocalPath:   entry.LocalPath,
-		PackageRoot: entry.PackageRoot,
+		LocalPath:       entry.LocalPath,
+		PackageRoot:     entry.PackageRoot,
+		ResolvedVersion: strings.TrimSpace(entry.Version),
 	})
 }
 

--- a/pkg/parser/terraform/modules/resolver/prefetched_test.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched_test.go
@@ -66,6 +66,7 @@ func TestPrefetchedResolverUsesManifest(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, moduleDir, got.LocalPath)
+	require.Equal(t, "5.0.0", got.ResolvedVersion)
 }
 
 func TestLoadManifestPreservesPackageRootForSiblingModules(t *testing.T) {

--- a/pkg/parser/terraform/modules/resolver/registry_test.go
+++ b/pkg/parser/terraform/modules/resolver/registry_test.go
@@ -471,6 +471,9 @@ func TestDotTerraformResolverUnpinnedUsesInitializedVersion(t *testing.T) {
 	if res.LocalPath != filepath.Join(root, "v2") {
 		t.Fatalf("LocalPath = %q, want %q", res.LocalPath, filepath.Join(root, "v2"))
 	}
+	if res.ResolvedVersion != "2.0.0" {
+		t.Fatalf("ResolvedVersion = %q, want %q", res.ResolvedVersion, "2.0.0")
+	}
 }
 
 func TestDotTerraformResolverUnversionedDuplicateSourceUsesModuleName(t *testing.T) {

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -67,6 +67,9 @@ type ResolvedResource struct {
 	// Source location and module address for finding attribution.
 	DefinedIn     string
 	DefLine       int
+	DefEndLine    int
+	DefColumn     int
+	DefEndColumn  int
 	ModuleAddress string // "" for root module resources
 	CallChain     []CallSite
 	// ExpansionTruncated is set when count/for_each produced more instances than
@@ -76,10 +79,14 @@ type ResolvedResource struct {
 
 // CallSite records one hop in a module call chain.
 type CallSite struct {
-	ModuleName string
-	Source     string
-	CalledFrom string
-	CalledLine int
+	ModuleName      string
+	Source          string
+	Version         string
+	CalledFrom      string
+	CalledLine      int
+	CalledEndLine   int
+	CalledColumn    int
+	CalledEndColumn int
 }
 
 // Evaluator evaluates local Terraform modules.
@@ -572,10 +579,14 @@ func (e *Evaluator) evaluateLocalModuleBlocks(
 		modInputs := e.evalBody(mb.Body, evalCtx, reservedModuleAttrs)
 
 		site := CallSite{
-			ModuleName: label,
-			Source:     source,
-			CalledFrom: mb.TypeRange.Filename,
-			CalledLine: mb.TypeRange.Start.Line,
+			ModuleName:      label,
+			Source:          source,
+			Version:         version,
+			CalledFrom:      mb.TypeRange.Filename,
+			CalledLine:      mb.TypeRange.Start.Line,
+			CalledEndLine:   mb.Range().End.Line,
+			CalledColumn:    mb.TypeRange.Start.Column,
+			CalledEndColumn: mb.Range().End.Column,
 		}
 		childAddr := joinAddr(addr, "module."+label)
 
@@ -696,6 +707,9 @@ func (e *Evaluator) expandResourceBlock(
 			Body:          rb.Body,
 			DefinedIn:     rb.TypeRange.Filename,
 			DefLine:       rb.TypeRange.Start.Line,
+			DefEndLine:    rb.Range().End.Line,
+			DefColumn:     rb.TypeRange.Start.Column,
+			DefEndColumn:  rb.Range().End.Column,
 			ModuleAddress: addr,
 			CallChain:     cloneChain(chain),
 		}
@@ -819,7 +833,8 @@ func injectResourceRefs(evalCtx *hcl.EvalContext, resources []ResolvedResource) 
 		expanded bool // true when any instance has brackets (count or for_each)
 	}
 	byType := make(map[string]map[string]*instBucket)
-	for _, r := range resources {
+	for i := range resources {
+		r := &resources[i]
 		base, key, isCount, expanded := parseResourceInstanceKey(r.Name)
 		if byType[r.Type] == nil {
 			byType[r.Type] = make(map[string]*instBucket)
@@ -1041,10 +1056,14 @@ func (e *Evaluator) preliminaryModuleOutputs(
 		}
 		modInputs := e.evalBody(mb.Body, evalCtx, reservedModuleAttrs)
 		site := CallSite{
-			ModuleName: label,
-			Source:     source,
-			CalledFrom: mb.TypeRange.Filename,
-			CalledLine: mb.TypeRange.Start.Line,
+			ModuleName:      label,
+			Source:          source,
+			Version:         version,
+			CalledFrom:      mb.TypeRange.Filename,
+			CalledLine:      mb.TypeRange.Start.Line,
+			CalledEndLine:   mb.Range().End.Line,
+			CalledColumn:    mb.TypeRange.Start.Column,
+			CalledEndColumn: mb.Range().End.Column,
 		}
 		childAddr := joinAddr(addr, "module."+label)
 		childChain := append(cloneChain(chain), site)

--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -557,6 +557,40 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 				artifactPath = ""
 			}
 
+			primaryURI := artifactPath
+			primaryStart := resourceStartLocation
+			primaryEnd := resourceEndLocation
+			resultProperties := sarifProperties{"tags": resultTags}
+			moduleAttribution := vulnerability.ModuleAttribution
+			if moduleAttribution != nil && moduleAttribution.CodeLocation.Filename != "" {
+				primaryURI = moduleAttribution.CodeLocation.Filename
+				primaryStart = model.SarifResourceLocation{
+					Line: moduleAttribution.CodeLocation.LineStart,
+					Col:  moduleAttribution.CodeLocation.ColumnStart,
+				}
+				primaryEnd = model.SarifResourceLocation{
+					Line: moduleAttribution.CodeLocation.LineEnd,
+					Col:  moduleAttribution.CodeLocation.ColumnEnd,
+				}
+				if primaryStart.Col <= 0 {
+					primaryStart.Col = 1
+				}
+				if primaryEnd.Line < primaryStart.Line {
+					primaryEnd.Line = primaryStart.Line
+				}
+				if primaryEnd.Col <= 0 {
+					primaryEnd.Col = 1
+				}
+				if primaryEnd.Line == primaryStart.Line && primaryEnd.Col <= primaryStart.Col {
+					primaryEnd.Col = primaryStart.Col + 1
+				}
+				if modulePayload := model.ModuleAttributionForSARIF(moduleAttribution); modulePayload != nil {
+					resultProperties["module"] = modulePayload
+				}
+			}
+
+			primaryURI = filepath.ToSlash(primaryURI)
+
 			result := sarifResult{
 				ResultRuleID:    issue.QueryName,
 				ResultRuleIndex: ruleIndex,
@@ -567,25 +601,24 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 				ResultLocations: []SarifLocation{
 					{
 						PhysicalLocation: sarifPhysicalLocation{
-							ArtifactLocation: sarifArtifactLocation{ArtifactURI: artifactPath},
+							ArtifactLocation: sarifArtifactLocation{ArtifactURI: primaryURI},
 							Region: model.SarifRegion{
-								StartLine:   resourceStartLocation.Line,
-								EndLine:     resourceEndLocation.Line,
-								StartColumn: resourceStartLocation.Col,
-								EndColumn:   resourceEndLocation.Col,
+								StartLine:   primaryStart.Line,
+								EndLine:     primaryEnd.Line,
+								StartColumn: primaryStart.Col,
+								EndColumn:   primaryEnd.Col,
 							},
 						},
 					},
 				},
-				ResultProperties: sarifProperties{
-					"tags": resultTags,
-				},
+				ResultProperties: resultProperties,
 				PartialFingerprints: SarifPartialFingerprints{
 					DatadogFingerprint: vulnerability.Fingerprint,
 				},
 				Suppressions: buildSarifSuppressions(ctx, &vulnerability),
 			}
-			if vulnerability.Remediation != "" && vulnerability.RemediationType != "" {
+			remediationAllowed := moduleAttribution == nil || moduleAttribution.ModuleCodeOwned
+			if vulnerability.Remediation != "" && vulnerability.RemediationType != "" && remediationAllowed {
 				sarifFix, err := remediationsHelper.TransformToSarifFix(
 					ctx,
 					vulnerability,
@@ -593,10 +626,11 @@ func (sr *sarifReport) BuildSarifIssue(ctx context.Context, issue *model.QueryRe
 					remediationEndLocation,
 				)
 				if err == nil {
-					// we want the location displayed in the UI to properly highlight the remediation
-					result.ResultLocations[0].PhysicalLocation.Region.StartLine = remediationStartLocation.Line
-					result.ResultLocations[0].PhysicalLocation.Region.EndLine = remediationEndLocation.Line
-
+					if moduleAttribution == nil {
+						// we want the location displayed in the UI to properly highlight the remediation
+						result.ResultLocations[0].PhysicalLocation.Region.StartLine = remediationStartLocation.Line
+						result.ResultLocations[0].PhysicalLocation.Region.EndLine = remediationEndLocation.Line
+					}
 					result.ResultFixes = append(result.ResultFixes, sarifFix)
 				}
 			}

--- a/pkg/report/model/sarif_module_test.go
+++ b/pkg/report/model/sarif_module_test.go
@@ -1,0 +1,159 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSarifIssue_ModuleAttribution(t *testing.T) {
+	issue := model.QueryResult{
+		QueryName: "acl_rule",
+		QueryID:   "acl-rule",
+		Severity:  model.SeverityHigh,
+		Platform:  "terraform",
+		Files: []model.VulnerableFile{{
+			FileName: "modules/bucket/main.tf",
+			Fingerprint: model.GetDatadogFingerprintHash(
+				model.SCIInfo{}, "modules/bucket/main.tf", "terraform",
+				"aws_s3_bucket", "this", "acl-rule", "acl = public-read", "stack|module.bucket",
+			),
+			Line: 3,
+			ResourceLocation: model.ResourceLocation{
+				Start: model.ResourceLine{Line: 2, Col: 1},
+				End:   model.ResourceLine{Line: 4, Col: 1},
+			},
+			ResourceType:    "aws_s3_bucket",
+			ResourceName:    "this",
+			Remediation:     "remove insecure ACL",
+			RemediationType: "removal",
+			ModuleAttribution: &model.ModuleAttribution{
+				Name:           "bucket",
+				Source:         "modules/bucket",
+				SourceType:     "local",
+				DependencyType: "direct",
+				CodeLocation: model.SourceLocation{
+					Filename:    "stack/main.tf",
+					LineStart:   2,
+					LineEnd:     2,
+					ColumnStart: 1,
+					ColumnEnd:   43,
+				},
+				ModuleCodeLocation: model.SourceLocation{
+					Filename:    "main.tf",
+					LineStart:   2,
+					LineEnd:     4,
+					ColumnStart: 1,
+					ColumnEnd:   2,
+				},
+				ModuleCodeOwned: true,
+			},
+		}},
+	}
+
+	report := NewSarifReport().(*sarifReport)
+	_, err := report.BuildSarifIssue(context.Background(), &issue, model.SCIInfo{})
+	require.NoError(t, err)
+	require.Len(t, report.Runs[0].Results, 1)
+
+	result := report.Runs[0].Results[0]
+	require.Equal(t, "stack/main.tf", result.ResultLocations[0].PhysicalLocation.ArtifactLocation.ArtifactURI)
+	require.Equal(t, 2, result.ResultLocations[0].PhysicalLocation.Region.StartLine)
+	require.Equal(t, 2, result.ResultLocations[0].PhysicalLocation.Region.EndLine)
+	require.Equal(t, 1, result.ResultLocations[0].PhysicalLocation.Region.StartColumn)
+	require.Equal(t, 43, result.ResultLocations[0].PhysicalLocation.Region.EndColumn)
+	require.Len(t, result.ResultFixes, 1)
+	require.Equal(t, "modules/bucket/main.tf", result.ResultFixes[0].ArtifactChanges[0].ArtifactLocation.URI)
+
+	moduleRaw, ok := result.ResultProperties["module"]
+	require.True(t, ok)
+	payload, err := json.Marshal(moduleRaw)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"name": "bucket",
+		"source": "modules/bucket",
+		"source_type": "local",
+		"dependency_type": "direct",
+		"code_location": {
+			"filename": "main.tf",
+			"line_start": 2,
+			"line_end": 4
+		}
+	}`, string(payload))
+}
+
+func TestBuildSarifIssue_RemoteModuleOmitsFix(t *testing.T) {
+	issue := model.QueryResult{
+		QueryName: "acl_rule",
+		QueryID:   "acl-rule",
+		Severity:  model.SeverityHigh,
+		Platform:  "terraform",
+		Files: []model.VulnerableFile{{
+			FileName:        "main.tf",
+			ResourceType:    "aws_s3_bucket",
+			ResourceName:    "this",
+			Remediation:     "remove insecure ACL",
+			RemediationType: "removal",
+			ResourceLocation: model.ResourceLocation{
+				Start: model.ResourceLine{Line: 2, Col: 1},
+				End:   model.ResourceLine{Line: 4, Col: 1},
+			},
+			ModuleAttribution: &model.ModuleAttribution{
+				Name:           "bucket",
+				Source:         "registry.terraform.io/acme/bucket/aws",
+				SourceType:     "registry",
+				DependencyType: "direct",
+				CodeLocation: model.SourceLocation{
+					Filename:  "stack/main.tf",
+					LineStart: 2,
+					LineEnd:   5,
+				},
+				ModuleCodeLocation: model.SourceLocation{Filename: "main.tf", LineStart: 2, LineEnd: 4},
+			},
+		}},
+	}
+
+	report := NewSarifReport().(*sarifReport)
+	_, err := report.BuildSarifIssue(context.Background(), &issue, model.SCIInfo{})
+	require.NoError(t, err)
+	require.Empty(t, report.Runs[0].Results[0].ResultFixes)
+}
+
+func TestBuildSarifIssue_NonModuleFindingUnchanged(t *testing.T) {
+	issue := model.QueryResult{
+		QueryName: "root_rule",
+		QueryID:   "root-rule",
+		Severity:  model.SeverityHigh,
+		Platform:  "terraform",
+		Files: []model.VulnerableFile{{
+			FileName: "main.tf",
+			Fingerprint: model.GetDatadogFingerprintHash(
+				model.SCIInfo{}, "main.tf", "terraform",
+				"aws_s3_bucket", "root", "root-rule", "acl = private", "",
+			),
+			Line: 1,
+			ResourceLocation: model.ResourceLocation{
+				Start: model.ResourceLine{Line: 1, Col: 1},
+				End:   model.ResourceLine{Line: 3, Col: 1},
+			},
+			ResourceType: "aws_s3_bucket",
+			ResourceName: "root",
+		}},
+	}
+
+	report := NewSarifReport().(*sarifReport)
+	_, err := report.BuildSarifIssue(context.Background(), &issue, model.SCIInfo{})
+	require.NoError(t, err)
+	result := report.Runs[0].Results[0]
+	require.Equal(t, "main.tf", result.ResultLocations[0].PhysicalLocation.ArtifactLocation.ArtifactURI)
+	_, hasModule := result.ResultProperties["module"]
+	require.False(t, hasModule)
+}

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -15,8 +15,14 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/modulegraph"
 	tfresolver "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+)
+
+const (
+	moduleSourceTypeGit     = "git"
+	moduleSourceTypeUnknown = "unknown"
 )
 
 func (c *Client) resolveTerraformModulesForScan(
@@ -28,20 +34,21 @@ func (c *Client) resolveTerraformModulesForScan(
 	moduleCleanup func(),
 	remoteModulePaths []string,
 	remoteSourceDirs map[string]engine.RemoteModuleDirectory,
+	remoteModuleProvenance map[string]engine.RemoteModuleProvenance,
 	err error,
 ) {
 	if !platformsIncludeTerraform(paramsPlatforms) || !c.shouldPreScanTerraformModules(extractedPaths.Path) {
-		return nil, nil, nil, nil
+		return nil, nil, nil, nil, nil
 	}
 
 	contextLogger := logger.FromContext(ctx)
 	filteredFilesSource, err := c.getFileSystemSourceProvider(ctx, extractedPaths.Path)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	moduleDiscoveryPaths, err := filteredFilesSource.TerraformFiles(ctx)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	chain := c.buildModuleResolverChain(ctx, moduleDiscoveryPaths)
 
@@ -98,23 +105,43 @@ func (c *Client) resolveTerraformModulesForScan(
 		}
 	}
 	remoteSourceDirs = make(map[string]engine.RemoteModuleDirectory, len(result.Modules)*3)
+	remoteModuleProvenance = make(map[string]engine.RemoteModuleProvenance, len(result.Modules)*3)
 	for i := range result.Modules {
 		module := &result.Modules[i]
 		directory := engine.RemoteModuleDirectory{
 			Path:        module.LocalPath,
 			PackageRoot: module.PackageRoot,
 		}
-		remoteSourceDirs[engine.RemoteModuleKey(
-			module.CallerRoot, module.Source, module.Version,
-		)] = directory
-		remoteSourceDirs[engine.RemoteModuleCallKey(
-			module.CallerRoot, module.Source, module.Version, module.Name,
-		)] = directory
-		remoteSourceDirs[engine.RemoteModuleCallKey(
-			module.CallerRoot, module.Source, "", module.Name,
-		)] = directory
+		sourceType := resolvedModuleSourceType(module)
+		provenance := engine.RemoteModuleProvenance{
+			Source:          module.Source,
+			ResolvedVersion: module.ResolvedVersion,
+			ResolvedRef:     module.ResolvedRef,
+			CanonicalSource: module.CanonicalSource,
+			SourceType:      sourceType,
+			ModuleRoot:      module.LocalPath,
+		}
+		for _, key := range []string{
+			engine.RemoteModuleKey(module.CallerRoot, module.Source, module.Version),
+			engine.RemoteModuleCallKey(module.CallerRoot, module.Source, module.Version, module.Name),
+			engine.RemoteModuleCallKey(module.CallerRoot, module.Source, "", module.Name),
+		} {
+			remoteSourceDirs[key] = directory
+			remoteModuleProvenance[key] = provenance
+		}
 	}
-	return result.Cleanup, result.ScanPaths, remoteSourceDirs, nil
+	return result.Cleanup, result.ScanPaths, remoteSourceDirs, remoteModuleProvenance, nil
+}
+
+// resolvedModuleSourceType keeps the type detected from the declared source. A resolved Git ref only
+// classifies otherwise unknown sources, since registry downloads may be Git-backed and must stay
+// registry modules so their semver, not the commit SHA, is reported.
+func resolvedModuleSourceType(module *modulegraph.ResolvedModule) string {
+	sourceType, _ := tfmodules.DetectModuleSourceType(module.Source)
+	if sourceType == moduleSourceTypeUnknown && module.ResolvedRef != "" {
+		return moduleSourceTypeGit
+	}
+	return sourceType
 }
 
 func (c *Client) shouldPreScanTerraformModules(scanPaths []string) bool {

--- a/pkg/scan/remote_modules_test.go
+++ b/pkg/scan/remote_modules_test.go
@@ -11,10 +11,30 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/source"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/modulegraph"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
 	consolePrinter "github.com/DataDog/datadog-iac-scanner/pkg/printer"
 	"github.com/stretchr/testify/require"
 )
+
+func TestResolvedModuleSourceTypeUsesResolvedGitRef(t *testing.T) {
+	module := &modulegraph.ResolvedModule{
+		Source:      "https://github.com/acme/network.git//modules/vpc",
+		ResolvedRef: "45ea6a143c2d",
+	}
+
+	require.Equal(t, "git", resolvedModuleSourceType(module))
+}
+
+func TestResolvedModuleSourceTypeKeepsRegistryForGitBackedDownload(t *testing.T) {
+	module := &modulegraph.ResolvedModule{
+		Source:          "terraform-aws-modules/vpc/aws",
+		ResolvedRef:     "45ea6a143c2d",
+		ResolvedVersion: "5.0.0",
+	}
+
+	require.Equal(t, "registry", resolvedModuleSourceType(module))
+}
 
 func TestRemoteModulesDisabledByDefault(t *testing.T) {
 	root := t.TempDir()

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -85,7 +85,7 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 			baselinePaths = append(baselinePaths, path)
 		}
 	}
-	moduleCleanup, remoteModulePaths, remoteSourceDirs, err := c.resolveTerraformModulesForScan(
+	moduleCleanup, remoteModulePaths, remoteSourceDirs, remoteModuleProvenance, err := c.resolveTerraformModulesForScan(
 		ctx, paramsPlatforms, &extractedPaths, baselinePaths,
 	)
 	if err != nil {
@@ -135,6 +135,9 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 
 	if len(remoteSourceDirs) > 0 {
 		inspector.SetRemoteModuleDirectories(remoteSourceDirs)
+	}
+	if len(remoteModuleProvenance) > 0 {
+		inspector.SetRemoteModuleProvenance(remoteModuleProvenance)
 	}
 	inspector.SetExternalModulePaths(remoteModulePaths)
 


### PR DESCRIPTION
## Motivation

Instantiated Terraform module findings currently anchor SARIF on the module body, which is not customer-owned code and cannot be matched to a pull-request diff for remote modules. This change anchors the finding on the repository module declaration while retaining compact leaf-module provenance for evidence and downstream findings.

Related ticket: [K9CODESEC-5295](https://datadoghq.atlassian.net/browse/K9CODESEC-5295)

## Changes

**Terraform attribution**

Capture declaration spans and resolved module provenance for evaluated local and remote resources. Transitive findings retain the ordered module call path from the customer declaration to the leaf module.

**SARIF reporting**

Set `locations[0]` to the customer-owned root `module` declaration. Emit a compact `properties.module` object with `name`, one normalized credential-free `source`, `source_type`, `dependency_type`, optional concrete `version`, and a module-relative `code_location` for the vulnerable resource block.

Registry modules use the resolved semver in `version`; Git modules use the resolved commit SHA; local or unresolved modules omit it. Direct findings omit the redundant one-element `module_path`, while transitive findings include the complete ordered path.

The payload deliberately omits source aliases, requested constraints, separate ref fields, resource and instance identifiers, location URLs, and synthetic `relatedLocations`. Module findings also omit automated fixes that would target non-customer module files. Existing fingerprints remain unchanged.

**Direct local module result**

```json
{
  "locations": [{
    "physicalLocation": {
      "artifactLocation": { "uri": "stack/main.tf" },
      "region": { "startLine": 2, "endLine": 5, "startColumn": 1, "endColumn": 1 }
    }
  }],
  "properties": {
    "module": {
      "name": "bucket",
      "source": "modules/bucket",
      "source_type": "local",
      "dependency_type": "direct",
      "code_location": {
        "filename": "main.tf",
        "line_start": 2,
        "line_end": 4
      }
    }
  }
}
```

**Transitive remote module result**

```json
{
  "locations": [{
    "physicalLocation": {
      "artifactLocation": { "uri": "environments/production/main.tf" },
      "region": { "startLine": 42, "endLine": 47, "startColumn": 1, "endColumn": 1 }
    }
  }],
  "properties": {
    "module": {
      "name": "bucket",
      "source": "registry.terraform.io/cloud-inventory/bucket/aws",
      "source_type": "registry",
      "version": "9.3.2",
      "dependency_type": "transitive",
      "code_location": {
        "filename": "main.tf",
        "line_start": 236,
        "line_end": 241
      },
      "module_path": [
        {
          "name": "platform",
          "source": "modules/platform",
          "source_type": "local",
          "code_location": {
            "filename": "environments/production/main.tf",
            "line_start": 42,
            "line_end": 47
          }
        },
        {
          "name": "bucket",
          "source": "registry.terraform.io/cloud-inventory/bucket/aws",
          "source_type": "registry",
          "version": "9.3.2",
          "code_location": {
            "filename": "main.tf",
            "line_start": 20,
            "line_end": 25
          }
        }
      ]
    }
  }
}
```

Downstream, the SARIF primary location maps to top-level `code_location`, and `properties.module` will map to `iac_resource.module` when the changes will be made. For now, nothing should be impacted downstream.

## Author Checklist

1. [x] I have reviewed my own PR.
2. [x] I have added or updated relevant unit tests where necessary.
3. [x] All new and existing targeted tests pass.
4. [ ] I have tested my changes on staging, if applicable.
5. [x] I have updated the related design artifacts and ticket.

## QA Instruction

1. `go test ./pkg/model ./pkg/engine ./pkg/report/model ./pkg/scan ./pkg/parser/terraform/modules ./pkg/parser/terraform/tfeval -count=1`
2. `golangci-lint run -c .golangci.yml --timeout 20m`
3. Confirm direct module SARIF omits `module_path`, transitive SARIF contains the complete ordered path, and `locations[0]` always names a file from the scanned repository.

## Impact

This affects Terraform module attribution in SARIF and the internal finding model. Rule evaluation, regular JSON report shapes, non-module SARIF results, and existing fingerprints are unchanged.

## Additional Notes

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-5295]: https://datadoghq.atlassian.net/browse/K9CODESEC-5295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ