### PR TITLE
fix: nested cicd custom rules tests below .github folder

### DIFF
--- a/pkg/scan/custom_scan.go
+++ b/pkg/scan/custom_scan.go
@@ -69,11 +69,12 @@ func RunCustomRegoQuery(
 	if err := os.WriteFile(tmpFile, fileContent, ownerReadWritePerm); err != nil {
 		return nil, nil, fmt.Errorf("writing temp file: %w", err)
 	}
+	scanTargetPath := filepath.ToSlash(tmpFile)
 
 	// LibrariesDefaultBasePath ("./assets/libraries") is CWD-relative; the CLI is
 	// always invoked from the repo root so this resolves correctly.
 	params := &Parameters{
-		Path:                    []string{tmpFile},
+		Path:                    []string{scanTargetPath},
 		QueriesPath:             []string{"."},
 		LibrariesPath:           source.LibrariesDefaultBasePath,
 		PreviewLines:            3,

--- a/pkg/scan/custom_scan.go
+++ b/pkg/scan/custom_scan.go
@@ -32,7 +32,7 @@ var platformExtensions = map[string]string{
 	"CloudFormation": scanTargetJSON,
 	"Kubernetes":     "scan-target.yaml",
 	"Ansible":        "scan-target.yaml",
-	"CICD":           "scan-target.yaml",
+	"CICD":           ".github/scan-target.yaml",
 	"Dockerfile":     "Dockerfile",
 }
 
@@ -62,6 +62,10 @@ func RunCustomRegoQuery(
 
 	const ownerReadWritePerm = 0600
 	tmpFile := filepath.Join(tmpDir, platformTempFileName(platform))
+	if err := os.MkdirAll(filepath.Dir(tmpFile), 0700); err != nil {
+		return nil, nil, fmt.Errorf("creating temp file dir: %w", err)
+	}
+
 	if err := os.WriteFile(tmpFile, fileContent, ownerReadWritePerm); err != nil {
 		return nil, nil, fmt.Errorf("writing temp file: %w", err)
 	}

--- a/pkg/scan/custom_scan.go
+++ b/pkg/scan/custom_scan.go
@@ -60,9 +60,12 @@ func RunCustomRegoQuery(
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	const ownerReadWritePerm = 0600
+	const (
+		ownerReadWritePerm = 0600
+		ownerReadWriteExec = 0700
+	)
 	tmpFile := filepath.Join(tmpDir, platformTempFileName(platform))
-	if err := os.MkdirAll(filepath.Dir(tmpFile), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(tmpFile), ownerReadWriteExec); err != nil {
 		return nil, nil, fmt.Errorf("creating temp file dir: %w", err)
 	}
 

--- a/pkg/scan/custom_scan_test.go
+++ b/pkg/scan/custom_scan_test.go
@@ -112,7 +112,7 @@ func allCodes(errs []RegoValidationError) []string {
 func TestPlatformTempFileName_CoversAllSupportedPlatforms(t *testing.T) {
 	expected := map[string]string{
 		"Ansible":        "scan-target.yaml",
-		"CICD":           "scan-target.yaml",
+		"CICD":           ".github/scan-target.yaml",
 		"CloudFormation": scanTargetJSON,
 		"Dockerfile":     "Dockerfile",
 		"Kubernetes":     "scan-target.yaml",


### PR DESCRIPTION
## Motivation

CICD custom rules send only false negatives. They ignore the test files since they are not nested under a `.github/` folder. This PR intends to create that folder to allow the tests to report findings.

JIRA Ticket

## Changes

- Nest the CICD tests under a `.github/` folder.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [x] I have updated any relevant documentation (if applicable).

## QA Instruction

Tell the reviewer how they can make sure the PR is indeed working as intended. Tell them what they should be looking for.

## Blast Radius

* iac-scanning

## Additional Notes

If you need to share anything else along with your PR, please do it here.

I submit this contribution under the Apache-2.0 license.
