### PR TITLE
Regression detector: OOM fix with always-on local module eval

### DIFF
--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -176,6 +176,15 @@ func (e *Engine) expToStringLiteralValue(t *hclsyntax.LiteralValueExpr) (string,
 	if err != nil {
 		return "", err
 	}
+	// Converting to string succeeds for null and unknown values but AsString
+	// panics on both, so a literal `null` in a body would take down the whole
+	// enclosing resolve rather than this one expression.
+	if s.IsNull() {
+		return "", fmt.Errorf("can't convert null literal to string")
+	}
+	if !s.IsKnown() {
+		return "", fmt.Errorf("can't convert unknown literal to string")
+	}
 	return s.AsString(), nil
 }
 

--- a/pkg/builder/engine/engine_null_literal_test.go
+++ b/pkg/builder/engine/engine_null_literal_test.go
@@ -1,0 +1,76 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// A null or unknown literal converts to cty.String without error but cannot be
+// read with AsString. ExpToString has to report that as an error, because it
+// runs under a per-directory singleflight: a panic there aborts the resolve for
+// every file in the directory, not just the expression that caused it.
+func TestExpToString_NullAndUnknownLiteralsReturnError(t *testing.T) {
+	cases := []struct {
+		name string
+		val  cty.Value
+	}{
+		{"null string", cty.NullVal(cty.String)},
+		{"null number", cty.NullVal(cty.Number)},
+		{"null bool", cty.NullVal(cty.Bool)},
+		{"null dynamic", cty.NullVal(cty.DynamicPseudoType)},
+		{"unknown string", cty.UnknownVal(cty.String)},
+		{"unknown dynamic", cty.UnknownVal(cty.DynamicPseudoType)},
+	}
+
+	e := &Engine{}
+	ctx := context.Background()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr := &hclsyntax.LiteralValueExpr{Val: tc.val}
+			got, err := e.ExpToString(ctx, expr)
+			if err == nil {
+				t.Fatalf("ExpToString(%s) = %q, want an error rather than a panic", tc.name, got)
+			}
+			if got != "" {
+				t.Fatalf("ExpToString(%s) = %q, want the empty string alongside the error", tc.name, got)
+			}
+		})
+	}
+}
+
+// Known literals must keep converting exactly as before.
+func TestExpToString_KnownLiteralsStillConvert(t *testing.T) {
+	cases := []struct {
+		name string
+		val  cty.Value
+		want string
+	}{
+		{"string", cty.StringVal("hello"), "hello"},
+		{"number", cty.NumberIntVal(42), "42"},
+		{"bool", cty.BoolVal(true), "true"},
+		{"empty string", cty.StringVal(""), ""},
+	}
+
+	e := &Engine{}
+	ctx := context.Background()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr := &hclsyntax.LiteralValueExpr{Val: tc.val}
+			got, err := e.ExpToString(ctx, expr)
+			if err != nil {
+				t.Fatalf("ExpToString(%s) returned error %v", tc.name, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ExpToString(%s) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -444,15 +444,14 @@ func (c *Inspector) Inspect(
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("engine.Inspect()")
 
-	// Terraform local-module instantiation is gated so it can be disabled remotely.
+	// Temporarily enable Terraform local-module instantiation unconditionally so
+	// regression detection exercises this path.
 	queries := c.getQueriesByPlat(platforms)
 
 	var moduleDocs []model.Document
 	var moduleExtras map[string][]extraCallerInfo
 	var syntheticFiles []*model.FileMetadata
-	if shouldInstantiateLocalModules(platforms, files) &&
-		c.flagEvaluator != nil &&
-		c.flagEvaluator.EvaluateWithOrg(featureflags.IacEnableLocalModuleEval) {
+	if shouldInstantiateLocalModules(platforms, files) {
 		targets := ruleTargetedResourceTypes(queries, c.terraformRuleLibraries()...)
 		moduleDocs, syntheticFiles, moduleExtras = c.instantiateLocalModules(ctx, files, targets)
 	}

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -335,6 +335,7 @@ func evaluateRootModules(
 ) {
 	contextLogger := logger.FromContext(ctx)
 	for _, dir := range roots {
+		evaluator.ResetInstantiationBudget()
 		resources, _, childDirs, err := evaluator.EvaluateModule(ctx, dir, tfeval.LoadRootVars(dir))
 		if err != nil {
 			contextLogger.Warn().Err(err).Msgf("tfeval: failed to evaluate root module %s", dir)
@@ -355,6 +356,12 @@ func evaluateRootModules(
 		*extra = append(*extra, docs...)
 		*syntheticFiles = append(*syntheticFiles, syn...)
 		*resourceCount += count
+		// instantiatedDocs has copied everything this root needs into plain
+		// documents, so the evaluator's cty values are dead here. Another root
+		// could in principle reuse them, but each root passes its own values to
+		// the modules it shares, so the hit rate does not pay for a peak that
+		// grows with the whole repository rather than the largest single root.
+		evaluator.ReleaseEvalCache()
 	}
 }
 

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -38,7 +38,7 @@ type moduleResolutionResult struct {
 	calledDirs           map[string]bool
 	successfulRoots      map[string]bool
 	rootDirs             []string
-	failedRootModuleDirs map[string]bool
+	unresolvedModuleDirs map[string]bool
 	extras               map[string][]extraCallerInfo
 	resourceCount        int
 	ok                   bool
@@ -84,7 +84,7 @@ func (c *Inspector) instantiateLocalModules(
 			continue
 		}
 		if replaced := res.suppressed[f.ID]; len(replaced) > 0 {
-			if res.failedRootModuleDirs[moduleFileDir(f.FilePath, c.repoPath)] {
+			if res.unresolvedModuleDirs[moduleFileDir(f.FilePath, c.repoPath)] {
 				continue
 			}
 			// Only the blocks that came back as instantiated documents are
@@ -326,7 +326,7 @@ func evaluateRootModules(
 	extras map[string][]extraCallerInfo,
 	instantiated instantiatedIndex,
 	successfulRoots map[string]bool,
-	failedRootModuleDirs map[string]bool,
+	unresolvedModuleDirs map[string]bool,
 	actualCalledDirs map[string]bool,
 	extra *[]model.Document,
 	syntheticFiles *[]*model.FileMetadata,
@@ -342,7 +342,7 @@ func evaluateRootModules(
 			for _, called := range discoverCalledModuleClosure(
 				ctx, evaluator, filesByDir, repoPath, resolver, dir,
 			) {
-				failedRootModuleDirs[called] = true
+				unresolvedModuleDirs[called] = true
 			}
 			continue
 		}
@@ -365,17 +365,63 @@ func evaluateRootModules(
 	}
 }
 
-func scrubInstantiatedForFailedRoots(
+// collectNotEvaluatedDirs marks the directories the evaluator skipped, and
+// everything they call, as unresolved.
+//
+// A directory is reached from several call sites, and depth, cycle and budget
+// stops apply to one call site at a time, so a directory can come out of a scan
+// with some instances resolved and others skipped. Suppression is decided per
+// directory, so without this the resolved instances would suppress the body and
+// the skipped ones would be represented by nothing at all — a silent false
+// negative for exactly the inputs that were never evaluated. Keeping the body
+// costs a finding that also appears on a resolved instance, which is the safe
+// side of that trade. The subtree is included because a skipped call site did
+// not materialize any of the modules underneath it either.
+func collectNotEvaluatedDirs(
+	ctx context.Context,
+	evaluator *tfeval.Evaluator,
+	filesByDir map[string][]*model.FileMetadata,
+	repoPath string,
+	resolver tfeval.RemoteResolver,
+	unresolvedModuleDirs map[string]bool,
+) {
+	// One walk over every skipped directory at once, using the result set as the
+	// visited set: the subtrees overlap heavily, and dirs marked by a failed root
+	// already had their own subtree walked.
+	var queue []string
+	for _, dir := range evaluator.NotEvaluatedDirs() {
+		if unresolvedModuleDirs[dir] {
+			continue
+		}
+		unresolvedModuleDirs[dir] = true
+		queue = append(queue, dir)
+	}
+	for len(queue) > 0 {
+		dir := queue[0]
+		queue = queue[1:]
+		for _, called := range discoverCalledModuleDirs(
+			ctx, evaluator, filesByDir[dir], repoPath, resolver, dir,
+		) {
+			if unresolvedModuleDirs[called] {
+				continue
+			}
+			unresolvedModuleDirs[called] = true
+			queue = append(queue, called)
+		}
+	}
+}
+
+func scrubInstantiatedForUnresolvedDirs(
 	instantiated instantiatedIndex,
 	files model.FileMetadatas,
-	failedRootModuleDirs map[string]bool,
+	unresolvedModuleDirs map[string]bool,
 	repoPath string,
 ) {
 	for _, f := range files {
 		if f == nil {
 			continue
 		}
-		if failedRootModuleDirs[moduleFileDir(f.FilePath, repoPath)] {
+		if unresolvedModuleDirs[moduleFileDir(f.FilePath, repoPath)] {
 			delete(instantiated, f.ID)
 		}
 	}
@@ -422,7 +468,7 @@ func resolveModuleDocuments(
 	var rootEvalOK bool
 	actualCalledDirs := make(map[string]bool)
 	successfulRoots := make(map[string]bool)
-	failedRootModuleDirs := make(map[string]bool)
+	unresolvedModuleDirs := make(map[string]bool)
 	var extra []model.Document
 	var syntheticFiles []*model.FileMetadata
 	var resourceCount int
@@ -442,8 +488,11 @@ func resolveModuleDocuments(
 	evaluateRootModules(
 		ctx, evaluator, roots, filesByDir, repoPath, resolver, targets,
 		byAbsPath, seen, extras, instantiated,
-		successfulRoots, failedRootModuleDirs, actualCalledDirs,
+		successfulRoots, unresolvedModuleDirs, actualCalledDirs,
 		&extra, &syntheticFiles, &resourceCount, &rootEvalOK,
+	)
+	collectNotEvaluatedDirs(
+		ctx, evaluator, filesByDir, repoPath, resolver, unresolvedModuleDirs,
 	)
 	evaluator.ReleaseCaches()
 
@@ -460,6 +509,13 @@ func resolveModuleDocuments(
 	// their place.
 	strippedDirs := make(map[string]bool, len(actualCalledDirs))
 	for dir := range actualCalledDirs {
+		// A directory with any unevaluated call site keeps its call sites too. The
+		// resolved instances no longer stand in for the whole directory, so removing
+		// the call-site blocks would drop the rules that match them for an instance
+		// that has nothing else representing it.
+		if unresolvedModuleDirs[dir] {
+			continue
+		}
 		for _, f := range filesByDir[dir] {
 			if len(instantiated[f.ID]) > 0 {
 				strippedDirs[dir] = true
@@ -468,7 +524,7 @@ func resolveModuleDocuments(
 		}
 	}
 
-	scrubInstantiatedForFailedRoots(instantiated, files, failedRootModuleDirs, repoPath)
+	scrubInstantiatedForUnresolvedDirs(instantiated, files, unresolvedModuleDirs, repoPath)
 
 	return moduleResolutionResult{
 		docs:                 extra,
@@ -477,7 +533,7 @@ func resolveModuleDocuments(
 		calledDirs:           strippedDirs,
 		successfulRoots:      successfulRoots,
 		rootDirs:             roots,
-		failedRootModuleDirs: failedRootModuleDirs,
+		unresolvedModuleDirs: unresolvedModuleDirs,
 		extras:               extras,
 		resourceCount:        resourceCount,
 		ok:                   true,
@@ -827,8 +883,8 @@ func discoverCalledModuleDirs(
 }
 
 // discoverCalledModuleClosure returns every module transitively reachable from
-// dir. It is used only after root evaluation fails, when suppression must be
-// conservative because no synthetic documents exist for that call chain.
+// dir. It is used when a call chain was not evaluated and suppression must be
+// conservative, because no synthetic documents exist for anything under it.
 func discoverCalledModuleClosure(
 	ctx context.Context,
 	evaluator *tfeval.Evaluator,

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -824,9 +824,9 @@ resource "aws_s3_bucket" "this" {
 	require.Len(t, vulns, numQueries)
 }
 
-// TestInspect_LocalModuleEvalWithFlagEnabled confirms that local module evaluation
-// runs when the feature flag is on and synthetic docs are injected for resolved modules.
-func TestInspect_LocalModuleEvalWithFlagEnabled(t *testing.T) {
+// TestInspect_LocalModuleEvalAlwaysRuns confirms that local module evaluation
+// runs unconditionally and synthetic docs are injected for resolved modules.
+func TestInspect_LocalModuleEvalAlwaysRuns(t *testing.T) {
 	root := t.TempDir()
 	rootPath := filepath.Join(root, "main.tf")
 	modDir := filepath.Join(root, "modules", "s3")

--- a/pkg/engine/module_resolve_nesting_test.go
+++ b/pkg/engine/module_resolve_nesting_test.go
@@ -127,3 +127,78 @@ func TestResolveModuleDocuments_NoDirectorySuppressedWithoutReplacement(t *testi
 	t.Logf("instantiated=%d documents=%d suppressed_files=%d",
 		res.resourceCount, len(res.docs), len(res.suppressed))
 }
+
+// writePartiallyResolvedShare lays down a module directory reached twice: once
+// directly from the root, and once at the bottom of a chain long enough that the
+// evaluator's depth cap stops before it. The direct call resolves, the deep one
+// never does, so the directory ends the scan only partially resolved.
+func writePartiallyResolvedShare(t *testing.T, levels int) (string, model.FileMetadatas) {
+	t.Helper()
+	root := t.TempDir()
+
+	shared := filepath.Join(root, "shared")
+	writeFile(t, shared, "main.tf",
+		"variable \"name\" { type = string }\nresource \"aws_s3_bucket\" \"b\" { bucket = var.name }\n")
+	files := model.FileMetadatas{fileMeta("shared", filepath.Join(shared, "main.tf"))}
+
+	for i := 0; i < levels; i++ {
+		body := "variable \"name\" { type = string }\n"
+		if i == levels-1 {
+			body += "module \"shared\" {\n  source = \"../shared\"\n  name = var.name\n}\n"
+		} else {
+			body += fmt.Sprintf("module \"next\" {\n  source = \"../lvl%02d\"\n  name = var.name\n}\n", i+1)
+		}
+		dir := filepath.Join(root, fmt.Sprintf("lvl%02d", i))
+		writeFile(t, dir, "main.tf", body)
+		files = append(files, fileMeta(fmt.Sprintf("lvl-%02d", i), filepath.Join(dir, "main.tf")))
+	}
+
+	stack := filepath.Join(root, "stack")
+	writeFile(t, stack, "main.tf", `
+module "shallow" {
+  source = "../shared"
+  name   = "shallow"
+}
+module "deep" {
+  source = "../lvl00"
+  name   = "deep"
+}
+`)
+	files = append(files, fileMeta("stack", filepath.Join(stack, "main.tf")))
+	return root, files
+}
+
+// A directory is suppressed for the whole scan at once, but depth, cycle and
+// budget stops apply to a single call site. So a directory can finish the scan
+// with one instance resolved and another skipped, and suppressing it then leaves
+// the skipped instance represented by nothing: not by a synthetic document, since
+// it was never evaluated, and not by its own body, since that was removed. The
+// body has to stay.
+func TestResolveModuleDocuments_PartiallyResolvedModuleKeepsItsBody(t *testing.T) {
+	// Comfortably past the evaluator's depth cap, so the chain is cut short.
+	root, files := writePartiallyResolvedShare(t, 25)
+
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+
+	if !res.ok {
+		t.Fatal("expected module resolution to succeed for the shallow call")
+	}
+	if res.resourceCount == 0 {
+		t.Fatal("expected the shallow call to instantiate the shared module")
+	}
+
+	sharedFile := filepath.Join(root, "shared", "main.tf")
+	if !res.unresolvedModuleDirs[filepath.Dir(sharedFile)] {
+		t.Error("the shared module has a call site that was never evaluated but is not " +
+			"marked unresolved, so its body will be suppressed with nothing standing in")
+	}
+	for _, f := range files {
+		if f.FilePath != sharedFile {
+			continue
+		}
+		if blocks := res.suppressed[f.ID]; len(blocks) > 0 {
+			t.Errorf("shared module body is suppressed (%v) even though one of its call "+
+				"sites was never resolved; that instance is now scanned by nothing", blocks)
+		}
+	}
+}

--- a/pkg/engine/module_resolve_nesting_test.go
+++ b/pkg/engine/module_resolve_nesting_test.go
@@ -1,0 +1,129 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package engine
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+)
+
+// writeBudgetFanOut lays down `roots` root modules that each call a shared
+// module declaring `perModule` resources, so the total instantiated count is
+// roots*perModule and every root contributes the same amount.
+func writeBudgetFanOut(t *testing.T, roots, perModule int) (string, model.FileMetadatas) {
+	t.Helper()
+	root := t.TempDir()
+
+	modDir := filepath.Join(root, "modules", "app")
+	src := `variable "name" { type = string }` + "\n"
+	for i := 0; i < perModule; i++ {
+		src += fmt.Sprintf("resource \"aws_s3_bucket\" \"b%d\" {\n  bucket = \"${var.name}-%d\"\n}\n", i, i)
+	}
+	writeFile(t, modDir, "main.tf", src)
+
+	files := model.FileMetadatas{fileMeta("mod-main", filepath.Join(modDir, "main.tf"))}
+	for i := 0; i < roots; i++ {
+		dir := filepath.Join(root, fmt.Sprintf("stack-%02d", i))
+		writeFile(t, dir, "main.tf", fmt.Sprintf(`
+module "app" {
+  source = "../modules/app"
+  name   = "stack-%02d"
+}
+`, i))
+		files = append(files, fileMeta(fmt.Sprintf("root-%02d", i), filepath.Join(dir, "main.tf")))
+	}
+	return root, files
+}
+
+// writeDeepFanOut lays down `depth` nested module levels where every level calls
+// the level below it `branch` times. The number of module instances is branch^depth
+// even though the repository is one file per level, which is the shape that made a
+// tiny repository able to exhaust any memory limit.
+func writeDeepFanOut(t *testing.T, depth, branch int) (string, model.FileMetadatas) {
+	t.Helper()
+	root := t.TempDir()
+	files := model.FileMetadatas{}
+
+	for i := 0; i < depth; i++ {
+		dir := filepath.Join(root, fmt.Sprintf("lvl%02d", i))
+		body := "variable \"in\" { type = string }\n"
+		if i == depth-1 {
+			body += "resource \"aws_s3_bucket\" \"leaf\" { bucket = var.in }\noutput \"out\" { value = var.in }\n"
+		} else {
+			for b := 0; b < branch; b++ {
+				body += fmt.Sprintf("module \"m%d\" {\n  source = \"../lvl%02d\"\n  in = var.in\n}\n", b, i+1)
+			}
+			body += "output \"out\" { value = module.m0.out }\n"
+		}
+		writeFile(t, dir, "main.tf", body)
+		files = append(files, fileMeta(fmt.Sprintf("lvl-%02d", i), filepath.Join(dir, "main.tf")))
+	}
+
+	stack := filepath.Join(root, "stack")
+	writeFile(t, stack, "main.tf", "module \"m\" {\n  source = \"../lvl00\"\n  in = \"seed\"\n}\n")
+	files = append(files, fileMeta("stack", filepath.Join(stack, "main.tf")))
+	return root, files
+}
+
+// Memoizing evaluations on their inputs rather than on the path taken to reach
+// them is what keeps a deeply nested module tree affordable. Without it this
+// shape evaluates branch^depth times for depth+1 distinct results, which is how a
+// handful of files reached tens of gigabytes.
+func TestResolveModuleDocuments_DeepFanOutStaysAffordable(t *testing.T) {
+	const depth, branch = 12, 2
+	root, files := writeDeepFanOut(t, depth, branch)
+
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+
+	if res.resourceCount == 0 {
+		t.Fatal("expected the nested module tree to instantiate resources, got none")
+	}
+	if len(res.docs) == 0 {
+		t.Fatal("expected synthetic documents for the nested module tree, got none")
+	}
+	// The instantiated count follows the tree, while the documents collapse to the
+	// handful of distinct contents behind it.
+	if res.resourceCount < branch {
+		t.Errorf("instantiated %d resources, expected at least the branching factor %d",
+			res.resourceCount, branch)
+	}
+	t.Logf("depth=%d branch=%d instantiated=%d documents=%d",
+		depth, branch, res.resourceCount, len(res.docs))
+}
+
+// Every directory whose body is suppressed from the scan must be replaced by at
+// least one synthetic document. A module that was skipped rather than resolved
+// (budget, depth cap, cycle) resolves to nothing, and treating that as a
+// successful evaluation would drop it from the scan entirely.
+func TestResolveModuleDocuments_NoDirectorySuppressedWithoutReplacement(t *testing.T) {
+	root, files := writeBudgetFanOut(t, 6, 4)
+
+	res := resolveModuleDocuments(context.Background(), files, root, nil, nil)
+
+	if res.resourceCount == 0 {
+		t.Fatal("expected resources to be instantiated")
+	}
+	if len(res.suppressed) == 0 {
+		t.Fatal("expected the shared module to be suppressed in favour of instantiated copies")
+	}
+	// Nothing may be suppressed unless resources were instantiated to stand in for
+	// it, which is what keeps a skipped module in the scan rather than dropping it.
+	if len(res.docs) == 0 {
+		t.Error("resources were suppressed but no synthetic documents replace them")
+	}
+	for dir := range res.calledDirs {
+		if !strings.HasPrefix(dir, root) {
+			t.Errorf("called dir %s escapes the repository root %s", dir, root)
+		}
+	}
+	t.Logf("instantiated=%d documents=%d suppressed_files=%d",
+		res.resourceCount, len(res.docs), len(res.suppressed))
+}

--- a/pkg/parser/terraform/tfeval/cache.go
+++ b/pkg/parser/terraform/tfeval/cache.go
@@ -8,42 +8,94 @@ package tfeval
 
 import (
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
-// evalCacheKey: dir + package root + addr + inputs + call chain.
-// Chain splits identical-input callers; pre-pass and main loop share the same chain and hit the same entry.
+// evalCacheKey identifies a module evaluation by its inputs alone: dir + package
+// root + resolved inputs.
+//
+// The module address and call chain are deliberately absent. They describe where
+// a module was called from, not what it evaluates to, so including them made a
+// module reached by N distinct paths evaluate N times for identical results. With
+// branching factor B and depth D that is B^D evaluations where only D+1 distinct
+// ones exist — a nesting depth of 15 with two calls per level reaches 65k
+// evaluations, and enough depth exhausts any memory limit from a handful of
+// files. Callers re-stamp the address and chain onto a cached result instead,
+// which is a per-resource string rewrite rather than a re-evaluation.
 type evalCacheKey struct {
 	dir         string
 	packageRoot string
-	addr        string
 	inputs      string // canonical encoding of the resolved input map
-	chain       string // canonical encoding of the module call chain
-}
-
-// chainKey encodes each hop as calledFrom#line#module.name; joined by "/".
-func chainKey(chain []CallSite) string {
-	if len(chain) == 0 {
-		return ""
-	}
-	parts := make([]string, len(chain))
-	for i, s := range chain {
-		parts[i] = s.CalledFrom + "#" + strconv.Itoa(s.CalledLine) + "#module." + s.ModuleName
-	}
-	return strings.Join(parts, "/")
 }
 
 // evalCacheEntry holds the result of a completed module evaluation.
 // visitedDirs is the set of child dirs that were added to allVisited *inside* this
 // evaluation (not including the module dir itself, which is tracked by the caller).
+//
+// baseAddr and baseChainLen record the position the entry was first evaluated at,
+// so a caller reaching the same module by another path can rewrite the recorded
+// address and chain onto the result. Outputs need no rewrite: they are values, and
+// values do not depend on the path taken to reach them.
 type evalCacheEntry struct {
-	resources   []ResolvedResource
-	outputs     map[string]cty.Value
-	visitedDirs []string
+	resources    []ResolvedResource
+	outputs      map[string]cty.Value
+	visitedDirs  []string
+	baseAddr     string
+	baseChainLen int
+}
+
+// rebase returns the cached resources as they would have been recorded had the
+// module been evaluated at addr/chain instead of the position it was first
+// evaluated at.
+//
+// Attributes and Body are shared rather than copied. They are the expensive part
+// of a resolved resource and they are identical for identical inputs, so sharing
+// them is what makes reuse cheap; both are treated as read-only after evaluation.
+func (entry *evalCacheEntry) rebase(addr string, chain []CallSite) []ResolvedResource {
+	if entry.baseAddr == addr && entry.baseChainLen == len(chain) {
+		return entry.resources
+	}
+	out := make([]ResolvedResource, len(entry.resources))
+	for i := range entry.resources {
+		r := entry.resources[i]
+		r.ModuleAddress = rebaseAddr(r.ModuleAddress, entry.baseAddr, addr)
+		r.CallChain = rebaseChain(r.CallChain, entry.baseChainLen, chain)
+		out[i] = r
+	}
+	return out
+}
+
+// rebaseAddr swaps the prefix a cached address was recorded under for the current
+// one, keeping the part that describes position *within* the cached subtree.
+func rebaseAddr(recorded, baseAddr, addr string) string {
+	suffix := recorded
+	if baseAddr != "" {
+		suffix = strings.TrimPrefix(recorded, baseAddr)
+		suffix = strings.TrimPrefix(suffix, ".")
+	}
+	if suffix == "" {
+		return addr
+	}
+	return joinAddr(addr, suffix)
+}
+
+// rebaseChain replaces the leading hops a cached chain was recorded under with the
+// current caller's hops, preserving the hops taken inside the cached subtree.
+func rebaseChain(recorded []CallSite, baseLen int, chain []CallSite) []CallSite {
+	if baseLen > len(recorded) {
+		baseLen = len(recorded)
+	}
+	inner := recorded[baseLen:]
+	if len(inner) == 0 {
+		return cloneChain(chain)
+	}
+	out := make([]CallSite, 0, len(chain)+len(inner))
+	out = append(out, chain...)
+	out = append(out, inner...)
+	return out
 }
 
 // canonicalInputsKey returns a stable string for a set of resolved module inputs.

--- a/pkg/parser/terraform/tfeval/eval_cache_key_test.go
+++ b/pkg/parser/terraform/tfeval/eval_cache_key_test.go
@@ -1,0 +1,243 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package tfeval
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// writeNestedFanOut lays down `depth` nested module levels where every level
+// calls the level below it `branch` times. The repository is one file per level,
+// but the module tree it describes has branch^depth instances.
+func writeNestedFanOut(t *testing.T, depth, branch int) string {
+	t.Helper()
+	root := t.TempDir()
+
+	for i := 0; i < depth; i++ {
+		dir := filepath.Join(root, fmt.Sprintf("lvl%02d", i))
+		body := "variable \"in\" { type = string }\n"
+		if i == depth-1 {
+			body += "resource \"aws_s3_bucket\" \"leaf\" { bucket = var.in }\noutput \"out\" { value = var.in }\n"
+		} else {
+			for b := 0; b < branch; b++ {
+				body += fmt.Sprintf("module \"m%d\" {\n  source = \"../lvl%02d\"\n  in = var.in\n}\n", b, i+1)
+			}
+			body += "output \"out\" { value = module.m0.out }\n"
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	stack := filepath.Join(root, "stack")
+	if err := os.MkdirAll(stack, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stack, "main.tf"),
+		[]byte("module \"m\" {\n  source = \"../lvl00\"\n  in = \"seed\"\n}\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return stack
+}
+
+// A module reached by many paths with the same inputs must be evaluated once. When
+// the call chain was part of the cache key this shape cost branch^depth
+// evaluations, so a repository of a dozen files could exhaust any memory limit:
+// depth 12 alone produced over 8,000 cache entries.
+func TestEvalCache_NestedFanOutEvaluatesEachModuleOnce(t *testing.T) {
+	for _, tc := range []struct{ depth, branch int }{{8, 2}, {12, 2}, {6, 3}} {
+		name := fmt.Sprintf("depth%d_branch%d", tc.depth, tc.branch)
+		t.Run(name, func(t *testing.T) {
+			stack := writeNestedFanOut(t, tc.depth, tc.branch)
+
+			e := New()
+			resources, _, _, err := e.EvaluateModule(context.Background(), stack, nil)
+			if err != nil {
+				t.Fatalf("EvaluateModule: %v", err)
+			}
+
+			// One distinct (dir, inputs) pair per level, plus the root stack.
+			wantEntries := tc.depth + 1
+			if got := len(e.cache); got > wantEntries {
+				t.Errorf("cache holds %d entries, want at most %d (one per distinct module); "+
+					"evaluation is scaling with the number of call paths, not with distinct modules",
+					got, wantEntries)
+			}
+			if len(resources) == 0 {
+				t.Error("expected the nested tree to resolve resources, got none")
+			}
+		})
+	}
+}
+
+// Reusing an evaluation across call paths must not blur where its resources came
+// from: each instance keeps the address and chain of the path that reached it,
+// since findings are attributed with them.
+func TestEvalCache_ReusedEvaluationKeepsPerPathAttribution(t *testing.T) {
+	root := t.TempDir()
+
+	child := filepath.Join(root, "child")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(child, "main.tf"),
+		[]byte("variable \"in\" { type = string }\nresource \"aws_s3_bucket\" \"b\" { bucket = var.in }\n"),
+		0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	stack := filepath.Join(root, "stack")
+	if err := os.MkdirAll(stack, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Same source, same inputs, two call sites: one evaluation, two attributions.
+	if err := os.WriteFile(filepath.Join(stack, "main.tf"), []byte(`
+module "alpha" {
+  source = "../child"
+  in     = "same"
+}
+module "beta" {
+  source = "../child"
+  in     = "same"
+}
+`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	e := New()
+	resources, _, _, err := e.EvaluateModule(context.Background(), stack, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("resolved %d resources, want 2 (one per call site)", len(resources))
+	}
+
+	addrs := map[string]bool{}
+	for _, r := range resources {
+		addrs[r.ModuleAddress] = true
+		if len(r.CallChain) != 1 {
+			t.Errorf("resource at %s has a %d-hop call chain, want 1",
+				r.ModuleAddress, len(r.CallChain))
+			continue
+		}
+		// The chain must name the call site that reached this instance.
+		wantName := strings.TrimPrefix(r.ModuleAddress, "module.")
+		if got := r.CallChain[0].ModuleName; got != wantName {
+			t.Errorf("resource at %s records call site %q, want %q",
+				r.ModuleAddress, got, wantName)
+		}
+	}
+	for _, want := range []string{"module.alpha", "module.beta"} {
+		if !addrs[want] {
+			t.Errorf("no resource attributed to %s; got %v", want, addrs)
+		}
+	}
+}
+
+// A module the evaluator declines to evaluate must be reported as not evaluated
+// rather than as a module that resolved to nothing. The caller uses that to keep
+// it in the scan, so conflating the two silently drops it.
+func TestEvaluate_DepthCapReportsNotEvaluated(t *testing.T) {
+	root := t.TempDir()
+	// One level deeper than the evaluator will follow.
+	depth := defaultMaxDepth + 3
+	for i := 0; i < depth; i++ {
+		dir := filepath.Join(root, fmt.Sprintf("lvl%02d", i))
+		body := "variable \"in\" { type = string }\n"
+		if i == depth-1 {
+			body += "resource \"aws_s3_bucket\" \"leaf\" { bucket = var.in }\n"
+		} else {
+			body += fmt.Sprintf("module \"next\" {\n  source = \"../lvl%02d\"\n  in = var.in\n}\n", i+1)
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	e := New()
+	_, _, visited, err := e.EvaluateModule(context.Background(), filepath.Join(root, "lvl00"),
+		map[string]cty.Value{"in": cty.StringVal("seed")})
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	// The levels past the cap were never resolved, so they must not be recorded as
+	// evaluated — otherwise their bodies are suppressed with nothing standing in.
+	for i := defaultMaxDepth + 1; i < depth; i++ {
+		dir := filepath.Join(root, fmt.Sprintf("lvl%02d", i))
+		if visited[dir] {
+			t.Errorf("%s was not evaluated (past the depth cap) but is recorded as visited, "+
+				"so it would be dropped from the scan", dir)
+		}
+	}
+}
+
+// The instantiation budget is a backstop for shapes that are genuinely enormous.
+// It must stop the recursion rather than let a single root grow without bound.
+func TestInstantiationBudget_StopsRecursion(t *testing.T) {
+	stack := writeNestedFanOut(t, 10, 3)
+
+	unbounded := New()
+	unbounded.SetMaxInstantiated(0)
+	all, _, _, err := unbounded.EvaluateModule(context.Background(), stack, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	if unbounded.BudgetExceeded() {
+		t.Error("budget reported exceeded when disabled")
+	}
+
+	bounded := New()
+	bounded.SetMaxInstantiated(4)
+	limited, _, _, err := bounded.EvaluateModule(context.Background(), stack, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	if !bounded.BudgetExceeded() {
+		t.Error("budget was not reported as exceeded")
+	}
+	if len(limited) >= len(all) {
+		t.Errorf("bounded run resolved %d resources, want fewer than the %d of an unbounded run",
+			len(limited), len(all))
+	}
+}
+
+func TestResetInstantiationBudget_FreshQuotaPerRoot(t *testing.T) {
+	e := New()
+	e.SetMaxInstantiated(100)
+	ctx := context.Background()
+
+	e.chargeInstantiationBudget(ctx, 80)
+	if e.BudgetExceeded() {
+		t.Fatal("budget should not be exceeded at 80 of 100")
+	}
+
+	e.ResetInstantiationBudget()
+	e.chargeInstantiationBudget(ctx, 80)
+	if e.BudgetExceeded() {
+		t.Fatal("after reset, a second root should get a fresh quota of 100")
+	}
+
+	e.chargeInstantiationBudget(ctx, 25)
+	if !e.BudgetExceeded() {
+		t.Fatal("budget should exceed once a single root passes 100 resources")
+	}
+}

--- a/pkg/parser/terraform/tfeval/eval_cache_key_test.go
+++ b/pkg/parser/terraform/tfeval/eval_cache_key_test.go
@@ -220,6 +220,30 @@ func TestInstantiationBudget_StopsRecursion(t *testing.T) {
 	}
 }
 
+func TestInstantiationBudget_CountsFinalInstancesOnce(t *testing.T) {
+	stack := writeNestedFanOut(t, 12, 3)
+
+	e := New()
+	resources, _, _, err := e.EvaluateModule(context.Background(), stack, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	const want = 177147
+	if got := len(resources); got != want {
+		t.Fatalf("resolved %d resources after counting %d, want %d below the %d-resource budget",
+			got, e.instantiated, want, defaultMaxInstantiated)
+	}
+	if e.BudgetExceeded() {
+		t.Fatalf("budget was exhausted after resolving %d resources below its %d limit",
+			len(resources), defaultMaxInstantiated)
+	}
+	if e.instantiated != len(resources) {
+		t.Fatalf("budget counted %d instances for %d returned resources",
+			e.instantiated, len(resources))
+	}
+}
+
 func TestResetInstantiationBudget_FreshQuotaPerRoot(t *testing.T) {
 	e := New()
 	e.SetMaxInstantiated(100)
@@ -239,6 +263,61 @@ func TestResetInstantiationBudget_FreshQuotaPerRoot(t *testing.T) {
 	e.chargeInstantiationBudget(ctx, 25)
 	if !e.BudgetExceeded() {
 		t.Fatal("budget should exceed once a single root passes 100 resources")
+	}
+}
+
+func TestEvalCache_DoesNotReuseDepthTruncatedResult(t *testing.T) {
+	root := t.TempDir()
+	leaf := filepath.Join(root, "leaf")
+	target := filepath.Join(root, "target")
+	for _, dir := range []string{leaf, target} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(leaf, "main.tf"), []byte(`
+variable "in" { type = string }
+resource "aws_s3_bucket" "leaf" { bucket = var.in }
+`), 0o644); err != nil {
+		t.Fatalf("write leaf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "main.tf"), []byte(`
+variable "in" { type = string }
+resource "aws_s3_bucket" "target" { bucket = var.in }
+module "leaf" {
+  source = "../leaf"
+  in     = var.in
+}
+`), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	e := New()
+	inputs := map[string]cty.Value{"in": cty.StringVal("same")}
+	partial, _, err := e.evaluate(
+		context.Background(), target, "", inputs, "module.deep", nil,
+		e.maxDepth, map[string]bool{}, map[string]bool{},
+	)
+	if err != nil {
+		t.Fatalf("deep evaluate: %v", err)
+	}
+	if len(partial) != 1 {
+		t.Fatalf("deep evaluate returned %d resources, want the target resource only", len(partial))
+	}
+	key := evalCacheKey{dir: target, inputs: canonicalInputsKey(inputs)}
+	if _, ok := e.cache[key]; ok {
+		t.Fatal("depth-truncated evaluation was cached as complete")
+	}
+
+	complete, _, err := e.evaluate(
+		context.Background(), target, "", inputs, "module.shallow", nil,
+		0, map[string]bool{}, map[string]bool{},
+	)
+	if err != nil {
+		t.Fatalf("shallow evaluate: %v", err)
+	}
+	if len(complete) != 2 {
+		t.Fatalf("shallow evaluate returned %d resources, want target and leaf", len(complete))
 	}
 }
 

--- a/pkg/parser/terraform/tfeval/eval_cache_key_test.go
+++ b/pkg/parser/terraform/tfeval/eval_cache_key_test.go
@@ -241,3 +241,44 @@ func TestResetInstantiationBudget_FreshQuotaPerRoot(t *testing.T) {
 		t.Fatal("budget should exceed once a single root passes 100 resources")
 	}
 }
+
+// Whether a module was resolved is decided per directory by the caller, but the
+// stops are per call site: the same directory can be resolved on one path and
+// skipped on another. Every skipped directory has to be reported, or the caller
+// suppresses a body whose skipped instances nothing replaces.
+func TestNotEvaluatedDirs_ReportsSkippedDirectories(t *testing.T) {
+	stack := writeNestedFanOut(t, 10, 3)
+
+	unbounded := New()
+	unbounded.SetMaxInstantiated(0)
+	if _, _, _, err := unbounded.EvaluateModule(context.Background(), stack, nil); err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	if dirs := unbounded.NotEvaluatedDirs(); len(dirs) != 0 {
+		t.Errorf("nothing was skipped, yet %d directories are reported as not evaluated: %v",
+			len(dirs), dirs)
+	}
+
+	bounded := New()
+	bounded.SetMaxInstantiated(4)
+	if _, _, _, err := bounded.EvaluateModule(context.Background(), stack, nil); err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	skipped := bounded.NotEvaluatedDirs()
+	if len(skipped) == 0 {
+		t.Fatal("the budget stopped the recursion but no directory is reported as not evaluated")
+	}
+	for _, dir := range skipped {
+		if !strings.HasPrefix(dir, filepath.Dir(stack)) {
+			t.Errorf("reported directory %s is outside the fixture", dir)
+		}
+	}
+
+	// The budget resets per root, but a skipped directory stays skipped: the
+	// caller's suppression decision spans every root.
+	bounded.ResetInstantiationBudget()
+	if got := len(bounded.NotEvaluatedDirs()); got != len(skipped) {
+		t.Errorf("resetting the budget changed the skipped set from %d to %d directories",
+			len(skipped), got)
+	}
+}

--- a/pkg/parser/terraform/tfeval/eval_cache_retention_test.go
+++ b/pkg/parser/terraform/tfeval/eval_cache_retention_test.go
@@ -1,0 +1,172 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package tfeval
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeSharedModuleFanout lays down `roots` independent root modules that all
+// call the same shared module chain, which is the shape of a Terraform monorepo:
+// one root per environment/region/stack over a common module library.
+func writeSharedModuleFanout(t *testing.T, base string, roots, sharedDepth, resourcesPerModule int) []string {
+	t.Helper()
+
+	for i := 0; i < sharedDepth; i++ {
+		dir := filepath.Join(base, "modules", fmt.Sprintf("m%d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		src := fmt.Sprintf("variable \"in\" { default = \"x\" }\nlocals { p = \"${var.in}-%d\" }\n", i)
+		for r := 0; r < resourcesPerModule; r++ {
+			src += fmt.Sprintf(`
+resource "aws_s3_bucket" "b%d" {
+  bucket = "${local.p}-%d"
+  tags   = { Name = "${local.p}-%d", Layer = "%d" }
+}
+`, r, r, r, i)
+		}
+		if i < sharedDepth-1 {
+			src += fmt.Sprintf("module \"next\" {\n  source = \"../m%d\"\n  in     = local.p\n}\n", i+1)
+			src += "output \"out\" { value = module.next.out }\n"
+		} else {
+			src += "output \"out\" { value = local.p }\n"
+		}
+		if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(src), 0o644); err != nil {
+			t.Fatalf("write %s: %v", dir, err)
+		}
+	}
+
+	dirs := make([]string, 0, roots)
+	for i := 0; i < roots; i++ {
+		dir := filepath.Join(base, "stacks", fmt.Sprintf("stack%d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		src := fmt.Sprintf(`
+module "shared" {
+  source = "../../modules/m0"
+  in     = "stack%d"
+}
+resource "aws_s3_bucket" "root" { bucket = "stack%d-root" }
+`, i, i)
+		if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(src), 0o644); err != nil {
+			t.Fatalf("write %s: %v", dir, err)
+		}
+		dirs = append(dirs, dir)
+	}
+	return dirs
+}
+
+// cachedResources counts the ResolvedResource structs the evaluation cache is
+// holding. Every entry stores its whole subtree, so this is what a scan actually
+// retains, not the number of resources it reports.
+func cachedResources(e *Evaluator) int {
+	total := 0
+	for _, entry := range e.cache {
+		total += len(entry.resources)
+	}
+	return total
+}
+
+// Every cache entry holds the resolved resources of its whole subtree, so holding
+// entries for a whole repository makes peak memory scale with the number of
+// roots, which is what puts a monorepo over its memory limit. Releasing between
+// roots must keep retention flat as roots are added.
+func TestReleaseEvalCache_RetentionDoesNotGrowWithRootCount(t *testing.T) {
+	const sharedDepth = 6
+	const resourcesPerModule = 4
+
+	var firstRootRetention int
+	for _, roots := range []int{1, 8, 64} {
+		dirs := writeSharedModuleFanout(t, t.TempDir(), roots, sharedDepth, resourcesPerModule)
+
+		e := New()
+		peak := 0
+		for _, dir := range dirs {
+			if _, _, _, err := e.EvaluateModule(context.Background(), dir, nil); err != nil {
+				t.Fatalf("roots=%d: EvaluateModule(%s): %v", roots, dir, err)
+			}
+			if got := cachedResources(e); got > peak {
+				peak = got
+			}
+			e.ReleaseEvalCache()
+		}
+
+		if roots == 1 {
+			firstRootRetention = peak
+			continue
+		}
+		if peak != firstRootRetention {
+			t.Fatalf("roots=%d: peak cached resources = %d, want %d (one root's worth); "+
+				"retention must not scale with the number of roots",
+				roots, peak, firstRootRetention)
+		}
+	}
+}
+
+// Dropping the evaluation cache between roots must not change what a root
+// resolves; releasing it trades a low cross-root hit rate for a bounded peak.
+func TestReleaseEvalCache_PreservesResolvedResources(t *testing.T) {
+	dirs := writeSharedModuleFanout(t, t.TempDir(), 6, 5, 3)
+
+	kept := New()
+	var withCache []int
+	for _, dir := range dirs {
+		res, _, _, err := kept.EvaluateModule(context.Background(), dir, nil)
+		if err != nil {
+			t.Fatalf("EvaluateModule(%s): %v", dir, err)
+		}
+		withCache = append(withCache, len(res))
+	}
+
+	released := New()
+	for i, dir := range dirs {
+		res, _, _, err := released.EvaluateModule(context.Background(), dir, nil)
+		if err != nil {
+			t.Fatalf("EvaluateModule(%s): %v", dir, err)
+		}
+		if len(res) != withCache[i] {
+			t.Fatalf("root %s resolved %d resources with a per-root cache release, want %d",
+				dir, len(res), withCache[i])
+		}
+		released.ReleaseEvalCache()
+	}
+}
+
+// ReleaseEvalCache must keep the parse cache, which is keyed by directory alone
+// and is the one thing every root genuinely shares.
+func TestReleaseEvalCache_KeepsParsedDirectories(t *testing.T) {
+	dirs := writeSharedModuleFanout(t, t.TempDir(), 2, 4, 2)
+
+	e := New()
+	if _, _, _, err := e.EvaluateModule(context.Background(), dirs[0], nil); err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	parsedBefore := len(e.dirCache)
+	if parsedBefore == 0 {
+		t.Fatal("expected the first root to populate the parse cache")
+	}
+
+	e.ReleaseEvalCache()
+
+	if got := len(e.cache); got != 0 {
+		t.Fatalf("evaluation cache holds %d entries after release, want 0", got)
+	}
+	if got := len(e.dirCache); got != parsedBefore {
+		t.Fatalf("parse cache holds %d entries after release, want %d — parsed bodies are shared across roots",
+			got, parsedBefore)
+	}
+
+	e.ReleaseCaches()
+	if got := len(e.dirCache); got != 0 {
+		t.Fatalf("parse cache holds %d entries after ReleaseCaches, want 0", got)
+	}
+}

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -11,6 +11,7 @@ package tfeval
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -38,7 +39,19 @@ const (
 	resourceRefPasses = 3
 	// maxCountExpansion caps instances per count/for_each block.
 	maxCountExpansion = 10
+	// defaultMaxInstantiated is the last-resort cap on resources one scan may
+	// instantiate. Memoizing on inputs removes the exponential path that made a
+	// small repository able to exhaust any limit, so this exists only for shapes
+	// that are genuinely, and not just redundantly, that large. Reaching it costs
+	// resolved values for the modules beyond it, which are still scanned as
+	// written — strictly better than the scan dying and reporting nothing.
+	defaultMaxInstantiated = 200000
 )
+
+// ErrModuleNotEvaluated reports that a module was skipped rather than evaluated,
+// so callers must leave it to be scanned as written instead of treating it as a
+// module that resolved to nothing.
+var ErrModuleNotEvaluated = errors.New("tfeval: module not evaluated")
 
 // ResolvedResource is a resource block after evaluation with attributes
 // resolved to concrete cty values where possible, unknown otherwise.
@@ -73,13 +86,20 @@ type CallSite struct {
 type Evaluator struct {
 	funcs    map[string]function.Function
 	maxDepth int
-	// cache memoizes completed module evaluations keyed by (dir, addr, canonical-inputs).
-	// A single Evaluator is used for an entire scan, so the cache is shared across root
-	// module calls — entries with the same key represent the same module called with the
-	// same resolved inputs from the same structural position in the module tree.
+	// cache memoizes completed module evaluations keyed by (dir, packageRoot,
+	// canonical-inputs). A single Evaluator is used for an entire scan, so entries
+	// with the same key represent the same module reached with the same resolved
+	// inputs, whatever path led there.
 	cache map[evalCacheKey]*evalCacheEntry
 	// When set, non-local module sources resolve here and recurse with caller inputs.
 	remoteResolver RemoteResolver
+
+	// Aggregate cap on resources this evaluator will instantiate, enforced inside
+	// the recursion rather than between root modules: a single root can expand
+	// without bound, so a check that only runs at root boundaries never fires.
+	maxInstantiated int
+	instantiated    int
+	budgetExceeded  bool
 
 	parseMu  sync.Mutex
 	dirCache map[string]dirParse
@@ -92,12 +112,17 @@ type dirParse struct {
 
 func New() *Evaluator {
 	return &Evaluator{
-		funcs:    tffunctions.TerraformFuncs,
-		maxDepth: defaultMaxDepth,
-		cache:    make(map[evalCacheKey]*evalCacheEntry),
-		dirCache: make(map[string]dirParse),
+		funcs:           tffunctions.TerraformFuncs,
+		maxDepth:        defaultMaxDepth,
+		maxInstantiated: defaultMaxInstantiated,
+		cache:           make(map[evalCacheKey]*evalCacheEntry),
+		dirCache:        make(map[string]dirParse),
 	}
 }
+
+// SetMaxInstantiated overrides the instantiation budget. A value of zero or less
+// disables it.
+func (e *Evaluator) SetMaxInstantiated(n int) { e.maxInstantiated = n }
 
 func (e *Evaluator) parseDir(dir, packageRoot string) ([]*hclsyntax.Body, error) {
 	key := filepath.Clean(dir) + "\x00" + filepath.Clean(packageRoot)
@@ -122,10 +147,21 @@ func (e *Evaluator) SetRemoteResolver(r RemoteResolver) {
 }
 
 func (e *Evaluator) ReleaseCaches() {
-	e.cache = make(map[evalCacheKey]*evalCacheEntry)
+	e.ReleaseEvalCache()
 	e.parseMu.Lock()
 	e.dirCache = make(map[string]dirParse)
 	e.parseMu.Unlock()
+}
+
+// ReleaseEvalCache drops memoized module evaluations while keeping parsed HCL
+// bodies. Every entry holds the resolved resources of its whole subtree, so
+// retaining entries for a whole repository scales peak memory with the number of
+// roots. Entries are reusable across roots now that the key is the inputs alone,
+// but in practice each root passes its own values to the shared modules it calls,
+// so the hit rate across roots is low and not worth that peak. The parse cache is
+// keyed by directory alone, genuinely is shared by every root, and is kept.
+func (e *Evaluator) ReleaseEvalCache() {
+	e.cache = make(map[evalCacheKey]*evalCacheEntry)
 }
 
 // EvaluateModule evaluates the module rooted at dir with the given inputs and
@@ -165,28 +201,37 @@ func (e *Evaluator) evaluate(
 ) ([]ResolvedResource, map[string]cty.Value, error) {
 	contextLogger := logger.FromContext(ctx)
 
+	// These three return ErrModuleNotEvaluated rather than an empty result. An
+	// empty result is indistinguishable from a module that legitimately declares
+	// no resources, and the caller would record the directory as evaluated — which
+	// suppresses its body from the scan with no synthetic document to replace it.
+	// Reporting "not evaluated" keeps the module scanned as written instead.
 	if depth > e.maxDepth {
 		contextLogger.Warn().Msgf("tfeval: max module depth %d exceeded at %s", e.maxDepth, dir)
-		return nil, map[string]cty.Value{}, nil
+		return nil, nil, ErrModuleNotEvaluated
 	}
 	if visiting[dir] {
 		contextLogger.Warn().Msgf("tfeval: module cycle detected at %s, stopping recursion", dir)
-		return nil, map[string]cty.Value{}, nil
+		return nil, nil, ErrModuleNotEvaluated
+	}
+	if e.instantiationBudgetExhausted() {
+		return nil, nil, ErrModuleNotEvaluated
 	}
 
-	// Pre-pass and main loop share (dir, addr, inputs, chain); distinct callers differ in chain only.
+	// Keyed on inputs only, so every path to the same module with the same inputs
+	// shares one evaluation and is re-stamped for its own position.
 	cacheKey := evalCacheKey{
 		dir:         dir,
 		packageRoot: packageRoot,
-		addr:        addr,
 		inputs:      canonicalInputsKey(inputs),
-		chain:       chainKey(chain),
 	}
 	if entry, ok := e.cache[cacheKey]; ok {
 		for _, d := range entry.visitedDirs {
 			allVisited[d] = true
 		}
-		return entry.resources, entry.outputs, nil
+		reused := entry.rebase(addr, chain)
+		e.chargeInstantiationBudget(ctx, len(reused))
+		return reused, entry.outputs, nil
 	}
 
 	visiting[dir] = true
@@ -266,12 +311,51 @@ func (e *Evaluator) evaluate(
 		}
 	}
 	e.cache[cacheKey] = &evalCacheEntry{
-		resources:   resources,
-		outputs:     outputs,
-		visitedDirs: visitedDirs,
+		resources:    resources,
+		outputs:      outputs,
+		visitedDirs:  visitedDirs,
+		baseAddr:     addr,
+		baseChainLen: len(chain),
 	}
+	e.chargeInstantiationBudget(ctx, len(resources))
 
 	return resources, outputs, nil
+}
+
+// chargeInstantiationBudget counts resources as they are handed to a caller,
+// including reused ones. Memoizing removes the repeated *evaluation* of a shared
+// subtree but not the repeated materialization of its resources: every caller gets
+// its own copies, attributed to its own path. Those copies are the memory the
+// budget exists to bound, so counting evaluations instead would never fire.
+func (e *Evaluator) chargeInstantiationBudget(ctx context.Context, n int) {
+	if e.maxInstantiated <= 0 {
+		return
+	}
+	e.instantiated += n
+	if e.instantiated >= e.maxInstantiated && !e.budgetExceeded {
+		e.budgetExceeded = true
+		contextLogger := logger.FromContext(ctx)
+		contextLogger.Warn().
+			Int("resources_instantiated", e.instantiated).
+			Int("resource_budget", e.maxInstantiated).
+			Msg("tfeval: module instantiation budget exhausted; " +
+				"stopping recursion, remaining modules are scanned as written")
+	}
+}
+
+func (e *Evaluator) instantiationBudgetExhausted() bool {
+	return e.maxInstantiated > 0 && e.instantiated >= e.maxInstantiated
+}
+
+// BudgetExceeded reports whether evaluation stopped early for budget, so callers
+// can leave the modules it did not reach to be scanned as written.
+func (e *Evaluator) BudgetExceeded() bool { return e.budgetExceeded }
+
+// ResetInstantiationBudget clears per-root instantiation counters so one large
+// root cannot consume the quota for every subsequent root in a monorepo.
+func (e *Evaluator) ResetInstantiationBudget() {
+	e.instantiated = 0
+	e.budgetExceeded = false
 }
 
 func (e *Evaluator) applySiblingModulePrepass(
@@ -361,7 +445,11 @@ func (e *Evaluator) evaluateLocalModuleBlocks(
 			append(cloneChain(chain), site), depth+1, visiting, allVisited,
 		)
 		if cErr != nil {
-			contextLogger.Warn().Msgf("tfeval: failed to evaluate module %q at %s: %v", label, childDir, cErr)
+			if !errors.Is(cErr, ErrModuleNotEvaluated) {
+				contextLogger.Warn().Msgf("tfeval: failed to evaluate module %q at %s: %v", label, childDir, cErr)
+			}
+			// Deliberately not added to allVisited: the module was not resolved, so
+			// it must keep being scanned where it is written.
 			continue
 		}
 		allVisited[childDir] = true

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -101,6 +101,13 @@ type Evaluator struct {
 	instantiated    int
 	budgetExceeded  bool
 
+	// notEvaluatedDirs holds every module directory this evaluator declined to
+	// evaluate for depth, cycle or budget. It accumulates for the whole scan
+	// because suppression is decided per directory over all call sites at once:
+	// one skipped instance means the directory is only partially resolved, so
+	// its body must stay in the scan even though other instances did resolve.
+	notEvaluatedDirs map[string]bool
+
 	parseMu  sync.Mutex
 	dirCache map[string]dirParse
 }
@@ -112,12 +119,31 @@ type dirParse struct {
 
 func New() *Evaluator {
 	return &Evaluator{
-		funcs:           tffunctions.TerraformFuncs,
-		maxDepth:        defaultMaxDepth,
-		maxInstantiated: defaultMaxInstantiated,
-		cache:           make(map[evalCacheKey]*evalCacheEntry),
-		dirCache:        make(map[string]dirParse),
+		funcs:            tffunctions.TerraformFuncs,
+		maxDepth:         defaultMaxDepth,
+		maxInstantiated:  defaultMaxInstantiated,
+		cache:            make(map[evalCacheKey]*evalCacheEntry),
+		dirCache:         make(map[string]dirParse),
+		notEvaluatedDirs: make(map[string]bool),
 	}
+}
+
+// skipEvaluation records dir as not evaluated and returns ErrModuleNotEvaluated.
+func (e *Evaluator) skipEvaluation(dir string) error {
+	e.notEvaluatedDirs[filepath.Clean(dir)] = true
+	return ErrModuleNotEvaluated
+}
+
+// NotEvaluatedDirs returns the module directories that were skipped rather than
+// evaluated. Callers must keep the content of these directories in the scan: a
+// directory can have both resolved and skipped call sites, and the skipped ones
+// have no synthetic document standing in for them.
+func (e *Evaluator) NotEvaluatedDirs() []string {
+	dirs := make([]string, 0, len(e.notEvaluatedDirs))
+	for dir := range e.notEvaluatedDirs {
+		dirs = append(dirs, dir)
+	}
+	return dirs
 }
 
 // SetMaxInstantiated overrides the instantiation budget. A value of zero or less
@@ -205,17 +231,19 @@ func (e *Evaluator) evaluate(
 	// empty result is indistinguishable from a module that legitimately declares
 	// no resources, and the caller would record the directory as evaluated — which
 	// suppresses its body from the scan with no synthetic document to replace it.
-	// Reporting "not evaluated" keeps the module scanned as written instead.
+	// Reporting "not evaluated" keeps the module scanned as written instead, and
+	// recording the directory keeps it scanned even when another call site of the
+	// same directory did resolve.
 	if depth > e.maxDepth {
 		contextLogger.Warn().Msgf("tfeval: max module depth %d exceeded at %s", e.maxDepth, dir)
-		return nil, nil, ErrModuleNotEvaluated
+		return nil, nil, e.skipEvaluation(dir)
 	}
 	if visiting[dir] {
 		contextLogger.Warn().Msgf("tfeval: module cycle detected at %s, stopping recursion", dir)
-		return nil, nil, ErrModuleNotEvaluated
+		return nil, nil, e.skipEvaluation(dir)
 	}
 	if e.instantiationBudgetExhausted() {
-		return nil, nil, ErrModuleNotEvaluated
+		return nil, nil, e.skipEvaluation(dir)
 	}
 
 	// Keyed on inputs only, so every path to the same module with the same inputs

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -99,7 +99,11 @@ type Evaluator struct {
 	// without bound, so a check that only runs at root boundaries never fires.
 	maxInstantiated int
 	instantiated    int
-	budgetExceeded  bool
+	// Speculative sibling evaluation is bounded separately from final instances.
+	prepassInstantiated int
+	prepassDepth        int
+	budgetExceeded      bool
+	skipped             uint64
 
 	// notEvaluatedDirs holds every module directory this evaluator declined to
 	// evaluate for depth, cycle or budget. It accumulates for the whole scan
@@ -130,6 +134,7 @@ func New() *Evaluator {
 
 // skipEvaluation records dir as not evaluated and returns ErrModuleNotEvaluated.
 func (e *Evaluator) skipEvaluation(dir string) error {
+	e.skipped++
 	e.notEvaluatedDirs[filepath.Clean(dir)] = true
 	return ErrModuleNotEvaluated
 }
@@ -225,45 +230,24 @@ func (e *Evaluator) evaluate(
 	visiting map[string]bool,
 	allVisited map[string]bool,
 ) ([]ResolvedResource, map[string]cty.Value, error) {
-	contextLogger := logger.FromContext(ctx)
-
-	// These three return ErrModuleNotEvaluated rather than an empty result. An
-	// empty result is indistinguishable from a module that legitimately declares
-	// no resources, and the caller would record the directory as evaluated — which
-	// suppresses its body from the scan with no synthetic document to replace it.
-	// Reporting "not evaluated" keeps the module scanned as written instead, and
-	// recording the directory keeps it scanned even when another call site of the
-	// same directory did resolve.
-	if depth > e.maxDepth {
-		contextLogger.Warn().Msgf("tfeval: max module depth %d exceeded at %s", e.maxDepth, dir)
-		return nil, nil, e.skipEvaluation(dir)
-	}
-	if visiting[dir] {
-		contextLogger.Warn().Msgf("tfeval: module cycle detected at %s, stopping recursion", dir)
-		return nil, nil, e.skipEvaluation(dir)
-	}
-	if e.instantiationBudgetExhausted() {
-		return nil, nil, e.skipEvaluation(dir)
+	if err := e.evaluationStop(ctx, dir, depth, visiting); err != nil {
+		return nil, nil, err
 	}
 
-	// Keyed on inputs only, so every path to the same module with the same inputs
-	// shares one evaluation and is re-stamped for its own position.
 	cacheKey := evalCacheKey{
 		dir:         dir,
 		packageRoot: packageRoot,
 		inputs:      canonicalInputsKey(inputs),
 	}
-	if entry, ok := e.cache[cacheKey]; ok {
-		for _, d := range entry.visitedDirs {
-			allVisited[d] = true
-		}
-		reused := entry.rebase(addr, chain)
-		e.chargeInstantiationBudget(ctx, len(reused))
-		return reused, entry.outputs, nil
+	if resources, outputs, hit, err := e.reuseCachedEvaluation(
+		ctx, cacheKey, dir, addr, chain, allVisited,
+	); hit {
+		return resources, outputs, err
 	}
 
 	visiting[dir] = true
 	defer delete(visiting, dir)
+	skippedBefore := e.skipped
 
 	// Snapshot allVisited so we can determine which dirs this subtree adds.
 	prevAllVisited := make(map[string]bool, len(allVisited))
@@ -287,16 +271,10 @@ func (e *Evaluator) evaluate(
 		Functions: e.funcs,
 	}
 
-	localVals := e.resolveLocals(localExprs, evalCtx)
-	evalCtx.Variables["local"] = objectOrEmpty(localVals)
+	evalCtx.Variables["local"] = objectOrEmpty(e.resolveLocals(localExprs, evalCtx))
 
-	// Pre-inject sibling resource attrs so module inputs that reference them
-	// (e.g. module "x" { val = aws_resource.y.attr }) resolve on first evaluation.
-	if len(resourceBlocks) > 0 && len(moduleBlocks) > 0 {
-		earlyRes := e.evalResourceBlocks(resourceBlocks, evalCtx, addr, chain)
-		injectResourceRefs(evalCtx, earlyRes)
-		localVals = e.resolveLocals(localExprs, evalCtx)
-		evalCtx.Variables["local"] = objectOrEmpty(localVals)
+	if !e.preinjectResourceRefs(resourceBlocks, moduleBlocks, localExprs, evalCtx, addr, chain) {
+		return nil, nil, e.skipEvaluation(dir)
 	}
 
 	e.applySiblingModulePrepass(ctx, moduleBlocks, evalCtx, localExprs, dir, packageRoot, addr, chain, depth, visiting)
@@ -307,19 +285,22 @@ func (e *Evaluator) evaluate(
 
 	if len(moduleOutputs) > 0 {
 		evalCtx.Variables["module"] = cty.ObjectVal(moduleOutputs)
-		localVals = e.resolveLocals(localExprs, evalCtx)
-		evalCtx.Variables["local"] = objectOrEmpty(localVals)
+		evalCtx.Variables["local"] = objectOrEmpty(e.resolveLocals(localExprs, evalCtx))
 	}
 
-	rootResources := e.rootResourcesWithRefPasses(resourceBlocks, localExprs, evalCtx, addr, chain)
+	rootResources, err := e.evaluateRootResources(
+		ctx, dir, resourceBlocks, localExprs, evalCtx, addr, chain,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// Re-inject the final-pass resource values so that outputs and locals that
 	// reference the Nth hop of an N-hop chain can resolve. For chains shorter
 	// than resourceRefPasses hops all resources were already injected inside the
 	// loop, so injectResourceRefs returns false and the locals refresh is skipped.
 	if injectResourceRefs(evalCtx, rootResources) {
-		localVals = e.resolveLocals(localExprs, evalCtx)
-		evalCtx.Variables["local"] = objectOrEmpty(localVals)
+		evalCtx.Variables["local"] = objectOrEmpty(e.resolveLocals(localExprs, evalCtx))
 	}
 
 	resources := make([]ResolvedResource, 0, len(rootResources)+len(childResources))
@@ -338,41 +319,170 @@ func (e *Evaluator) evaluate(
 			visitedDirs = append(visitedDirs, d)
 		}
 	}
-	e.cache[cacheKey] = &evalCacheEntry{
-		resources:    resources,
-		outputs:      outputs,
-		visitedDirs:  visitedDirs,
-		baseAddr:     addr,
-		baseChainLen: len(chain),
-	}
-	e.chargeInstantiationBudget(ctx, len(resources))
+	e.cacheCompletedEvaluation(
+		cacheKey, skippedBefore, resources, outputs, visitedDirs, addr, len(chain),
+	)
 
 	return resources, outputs, nil
 }
 
-// chargeInstantiationBudget counts resources as they are handed to a caller,
-// including reused ones. Memoizing removes the repeated *evaluation* of a shared
-// subtree but not the repeated materialization of its resources: every caller gets
-// its own copies, attributed to its own path. Those copies are the memory the
-// budget exists to bound, so counting evaluations instead would never fire.
-func (e *Evaluator) chargeInstantiationBudget(ctx context.Context, n int) {
-	if e.maxInstantiated <= 0 {
+func (e *Evaluator) evaluationStop(
+	ctx context.Context,
+	dir string,
+	depth int,
+	visiting map[string]bool,
+) error {
+	contextLogger := logger.FromContext(ctx)
+	if depth > e.maxDepth {
+		contextLogger.Warn().Msgf("tfeval: max module depth %d exceeded at %s", e.maxDepth, dir)
+		return e.skipEvaluation(dir)
+	}
+	if visiting[dir] {
+		contextLogger.Warn().Msgf("tfeval: module cycle detected at %s, stopping recursion", dir)
+		return e.skipEvaluation(dir)
+	}
+	if e.instantiationBudgetExhausted() {
+		return e.skipEvaluation(dir)
+	}
+	return nil
+}
+
+func (e *Evaluator) reuseCachedEvaluation(
+	ctx context.Context,
+	key evalCacheKey,
+	dir, addr string,
+	chain []CallSite,
+	allVisited map[string]bool,
+) (
+	resources []ResolvedResource,
+	outputs map[string]cty.Value,
+	hit bool,
+	err error,
+) {
+	entry, ok := e.cache[key]
+	if !ok {
+		return nil, nil, false, nil
+	}
+	if e.prepassDepth == 0 || entry.baseAddr != addr || entry.baseChainLen != len(chain) {
+		if !e.chargeInstantiationBudget(ctx, len(entry.resources)) {
+			return nil, nil, true, e.skipEvaluation(dir)
+		}
+	}
+	for _, visited := range entry.visitedDirs {
+		allVisited[visited] = true
+	}
+	return entry.rebase(addr, chain), entry.outputs, true, nil
+}
+
+func (e *Evaluator) preinjectResourceRefs(
+	resourceBlocks, moduleBlocks []*hclsyntax.Block,
+	localExprs map[string]hclsyntax.Expression,
+	evalCtx *hcl.EvalContext,
+	addr string,
+	chain []CallSite,
+) bool {
+	if len(resourceBlocks) == 0 || len(moduleBlocks) == 0 {
+		return true
+	}
+	resources, complete := e.evalResourceBlocks(
+		resourceBlocks, evalCtx, addr, chain, e.remainingInstantiationBudget(),
+	)
+	if !complete {
+		return false
+	}
+	injectResourceRefs(evalCtx, resources)
+	evalCtx.Variables["local"] = objectOrEmpty(e.resolveLocals(localExprs, evalCtx))
+	return true
+}
+
+func (e *Evaluator) evaluateRootResources(
+	ctx context.Context,
+	dir string,
+	resourceBlocks []*hclsyntax.Block,
+	localExprs map[string]hclsyntax.Expression,
+	evalCtx *hcl.EvalContext,
+	addr string,
+	chain []CallSite,
+) ([]ResolvedResource, error) {
+	resources, complete := e.rootResourcesWithRefPasses(
+		resourceBlocks, localExprs, evalCtx, addr, chain,
+	)
+	if !complete || !e.chargeInstantiationBudget(ctx, len(resources)) {
+		return nil, e.skipEvaluation(dir)
+	}
+	return resources, nil
+}
+
+func (e *Evaluator) cacheCompletedEvaluation(
+	key evalCacheKey,
+	skippedBefore uint64,
+	resources []ResolvedResource,
+	outputs map[string]cty.Value,
+	visitedDirs []string,
+	addr string,
+	chainLen int,
+) {
+	if e.skipped != skippedBefore {
 		return
 	}
-	e.instantiated += n
-	if e.instantiated >= e.maxInstantiated && !e.budgetExceeded {
-		e.budgetExceeded = true
-		contextLogger := logger.FromContext(ctx)
-		contextLogger.Warn().
-			Int("resources_instantiated", e.instantiated).
-			Int("resource_budget", e.maxInstantiated).
-			Msg("tfeval: module instantiation budget exhausted; " +
-				"stopping recursion, remaining modules are scanned as written")
+	e.cache[key] = &evalCacheEntry{
+		resources:    resources,
+		outputs:      outputs,
+		visitedDirs:  visitedDirs,
+		baseAddr:     addr,
+		baseChainLen: chainLen,
 	}
 }
 
+func (e *Evaluator) chargeInstantiationBudget(ctx context.Context, n int) bool {
+	if n == 0 || e.maxInstantiated <= 0 {
+		return true
+	}
+	instantiated := e.currentInstantiationCount()
+	if n <= e.maxInstantiated-*instantiated {
+		*instantiated += n
+		if *instantiated == e.maxInstantiated {
+			e.reportInstantiationBudgetExceeded(ctx, *instantiated)
+		}
+		return true
+	}
+	e.reportInstantiationBudgetExceeded(ctx, *instantiated)
+	return false
+}
+
+func (e *Evaluator) reportInstantiationBudgetExceeded(ctx context.Context, instantiated int) {
+	if e.prepassDepth > 0 {
+		return
+	}
+	if e.budgetExceeded {
+		return
+	}
+	e.budgetExceeded = true
+	contextLogger := logger.FromContext(ctx)
+	contextLogger.Warn().
+		Int("resources_instantiated", instantiated).
+		Int("resource_budget", e.maxInstantiated).
+		Msg("tfeval: module instantiation budget exhausted; " +
+			"stopping recursion, remaining modules are scanned as written")
+}
+
+func (e *Evaluator) remainingInstantiationBudget() int {
+	if e.maxInstantiated <= 0 {
+		return -1
+	}
+	return e.maxInstantiated - *e.currentInstantiationCount()
+}
+
+func (e *Evaluator) currentInstantiationCount() *int {
+	if e.prepassDepth > 0 {
+		return &e.prepassInstantiated
+	}
+	return &e.instantiated
+}
+
 func (e *Evaluator) instantiationBudgetExhausted() bool {
-	return e.maxInstantiated > 0 && e.instantiated >= e.maxInstantiated
+	return e.maxInstantiated > 0 &&
+		*e.currentInstantiationCount() >= e.maxInstantiated
 }
 
 // BudgetExceeded reports whether evaluation stopped early for budget, so callers
@@ -383,6 +493,7 @@ func (e *Evaluator) BudgetExceeded() bool { return e.budgetExceeded }
 // root cannot consume the quota for every subsequent root in a monorepo.
 func (e *Evaluator) ResetInstantiationBudget() {
 	e.instantiated = 0
+	e.prepassInstantiated = 0
 	e.budgetExceeded = false
 }
 
@@ -514,10 +625,16 @@ func (e *Evaluator) rootResourcesWithRefPasses(
 	evalCtx *hcl.EvalContext,
 	addr string,
 	chain []CallSite,
-) []ResolvedResource {
+) ([]ResolvedResource, bool) {
 	var rootResources []ResolvedResource
 	for pass := 0; pass < resourceRefPasses; pass++ {
-		rootResources = e.evalResourceBlocks(resourceBlocks, evalCtx, addr, chain)
+		var complete bool
+		rootResources, complete = e.evalResourceBlocks(
+			resourceBlocks, evalCtx, addr, chain, e.remainingInstantiationBudget(),
+		)
+		if !complete {
+			return nil, false
+		}
 		// Always inject so resolved attrs reach evalCtx on every pass including the last.
 		changed := injectResourceRefs(evalCtx, rootResources)
 		if !changed {
@@ -534,7 +651,9 @@ func (e *Evaluator) rootResourcesWithRefPasses(
 	// One final evaluation picks up attrs that were only injected on the last pass
 	// (e.g. the Nth resource in an A→B→C→D chain whose evalCtx was updated after the
 	// last evalResourceBlocks call).
-	return e.evalResourceBlocks(resourceBlocks, evalCtx, addr, chain)
+	return e.evalResourceBlocks(
+		resourceBlocks, evalCtx, addr, chain, e.remainingInstantiationBudget(),
+	)
 }
 
 // evalResourceBlocks evaluates resource blocks (count/for_each expanded when known).
@@ -543,12 +662,17 @@ func (e *Evaluator) evalResourceBlocks(
 	evalCtx *hcl.EvalContext,
 	addr string,
 	chain []CallSite,
-) []ResolvedResource {
+	limit int,
+) ([]ResolvedResource, bool) {
 	resources := make([]ResolvedResource, 0, len(resourceBlocks))
 	for _, rb := range resourceBlocks {
-		resources = append(resources, e.expandResourceBlock(rb, evalCtx, addr, chain)...)
+		expanded := e.expandResourceBlock(rb, evalCtx, addr, chain)
+		if limit >= 0 && len(resources)+len(expanded) > limit {
+			return resources, false
+		}
+		resources = append(resources, expanded...)
 	}
-	return resources
+	return resources, true
 }
 
 // expandResourceBlock emits zero, one, or N instances per block; known count/for_each
@@ -885,6 +1009,9 @@ func (e *Evaluator) preliminaryModuleOutputs(
 	depth int,
 	visiting map[string]bool,
 ) map[string]cty.Value {
+	e.prepassDepth++
+	defer func() { e.prepassDepth-- }()
+
 	out := map[string]cty.Value{}
 	tmpVisiting := make(map[string]bool, len(visiting))
 	for k, v := range visiting {

--- a/pkg/parser/terraform/tfeval/oom_repro_probe_test.go
+++ b/pkg/parser/terraform/tfeval/oom_repro_probe_test.go
@@ -78,9 +78,9 @@ func TestProbe_OOMReproBeforeAfter(t *testing.T) {
 	}
 
 	stack := writeNestedFanOutForProbe(t, depth, branch)
-	theoretical := powInt(branch, depth)
+	theoretical := powInt(branch, depth-1)
 
-	t.Logf("fixture: depth=%d branch=%d files=%d theoretical_instances=branch^depth=%d",
+	t.Logf("fixture: depth=%d branch=%d files=%d theoretical_resources=branch^(depth-1)=%d",
 		depth, branch, depth+1, theoretical)
 
 	run := func(label string) (resources, cacheEntries int, peakMiB float64, elapsed time.Duration, oom bool) {
@@ -125,6 +125,10 @@ func TestProbe_OOMReproBeforeAfter(t *testing.T) {
 
 	if cache > depth+2 {
 		t.Errorf("WITH FIX: cache has %d entries, expected ~%d", cache, depth+1)
+	}
+	if theoretical <= defaultMaxInstantiated && res != theoretical {
+		t.Errorf("resolved %d resources, want %d below the instantiation budget",
+			res, theoretical)
 	}
 }
 

--- a/pkg/parser/terraform/tfeval/oom_repro_probe_test.go
+++ b/pkg/parser/terraform/tfeval/oom_repro_probe_test.go
@@ -1,0 +1,137 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package tfeval
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func writeNestedFanOutForProbe(t *testing.T, depth, branch int) string {
+	t.Helper()
+	root := t.TempDir()
+	for i := 0; i < depth; i++ {
+		dir := filepath.Join(root, fmt.Sprintf("lvl%02d", i))
+		body := "variable \"in\" { type = string }\n"
+		if i == depth-1 {
+			body += "resource \"aws_s3_bucket\" \"leaf\" { bucket = var.in }\noutput \"out\" { value = var.in }\n"
+		} else {
+			for b := 0; b < branch; b++ {
+				body += fmt.Sprintf("module \"m%d\" {\n  source = \"../lvl%02d\"\n  in = var.in\n}\n", b, i+1)
+			}
+			body += "output \"out\" { value = module.m0.out }\n"
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	stack := filepath.Join(root, "stack")
+	if err := os.MkdirAll(stack, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stack, "main.tf"),
+		[]byte("module \"m\" {\n  source = \"../lvl00\"\n  in = \"seed\"\n}\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return stack
+}
+
+// TestProbe_OOMReproBeforeAfter compares peak heap for the nested fan-out shape
+// that matches production OOMs. Run explicitly:
+//
+//	go test ./pkg/parser/terraform/tfeval -run TestProbe_OOMReproBeforeAfter -v -count=1
+//
+// Set IAC_PROBE_DEPTH and IAC_PROBE_BRANCH to tune (defaults depth=12 branch=3).
+func TestProbe_OOMReproBeforeAfter(t *testing.T) {
+	if os.Getenv("IAC_PROBE_OOM") == "" {
+		t.Skip("set IAC_PROBE_OOM=1 to run the OOM reproduction probe")
+	}
+
+	depth := 12
+	if v := os.Getenv("IAC_PROBE_DEPTH"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			t.Fatalf("IAC_PROBE_DEPTH: %v", err)
+		}
+		depth = n
+	}
+	branch := 3
+	if v := os.Getenv("IAC_PROBE_BRANCH"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			t.Fatalf("IAC_PROBE_BRANCH: %v", err)
+		}
+		branch = n
+	}
+
+	stack := writeNestedFanOutForProbe(t, depth, branch)
+	theoretical := powInt(branch, depth)
+
+	t.Logf("fixture: depth=%d branch=%d files=%d theoretical_instances=branch^depth=%d",
+		depth, branch, depth+1, theoretical)
+
+	run := func(label string) (resources, cacheEntries int, peakMiB float64, elapsed time.Duration, oom bool) {
+		debug.SetGCPercent(-1) // disable GC so peak allocation is visible
+		defer debug.SetGCPercent(100)
+
+		runtime.GC()
+		var start runtime.MemStats
+		runtime.ReadMemStats(&start)
+		peak := start.HeapAlloc
+
+		e := New()
+		begin := time.Now()
+		res, _, _, err := e.EvaluateModule(context.Background(), stack, nil)
+		elapsed = time.Since(begin)
+		if err != nil {
+			t.Logf("%s: EvaluateModule error: %v", label, err)
+		}
+
+		var end runtime.MemStats
+		runtime.ReadMemStats(&end)
+		if end.HeapAlloc > peak {
+			peak = end.HeapAlloc
+		}
+		peakMiB = float64(peak-start.HeapAlloc) / (1 << 20)
+
+		// Detect if we hit swap/OOM pressure via runtime
+		if peakMiB > 30000 {
+			oom = true
+		}
+		return len(res), len(e.cache), peakMiB, elapsed, oom
+	}
+
+	mode := os.Getenv("IAC_PROBE_MODE")
+	if mode == "" {
+		mode = "current"
+	}
+
+	res, cache, peak, elapsed, _ := run(mode)
+	t.Logf("%s: resources=%d cache_entries=%d peak_heap=%.1f MiB elapsed=%s",
+		mode, res, cache, peak, elapsed.Round(time.Millisecond))
+
+	if cache > depth+2 {
+		t.Errorf("WITH FIX: cache has %d entries, expected ~%d", cache, depth+1)
+	}
+}
+
+func powInt(base, exp int) int {
+	r := 1
+	for i := 0; i < exp; i++ {
+		r *= base
+	}
+	return r
+}


### PR DESCRIPTION
## Motivation

[PR #321](https://github.com/DataDog/datadog-iac-scanner/pull/321) fixes exponential memory growth in local Terraform module resolution, but production still gates that path behind `k9-iac-enable-local-module-eval`. The private regression detector compares each PR against `main` with the flag off, so it would not exercise module eval unless we add a temporary always-on bypass (same pattern as [#302](https://github.com/DataDog/datadog-iac-scanner/pull/302)).

This draft PR stacks the #321 commits plus one commit that enables local module instantiation unconditionally so CI can measure wall time, peak RSS, and finding-count deltas on cloud-inventory (repo A) with module eval active.

**Do not merge.** Revert the last commit before any production release; merge [#321](https://github.com/DataDog/datadog-iac-scanner/pull/321) for the actual fix.

## Changes

**Engine**

Local module instantiation in `Inspect` no longer checks `k9-iac-enable-local-module-eval`. The integration test is renamed to reflect always-on behaviour.

Everything else matches #321: eval cache keyed on directory and inputs, cache release per root, instantiation budget enforcement, and partial-resolution coverage fixes.

## QA Instruction

1. Wait for the regression detector comment on this PR (downstream GitLab trigger from `.gitlab-ci.yml`).
2. Compare repo A (cloud-inventory) wall time and peak RSS against #321 and `main`.
3. `go test ./pkg/engine/... -run TestInspect_LocalModuleEvalAlwaysRuns -count=1`

## Impact

Terraform local module evaluation only. This branch temporarily bypasses the org flag; not intended for release.

**Related PR:** [#321](https://github.com/DataDog/datadog-iac-scanner/pull/321)