### PR TITLE
[K9CODESEC-5296] Make offline Terraform module resolution authoritative

### DIFF
--- a/cmd/scanner/list_modules.go
+++ b/cmd/scanner/list_modules.go
@@ -65,52 +65,67 @@ func loadModuleDiscoveryFiles(paths []string) (model.FileMetadatas, []string, er
 	roots := make([]string, 0, len(paths))
 	seen := make(map[string]bool)
 	for _, input := range paths {
-		absolute, err := filepath.Abs(input)
+		walkRoot, root, err := resolveModuleDiscoveryRoot(input)
 		if err != nil {
-			return nil, nil, fmt.Errorf("resolving path %q: %w", input, err)
-		}
-		info, err := os.Stat(absolute)
-		if err != nil {
-			return nil, nil, fmt.Errorf("reading path %q: %w", input, err)
-		}
-		root := absolute
-		if !info.IsDir() {
-			root = filepath.Dir(absolute)
+			return nil, nil, err
 		}
 		roots = append(roots, root)
-		err = filepath.WalkDir(absolute, func(path string, entry fs.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
-			}
-			if entry.IsDir() {
-				if path != absolute && (entry.Name() == ".git" || entry.Name() == ".terraform") {
-					return filepath.SkipDir
-				}
-				return nil
-			}
-			if entry.Type()&fs.ModeSymlink != 0 || !strings.HasSuffix(strings.ToLower(entry.Name()), ".tf") {
-				return nil
-			}
-			clean := filepath.Clean(path)
-			if seen[clean] {
-				return nil
-			}
-			data, err := os.ReadFile(clean) //nolint:gosec
-			if err != nil {
-				return err
-			}
-			seen[clean] = true
-			files = append(files, &model.FileMetadata{
-				FilePath:     clean,
-				OriginalData: string(data),
-			})
-			return nil
-		})
-		if err != nil {
+		if err := walkTerraformDiscoveryRoot(walkRoot, seen, &files); err != nil {
 			return nil, nil, fmt.Errorf("walking path %q: %w", input, err)
 		}
 	}
 	return files, roots, nil
+}
+
+func resolveModuleDiscoveryRoot(input string) (walkRoot, root string, err error) {
+	absolute, err := filepath.Abs(input)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving path %q: %w", input, err)
+	}
+	walkRoot, err = filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving path %q: %w", input, err)
+	}
+	info, err := os.Stat(walkRoot)
+	if err != nil {
+		return "", "", fmt.Errorf("reading path %q: %w", input, err)
+	}
+	root = walkRoot
+	if !info.IsDir() {
+		root = filepath.Dir(walkRoot)
+	}
+	return walkRoot, root, nil
+}
+
+func walkTerraformDiscoveryRoot(walkRoot string, seen map[string]bool, files *model.FileMetadatas) error {
+	return filepath.WalkDir(walkRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if path != walkRoot && (entry.Name() == ".git" || entry.Name() == ".terraform") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.Type()&fs.ModeSymlink != 0 || !strings.HasSuffix(strings.ToLower(entry.Name()), ".tf") {
+			return nil
+		}
+		clean := filepath.Clean(path)
+		if seen[clean] {
+			return nil
+		}
+		data, err := os.ReadFile(clean) //nolint:gosec
+		if err != nil {
+			return err
+		}
+		seen[clean] = true
+		*files = append(*files, &model.FileMetadata{
+			FilePath:     clean,
+			OriginalData: string(data),
+		})
+		return nil
+	})
 }
 
 func modulePathRelativeToRoots(path string, roots []string) string {

--- a/cmd/scanner/list_modules.go
+++ b/cmd/scanner/list_modules.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+	cli "github.com/urfave/cli/v3"
+)
+
+var listModulesAction = &cli.Command{
+	Name:  "list-modules",
+	Usage: "Lists declared Terraform modules without fetching them",
+	Flags: []cli.Flag{
+		&cli.StringSliceFlag{
+			Name:     "path",
+			Aliases:  []string{"p"},
+			Usage:    "Terraform files or directories to inspect",
+			Required: true,
+		},
+		&cli.BoolFlag{
+			Name:  "include-local",
+			Usage: "include local module declarations",
+		},
+	},
+	Action: listModules,
+}
+
+func listModules(ctx context.Context, command *cli.Command) error {
+	entries, err := moduleEntriesFromPaths(ctx, command.StringSlice("path"), command.Bool("include-local"))
+	if err != nil {
+		return err
+	}
+	return writeModuleEntries(os.Stdout, entries)
+}
+
+func moduleEntriesFromPaths(
+	ctx context.Context, paths []string, includeLocal bool,
+) ([]tfmodules.ListModuleEntry, error) {
+	files, roots, err := loadModuleDiscoveryFiles(paths)
+	if err != nil {
+		return nil, err
+	}
+	modules, err := tfmodules.ParseTerraformModules(ctx, vfs.DiskFS{}, files, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parsing Terraform modules: %w", err)
+	}
+	entries := tfmodules.ListModuleEntries(modules, includeLocal)
+	for i := range entries {
+		entries[i].FileName = modulePathRelativeToRoots(entries[i].FileName, roots)
+	}
+	return entries, nil
+}
+
+func loadModuleDiscoveryFiles(paths []string) (model.FileMetadatas, []string, error) {
+	files := make(model.FileMetadatas, 0)
+	roots := make([]string, 0, len(paths))
+	seen := make(map[string]bool)
+	for _, input := range paths {
+		absolute, err := filepath.Abs(input)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving path %q: %w", input, err)
+		}
+		info, err := os.Stat(absolute)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading path %q: %w", input, err)
+		}
+		root := absolute
+		if !info.IsDir() {
+			root = filepath.Dir(absolute)
+		}
+		roots = append(roots, root)
+		err = filepath.WalkDir(absolute, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				if path != absolute && (entry.Name() == ".git" || entry.Name() == ".terraform") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if entry.Type()&fs.ModeSymlink != 0 || !strings.HasSuffix(strings.ToLower(entry.Name()), ".tf") {
+				return nil
+			}
+			clean := filepath.Clean(path)
+			if seen[clean] {
+				return nil
+			}
+			data, err := os.ReadFile(clean) //nolint:gosec
+			if err != nil {
+				return err
+			}
+			seen[clean] = true
+			files = append(files, &model.FileMetadata{
+				FilePath:     clean,
+				OriginalData: string(data),
+			})
+			return nil
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("walking path %q: %w", input, err)
+		}
+	}
+	return files, roots, nil
+}
+
+func modulePathRelativeToRoots(path string, roots []string) string {
+	for _, root := range roots {
+		relative, err := filepath.Rel(root, path)
+		if err == nil && filepath.IsLocal(relative) {
+			return filepath.ToSlash(relative)
+		}
+	}
+	return filepath.ToSlash(path)
+}
+
+func writeModuleEntries(writer io.Writer, entries []tfmodules.ListModuleEntry) error {
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(entries)
+}

--- a/cmd/scanner/list_modules_test.go
+++ b/cmd/scanner/list_modules_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModuleEntriesFromPathsListsDeclarationsWithoutFetching(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(`
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.0.0"
+}
+`), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".terraform", "modules", "ignored"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".terraform", "modules", "ignored", "main.tf"), []byte(`
+module "ignored" {
+  source = "example/ignored/aws"
+}
+`), 0o644))
+
+	entries, err := moduleEntriesFromPaths(t.Context(), []string{root}, false)
+	require.NoError(t, err)
+	require.Equal(t, []tfmodules.ListModuleEntry{{
+		Name:          "vpc",
+		Source:        "terraform-aws-modules/vpc/aws",
+		Version:       "5.0.0",
+		SourceType:    "registry",
+		RegistryScope: "public",
+		FileName:      "main.tf",
+		DefLine:       2,
+		DefEndLine:    5,
+	}}, entries)
+}
+
+func TestWriteModuleEntriesEmitsJSONArray(t *testing.T) {
+	var output bytes.Buffer
+	require.NoError(t, writeModuleEntries(&output, []tfmodules.ListModuleEntry{{
+		Name:       "vpc",
+		Source:     "./modules/vpc",
+		SourceType: "local",
+		FileName:   "main.tf",
+		DefLine:    1,
+		DefEndLine: 3,
+	}}))
+
+	var entries []tfmodules.ListModuleEntry
+	require.NoError(t, json.Unmarshal(output.Bytes(), &entries))
+	require.Len(t, entries, 1)
+	require.Equal(t, "vpc", entries[0].Name)
+}

--- a/cmd/scanner/list_modules_test.go
+++ b/cmd/scanner/list_modules_test.go
@@ -56,3 +56,23 @@ func TestWriteModuleEntriesEmitsJSONArray(t *testing.T) {
 	require.Len(t, entries, 1)
 	require.Equal(t, "vpc", entries[0].Name)
 }
+
+func TestModuleEntriesFromPathsFollowsSymlinkedRoot(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "repo")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(`
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+}
+`), 0o644))
+
+	link := filepath.Join(base, "repo-link")
+	require.NoError(t, os.Symlink(root, link))
+
+	entries, err := moduleEntriesFromPaths(t.Context(), []string{link}, false)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "vpc", entries[0].Name)
+	require.Equal(t, "main.tf", entries[0].FileName)
+}

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -36,6 +36,7 @@ func main() {
 			customAction,
 			listPlatformsAction,
 			listQueriesAction,
+			listModulesAction,
 			showConfigAction,
 			testRulesAction,
 			serveAction,

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -89,80 +89,67 @@ var scanAction = &cli.Command{
 			Usage:  "(experimental, will be removed soon) parse files in parallel",
 			Value:  true,
 		},
-		&cli.BoolFlag{
-			Name:   "x-local-module-eval",
-			Hidden: true,
-			Usage:  "(experimental) resolve Terraform local module variables before scanning",
-			Value:  false,
-		},
-		&cli.BoolFlag{
-			Name:   "x-remote-modules",
-			Hidden: true,
-			Usage:  "(experimental) resolve Terraform remote modules before scanning",
-			Value:  false,
+		&cli.StringFlag{
+			Name:  "terraform-modules-mode",
+			Usage: "Terraform module resolution mode: off, offline, or fetch",
+			Value: string(scan.TerraformModulesModeOff),
 		},
 		&cli.StringFlag{
-			Name:   "x-remote-modules-manifest",
-			Hidden: true,
-			Usage:  "(experimental) JSON manifest mapping Terraform module sources to local directories",
+			Name:  "terraform-modules-manifest",
+			Usage: "path to a Terraform modules manifest",
 		},
 		&cli.StringSliceFlag{
-			Name:   "x-remote-modules-allowed-host",
-			Hidden: true,
-			Usage:  "(experimental) host allowed for Terraform remote module downloads",
-			Value:  []string{},
+			Name:  "terraform-modules-allowed-host",
+			Usage: "host allowed for Terraform module downloads in fetch mode",
+			Value: []string{},
 		},
 		&cli.IntFlag{
-			Name:   "x-remote-modules-max-depth",
-			Hidden: true,
-			Usage:  "(experimental) maximum BFS depth for the remote module graph walker (default 8)",
-			Value:  scan.DefaultRemoteModuleMaxDepth,
+			Name:  "terraform-modules-max-depth",
+			Usage: "maximum traversal depth for the Terraform module graph",
+			Value: scan.DefaultRemoteModuleMaxDepth,
 		},
 		&cli.DurationFlag{
-			Name:   "x-remote-modules-fetch-timeout",
-			Hidden: true,
-			Usage:  "(experimental) per-module fetch timeout (default 30s)",
-			Value:  30 * time.Second,
+			Name:  "terraform-modules-fetch-timeout",
+			Usage: "per-module fetch timeout",
+			Value: 30 * time.Second,
+		},
+		&cli.DurationFlag{
+			Name:  "terraform-modules-resolution-timeout",
+			Usage: "whole-phase Terraform module resolution timeout",
+			Value: scan.DefaultModuleResolutionTimeout,
 		},
 		&cli.Int64Flag{
-			Name:   "x-remote-modules-max-bytes",
-			Hidden: true,
-			Usage:  "(experimental) total download size limit across all remote modules in bytes (default 200MiB)",
-			Value:  scan.DefaultRemoteModuleMaxTotalBytes,
+			Name:  "terraform-modules-max-bytes",
+			Usage: "total size limit across all resolved Terraform modules in bytes",
+			Value: scan.DefaultRemoteModuleMaxTotalBytes,
 		},
 		&cli.Int64Flag{
-			Name:   "x-remote-modules-max-package-bytes",
-			Hidden: true,
-			Usage:  "(experimental) maximum extracted size of one remote module package in bytes (default 128MiB)",
-			Value:  scan.DefaultRemoteModuleMaxPackageBytes,
+			Name:  "terraform-modules-max-package-bytes",
+			Usage: "maximum extracted size of one Terraform module package in bytes",
+			Value: scan.DefaultRemoteModuleMaxPackageBytes,
 		},
 		&cli.Int64Flag{
-			Name:   "x-remote-modules-max-file-bytes",
-			Hidden: true,
-			Usage:  "(experimental) maximum size of one file in a remote module package in bytes (default 5MiB)",
-			Value:  scan.DefaultRemoteModuleMaxFileBytes,
+			Name:  "terraform-modules-max-file-bytes",
+			Usage: "maximum size of one file in a Terraform module package in bytes",
+			Value: scan.DefaultRemoteModuleMaxFileBytes,
 		},
 		&cli.IntFlag{
-			Name:   "x-remote-modules-max-package-files",
-			Hidden: true,
-			Usage:  "(experimental) maximum number of files in one remote module package (default 10000)",
-			Value:  scan.DefaultRemoteModuleMaxPackageFiles,
+			Name:  "terraform-modules-max-package-files",
+			Usage: "maximum number of files in one Terraform module package",
+			Value: scan.DefaultRemoteModuleMaxPackageFiles,
 		},
 		&cli.Int64Flag{
-			Name:   "x-remote-modules-max-parse-bytes",
-			Hidden: true,
-			Usage:  "(experimental) target bytes admitted for repository and remote module parsing (default disabled)",
+			Name:  "terraform-modules-max-parse-bytes",
+			Usage: "target bytes admitted for repository and Terraform module parsing",
 		},
 		&cli.StringFlag{
-			Name:   "x-remote-modules-cache-dir",
-			Hidden: true,
-			Usage:  "(experimental) directory for fetched Terraform module caches",
+			Name:  "terraform-modules-cache-dir",
+			Usage: "directory for fetched Terraform module caches",
 		},
 		&cli.Int64Flag{
-			Name:   "x-remote-modules-cache-max-bytes",
-			Hidden: true,
-			Usage:  "(experimental) maximum on-disk size of the fetched Terraform module cache (default 2GiB)",
-			Value:  scan.DefaultRemoteModuleMaxCacheBytes,
+			Name:  "terraform-modules-cache-max-bytes",
+			Usage: "maximum on-disk size of the fetched Terraform module cache",
+			Value: scan.DefaultRemoteModuleMaxCacheBytes,
 		},
 		&cli.BoolFlag{
 			Name:   "x-terraform-plan",
@@ -357,12 +344,24 @@ func runScan(ctx context.Context, c *cli.Command) error {
 	if err := validateReportFormats(reportFormats); err != nil {
 		return errorWithExitCode(err, constants.InvalidConfigErrorCode)
 	}
-	if !c.Bool("x-remote-modules") &&
-		(c.String("x-remote-modules-manifest") != "" ||
-			len(c.StringSlice("x-remote-modules-allowed-host")) > 0 ||
-			c.String("x-remote-modules-cache-dir") != "") {
+	moduleMode, err := scan.ParseTerraformModulesMode(c.String("terraform-modules-mode"))
+	if err != nil {
+		return errorWithExitCode(err, constants.InvalidConfigErrorCode)
+	}
+	if moduleMode == scan.TerraformModulesModeOff &&
+		(c.String("terraform-modules-manifest") != "" ||
+			len(c.StringSlice("terraform-modules-allowed-host")) > 0 ||
+			c.String("terraform-modules-cache-dir") != "") {
 		return errorWithExitCode(
-			errors.New("remote module resolver options require --x-remote-modules"),
+			errors.New("Terraform module resolver options require --terraform-modules-mode=offline or fetch"),
+			constants.InvalidConfigErrorCode,
+		)
+	}
+	if moduleMode == scan.TerraformModulesModeOffline &&
+		(len(c.StringSlice("terraform-modules-allowed-host")) > 0 ||
+			c.String("terraform-modules-cache-dir") != "") {
+		return errorWithExitCode(
+			errors.New("network and cache options require --terraform-modules-mode=fetch"),
 			constants.InvalidConfigErrorCode,
 		)
 	}
@@ -412,18 +411,19 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		Config:                      *cfg,
 		ShouldScanTfPlans:           c.Bool("x-terraform-plan"),
 		DisableRuleIsolation:        c.Bool("x-disable-rule-isolation"),
-		EnableRemoteModules:         c.Bool("x-remote-modules"),
-		RemoteModulesManifestPath:   c.String("x-remote-modules-manifest"),
-		RemoteModulesHostAllowlist:  c.StringSlice("x-remote-modules-allowed-host"),
-		ModuleMaxDepth:              c.Int("x-remote-modules-max-depth"),
-		ModuleFetchTimeout:          c.Duration("x-remote-modules-fetch-timeout"),
-		MaxModuleBytesTotal:         c.Int64("x-remote-modules-max-bytes"),
-		MaxModulePackageBytes:       c.Int64("x-remote-modules-max-package-bytes"),
-		MaxModuleFileBytes:          c.Int64("x-remote-modules-max-file-bytes"),
-		MaxModulePackageFiles:       c.Int("x-remote-modules-max-package-files"),
-		MaxModuleParseBytes:         c.Int64("x-remote-modules-max-parse-bytes"),
-		RemoteModulesCacheDir:       c.String("x-remote-modules-cache-dir"),
-		MaxModuleCacheBytes:         c.Int64("x-remote-modules-cache-max-bytes"),
+		TerraformModulesMode:        moduleMode,
+		RemoteModulesManifestPath:   c.String("terraform-modules-manifest"),
+		RemoteModulesHostAllowlist:  c.StringSlice("terraform-modules-allowed-host"),
+		ModuleMaxDepth:              c.Int("terraform-modules-max-depth"),
+		ModuleFetchTimeout:          c.Duration("terraform-modules-fetch-timeout"),
+		ModuleResolutionTimeout:     c.Duration("terraform-modules-resolution-timeout"),
+		MaxModuleBytesTotal:         c.Int64("terraform-modules-max-bytes"),
+		MaxModulePackageBytes:       c.Int64("terraform-modules-max-package-bytes"),
+		MaxModuleFileBytes:          c.Int64("terraform-modules-max-file-bytes"),
+		MaxModulePackageFiles:       c.Int("terraform-modules-max-package-files"),
+		MaxModuleParseBytes:         c.Int64("terraform-modules-max-parse-bytes"),
+		RemoteModulesCacheDir:       c.String("terraform-modules-cache-dir"),
+		MaxModuleCacheBytes:         c.Int64("terraform-modules-cache-max-bytes"),
 	}
 
 	var opts []scan.ClientOption
@@ -740,9 +740,10 @@ func selectPlatforms(platforms []string) []string {
 }
 
 func getFeatureFlagEvaluator(c *cli.Command) featureflags.FlagEvaluator {
+	moduleMode, _ := scan.ParseTerraformModulesMode(c.String("terraform-modules-mode"))
 	overrides := map[string]bool{
 		featureflags.IaCEnableKicsParallelFileParsing: c.Bool("x-parallelparsing"),
-		featureflags.IacEnableLocalModuleEval:         c.Bool("x-local-module-eval") || c.Bool("x-remote-modules"),
+		featureflags.IacEnableLocalModuleEval:         moduleMode != scan.TerraformModulesModeOff,
 	}
 	return featureflags.NewLocalEvaluatorWithOverrides(overrides)
 }

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -89,6 +89,13 @@ var scanAction = &cli.Command{
 			Usage:  "(experimental, will be removed soon) parse files in parallel",
 			Value:  true,
 		},
+		&cli.BoolFlag{
+			Name:   "x-local-module-eval",
+			Hidden: true,
+			Usage: "(deprecated, will be removed after hosted worker migration) resolve Terraform local " +
+				"module variables before scanning; independent of --terraform-modules-mode",
+			Value: false,
+		},
 		&cli.StringFlag{
 			Name:  "terraform-modules-mode",
 			Usage: "Terraform module resolution mode: off, offline, or fetch",
@@ -739,11 +746,18 @@ func selectPlatforms(platforms []string) []string {
 	return out
 }
 
+func localModuleEvalEnabled(legacyLocalModuleEval bool, modulesMode scan.TerraformModulesMode) bool {
+	return legacyLocalModuleEval || modulesMode != scan.TerraformModulesModeOff
+}
+
 func getFeatureFlagEvaluator(c *cli.Command) featureflags.FlagEvaluator {
 	moduleMode, _ := scan.ParseTerraformModulesMode(c.String("terraform-modules-mode"))
 	overrides := map[string]bool{
 		featureflags.IaCEnableKicsParallelFileParsing: c.Bool("x-parallelparsing"),
-		featureflags.IacEnableLocalModuleEval:         moduleMode != scan.TerraformModulesModeOff,
+		featureflags.IacEnableLocalModuleEval: localModuleEvalEnabled(
+			c.Bool("x-local-module-eval"),
+			moduleMode,
+		),
 	}
 	return featureflags.NewLocalEvaluatorWithOverrides(overrides)
 }

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -99,7 +99,7 @@ var scanAction = &cli.Command{
 			Usage: "path to a Terraform modules manifest",
 		},
 		&cli.StringSliceFlag{
-			Name:  "terraform-modules-allowed-host",
+			Name:  "module-allowed-hosts",
 			Usage: "host allowed for Terraform module downloads in fetch mode",
 			Value: []string{},
 		},
@@ -114,7 +114,7 @@ var scanAction = &cli.Command{
 			Value: 30 * time.Second,
 		},
 		&cli.DurationFlag{
-			Name:  "terraform-modules-resolution-timeout",
+			Name:  "module-resolution-timeout",
 			Usage: "whole-phase Terraform module resolution timeout",
 			Value: scan.DefaultModuleResolutionTimeout,
 		},
@@ -143,11 +143,11 @@ var scanAction = &cli.Command{
 			Usage: "target bytes admitted for repository and Terraform module parsing",
 		},
 		&cli.StringFlag{
-			Name:  "terraform-modules-cache-dir",
+			Name:  "module-cache-dir",
 			Usage: "directory for fetched Terraform module caches",
 		},
 		&cli.Int64Flag{
-			Name:  "terraform-modules-cache-max-bytes",
+			Name:  "module-cache-max-bytes",
 			Usage: "maximum on-disk size of the fetched Terraform module cache",
 			Value: scan.DefaultRemoteModuleMaxCacheBytes,
 		},
@@ -350,16 +350,16 @@ func runScan(ctx context.Context, c *cli.Command) error {
 	}
 	if moduleMode == scan.TerraformModulesModeOff &&
 		(c.String("terraform-modules-manifest") != "" ||
-			len(c.StringSlice("terraform-modules-allowed-host")) > 0 ||
-			c.String("terraform-modules-cache-dir") != "") {
+			len(c.StringSlice("module-allowed-hosts")) > 0 ||
+			c.String("module-cache-dir") != "") {
 		return errorWithExitCode(
 			errors.New("terraform module resolver options require --terraform-modules-mode=offline or fetch"),
 			constants.InvalidConfigErrorCode,
 		)
 	}
 	if moduleMode == scan.TerraformModulesModeOffline &&
-		(len(c.StringSlice("terraform-modules-allowed-host")) > 0 ||
-			c.String("terraform-modules-cache-dir") != "") {
+		(len(c.StringSlice("module-allowed-hosts")) > 0 ||
+			c.String("module-cache-dir") != "") {
 		return errorWithExitCode(
 			errors.New("network and cache options require --terraform-modules-mode=fetch"),
 			constants.InvalidConfigErrorCode,
@@ -413,17 +413,17 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		DisableRuleIsolation:        c.Bool("x-disable-rule-isolation"),
 		TerraformModulesMode:        moduleMode,
 		RemoteModulesManifestPath:   c.String("terraform-modules-manifest"),
-		RemoteModulesHostAllowlist:  c.StringSlice("terraform-modules-allowed-host"),
+		RemoteModulesHostAllowlist:  c.StringSlice("module-allowed-hosts"),
 		ModuleMaxDepth:              c.Int("terraform-modules-max-depth"),
 		ModuleFetchTimeout:          c.Duration("terraform-modules-fetch-timeout"),
-		ModuleResolutionTimeout:     c.Duration("terraform-modules-resolution-timeout"),
+		ModuleResolutionTimeout:     c.Duration("module-resolution-timeout"),
 		MaxModuleBytesTotal:         c.Int64("terraform-modules-max-bytes"),
 		MaxModulePackageBytes:       c.Int64("terraform-modules-max-package-bytes"),
 		MaxModuleFileBytes:          c.Int64("terraform-modules-max-file-bytes"),
 		MaxModulePackageFiles:       c.Int("terraform-modules-max-package-files"),
 		MaxModuleParseBytes:         c.Int64("terraform-modules-max-parse-bytes"),
-		RemoteModulesCacheDir:       c.String("terraform-modules-cache-dir"),
-		MaxModuleCacheBytes:         c.Int64("terraform-modules-cache-max-bytes"),
+		RemoteModulesCacheDir:       c.String("module-cache-dir"),
+		MaxModuleCacheBytes:         c.Int64("module-cache-max-bytes"),
 	}
 
 	var opts []scan.ClientOption

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -92,8 +92,8 @@ var scanAction = &cli.Command{
 		&cli.BoolFlag{
 			Name:   "x-local-module-eval",
 			Hidden: true,
-			Usage: "(deprecated, will be removed after hosted worker migration) resolve Terraform local " +
-				"module variables before scanning; independent of --terraform-modules-mode",
+			Usage: "(experimental) resolve Terraform local module variables before scanning; " +
+				"independent of --terraform-modules-mode",
 			Value: false,
 		},
 		&cli.StringFlag{

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -353,7 +353,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 			len(c.StringSlice("terraform-modules-allowed-host")) > 0 ||
 			c.String("terraform-modules-cache-dir") != "") {
 		return errorWithExitCode(
-			errors.New("Terraform module resolver options require --terraform-modules-mode=offline or fetch"),
+			errors.New("terraform module resolver options require --terraform-modules-mode=offline or fetch"),
 			constants.InvalidConfigErrorCode,
 		)
 	}

--- a/cmd/scanner/scan_test.go
+++ b/cmd/scanner/scan_test.go
@@ -195,7 +195,10 @@ func TestTerraformModuleFlagsUseAuthoritativeMode(t *testing.T) {
 
 	require.True(t, names["terraform-modules-mode"])
 	require.True(t, names["terraform-modules-manifest"])
-	require.True(t, names["terraform-modules-resolution-timeout"])
+	require.True(t, names["module-resolution-timeout"])
+	require.True(t, names["module-cache-dir"])
+	require.True(t, names["module-cache-max-bytes"])
+	require.True(t, names["module-allowed-hosts"])
 	require.False(t, names["x-remote-modules"])
 	require.False(t, names["x-local-module-eval"])
 }

--- a/cmd/scanner/scan_test.go
+++ b/cmd/scanner/scan_test.go
@@ -174,6 +174,32 @@ func TestTerraformPlanFlag(t *testing.T) {
 	}
 }
 
+func TestTerraformModuleFlagsUseAuthoritativeMode(t *testing.T) {
+	names := make(map[string]bool)
+	for _, flag := range scanAction.Flags {
+		switch typed := flag.(type) {
+		case *cli.StringFlag:
+			names[typed.Name] = true
+		case *cli.StringSliceFlag:
+			names[typed.Name] = true
+		case *cli.IntFlag:
+			names[typed.Name] = true
+		case *cli.Int64Flag:
+			names[typed.Name] = true
+		case *cli.DurationFlag:
+			names[typed.Name] = true
+		case *cli.BoolFlag:
+			names[typed.Name] = true
+		}
+	}
+
+	require.True(t, names["terraform-modules-mode"])
+	require.True(t, names["terraform-modules-manifest"])
+	require.True(t, names["terraform-modules-resolution-timeout"])
+	require.False(t, names["x-remote-modules"])
+	require.False(t, names["x-local-module-eval"])
+}
+
 func TestValidateQueriesPaths(t *testing.T) {
 	tmp := t.TempDir()
 

--- a/cmd/scanner/scan_test.go
+++ b/cmd/scanner/scan_test.go
@@ -200,7 +200,47 @@ func TestTerraformModuleFlagsUseAuthoritativeMode(t *testing.T) {
 	require.True(t, names["module-cache-max-bytes"])
 	require.True(t, names["module-allowed-hosts"])
 	require.False(t, names["x-remote-modules"])
-	require.False(t, names["x-local-module-eval"])
+	require.True(t, names["x-local-module-eval"])
+}
+
+func TestLocalModuleEvalEnabled(t *testing.T) {
+	tests := []struct {
+		name       string
+		legacyFlag bool
+		mode       scan.TerraformModulesMode
+		want       bool
+	}{
+		{
+			name:       "default prod path keeps local eval without module pre-scan mode",
+			legacyFlag: true,
+			mode:       scan.TerraformModulesModeOff,
+			want:       true,
+		},
+		{
+			name:       "mode off without legacy flag disables local eval",
+			legacyFlag: false,
+			mode:       scan.TerraformModulesModeOff,
+			want:       false,
+		},
+		{
+			name:       "offline mode enables local eval for remote resolution",
+			legacyFlag: false,
+			mode:       scan.TerraformModulesModeOffline,
+			want:       true,
+		},
+		{
+			name:       "fetch mode enables local eval for remote resolution",
+			legacyFlag: false,
+			mode:       scan.TerraformModulesModeFetch,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, localModuleEvalEnabled(tt.legacyFlag, tt.mode))
+		})
+	}
 }
 
 func TestValidateQueriesPaths(t *testing.T) {

--- a/pkg/parser/terraform/modules/list_modules.go
+++ b/pkg/parser/terraform/modules/list_modules.go
@@ -15,6 +15,7 @@ type ListModuleEntry struct {
 	RegistryScope string `json:"registry_scope,omitempty"`
 	FileName      string `json:"file_name"`
 	DefLine       int    `json:"def_line"`
+	DefEndLine    int    `json:"def_end_line"`
 }
 
 // ListModuleEntries converts parsed modules to list-modules JSON rows.
@@ -36,6 +37,7 @@ func ListModuleEntries(modules map[string]ParsedModule, includeLocal bool) []Lis
 			RegistryScope: mod.RegistryScope,
 			FileName:      mod.FileName,
 			DefLine:       mod.DefLine,
+			DefEndLine:    mod.DefEndLine,
 		})
 	}
 	sort.Slice(entries, func(i, j int) bool {

--- a/pkg/parser/terraform/modules/list_modules_test.go
+++ b/pkg/parser/terraform/modules/list_modules_test.go
@@ -17,6 +17,7 @@ func TestListModuleEntriesJSONShape(t *testing.T) {
 			RegistryScope: "public",
 			FileName:      "/repo/main.tf",
 			DefLine:       12,
+			DefEndLine:    18,
 		},
 	}, false)
 
@@ -36,6 +37,7 @@ func TestListModuleEntriesJSONShape(t *testing.T) {
 	require.Equal(t, "public", row["registry_scope"])
 	require.Equal(t, "/repo/main.tf", row["file_name"])
 	require.Equal(t, float64(12), row["def_line"])
+	require.Equal(t, float64(18), row["def_end_line"])
 }
 
 func TestListModuleEntriesSkipsLocalByDefault(t *testing.T) {

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -61,6 +61,7 @@ type Result struct {
 	BudgetEvents         []BudgetEvent
 	BaselineParseBytes   int64
 	ModuleAdmissionBytes int64
+	TimedOut             bool
 	Cleanup              func()
 }
 
@@ -213,6 +214,7 @@ func Resolve(ctx context.Context, request *Request) Result {
 	result.BudgetEvents = snapshot.budgetEvents
 	result.BaselineParseBytes = baselineBytes
 	result.ModuleAdmissionBytes = moduleMaximum
+	result.TimedOut = errors.Is(ctx.Err(), context.DeadlineExceeded)
 
 	sort.Strings(result.ScanPaths)
 	sort.Slice(result.Modules, func(i, j int) bool {

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
@@ -89,6 +89,15 @@ func (r errorResolver) Resolve(
 	return resolver.Resolution{}, r.err
 }
 
+type contextBlockingResolver struct{}
+
+func (contextBlockingResolver) Resolve(
+	ctx context.Context, _ *tfmodules.ParsedModule,
+) (resolver.Resolution, error) {
+	<-ctx.Done()
+	return resolver.Resolution{}, ctx.Err()
+}
+
 type trackingResolver struct {
 	mu       sync.Mutex
 	bySource map[string]resolver.Resolution
@@ -857,6 +866,21 @@ module "extra" {
 	require.Contains(t, result.ScanPaths, filepath.Join(selected, "main.tf"))
 	require.Contains(t, result.ScanPaths, filepath.Join(shared, "main.tf"))
 	require.Contains(t, result.ScanPaths, filepath.Join(extra, "main.tf"))
+}
+
+func TestResolveReturnsPartialResultWhenPhaseDeadlineExpires(t *testing.T) {
+	root, _ := writeModuleGraphFixture(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+
+	result := Resolve(ctx, &Request{
+		RootPaths: []string{root},
+		Resolver:  contextBlockingResolver{},
+		MaxDepth:  2,
+	})
+
+	require.True(t, result.TimedOut)
+	require.Empty(t, result.Modules)
 }
 
 func writeModuleGraphFixture(t *testing.T) (string, string) {

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -38,6 +38,7 @@ type ParsedModule struct {
 	AttributesData map[string]ModuleAttributesInfo
 	FileName       string
 	DefLine        int
+	DefEndLine     int
 }
 
 type UnresolvedError struct {
@@ -121,10 +122,11 @@ type fileExtract struct {
 // and vars of every file in the directory, which is only known once all of them
 // have been extracted. A nil expression means the argument is absent.
 type moduleBlockExtract struct {
-	name    string
-	defLine int
-	source  hclsyntax.Expression
-	version hclsyntax.Expression
+	name       string
+	defLine    int
+	defEndLine int
+	source     hclsyntax.Expression
+	version    hclsyntax.Expression
 }
 
 func extractFile(body *hclsyntax.Body) *fileExtract {
@@ -158,7 +160,11 @@ func extractFile(body *hclsyntax.Body) *fileExtract {
 			if len(block.Labels) == 0 {
 				continue
 			}
-			mod := moduleBlockExtract{name: block.Labels[0], defLine: block.TypeRange.Start.Line}
+			mod := moduleBlockExtract{
+				name:       block.Labels[0],
+				defLine:    block.TypeRange.Start.Line,
+				defEndLine: block.Range().End.Line,
+			}
 			if attr, ok := block.Body.Attributes["source"]; ok {
 				mod.source = attr.Expr
 			}
@@ -355,9 +361,10 @@ func resolveModuleBlocks(
 ) {
 	for i := range blocks {
 		mod := ParsedModule{
-			Name:     blocks[i].name,
-			FileName: filePath,
-			DefLine:  blocks[i].defLine,
+			Name:       blocks[i].name,
+			FileName:   filePath,
+			DefLine:    blocks[i].defLine,
+			DefEndLine: blocks[i].defEndLine,
 		}
 		fillModuleAttrs(ctx, fsys, &mod, &blocks[i], baseDir, localsMap, varsMap)
 		key := moduleIdentityKey(&mod)

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -493,6 +493,7 @@ module "three" {
 			for i := range got {
 				got[i].FileName = ""
 				got[i].DefLine = 0
+				got[i].DefEndLine = 0
 			}
 			sort.Slice(got, func(i, j int) bool {
 				return got[i].Name < got[j].Name

--- a/pkg/parser/terraform/modules/resolver/manifest_digest.go
+++ b/pkg/parser/terraform/modules/resolver/manifest_digest.go
@@ -6,6 +6,7 @@
 package resolver
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -17,7 +18,10 @@ import (
 )
 
 // ComputePackageDigest hashes regular files by relative path, size, and content.
-func ComputePackageDigest(root string) (string, error) {
+func ComputePackageDigest(ctx context.Context, root string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	resolvedRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
 		return "", fmt.Errorf("resolving package root: %w", err)
@@ -26,6 +30,9 @@ func ComputePackageDigest(root string) (string, error) {
 	err = filepath.WalkDir(resolvedRoot, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 		if entry.IsDir() {
 			return nil

--- a/pkg/parser/terraform/modules/resolver/manifest_digest.go
+++ b/pkg/parser/terraform/modules/resolver/manifest_digest.go
@@ -1,0 +1,76 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ComputePackageDigest hashes regular files by relative path, size, and content.
+func ComputePackageDigest(root string) (string, error) {
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("resolving package root: %w", err)
+	}
+	hasher := sha256.New()
+	err = filepath.WalkDir(resolvedRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if entry.Type()&fs.ModeSymlink != 0 {
+			return fmt.Errorf("symlink %q is not allowed in a manifest package", path)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("non-regular file %q is not allowed in a manifest package", path)
+		}
+		relativePath, err := filepath.Rel(resolvedRoot, path)
+		if err != nil {
+			return err
+		}
+		if err := writeDigestField(hasher, []byte(filepath.ToSlash(relativePath))); err != nil {
+			return err
+		}
+		if err := binary.Write(hasher, binary.BigEndian, uint64(info.Size())); err != nil {
+			return err
+		}
+		file, err := os.Open(path) //nolint:gosec
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(hasher, file)
+		closeErr := file.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		return closeErr
+	})
+	if err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func writeDigestField(writer io.Writer, value []byte) error {
+	if err := binary.Write(writer, binary.BigEndian, uint64(len(value))); err != nil {
+		return err
+	}
+	_, err := writer.Write(value)
+	return err
+}

--- a/pkg/parser/terraform/modules/resolver/manifest_digest_test.go
+++ b/pkg/parser/terraform/modules/resolver/manifest_digest_test.go
@@ -19,14 +19,14 @@ func TestComputePackageDigestIsStableAndContentSensitive(t *testing.T) {
 	file := filepath.Join(root, "nested", "main.tf")
 	require.NoError(t, os.WriteFile(file, []byte("first"), 0o644))
 
-	first, err := ComputePackageDigest(root)
+	first, err := ComputePackageDigest(t.Context(), root)
 	require.NoError(t, err)
-	again, err := ComputePackageDigest(root)
+	again, err := ComputePackageDigest(t.Context(), root)
 	require.NoError(t, err)
 	require.Equal(t, first, again)
 
 	require.NoError(t, os.WriteFile(file, []byte("second"), 0o644))
-	second, err := ComputePackageDigest(root)
+	second, err := ComputePackageDigest(t.Context(), root)
 	require.NoError(t, err)
 	require.NotEqual(t, first, second)
 }

--- a/pkg/parser/terraform/modules/resolver/manifest_digest_test.go
+++ b/pkg/parser/terraform/modules/resolver/manifest_digest_test.go
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputePackageDigestIsStableAndContentSensitive(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, "nested"), 0o755))
+	file := filepath.Join(root, "nested", "main.tf")
+	require.NoError(t, os.WriteFile(file, []byte("first"), 0o644))
+
+	first, err := ComputePackageDigest(root)
+	require.NoError(t, err)
+	again, err := ComputePackageDigest(root)
+	require.NoError(t, err)
+	require.Equal(t, first, again)
+
+	require.NoError(t, os.WriteFile(file, []byte("second"), 0o644))
+	second, err := ComputePackageDigest(root)
+	require.NoError(t, err)
+	require.NotEqual(t, first, second)
+}

--- a/pkg/parser/terraform/modules/resolver/prefetched.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched.go
@@ -16,38 +16,226 @@ import (
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
 
-// ManifestEntry is one row in a --modules-manifest JSON file.
+const ManifestSchemaVersion = 1
+
 type ManifestEntry struct {
-	LocalPath   string `json:"local_path"`
-	PackageRoot string `json:"package_root,omitempty"`
-	Version     string `json:"version,omitempty"`
-	Origin      string `json:"origin,omitempty"`
+	LocalPath        string `json:"local_path"`
+	PackageRoot      string `json:"package_root,omitempty"`
+	Version          string `json:"version,omitempty"`
+	Origin           string `json:"origin,omitempty"`
+	RequestedVersion string `json:"requested_version,omitempty"`
+	ResolvedVersion  string `json:"resolved_version,omitempty"`
+	ResolvedRef      string `json:"resolved_ref,omitempty"`
+	Status           string `json:"status,omitempty"`
+	Failure          string `json:"failure,omitempty"`
 }
 
-// Manifest is validated JSON: optional root Dir plus source or source@version → ManifestEntry.
 type Manifest struct {
-	Dir     string                   `json:"dir"`
-	Modules map[string]ManifestEntry `json:"modules"`
+	SchemaVersion int                      `json:"schema_version,omitempty"`
+	Root          string                   `json:"root,omitempty"`
+	Dir           string                   `json:"dir,omitempty"`
+	Modules       map[string]ManifestEntry `json:"modules,omitempty"`
+	Entries       []ManifestModule         `json:"-"`
 }
 
-// LoadManifest parses and validates manifest JSON from path.
+type ManifestModule struct {
+	ID               string                `json:"id,omitempty"`
+	Source           string                `json:"source"`
+	CanonicalSource  string                `json:"canonical_source,omitempty"`
+	SourceType       string                `json:"source_type,omitempty"`
+	RegistryScope    string                `json:"registry_scope,omitempty"`
+	RequestedVersion string                `json:"requested_version,omitempty"`
+	ResolvedVersion  string                `json:"resolved_version,omitempty"`
+	ResolvedRef      string                `json:"resolved_ref,omitempty"`
+	ContentDigest    string                `json:"content_digest,omitempty"`
+	PackageRoot      string                `json:"package_root,omitempty"`
+	LocalPath        string                `json:"local_path,omitempty"`
+	Status           string                `json:"status"`
+	Failure          string                `json:"failure,omitempty"`
+	Declarations     []ManifestDeclaration `json:"declarations"`
+}
+
+type ManifestDeclaration struct {
+	Filename   string `json:"filename"`
+	LineStart  int    `json:"line_start"`
+	LineEnd    int    `json:"line_end"`
+	ModuleName string `json:"module_name"`
+}
+
+type manifestEnvelope struct {
+	SchemaVersion *int            `json:"schema_version"`
+	Root          string          `json:"root"`
+	Dir           string          `json:"dir"`
+	Modules       json.RawMessage `json:"modules"`
+}
+
 func LoadManifest(path string) (*Manifest, error) {
-	data, err := os.ReadFile(filepath.Clean(path))
+	manifestPath := filepath.Clean(path)
+	data, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading manifest %q: %w", path, err)
 	}
-	var m Manifest
-	if err := json.Unmarshal(data, &m); err != nil {
+	var envelope manifestEnvelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
 		return nil, fmt.Errorf("parsing manifest %q: %w", path, err)
+	}
+	var m *Manifest
+	if envelope.SchemaVersion == nil {
+		m, err = loadLegacyManifest(envelope)
+	} else if *envelope.SchemaVersion == ManifestSchemaVersion {
+		m, err = loadManifestV1(manifestPath, envelope)
+	} else {
+		err = fmt.Errorf("unsupported schema_version %d", *envelope.SchemaVersion)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("invalid manifest %q: %w", path, err)
 	}
 	if err := m.validate(); err != nil {
 		return nil, fmt.Errorf("invalid manifest %q: %w", path, err)
 	}
-	return &m, nil
+	return m, nil
+}
+
+func loadLegacyManifest(envelope manifestEnvelope) (*Manifest, error) {
+	var modules map[string]ManifestEntry
+	if err := json.Unmarshal(envelope.Modules, &modules); err != nil {
+		return nil, fmt.Errorf("parsing legacy modules: %w", err)
+	}
+	for key, entry := range modules {
+		entry.RequestedVersion = entry.Version
+		entry.ResolvedVersion = entry.Version
+		entry.Status = "resolved"
+		modules[key] = entry
+	}
+	return &Manifest{Dir: envelope.Dir, Modules: modules}, nil
+}
+
+func loadManifestV1(manifestPath string, envelope manifestEnvelope) (*Manifest, error) {
+	if envelope.Root == "" || !filepath.IsLocal(envelope.Root) {
+		return nil, fmt.Errorf("root must be a non-empty relative path")
+	}
+	root := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(envelope.Root))
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolving root: %w", err)
+	}
+	root, err = resolveDirectory(context.Background(), root)
+	if err != nil {
+		return nil, fmt.Errorf("resolving root: %w", err)
+	}
+	var entries []ManifestModule
+	if err := json.Unmarshal(envelope.Modules, &entries); err != nil {
+		return nil, fmt.Errorf("parsing modules: %w", err)
+	}
+	if entries == nil {
+		return nil, fmt.Errorf("modules must be an array")
+	}
+	manifest := &Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Root:          root,
+		Dir:           root,
+		Modules:       make(map[string]ManifestEntry, len(entries)),
+		Entries:       entries,
+	}
+	for i := range manifest.Entries {
+		if err := manifest.addV1Entry(&manifest.Entries[i]); err != nil {
+			return nil, fmt.Errorf("modules[%d]: %w", i, err)
+		}
+	}
+	return manifest, nil
+}
+
+func (m *Manifest) addV1Entry(module *ManifestModule) error {
+	module.Source = strings.TrimSpace(module.Source)
+	if module.Source == "" {
+		return fmt.Errorf("source is required")
+	}
+	if err := validateManifestDeclarations(module.Declarations); err != nil {
+		return err
+	}
+	key := manifestModuleKey(module.Source, strings.TrimSpace(module.RequestedVersion))
+	if _, exists := m.Modules[key]; exists {
+		return fmt.Errorf("duplicate module %q", key)
+	}
+	entry := ManifestEntry{
+		RequestedVersion: strings.TrimSpace(module.RequestedVersion),
+		ResolvedVersion:  strings.TrimSpace(module.ResolvedVersion),
+		ResolvedRef:      strings.TrimSpace(module.ResolvedRef),
+		Status:           module.Status,
+		Failure:          module.Failure,
+		Origin:           module.SourceType,
+	}
+	switch module.Status {
+	case "resolved":
+		if err := m.resolveV1Paths(module, &entry); err != nil {
+			return err
+		}
+		if module.ContentDigest == "" {
+			return fmt.Errorf("content_digest is required for a resolved module")
+		}
+		digest, err := ComputePackageDigest(entry.PackageRoot)
+		if err != nil {
+			return fmt.Errorf("computing content digest: %w", err)
+		}
+		if !strings.EqualFold(module.ContentDigest, digest) {
+			return fmt.Errorf("content_digest mismatch: got %q, computed %q", module.ContentDigest, digest)
+		}
+	case "unresolved":
+		if strings.TrimSpace(module.Failure) == "" {
+			return fmt.Errorf("failure is required for an unresolved module")
+		}
+	default:
+		return fmt.Errorf("status must be resolved or unresolved")
+	}
+	m.Modules[key] = entry
+	return nil
+}
+
+func (m *Manifest) resolveV1Paths(module *ManifestModule, entry *ManifestEntry) error {
+	if module.LocalPath == "" || !filepath.IsLocal(module.LocalPath) {
+		return fmt.Errorf("local_path must be a non-empty relative path")
+	}
+	packageRoot := module.PackageRoot
+	if packageRoot == "" {
+		packageRoot = module.LocalPath
+	}
+	if !filepath.IsLocal(packageRoot) {
+		return fmt.Errorf("package_root must be a relative path")
+	}
+	entry.LocalPath = filepath.Join(m.Root, filepath.FromSlash(module.LocalPath))
+	entry.PackageRoot = filepath.Join(m.Root, filepath.FromSlash(packageRoot))
+	if _, err := ResolvePathWithinRoot(context.Background(), m.Root, entry.PackageRoot); err != nil {
+		return fmt.Errorf("package_root %q escapes root: %w", module.PackageRoot, err)
+	}
+	if _, err := ResolvePathWithinRoot(context.Background(), entry.PackageRoot, entry.LocalPath); err != nil {
+		return fmt.Errorf("local_path %q escapes package root: %w", module.LocalPath, err)
+	}
+	return nil
+}
+
+func validateManifestDeclarations(declarations []ManifestDeclaration) error {
+	if len(declarations) == 0 {
+		return fmt.Errorf("declarations must not be empty")
+	}
+	for i, declaration := range declarations {
+		if declaration.Filename == "" || !filepath.IsLocal(declaration.Filename) {
+			return fmt.Errorf("declarations[%d].filename must be a non-empty relative path", i)
+		}
+		if declaration.ModuleName == "" {
+			return fmt.Errorf("declarations[%d].module_name is required", i)
+		}
+		if declaration.LineStart <= 0 || declaration.LineEnd < declaration.LineStart {
+			return fmt.Errorf("declarations[%d] has an invalid line range", i)
+		}
+	}
+	return nil
 }
 
 func (m *Manifest) validate() error {
 	for src, entry := range m.Modules {
+		if entry.Status == "unresolved" {
+			continue
+		}
 		if !filepath.IsAbs(entry.LocalPath) {
 			return fmt.Errorf("entry %q: local_path must be absolute, got %q", src, entry.LocalPath)
 		}
@@ -111,7 +299,10 @@ func (r *PrefetchedResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedM
 			Reason: fmt.Sprintf("module %q not found in manifest", mod.Source),
 		}
 	}
-	if entry.Version != "" && mod.Version != "" && entry.Version != mod.Version {
+	if entry.Status == "unresolved" {
+		return Resolution{}, &tfmodules.UnresolvedError{Reason: entry.Failure}
+	}
+	if entry.RequestedVersion != "" && mod.Version != "" && entry.RequestedVersion != mod.Version {
 		return Resolution{}, &tfmodules.UnresolvedError{
 			Reason: fmt.Sprintf("module %q version %q not found in manifest", mod.Source, mod.Version),
 		}
@@ -119,8 +310,18 @@ func (r *PrefetchedResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedM
 	return ConfineResolution(ctx, Resolution{
 		LocalPath:       entry.LocalPath,
 		PackageRoot:     entry.PackageRoot,
-		ResolvedVersion: strings.TrimSpace(entry.Version),
+		ResolvedVersion: firstNonEmpty(entry.ResolvedVersion, entry.Version),
+		ResolvedRef:     entry.ResolvedRef,
 	})
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func manifestModuleKey(source, version string) string {

--- a/pkg/parser/terraform/modules/resolver/prefetched.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched.go
@@ -16,7 +16,11 @@ import (
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
 
-const ManifestSchemaVersion = 1
+const (
+	ManifestSchemaVersion    = 1
+	manifestStatusResolved   = "resolved"
+	manifestStatusUnresolved = "unresolved"
+)
 
 type ManifestEntry struct {
 	LocalPath        string `json:"local_path"`
@@ -101,10 +105,11 @@ func loadLegacyManifest(envelope manifestEnvelope) (*Manifest, error) {
 	if err := json.Unmarshal(envelope.Modules, &modules); err != nil {
 		return nil, fmt.Errorf("parsing legacy modules: %w", err)
 	}
-	for key, entry := range modules {
+	for key := range modules {
+		entry := modules[key]
 		entry.RequestedVersion = entry.Version
 		entry.ResolvedVersion = entry.Version
-		entry.Status = "resolved"
+		entry.Status = manifestStatusResolved
 		modules[key] = entry
 	}
 	return &Manifest{Dir: envelope.Dir, Modules: modules}, nil
@@ -166,7 +171,7 @@ func (m *Manifest) addV1Entry(module *ManifestModule) error {
 		Origin:           module.SourceType,
 	}
 	switch module.Status {
-	case "resolved":
+	case manifestStatusResolved:
 		if err := m.resolveV1Paths(module, &entry); err != nil {
 			return err
 		}
@@ -180,7 +185,7 @@ func (m *Manifest) addV1Entry(module *ManifestModule) error {
 		if !strings.EqualFold(module.ContentDigest, digest) {
 			return fmt.Errorf("content_digest mismatch: got %q, computed %q", module.ContentDigest, digest)
 		}
-	case "unresolved":
+	case manifestStatusUnresolved:
 		if strings.TrimSpace(module.Failure) == "" {
 			return fmt.Errorf("failure is required for an unresolved module")
 		}
@@ -232,8 +237,9 @@ func validateManifestDeclarations(declarations []ManifestDeclaration) error {
 }
 
 func (m *Manifest) validate() error {
-	for src, entry := range m.Modules {
-		if entry.Status == "unresolved" {
+	for src := range m.Modules {
+		entry := m.Modules[src]
+		if entry.Status == manifestStatusUnresolved {
 			continue
 		}
 		if !filepath.IsAbs(entry.LocalPath) {
@@ -299,7 +305,7 @@ func (r *PrefetchedResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedM
 			Reason: fmt.Sprintf("module %q not found in manifest", mod.Source),
 		}
 	}
-	if entry.Status == "unresolved" {
+	if entry.Status == manifestStatusUnresolved {
 		return Resolution{}, &tfmodules.UnresolvedError{Reason: entry.Failure}
 	}
 	if entry.RequestedVersion != "" && mod.Version != "" && entry.RequestedVersion != mod.Version {

--- a/pkg/parser/terraform/modules/resolver/prefetched.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched.go
@@ -124,8 +124,7 @@ func loadManifestV1(manifestPath string, envelope manifestEnvelope) (*Manifest, 
 	if err != nil {
 		return nil, fmt.Errorf("resolving root: %w", err)
 	}
-	root, err = resolveDirectory(context.Background(), root)
-	if err != nil {
+	if _, err = resolveDirectory(context.Background(), root); err != nil {
 		return nil, fmt.Errorf("resolving root: %w", err)
 	}
 	var entries []ManifestModule

--- a/pkg/parser/terraform/modules/resolver/prefetched.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched.go
@@ -73,7 +73,10 @@ type manifestEnvelope struct {
 	Modules       json.RawMessage `json:"modules"`
 }
 
-func LoadManifest(path string) (*Manifest, error) {
+func LoadManifest(ctx context.Context, path string) (*Manifest, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	manifestPath := filepath.Clean(path)
 	data, err := os.ReadFile(manifestPath)
 	if err != nil {
@@ -87,14 +90,14 @@ func LoadManifest(path string) (*Manifest, error) {
 	if envelope.SchemaVersion == nil {
 		m, err = loadLegacyManifest(envelope)
 	} else if *envelope.SchemaVersion == ManifestSchemaVersion {
-		m, err = loadManifestV1(manifestPath, envelope)
+		m, err = loadManifestV1(ctx, manifestPath, envelope)
 	} else {
 		err = fmt.Errorf("unsupported schema_version %d", *envelope.SchemaVersion)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("invalid manifest %q: %w", path, err)
 	}
-	if err := m.validate(); err != nil {
+	if err := m.validate(ctx); err != nil {
 		return nil, fmt.Errorf("invalid manifest %q: %w", path, err)
 	}
 	return m, nil
@@ -115,7 +118,10 @@ func loadLegacyManifest(envelope manifestEnvelope) (*Manifest, error) {
 	return &Manifest{Dir: envelope.Dir, Modules: modules}, nil
 }
 
-func loadManifestV1(manifestPath string, envelope manifestEnvelope) (*Manifest, error) {
+func loadManifestV1(ctx context.Context, manifestPath string, envelope manifestEnvelope) (*Manifest, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if envelope.Root == "" || !filepath.IsLocal(envelope.Root) {
 		return nil, fmt.Errorf("root must be a non-empty relative path")
 	}
@@ -124,7 +130,7 @@ func loadManifestV1(manifestPath string, envelope manifestEnvelope) (*Manifest, 
 	if err != nil {
 		return nil, fmt.Errorf("resolving root: %w", err)
 	}
-	if _, err = resolveDirectory(context.Background(), root); err != nil {
+	if _, err = resolveDirectory(ctx, root); err != nil {
 		return nil, fmt.Errorf("resolving root: %w", err)
 	}
 	var entries []ManifestModule
@@ -142,14 +148,17 @@ func loadManifestV1(manifestPath string, envelope manifestEnvelope) (*Manifest, 
 		Entries:       entries,
 	}
 	for i := range manifest.Entries {
-		if err := manifest.addV1Entry(&manifest.Entries[i]); err != nil {
+		if err := manifest.addV1Entry(ctx, &manifest.Entries[i]); err != nil {
 			return nil, fmt.Errorf("modules[%d]: %w", i, err)
 		}
 	}
 	return manifest, nil
 }
 
-func (m *Manifest) addV1Entry(module *ManifestModule) error {
+func (m *Manifest) addV1Entry(ctx context.Context, module *ManifestModule) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	module.Source = strings.TrimSpace(module.Source)
 	if module.Source == "" {
 		return fmt.Errorf("source is required")
@@ -171,13 +180,13 @@ func (m *Manifest) addV1Entry(module *ManifestModule) error {
 	}
 	switch module.Status {
 	case manifestStatusResolved:
-		if err := m.resolveV1Paths(module, &entry); err != nil {
+		if err := m.resolveV1Paths(ctx, module, &entry); err != nil {
 			return err
 		}
 		if module.ContentDigest == "" {
 			return fmt.Errorf("content_digest is required for a resolved module")
 		}
-		digest, err := ComputePackageDigest(entry.PackageRoot)
+		digest, err := ComputePackageDigest(ctx, entry.PackageRoot)
 		if err != nil {
 			return fmt.Errorf("computing content digest: %w", err)
 		}
@@ -195,7 +204,10 @@ func (m *Manifest) addV1Entry(module *ManifestModule) error {
 	return nil
 }
 
-func (m *Manifest) resolveV1Paths(module *ManifestModule, entry *ManifestEntry) error {
+func (m *Manifest) resolveV1Paths(ctx context.Context, module *ManifestModule, entry *ManifestEntry) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if module.LocalPath == "" || !filepath.IsLocal(module.LocalPath) {
 		return fmt.Errorf("local_path must be a non-empty relative path")
 	}
@@ -208,10 +220,10 @@ func (m *Manifest) resolveV1Paths(module *ManifestModule, entry *ManifestEntry) 
 	}
 	entry.LocalPath = filepath.Join(m.Root, filepath.FromSlash(module.LocalPath))
 	entry.PackageRoot = filepath.Join(m.Root, filepath.FromSlash(packageRoot))
-	if _, err := ResolvePathWithinRoot(context.Background(), m.Root, entry.PackageRoot); err != nil {
+	if _, err := ResolvePathWithinRoot(ctx, m.Root, entry.PackageRoot); err != nil {
 		return fmt.Errorf("package_root %q escapes root: %w", module.PackageRoot, err)
 	}
-	if _, err := ResolvePathWithinRoot(context.Background(), entry.PackageRoot, entry.LocalPath); err != nil {
+	if _, err := ResolvePathWithinRoot(ctx, entry.PackageRoot, entry.LocalPath); err != nil {
 		return fmt.Errorf("local_path %q escapes package root: %w", module.LocalPath, err)
 	}
 	return nil
@@ -235,7 +247,10 @@ func validateManifestDeclarations(declarations []ManifestDeclaration) error {
 	return nil
 }
 
-func (m *Manifest) validate() error {
+func (m *Manifest) validate(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	for src := range m.Modules {
 		entry := m.Modules[src]
 		if entry.Status == manifestStatusUnresolved {
@@ -261,7 +276,7 @@ func (m *Manifest) validate() error {
 				}
 			}
 		}
-		confined, err := ConfineResolution(context.Background(), Resolution{
+		confined, err := ConfineResolution(ctx, Resolution{
 			LocalPath:   entry.LocalPath,
 			PackageRoot: entry.PackageRoot,
 		})
@@ -273,7 +288,7 @@ func (m *Manifest) validate() error {
 				"local_path":   confined.LocalPath,
 				"package_root": confined.PackageRoot,
 			} {
-				if _, err := ResolvePathWithinRoot(context.Background(), m.Dir, path); err != nil {
+				if _, err := ResolvePathWithinRoot(ctx, m.Dir, path); err != nil {
 					return fmt.Errorf("entry %q: resolved %s %q escapes dir %q: %w", src, field, path, m.Dir, err)
 				}
 			}

--- a/pkg/parser/terraform/modules/resolver/prefetched_test.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched_test.go
@@ -107,12 +107,8 @@ func TestLoadManifestV1ResolvesRelativePackageAndVerifiesDigest(t *testing.T) {
 		Version: "~> 5.0",
 	})
 	require.NoError(t, err)
-	resolvedModuleDir, err := filepath.EvalSymlinks(moduleDir)
-	require.NoError(t, err)
-	resolvedPackageRoot, err := filepath.EvalSymlinks(packageRoot)
-	require.NoError(t, err)
-	require.Equal(t, resolvedModuleDir, resolution.LocalPath)
-	require.Equal(t, resolvedPackageRoot, resolution.PackageRoot)
+	require.Equal(t, moduleDir, resolution.LocalPath)
+	require.Equal(t, packageRoot, resolution.PackageRoot)
 	require.Equal(t, "5.4.0", resolution.ResolvedVersion)
 }
 

--- a/pkg/parser/terraform/modules/resolver/prefetched_test.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -31,7 +32,7 @@ func TestLoadManifestJSONShape(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(manifestPath, manifestData, 0o644))
 
-	m, err := LoadManifest(manifestPath)
+	m, err := LoadManifest(t.Context(), manifestPath)
 	require.NoError(t, err)
 	require.Equal(t, resolvedDir, m.Dir)
 
@@ -75,7 +76,7 @@ func TestLoadManifestV1ResolvesRelativePackageAndVerifiesDigest(t *testing.T) {
 	moduleDir := filepath.Join(packageRoot, "modules", "vpc")
 	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte(`resource "x" "y" {}`), 0o644))
-	digest, err := ComputePackageDigest(packageRoot)
+	digest, err := ComputePackageDigest(t.Context(), packageRoot)
 	require.NoError(t, err)
 
 	manifestPath := filepath.Join(dir, "modules.json")
@@ -100,7 +101,7 @@ func TestLoadManifestV1ResolvesRelativePackageAndVerifiesDigest(t *testing.T) {
 		}},
 	})
 
-	manifest, err := LoadManifest(manifestPath)
+	manifest, err := LoadManifest(t.Context(), manifestPath)
 	require.NoError(t, err)
 	resolution, err := NewPrefetchedResolver(manifest).Resolve(t.Context(), &tfmodules.ParsedModule{
 		Source:  "terraform-aws-modules/vpc/aws",
@@ -133,7 +134,7 @@ func TestLoadManifestV1PreservesUnresolvedStatus(t *testing.T) {
 		}},
 	})
 
-	manifest, err := LoadManifest(manifestPath)
+	manifest, err := LoadManifest(t.Context(), manifestPath)
 	require.NoError(t, err)
 	_, err = NewPrefetchedResolver(manifest).Resolve(t.Context(), &tfmodules.ParsedModule{
 		Source: "example.invalid/module",
@@ -164,7 +165,7 @@ func TestLoadManifestV1RejectsDigestMismatch(t *testing.T) {
 		}},
 	})
 
-	_, err := LoadManifest(manifestPath)
+	_, err := LoadManifest(t.Context(), manifestPath)
 	require.ErrorContains(t, err, "content_digest mismatch")
 }
 
@@ -193,7 +194,7 @@ func TestLoadManifestV1RejectsLocalPathOutsidePackageRoot(t *testing.T) {
 		}},
 	})
 
-	_, err := LoadManifest(manifestPath)
+	_, err := LoadManifest(t.Context(), manifestPath)
 	require.ErrorContains(t, err, "escapes package root")
 }
 
@@ -225,7 +226,7 @@ func TestLoadManifestPreservesPackageRootForSiblingModules(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(manifestPath, manifestData, 0o644))
 
-	manifest, err := LoadManifest(manifestPath)
+	manifest, err := LoadManifest(t.Context(), manifestPath)
 	require.NoError(t, err)
 	resolution, err := NewPrefetchedResolver(manifest).Resolve(t.Context(), &tfmodules.ParsedModule{
 		Source: "example/module/aws",
@@ -258,6 +259,41 @@ func TestLoadManifestRejectsSymlinkEscape(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(manifestPath, manifestData, 0o644))
 
-	_, err = LoadManifest(manifestPath)
+	_, err = LoadManifest(t.Context(), manifestPath)
 	require.ErrorContains(t, err, "escapes package root")
+}
+
+func TestLoadManifestRespectsCancelledContext(t *testing.T) {
+	dir := t.TempDir()
+	packageRoot := filepath.Join(dir, "modules", "vpc-package")
+	moduleDir := filepath.Join(packageRoot, "modules", "vpc")
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte(`resource "x" "y" {}`), 0o644))
+	digest, err := ComputePackageDigest(t.Context(), packageRoot)
+	require.NoError(t, err)
+
+	manifestPath := filepath.Join(dir, "modules.json")
+	writeManifestJSON(t, manifestPath, map[string]any{
+		"schema_version": ManifestSchemaVersion,
+		"root":           "modules",
+		"modules": []map[string]any{{
+			"source":           "terraform-aws-modules/vpc/aws",
+			"package_root":     "vpc-package",
+			"local_path":       "vpc-package/modules/vpc",
+			"content_digest":   digest,
+			"status":           "resolved",
+			"declarations": []map[string]any{{
+				"filename":    "infra/main.tf",
+				"line_start":  12,
+				"line_end":    18,
+				"module_name": "vpc",
+			}},
+		}},
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err = LoadManifest(ctx, manifestPath)
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/pkg/parser/terraform/modules/resolver/prefetched_test.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched_test.go
@@ -69,6 +69,145 @@ func TestPrefetchedResolverUsesManifest(t *testing.T) {
 	require.Equal(t, "5.0.0", got.ResolvedVersion)
 }
 
+func TestLoadManifestV1ResolvesRelativePackageAndVerifiesDigest(t *testing.T) {
+	dir := t.TempDir()
+	packageRoot := filepath.Join(dir, "modules", "vpc-package")
+	moduleDir := filepath.Join(packageRoot, "modules", "vpc")
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte(`resource "x" "y" {}`), 0o644))
+	digest, err := ComputePackageDigest(packageRoot)
+	require.NoError(t, err)
+
+	manifestPath := filepath.Join(dir, "modules.json")
+	writeManifestJSON(t, manifestPath, map[string]any{
+		"schema_version": ManifestSchemaVersion,
+		"root":           "modules",
+		"modules": []map[string]any{{
+			"source":            "terraform-aws-modules/vpc/aws",
+			"requested_version": "~> 5.0",
+			"resolved_version":  "5.4.0",
+			"source_type":       "registry",
+			"package_root":      "vpc-package",
+			"local_path":        "vpc-package/modules/vpc",
+			"content_digest":    digest,
+			"status":            "resolved",
+			"declarations": []map[string]any{{
+				"filename":    "infra/main.tf",
+				"line_start":  12,
+				"line_end":    18,
+				"module_name": "vpc",
+			}},
+		}},
+	})
+
+	manifest, err := LoadManifest(manifestPath)
+	require.NoError(t, err)
+	resolution, err := NewPrefetchedResolver(manifest).Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source:  "terraform-aws-modules/vpc/aws",
+		Version: "~> 5.0",
+	})
+	require.NoError(t, err)
+	resolvedModuleDir, err := filepath.EvalSymlinks(moduleDir)
+	require.NoError(t, err)
+	resolvedPackageRoot, err := filepath.EvalSymlinks(packageRoot)
+	require.NoError(t, err)
+	require.Equal(t, resolvedModuleDir, resolution.LocalPath)
+	require.Equal(t, resolvedPackageRoot, resolution.PackageRoot)
+	require.Equal(t, "5.4.0", resolution.ResolvedVersion)
+}
+
+func TestLoadManifestV1PreservesUnresolvedStatus(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "modules.json")
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "modules"), 0o755))
+	writeManifestJSON(t, manifestPath, map[string]any{
+		"schema_version": ManifestSchemaVersion,
+		"root":           "modules",
+		"modules": []map[string]any{{
+			"source":      "example.invalid/module",
+			"source_type": "git",
+			"status":      "unresolved",
+			"failure":     "credentials_unavailable",
+			"declarations": []map[string]any{{
+				"filename":    "main.tf",
+				"line_start":  1,
+				"line_end":    3,
+				"module_name": "example",
+			}},
+		}},
+	})
+
+	manifest, err := LoadManifest(manifestPath)
+	require.NoError(t, err)
+	_, err = NewPrefetchedResolver(manifest).Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source: "example.invalid/module",
+	})
+	require.ErrorContains(t, err, "credentials_unavailable")
+}
+
+func TestLoadManifestV1RejectsDigestMismatch(t *testing.T) {
+	dir := t.TempDir()
+	moduleDir := filepath.Join(dir, "modules", "vpc")
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("content"), 0o644))
+	manifestPath := filepath.Join(dir, "modules.json")
+	writeManifestJSON(t, manifestPath, map[string]any{
+		"schema_version": ManifestSchemaVersion,
+		"root":           "modules",
+		"modules": []map[string]any{{
+			"source":         "example/module/aws",
+			"local_path":     "vpc",
+			"content_digest": "sha256:invalid",
+			"status":         "resolved",
+			"declarations": []map[string]any{{
+				"filename":    "main.tf",
+				"line_start":  1,
+				"line_end":    3,
+				"module_name": "vpc",
+			}},
+		}},
+	})
+
+	_, err := LoadManifest(manifestPath)
+	require.ErrorContains(t, err, "content_digest mismatch")
+}
+
+func TestLoadManifestV1RejectsLocalPathOutsidePackageRoot(t *testing.T) {
+	dir := t.TempDir()
+	packageRoot := filepath.Join(dir, "modules", "package")
+	selected := filepath.Join(dir, "modules", "selected")
+	require.NoError(t, os.MkdirAll(packageRoot, 0o755))
+	require.NoError(t, os.MkdirAll(selected, 0o755))
+	manifestPath := filepath.Join(dir, "modules.json")
+	writeManifestJSON(t, manifestPath, map[string]any{
+		"schema_version": ManifestSchemaVersion,
+		"root":           "modules",
+		"modules": []map[string]any{{
+			"source":         "example/module/aws",
+			"package_root":   "package",
+			"local_path":     "selected",
+			"content_digest": "sha256:unused",
+			"status":         "resolved",
+			"declarations": []map[string]any{{
+				"filename":    "main.tf",
+				"line_start":  1,
+				"line_end":    3,
+				"module_name": "example",
+			}},
+		}},
+	})
+
+	_, err := LoadManifest(manifestPath)
+	require.ErrorContains(t, err, "escapes package root")
+}
+
+func writeManifestJSON(t *testing.T, path string, manifest any) {
+	t.Helper()
+	data, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+}
+
 func TestLoadManifestPreservesPackageRootForSiblingModules(t *testing.T) {
 	dir := t.TempDir()
 	packageRoot := filepath.Join(dir, "package")

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -7,6 +7,7 @@ package scan
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/storage"
@@ -22,6 +23,24 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/rs/zerolog/log"
 )
+
+type TerraformModulesMode string
+
+const (
+	TerraformModulesModeOff     TerraformModulesMode = "off"
+	TerraformModulesModeOffline TerraformModulesMode = "offline"
+	TerraformModulesModeFetch   TerraformModulesMode = "fetch"
+)
+
+func ParseTerraformModulesMode(value string) (TerraformModulesMode, error) {
+	mode := TerraformModulesMode(value)
+	switch mode {
+	case TerraformModulesModeOff, TerraformModulesModeOffline, TerraformModulesModeFetch:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("invalid Terraform modules mode %q: expected off, offline, or fetch", value)
+	}
+}
 
 const (
 	DefaultRemoteModuleMaxDepth        = 8
@@ -68,19 +87,20 @@ type Parameters struct {
 	ShouldScanTfPlans           bool
 	DisableRuleIsolation        bool
 	UseRulesCache               bool
-	EnableRemoteModules         bool
+	TerraformModulesMode        TerraformModulesMode
 	RemoteModulesManifestPath   string
 	RemoteModulesHostAllowlist  []string
 	// ModuleMaxDepth caps the BFS depth of the remote-module graph walker (0 disables traversal entirely).
-	ModuleMaxDepth        int
-	ModuleFetchTimeout    time.Duration
-	MaxModuleBytesTotal   int64
-	MaxModulePackageBytes int64
-	MaxModuleFileBytes    int64
-	MaxModulePackageFiles int
-	MaxModuleParseBytes   int64
-	RemoteModulesCacheDir string
-	MaxModuleCacheBytes   int64
+	ModuleMaxDepth          int
+	ModuleFetchTimeout      time.Duration
+	MaxModuleBytesTotal     int64
+	MaxModulePackageBytes   int64
+	MaxModuleFileBytes      int64
+	MaxModulePackageFiles   int
+	MaxModuleParseBytes     int64
+	ModuleResolutionTimeout time.Duration
+	RemoteModulesCacheDir   string
+	MaxModuleCacheBytes     int64
 }
 
 func (p *Parameters) GetEffectivePlatforms() []string {
@@ -181,12 +201,14 @@ func GetDefaultParameters(ctx context.Context, rootPath string) (*Parameters, co
 		MaxFileSizeFlag:             5,
 		UseOldSeverities:            false,
 		MaxResolverDepth:            15,
+		TerraformModulesMode:        TerraformModulesModeOff,
 		ModuleMaxDepth:              DefaultRemoteModuleMaxDepth,
 		ModuleFetchTimeout:          30 * time.Second,
 		MaxModuleBytesTotal:         DefaultRemoteModuleMaxTotalBytes,
 		MaxModulePackageBytes:       DefaultRemoteModuleMaxPackageBytes,
 		MaxModuleFileBytes:          DefaultRemoteModuleMaxFileBytes,
 		MaxModulePackageFiles:       DefaultRemoteModuleMaxPackageFiles,
+		ModuleResolutionTimeout:     DefaultModuleResolutionTimeout,
 		MaxModuleCacheBytes:         DefaultRemoteModuleMaxCacheBytes,
 	}, logCtx
 }

--- a/pkg/scan/client_test.go
+++ b/pkg/scan/client_test.go
@@ -8,6 +8,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseTerraformModulesMode(t *testing.T) {
+	for _, value := range []string{"off", "offline", "fetch"} {
+		mode, err := ParseTerraformModulesMode(value)
+		require.NoError(t, err)
+		require.Equal(t, TerraformModulesMode(value), mode)
+	}
+
+	_, err := ParseTerraformModulesMode("online")
+	require.ErrorContains(t, err, "expected off, offline, or fetch")
+}
+
 func Test_Client(t *testing.T) {
 	ctx := context.Background()
 	params := &Parameters{

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
@@ -23,6 +24,8 @@ import (
 const (
 	moduleSourceTypeGit     = "git"
 	moduleSourceTypeUnknown = "unknown"
+
+	DefaultModuleResolutionTimeout = 5 * time.Minute
 )
 
 func (c *Client) resolveTerraformModulesForScan(
@@ -50,9 +53,12 @@ func (c *Client) resolveTerraformModulesForScan(
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	chain := c.buildModuleResolverChain(ctx, moduleDiscoveryPaths)
+	chain, err := c.buildModuleResolverChain(ctx, moduleDiscoveryPaths)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
 
-	if c.ScanParams.EnableRemoteModules {
+	if c.ScanParams.TerraformModulesMode == TerraformModulesModeFetch {
 		contextLogger.Info().Msg("Resolving remote Terraform modules...")
 	} else {
 		contextLogger.Debug().Msg("Resolving Terraform modules from local, manifest, or .terraform/modules sources only")
@@ -70,7 +76,14 @@ func (c *Client) resolveTerraformModulesForScan(
 	if packageFiles == 0 {
 		packageFiles = DefaultRemoteModuleMaxPackageFiles
 	}
-	result := modulegraph.Resolve(ctx, &modulegraph.Request{
+	resolveCtx := ctx
+	cancel := func() {}
+	if timeout := c.ScanParams.ModuleResolutionTimeout; timeout > 0 {
+		resolveCtx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	defer cancel()
+
+	result := modulegraph.Resolve(resolveCtx, &modulegraph.Request{
 		RootPaths:      extractedPaths.Path,
 		DiscoveryPaths: moduleDiscoveryPaths,
 		Resolver:       chain,
@@ -85,6 +98,10 @@ func (c *Client) resolveTerraformModulesForScan(
 		TotalParseBytes: c.ScanParams.MaxModuleParseBytes,
 		FS:              c.fsys,
 	})
+	if result.TimedOut {
+		contextLogger.Warn().Dur("timeout", c.ScanParams.ModuleResolutionTimeout).
+			Msg("Terraform module resolution timed out; scanning modules resolved before the deadline")
+	}
 	for _, event := range result.BudgetEvents {
 		contextLogger.Warn().
 			Str("module_source", event.Source).
@@ -144,22 +161,14 @@ func resolvedModuleSourceType(module *modulegraph.ResolvedModule) string {
 	return sourceType
 }
 
-func (c *Client) shouldPreScanTerraformModules(scanPaths []string) bool {
-	if !c.ScanParams.EnableRemoteModules {
-		return false
-	}
-	if c.ScanParams.RemoteModulesManifestPath != "" {
-		return true
-	}
-	for _, root := range dotTerraformRootDirs(scanPaths) {
-		if hasTerraformModulesManifest(root) {
-			return true
-		}
-	}
-	return true
+func (c *Client) shouldPreScanTerraformModules(_ []string) bool {
+	mode := c.ScanParams.TerraformModulesMode
+	return mode == TerraformModulesModeOffline || mode == TerraformModulesModeFetch
 }
 
-func (c *Client) buildModuleResolverChain(ctx context.Context, moduleDiscoveryPaths []string) *tfresolver.ChainResolver {
+func (c *Client) buildModuleResolverChain(
+	ctx context.Context, moduleDiscoveryPaths []string,
+) (*tfresolver.ChainResolver, error) {
 	contextLogger := logger.FromContext(ctx)
 
 	resolvers := []tfresolver.Resolver{
@@ -170,16 +179,16 @@ func (c *Client) buildModuleResolverChain(ctx context.Context, moduleDiscoveryPa
 	if c.ScanParams.RemoteModulesManifestPath != "" {
 		manifest, err := tfresolver.LoadManifest(c.ScanParams.RemoteModulesManifestPath)
 		if err != nil {
-			contextLogger.Warn().Err(err).
-				Msgf("Failed to load modules manifest %q; remote modules from manifest will be unresolved",
-					c.ScanParams.RemoteModulesManifestPath)
-		} else {
-			resolvers = append(resolvers, tfresolver.NewPrefetchedResolver(manifest))
+			return nil, err
 		}
+		resolvers = append(resolvers, tfresolver.NewPrefetchedResolver(manifest))
+	}
+
+	if c.ScanParams.TerraformModulesMode != TerraformModulesModeFetch {
+		return tfresolver.NewChainResolver(resolvers...), nil
 	}
 
 	ggCfg := tfresolver.NewGoGetterConfig()
-	ggCfg.Disabled = !c.ScanParams.EnableRemoteModules
 	if t := c.ScanParams.ModuleFetchTimeout; t > 0 {
 		ggCfg.FetchTimeout = t
 	}
@@ -194,47 +203,41 @@ func (c *Client) buildModuleResolverChain(ctx context.Context, moduleDiscoveryPa
 		cacheRoot string
 		budget    *tfresolver.ModuleCacheBudget
 	)
-	if !ggCfg.Disabled {
-		cacheRoot = strings.TrimSpace(c.ScanParams.RemoteModulesCacheDir)
-		if cacheRoot == "" {
-			var rootErr error
-			cacheRoot, rootErr = tfresolver.DefaultModuleCacheRoot()
-			if rootErr != nil {
-				contextLogger.Warn().Err(rootErr).Msg("Remote module cache root unavailable; cache limits will not be enforced")
-			}
+	cacheRoot = strings.TrimSpace(c.ScanParams.RemoteModulesCacheDir)
+	if cacheRoot == "" {
+		var rootErr error
+		cacheRoot, rootErr = tfresolver.DefaultModuleCacheRoot()
+		if rootErr != nil {
+			contextLogger.Warn().Err(rootErr).Msg("Remote module cache root unavailable; cache limits will not be enforced")
 		}
-		if cacheRoot != "" {
-			var budgetErr error
-			budget, budgetErr = tfresolver.NewModuleCacheBudget(cacheRoot, cacheBytes)
-			if budgetErr != nil {
-				contextLogger.Warn().Err(budgetErr).Msg("Remote module cache budget unavailable; cache limits will not be enforced")
-			}
+	}
+	if cacheRoot != "" {
+		var budgetErr error
+		budget, budgetErr = tfresolver.NewModuleCacheBudget(cacheRoot, cacheBytes)
+		if budgetErr != nil {
+			contextLogger.Warn().Err(budgetErr).Msg("Remote module cache budget unavailable; cache limits will not be enforced")
 		}
 	}
 
-	if c.ScanParams.EnableRemoteModules {
-		gitCacheDir := tfresolver.ModuleCacheSubdir(cacheRoot, tfresolver.CacheSubdirGitBare)
-		localCacheDir := tfresolver.ModuleCacheSubdir(cacheRoot, tfresolver.CacheSubdirGitLocal)
-		git := tfresolver.NewBareGitResolver(gitCacheDir, c.ScanParams.RemoteModulesHostAllowlist...)
-		git.Budget = budget
-		ggCfg.Git = git
-		localGit := tfresolver.NewLocalGitRefResolver(dotTerraformRootDirs(moduleDiscoveryPaths), localCacheDir)
-		localGit.Budget = budget
-		resolvers = append(resolvers, localGit, git)
-	}
+	gitCacheDir := tfresolver.ModuleCacheSubdir(cacheRoot, tfresolver.CacheSubdirGitBare)
+	localCacheDir := tfresolver.ModuleCacheSubdir(cacheRoot, tfresolver.CacheSubdirGitLocal)
+	git := tfresolver.NewBareGitResolver(gitCacheDir, c.ScanParams.RemoteModulesHostAllowlist...)
+	git.Budget = budget
+	ggCfg.Git = git
+	localGit := tfresolver.NewLocalGitRefResolver(dotTerraformRootDirs(moduleDiscoveryPaths), localCacheDir)
+	localGit.Budget = budget
+	resolvers = append(resolvers, localGit, git)
 
-	if !ggCfg.Disabled {
-		moduleCacheDir := tfresolver.ModuleCacheSubdir(cacheRoot, tfresolver.CacheSubdirModules)
-		cache, err := tfresolver.NewModuleCacheWithDir(moduleCacheDir, budget)
-		if err != nil {
-			contextLogger.Warn().Err(err).Msg("Module disk cache unavailable; fetched modules will not be cached")
-		} else {
-			ggCfg.Cache = cache
-		}
+	moduleCacheDir := tfresolver.ModuleCacheSubdir(cacheRoot, tfresolver.CacheSubdirModules)
+	cache, err := tfresolver.NewModuleCacheWithDir(moduleCacheDir, budget)
+	if err != nil {
+		contextLogger.Warn().Err(err).Msg("Module disk cache unavailable; fetched modules will not be cached")
+	} else {
+		ggCfg.Cache = cache
 	}
 
 	resolvers = append(resolvers, tfresolver.NewGoGetterResolver(ggCfg))
-	return tfresolver.NewChainResolver(resolvers...)
+	return tfresolver.NewChainResolver(resolvers...), nil
 }
 
 func dotTerraformRootDirs(paths []string) []string {

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -64,40 +64,7 @@ func (c *Client) resolveTerraformModulesForScan(
 		contextLogger.Debug().Msg("Resolving Terraform modules from local, manifest, or .terraform/modules sources only")
 	}
 
-	packageBytes := c.ScanParams.MaxModulePackageBytes
-	if packageBytes == 0 {
-		packageBytes = DefaultRemoteModuleMaxPackageBytes
-	}
-	fileBytes := c.ScanParams.MaxModuleFileBytes
-	if fileBytes == 0 {
-		fileBytes = DefaultRemoteModuleMaxFileBytes
-	}
-	packageFiles := c.ScanParams.MaxModulePackageFiles
-	if packageFiles == 0 {
-		packageFiles = DefaultRemoteModuleMaxPackageFiles
-	}
-	resolveCtx := ctx
-	cancel := func() {}
-	if timeout := c.ScanParams.ModuleResolutionTimeout; timeout > 0 {
-		resolveCtx, cancel = context.WithTimeout(ctx, timeout)
-	}
-	defer cancel()
-
-	result := modulegraph.Resolve(resolveCtx, &modulegraph.Request{
-		RootPaths:      extractedPaths.Path,
-		DiscoveryPaths: moduleDiscoveryPaths,
-		Resolver:       chain,
-		MaxDepth:       c.ScanParams.ModuleMaxDepth,
-		ResourceLimits: tfresolver.ResourceLimits{
-			MaxPackageBytes: packageBytes,
-			MaxFileBytes:    fileBytes,
-			MaxPackageFiles: packageFiles,
-			MaxTotalBytes:   c.ScanParams.MaxModuleBytesTotal,
-		},
-		BaselinePaths:   baselinePaths,
-		TotalParseBytes: c.ScanParams.MaxModuleParseBytes,
-		FS:              c.fsys,
-	})
+	result := c.resolveTerraformModuleGraph(ctx, extractedPaths.Path, moduleDiscoveryPaths, baselinePaths, chain)
 	if result.TimedOut {
 		contextLogger.Warn().Dur("timeout", c.ScanParams.ModuleResolutionTimeout).
 			Msg("Terraform module resolution timed out; scanning modules resolved before the deadline")
@@ -148,6 +115,46 @@ func (c *Client) resolveTerraformModulesForScan(
 		}
 	}
 	return result.Cleanup, result.ScanPaths, remoteSourceDirs, remoteModuleProvenance, nil
+}
+
+func (c *Client) resolveTerraformModuleGraph(
+	ctx context.Context,
+	rootPaths, discoveryPaths, baselinePaths []string,
+	moduleResolver tfresolver.Resolver,
+) modulegraph.Result {
+	packageBytes := c.ScanParams.MaxModulePackageBytes
+	if packageBytes == 0 {
+		packageBytes = DefaultRemoteModuleMaxPackageBytes
+	}
+	fileBytes := c.ScanParams.MaxModuleFileBytes
+	if fileBytes == 0 {
+		fileBytes = DefaultRemoteModuleMaxFileBytes
+	}
+	packageFiles := c.ScanParams.MaxModulePackageFiles
+	if packageFiles == 0 {
+		packageFiles = DefaultRemoteModuleMaxPackageFiles
+	}
+	resolveCtx := ctx
+	cancel := func() {}
+	if timeout := c.ScanParams.ModuleResolutionTimeout; timeout > 0 {
+		resolveCtx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	defer cancel()
+	return modulegraph.Resolve(resolveCtx, &modulegraph.Request{
+		RootPaths:      rootPaths,
+		DiscoveryPaths: discoveryPaths,
+		Resolver:       moduleResolver,
+		MaxDepth:       c.ScanParams.ModuleMaxDepth,
+		ResourceLimits: tfresolver.ResourceLimits{
+			MaxPackageBytes: packageBytes,
+			MaxFileBytes:    fileBytes,
+			MaxPackageFiles: packageFiles,
+			MaxTotalBytes:   c.ScanParams.MaxModuleBytesTotal,
+		},
+		BaselinePaths:   baselinePaths,
+		TotalParseBytes: c.ScanParams.MaxModuleParseBytes,
+		FS:              c.fsys,
+	})
 }
 
 // resolvedModuleSourceType keeps the type detected from the declared source. A resolved Git ref only

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -53,7 +53,10 @@ func (c *Client) resolveTerraformModulesForScan(
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	chain, err := c.buildModuleResolverChain(ctx, moduleDiscoveryPaths)
+	resolveCtx, cancel := c.moduleResolutionContext(ctx)
+	defer cancel()
+
+	chain, err := c.buildModuleResolverChain(resolveCtx, moduleDiscoveryPaths)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -64,7 +67,7 @@ func (c *Client) resolveTerraformModulesForScan(
 		contextLogger.Debug().Msg("Resolving Terraform modules from local, manifest, or .terraform/modules sources only")
 	}
 
-	result := c.resolveTerraformModuleGraph(ctx, extractedPaths.Path, moduleDiscoveryPaths, baselinePaths, chain)
+	result := c.resolveTerraformModuleGraph(resolveCtx, extractedPaths.Path, moduleDiscoveryPaths, baselinePaths, chain)
 	if result.TimedOut {
 		contextLogger.Warn().Dur("timeout", c.ScanParams.ModuleResolutionTimeout).
 			Msg("Terraform module resolution timed out; scanning modules resolved before the deadline")
@@ -134,13 +137,7 @@ func (c *Client) resolveTerraformModuleGraph(
 	if packageFiles == 0 {
 		packageFiles = DefaultRemoteModuleMaxPackageFiles
 	}
-	resolveCtx := ctx
-	cancel := func() {}
-	if timeout := c.ScanParams.ModuleResolutionTimeout; timeout > 0 {
-		resolveCtx, cancel = context.WithTimeout(ctx, timeout)
-	}
-	defer cancel()
-	return modulegraph.Resolve(resolveCtx, &modulegraph.Request{
+	return modulegraph.Resolve(ctx, &modulegraph.Request{
 		RootPaths:      rootPaths,
 		DiscoveryPaths: discoveryPaths,
 		Resolver:       moduleResolver,
@@ -168,6 +165,13 @@ func resolvedModuleSourceType(module *modulegraph.ResolvedModule) string {
 	return sourceType
 }
 
+func (c *Client) moduleResolutionContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if timeout := c.ScanParams.ModuleResolutionTimeout; timeout > 0 {
+		return context.WithTimeout(ctx, timeout)
+	}
+	return ctx, func() {}
+}
+
 func (c *Client) shouldPreScanTerraformModules(_ []string) bool {
 	mode := c.ScanParams.TerraformModulesMode
 	return mode == TerraformModulesModeOffline || mode == TerraformModulesModeFetch
@@ -184,7 +188,7 @@ func (c *Client) buildModuleResolverChain(
 	}
 
 	if c.ScanParams.RemoteModulesManifestPath != "" {
-		manifest, err := tfresolver.LoadManifest(c.ScanParams.RemoteModulesManifestPath)
+		manifest, err := tfresolver.LoadManifest(ctx, c.ScanParams.RemoteModulesManifestPath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scan/remote_modules_test.go
+++ b/pkg/scan/remote_modules_test.go
@@ -120,7 +120,7 @@ resource "aws_vpc" "this" {
 			},
 		},
 	})
-	digest, err := resolver.ComputePackageDigest(moduleDir)
+	digest, err := resolver.ComputePackageDigest(t.Context(), moduleDir)
 	require.NoError(t, err)
 	v1Path := filepath.Join(base, "v1.json")
 	writeJSONFile(t, v1Path, map[string]any{

--- a/pkg/scan/remote_modules_test.go
+++ b/pkg/scan/remote_modules_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	engineprovider "github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
@@ -42,10 +43,38 @@ func TestRemoteModulesDisabledByDefault(t *testing.T) {
 
 	params := remoteModuleScanParams(root)
 	params.RemoteModulesManifestPath = manifestPath
-	params.EnableRemoteModules = false
+	params.TerraformModulesMode = TerraformModulesModeOff
 
 	results := executeRemoteModuleScan(t, params)
 	require.Empty(t, results.Results)
+}
+
+func TestOfflineModeBuildsOnlyDiskResolvers(t *testing.T) {
+	client := &Client{ScanParams: &Parameters{TerraformModulesMode: TerraformModulesModeOffline}}
+
+	chain, err := client.buildModuleResolverChain(t.Context(), []string{t.TempDir()})
+	require.NoError(t, err)
+
+	resolvers := reflect.ValueOf(chain).Elem().FieldByName("resolvers")
+	require.Equal(t, 2, resolvers.Len())
+	for i := 0; i < resolvers.Len(); i++ {
+		resolverType := resolvers.Index(i).Elem().Type().String()
+		require.NotContains(t, resolverType, "GoGetter")
+		require.NotContains(t, resolverType, "BareGit")
+		require.NotContains(t, resolverType, "LocalGitRef")
+	}
+}
+
+func TestOfflineModeRejectsMalformedManifest(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), "modules.json")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(`{"schema_version":1}`), 0o644))
+	client := &Client{ScanParams: &Parameters{
+		TerraformModulesMode:      TerraformModulesModeOffline,
+		RemoteModulesManifestPath: manifestPath,
+	}}
+
+	_, err := client.buildModuleResolverChain(t.Context(), []string{t.TempDir()})
+	require.ErrorContains(t, err, "root must be a non-empty relative path")
 }
 
 func TestRemoteModulesManifestEnablesModuleInstantiation(t *testing.T) {
@@ -53,7 +82,7 @@ func TestRemoteModulesManifestEnablesModuleInstantiation(t *testing.T) {
 	moduleDir, manifestPath := writeRemoteModuleFixture(t, root)
 
 	params := remoteModuleScanParams(root)
-	params.EnableRemoteModules = true
+	params.TerraformModulesMode = TerraformModulesModeOffline
 	params.RemoteModulesManifestPath = manifestPath
 
 	results := executeRemoteModuleScan(t, params)
@@ -66,7 +95,7 @@ func TestRemoteModuleMaxDepthZeroDisablesTraversal(t *testing.T) {
 	_, manifestPath := writeRemoteModuleFixture(t, root)
 
 	params := remoteModuleScanParams(root)
-	params.EnableRemoteModules = true
+	params.TerraformModulesMode = TerraformModulesModeOffline
 	params.RemoteModulesManifestPath = manifestPath
 	params.ModuleMaxDepth = 0
 

--- a/pkg/scan/remote_modules_test.go
+++ b/pkg/scan/remote_modules_test.go
@@ -90,6 +90,92 @@ func TestRemoteModulesManifestEnablesModuleInstantiation(t *testing.T) {
 	require.Equal(t, filepath.ToSlash(filepath.Join(moduleDir, "main.tf")), filepath.ToSlash(results.Results[0].FileName))
 }
 
+func TestManifestV1PreservesLegacyFindingOutput(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "repo")
+	moduleDir := filepath.Join(base, "modules", "vpc")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(`
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.0.0"
+  cidr    = "10.0.0.0/16"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte(`
+variable "cidr" {}
+resource "aws_vpc" "this" {
+  cidr_block = var.cidr
+}
+`), 0o644))
+
+	legacyPath := filepath.Join(base, "legacy.json")
+	writeJSONFile(t, legacyPath, resolver.Manifest{
+		Dir: base,
+		Modules: map[string]resolver.ManifestEntry{
+			"terraform-aws-modules/vpc/aws@5.0.0": {
+				LocalPath: moduleDir,
+				Version:   "5.0.0",
+			},
+		},
+	})
+	digest, err := resolver.ComputePackageDigest(moduleDir)
+	require.NoError(t, err)
+	v1Path := filepath.Join(base, "v1.json")
+	writeJSONFile(t, v1Path, map[string]any{
+		"schema_version": resolver.ManifestSchemaVersion,
+		"root":           "modules",
+		"modules": []map[string]any{{
+			"source":            "terraform-aws-modules/vpc/aws",
+			"requested_version": "5.0.0",
+			"resolved_version":  "5.0.0",
+			"source_type":       "registry",
+			"local_path":        "vpc",
+			"content_digest":    digest,
+			"status":            "resolved",
+			"declarations": []map[string]any{{
+				"filename":    "main.tf",
+				"line_start":  2,
+				"line_end":    6,
+				"module_name": "vpc",
+			}},
+		}},
+	})
+
+	legacyParams := remoteModuleScanParams(root)
+	legacyParams.TerraformModulesMode = TerraformModulesModeOffline
+	legacyParams.RemoteModulesManifestPath = legacyPath
+	v1Params := remoteModuleScanParams(root)
+	v1Params.TerraformModulesMode = TerraformModulesModeOffline
+	v1Params.RemoteModulesManifestPath = v1Path
+
+	legacy := executeRemoteModuleScan(t, legacyParams)
+	v1 := executeRemoteModuleScan(t, v1Params)
+	legacySummary := model.CreateSummary(
+		t.Context(),
+		model.Counters{},
+		legacy.Results,
+		legacyParams.ScanID,
+		legacy.ExtractedPaths.ExtractionMap,
+		root,
+		model.SCIInfo{},
+	)
+	v1Summary := model.CreateSummary(
+		t.Context(),
+		model.Counters{},
+		v1.Results,
+		v1Params.ScanID,
+		v1.ExtractedPaths.ExtractionMap,
+		root,
+		model.SCIInfo{},
+	)
+	require.Len(t, legacySummary.Queries, 1)
+	require.Len(t, v1Summary.Queries, 1)
+	require.Equal(t, legacySummary.Queries[0].Files[0].Fingerprint, v1Summary.Queries[0].Files[0].Fingerprint)
+	require.Equal(t, legacySummary.Queries[0].Files[0].ModuleAttribution, v1Summary.Queries[0].Files[0].ModuleAttribution)
+}
+
 func TestRemoteModuleMaxDepthZeroDisablesTraversal(t *testing.T) {
 	root := t.TempDir()
 	_, manifestPath := writeRemoteModuleFixture(t, root)
@@ -167,6 +253,13 @@ module "vpc" {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(manifestPath, data, 0o644))
 	return moduleDir, manifestPath
+}
+
+func writeJSONFile(t *testing.T, path string, value any) {
+	t.Helper()
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o644))
 }
 
 func remoteModuleScanParams(root string) *Parameters {


### PR DESCRIPTION
## Motivation

Hosted sandbox scans have no egress, so module resolution must be a strict disk-only contract rather than experimental flags that can still construct network-capable resolvers. This change replaces the boolean remote-module controls with an authoritative off|offline|fetch mode and a digest-verified manifest for prefetched packages.

Related ticket: [K9CODESEC-5296](https://datadoghq.atlassian.net/browse/K9CODESEC-5296)

## Changes

**Mode contract**

Replace `--x-remote-modules` and its siblings with `--terraform-modules-mode=off|offline|fetch` (default `off`). Offline mode builds a disk-only resolver chain (local paths, `.terraform/modules`, prefetched manifest) and never registers GoGetter, bare Git, or subprocess Git resolvers. Malformed manifests fail the scan instead of being skipped with a warning.

**Local module eval**

Keep hidden `--x-local-module-eval` for the hosted worker. Local module instantiation and module graph pre-scan are separate gates: the flag enables variable resolution only, while `--terraform-modules-mode=offline|fetch` enables the resolver pre-scan and also forces local eval on because remote findings need it.

**Manifest v1**

Add schema version 1 with bundle `root`, per-module declarations, status, resolved ref, and SHA-256 `content_digest` verification. Legacy map manifests without `schema_version` remain accepted for one release. Module paths must stay within their package root.

**CLI and discovery**

Rename module flags to the architecture names (`--terraform-modules-manifest`, `--terraform-modules-max-*`, `--module-resolution-timeout`, and related cache or host controls). Add `list-modules` to emit deterministic module declaration JSON without fetching.

**Resolution budget**

Apply a whole-phase `--module-resolution-timeout` (default 5m) so partial results are returned when the budget expires.

## Author Checklist

1. [x] I have reviewed my own PR.
2. [x] I have added or updated relevant unit tests where necessary.
3. [x] All new and existing targeted tests pass.
4. [ ] I have tested my changes on staging, if applicable.
5. [x] I have updated the related design artifacts and ticket.

## QA Instruction

1. `go test ./pkg/scan ./pkg/parser/terraform/modules/... ./cmd/scanner -count=1`
2. `golangci-lint run -c .golangci.yml --timeout 20m`
3. Confirm `--x-local-module-eval` with default `--terraform-modules-mode=off` still enables local module eval without running resolver pre-scan.
4. Scan with `--terraform-modules-mode=offline --terraform-modules-manifest=<manifest>` and confirm prefetched modules resolve without network access.
5. Run `datadog-iac-scanner list-modules -p <repo>` and confirm declaration JSON includes `def_end_line`.
6. Confirm legacy and v1 manifests produce the same finding fingerprints and module attribution for the same fixture.

## Impact

This affects Terraform module resolution in the CLI and scan client. Default behavior remains unchanged (`off` with no legacy flag). Prod scans that pass only `--x-local-module-eval` keep today's local-eval-only behavior. Fetch mode and non-module scan paths are unchanged. Hosted worker integration still passes `--x-local-module-eval` until dd-source wires `--terraform-modules-mode=offline`.

## Additional Notes

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-5296]: https://datadoghq.atlassian.net/browse/K9CODESEC-5296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ