### PR TITLE
Bound the Terraform module instantiation budget over the whole scan

### DIFF
--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -21,6 +21,7 @@ import (
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/tfeval"
 	"github.com/cespare/xxhash/v2"
+	"github.com/rs/zerolog"
 )
 
 // extraCallerInfo records a deduplicated module caller so its findings can be
@@ -42,6 +43,8 @@ type moduleResolutionResult struct {
 	unresolvedModuleDirs map[string]bool
 	extras               map[string][]extraCallerInfo
 	resourceCount        int
+	rootCount            int
+	budgetExceeded       bool
 	ok                   bool
 }
 
@@ -76,6 +79,7 @@ func (c *Inspector) instantiateLocalModules(
 			len(res.docs),
 			deduplicatedCallerCount(&res),
 		)
+	logModuleInstantiationSummary(&contextLogger, &res)
 	if !res.ok {
 		return nil, nil, nil
 	}
@@ -106,6 +110,23 @@ func (c *Inspector) instantiateLocalModules(
 		stripModuleCalls(f.Document, f.FilePath, c.repoPath, res.calledDirs, res.successfulRoots, rootDirs, resolver)
 	}
 	return res.docs, res.syntheticFiles, res.extras
+}
+
+// logModuleInstantiationSummary emits the fields an on-call search needs at warn
+// level. Production runs at warn, so the info-level count above is invisible there;
+// without this, a scan on its way to OOM looks identical to one that never ran
+// module evaluation.
+func logModuleInstantiationSummary(log *zerolog.Logger, res *moduleResolutionResult) {
+	if res.resourceCount == 0 && !res.budgetExceeded {
+		return
+	}
+	log.Warn().
+		Int("module_resources_instantiated", res.resourceCount).
+		Int("module_root_count", res.rootCount).
+		Int("module_documents", len(res.docs)).
+		Int("resource_budget", tfeval.MaxInstantiated()).
+		Bool("resource_budget_exhausted", res.budgetExceeded).
+		Msg("tfeval: module instantiation summary")
 }
 
 // declaresTargetedResource reports whether any scanned Terraform file declares
@@ -337,7 +358,7 @@ func evaluateRootModules(
 ) {
 	contextLogger := logger.FromContext(ctx)
 	for _, dir := range roots {
-		evaluator.ResetInstantiationBudget()
+		evaluator.ResetSpeculativeBudget()
 		resources, _, childDirs, err := evaluator.EvaluateModule(ctx, dir, tfeval.LoadRootVars(dir))
 		if err != nil {
 			contextLogger.Warn().Err(err).Msgf("tfeval: failed to evaluate root module %s", dir)
@@ -539,6 +560,8 @@ func resolveModuleDocuments(
 		unresolvedModuleDirs: unresolvedModuleDirs,
 		extras:               extras,
 		resourceCount:        resourceCount,
+		rootCount:            len(roots),
+		budgetExceeded:       evaluator.BudgetExceeded(),
 		ok:                   true,
 	}
 }

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -6,10 +6,12 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
@@ -17,6 +19,7 @@ import (
 	terraformParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform"
 	scanUtils "github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -138,6 +141,53 @@ resource "aws_s3_bucket" "this" {
 	require.Equal(t, "modules/bucket", v.ModuleAttribution.Source)
 	require.Equal(t, "main.tf", v.ModuleAttribution.ModuleCodeLocation.Filename)
 	require.Empty(t, v.ModuleAttribution.ModulePath)
+}
+
+func TestModuleInstantiationSummary_LoggedAtWarnLevel(t *testing.T) {
+	root := t.TempDir()
+	rootDir := filepath.Join(root, "stack")
+	modDir := filepath.Join(root, "modules", "bucket")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "main.tf"), []byte(`
+module "bucket" {
+  source = "../modules/bucket"
+  acl    = "public-read"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "main.tf"), []byte(`
+variable "acl" { type = string }
+resource "aws_s3_bucket" "this" { acl = var.acl }
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, filepath.Join(rootDir, "main.tf"))...)
+	files = append(files, parseTerraform(t, filepath.Join(modDir, "main.tf"))...)
+
+	queries := []model.QueryMetadata{{
+		Query: aclRule, InputData: "{}", Platform: "terraform",
+		Metadata: map[string]interface{}{"id": "acl-rule"}, Aggregation: 1,
+	}}
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries: queries, repoPath: root, vb: DefaultVulnerabilityBuilder,
+		flagEvaluator: moduleEvalEnabled(),
+	})
+
+	var logs bytes.Buffer
+	ctx := zerolog.New(&logs).Level(zerolog.WarnLevel).WithContext(context.Background())
+	ins.instantiateLocalModules(ctx, files, ruleTargetedResourceTypes(queries, ins.terraformRuleLibraries()...))
+
+	out := logs.String()
+	if !strings.Contains(out, "tfeval: module instantiation summary") {
+		t.Fatalf("expected warn-level summary for agents to grep, got %q", out)
+	}
+	if !strings.Contains(out, `"module_resources_instantiated":`) {
+		t.Fatalf("expected structured instantiation count, got %q", out)
+	}
+	if !strings.Contains(out, `"module_root_count":`) {
+		t.Fatalf("expected root count in summary, got %q", out)
+	}
 }
 
 // Two roots call the same module with the same inputs: expect two findings and two distinct ModuleCallChain values.

--- a/pkg/parser/terraform/tfeval/cache.go
+++ b/pkg/parser/terraform/tfeval/cache.go
@@ -45,6 +45,10 @@ type evalCacheEntry struct {
 	visitedDirs  []string
 	baseAddr     string
 	baseChainLen int
+	// evalDepth is the nesting depth this entry was evaluated at. A module cached
+	// from a deeper call may have truncated descendants; shallower callers need a
+	// fresh evaluation with more depth remaining.
+	evalDepth int
 }
 
 // rebase returns the cached resources as they would have been recorded had the

--- a/pkg/parser/terraform/tfeval/eval_cache_key_test.go
+++ b/pkg/parser/terraform/tfeval/eval_cache_key_test.go
@@ -224,6 +224,7 @@ func TestInstantiationBudget_CountsFinalInstancesOnce(t *testing.T) {
 	stack := writeNestedFanOut(t, 12, 3)
 
 	e := New()
+	e.SetMaxInstantiated(300000)
 	resources, _, _, err := e.EvaluateModule(context.Background(), stack, nil)
 	if err != nil {
 		t.Fatalf("EvaluateModule: %v", err)
@@ -232,11 +233,11 @@ func TestInstantiationBudget_CountsFinalInstancesOnce(t *testing.T) {
 	const want = 177147
 	if got := len(resources); got != want {
 		t.Fatalf("resolved %d resources after counting %d, want %d below the %d-resource budget",
-			got, e.instantiated, want, defaultMaxInstantiated)
+			got, e.instantiated, want, e.maxInstantiated)
 	}
 	if e.BudgetExceeded() {
 		t.Fatalf("budget was exhausted after resolving %d resources below its %d limit",
-			len(resources), defaultMaxInstantiated)
+			len(resources), e.maxInstantiated)
 	}
 	if e.instantiated != len(resources) {
 		t.Fatalf("budget counted %d instances for %d returned resources",
@@ -244,25 +245,70 @@ func TestInstantiationBudget_CountsFinalInstancesOnce(t *testing.T) {
 	}
 }
 
-func TestResetInstantiationBudget_FreshQuotaPerRoot(t *testing.T) {
+// Instantiated resources become documents that live until the scan ends, so the
+// budget has to bound their total. A budget handed back at every root boundary
+// bounds nothing, because the number of roots in a repository is not bounded.
+func TestInstantiationBudget_SpansRootsRatherThanResettingPerRoot(t *testing.T) {
 	e := New()
 	e.SetMaxInstantiated(100)
 	ctx := context.Background()
 
-	e.chargeInstantiationBudget(ctx, 80)
-	if e.BudgetExceeded() {
-		t.Fatal("budget should not be exceeded at 80 of 100")
+	if !e.chargeInstantiationBudget(ctx, 80) {
+		t.Fatal("80 resources should fit a budget of 100")
 	}
 
-	e.ResetInstantiationBudget()
-	e.chargeInstantiationBudget(ctx, 80)
-	if e.BudgetExceeded() {
-		t.Fatal("after reset, a second root should get a fresh quota of 100")
-	}
+	e.ResetSpeculativeBudget()
 
-	e.chargeInstantiationBudget(ctx, 25)
+	if e.chargeInstantiationBudget(ctx, 80) {
+		t.Fatal("a second root was granted 80 more instances on a budget of 100")
+	}
 	if !e.BudgetExceeded() {
-		t.Fatal("budget should exceed once a single root passes 100 resources")
+		t.Fatal("the budget stopped the recursion but was not reported as exceeded")
+	}
+	if !e.chargeInstantiationBudget(ctx, 20) {
+		t.Fatal("20 resources should still fit the 20 remaining of a budget of 100")
+	}
+}
+
+func TestInstantiationBudget_BoundsTotalAcrossManyRoots(t *testing.T) {
+	const (
+		budget = 500
+		roots  = 40
+	)
+
+	shared := writeNestedFanOut(t, 6, 2)
+	repo := filepath.Dir(shared)
+
+	e := New()
+	e.SetMaxInstantiated(budget)
+
+	total := 0
+	for i := 0; i < roots; i++ {
+		dir := filepath.Join(repo, fmt.Sprintf("root%02d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		body := fmt.Sprintf("module \"m\" {\n  source = \"../lvl00\"\n  in = \"seed%d\"\n}\n", i)
+		if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		e.ResetSpeculativeBudget()
+		resources, _, _, err := e.EvaluateModule(context.Background(), dir, nil)
+		if err != nil {
+			t.Fatalf("EvaluateModule root %d: %v", i, err)
+		}
+		total += len(resources)
+	}
+
+	if total > budget {
+		t.Errorf("%d roots instantiated %d resources against a budget of %d", roots, total, budget)
+	}
+	if total == 0 {
+		t.Error("no resources resolved at all")
+	}
+	if !e.BudgetExceeded() {
+		t.Error("the budget bound the scan but was never reported as exceeded")
 	}
 }
 
@@ -321,6 +367,175 @@ module "leaf" {
 	}
 }
 
+func TestEvalCache_DoesNotReuseResultCachedFromDeeperDepth(t *testing.T) {
+	root := t.TempDir()
+	leaf := filepath.Join(root, "leaf")
+	mid := filepath.Join(root, "mid")
+	wrapper := filepath.Join(root, "wrapper")
+	for _, dir := range []string{leaf, mid, wrapper} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(leaf, "main.tf"), []byte(`
+variable "in" { type = string }
+resource "aws_s3_bucket" "leaf" { bucket = var.in }
+`), 0o644); err != nil {
+		t.Fatalf("write leaf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mid, "main.tf"), []byte(`
+variable "in" { type = string }
+resource "aws_s3_bucket" "mid" { bucket = var.in }
+module "leaf" {
+  source = "../leaf"
+  in     = var.in
+}
+`), 0o644); err != nil {
+		t.Fatalf("write mid: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wrapper, "main.tf"), []byte(`
+variable "in" { type = string }
+module "mid" {
+  source = "../mid"
+  in     = var.in
+}
+`), 0o644); err != nil {
+		t.Fatalf("write wrapper: %v", err)
+	}
+
+	e := New()
+	inputs := map[string]cty.Value{"in": cty.StringVal("same")}
+	deepDepth := e.maxDepth - 1
+	deep, _, err := e.evaluate(
+		context.Background(), mid, "", inputs, "module.deep", nil,
+		deepDepth, map[string]bool{}, map[string]bool{},
+	)
+	if err != nil {
+		t.Fatalf("deep evaluate: %v", err)
+	}
+	if len(deep) != 2 {
+		t.Fatalf("deep evaluate returned %d resources, want mid and leaf", len(deep))
+	}
+	key := evalCacheKey{dir: mid, inputs: canonicalInputsKey(inputs)}
+	entry, ok := e.cache[key]
+	if !ok {
+		t.Fatal("expected mid module to cache its partial deep evaluation")
+	}
+	if entry.evalDepth != deepDepth {
+		t.Fatalf("cached evalDepth = %d, want %d", entry.evalDepth, deepDepth)
+	}
+
+	shallow, _, err := e.evaluate(
+		context.Background(), mid, "", inputs, "module.shallow", nil,
+		0, map[string]bool{}, map[string]bool{},
+	)
+	if err != nil {
+		t.Fatalf("shallow evaluate: %v", err)
+	}
+	if len(shallow) != 2 {
+		t.Fatalf("shallow evaluate returned %d resources, want mid and leaf", len(shallow))
+	}
+}
+
+func TestInstantiationBudget_IgnoresRootInlineResources(t *testing.T) {
+	root := t.TempDir()
+	modDir := filepath.Join(root, "modules", "bucket")
+	inlineDir := filepath.Join(root, "inline")
+	requireRoot := func(t *testing.T, err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+	}
+	requireRoot(t, os.MkdirAll(inlineDir, 0o755))
+	requireRoot(t, os.MkdirAll(filepath.Join(root, "stack"), 0o755))
+	requireRoot(t, os.MkdirAll(modDir, 0o755))
+	requireRoot(t, os.WriteFile(filepath.Join(modDir, "main.tf"), []byte(`
+resource "aws_s3_bucket" "this" {}
+`), 0o644))
+
+	var inlineResources strings.Builder
+	for i := 0; i < 200; i++ {
+		fmt.Fprintf(&inlineResources, "resource \"aws_iam_role\" \"r%d\" {}\n", i)
+	}
+	requireRoot(t, os.WriteFile(filepath.Join(inlineDir, "main.tf"), []byte(inlineResources.String()), 0o644))
+	requireRoot(t, os.WriteFile(filepath.Join(root, "stack", "main.tf"), []byte(`
+module "bucket" { source = "../modules/bucket" }
+`), 0o644))
+
+	e := New()
+	ctx := context.Background()
+
+	e.SetMaxInstantiated(0)
+	_, _, _, err := e.EvaluateModule(ctx, inlineDir, nil)
+	if err != nil {
+		t.Fatalf("inline-only root: %v", err)
+	}
+	if e.instantiated != 0 {
+		t.Fatalf("inline-only root charged %d resources against the retained-document budget", e.instantiated)
+	}
+
+	e.SetMaxInstantiated(10)
+	e.ResetSpeculativeBudget()
+	resources, _, _, err := e.EvaluateModule(ctx, filepath.Join(root, "stack"), nil)
+	if err != nil {
+		t.Fatalf("module root: %v", err)
+	}
+	if got := moduleResourceCount(resources); got != 1 {
+		t.Fatalf("module root resolved %d module resources, want 1", got)
+	}
+	if e.instantiated != 1 {
+		t.Fatalf("module root charged %d retained resources, want 1", e.instantiated)
+	}
+}
+
+func TestInstantiationBudget_RollsBackFailedRootCharges(t *testing.T) {
+	root := t.TempDir()
+	modDir := filepath.Join(root, "modules", "bucket")
+	requireRoot := func(t *testing.T, err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+	}
+	requireRoot(t, os.MkdirAll(filepath.Join(root, "stack-a"), 0o755))
+	requireRoot(t, os.MkdirAll(filepath.Join(root, "stack-b"), 0o755))
+	requireRoot(t, os.MkdirAll(modDir, 0o755))
+	requireRoot(t, os.WriteFile(filepath.Join(modDir, "main.tf"), []byte(`
+resource "aws_s3_bucket" "this" {}
+`), 0o644))
+	requireRoot(t, os.WriteFile(filepath.Join(root, "stack-a", "main.tf"), []byte(`
+module "bucket" { source = "../modules/bucket" }
+resource "aws_iam_role" "many" { count = 100 }
+`), 0o644))
+	requireRoot(t, os.WriteFile(filepath.Join(root, "stack-b", "main.tf"), []byte(`
+module "bucket" { source = "../modules/bucket" }
+`), 0o644))
+
+	e := New()
+	e.SetMaxInstantiated(10)
+	ctx := context.Background()
+
+	before := e.InstantiatedCount()
+	_, _, _, err := e.EvaluateModule(ctx, filepath.Join(root, "stack-a"), nil)
+	if err == nil {
+		t.Fatal("expected stack-a to fail once root expansion exceeds the remaining budget")
+	}
+	if e.InstantiatedCount() != before {
+		t.Fatalf("failed root left %d charged instances, want rollback to %d",
+			e.InstantiatedCount(), before)
+	}
+
+	e.ResetSpeculativeBudget()
+	resources, _, _, err := e.EvaluateModule(ctx, filepath.Join(root, "stack-b"), nil)
+	if err != nil {
+		t.Fatalf("stack-b should still fit after rollback: %v", err)
+	}
+	if got := moduleResourceCount(resources); got != 1 {
+		t.Fatalf("stack-b resolved %d module resources, want 1", got)
+	}
+}
+
 // Whether a module was resolved is decided per directory by the caller, but the
 // stops are per call site: the same directory can be resolved on one path and
 // skipped on another. Every skipped directory has to be reported, or the caller
@@ -353,9 +568,9 @@ func TestNotEvaluatedDirs_ReportsSkippedDirectories(t *testing.T) {
 		}
 	}
 
-	// The budget resets per root, but a skipped directory stays skipped: the
-	// caller's suppression decision spans every root.
-	bounded.ResetInstantiationBudget()
+	// A root boundary returns the speculative allowance, but a skipped directory
+	// stays skipped: the caller's suppression decision spans every root.
+	bounded.ResetSpeculativeBudget()
 	if got := len(bounded.NotEvaluatedDirs()); got != len(skipped) {
 		t.Errorf("resetting the budget changed the skipped set from %d to %d directories",
 			len(skipped), got)

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -40,12 +40,12 @@ const (
 	// maxCountExpansion caps instances per count/for_each block.
 	maxCountExpansion = 10
 	// defaultMaxInstantiated is the last-resort cap on resources one scan may
-	// instantiate. Memoizing on inputs removes the exponential path that made a
-	// small repository able to exhaust any limit, so this exists only for shapes
-	// that are genuinely, and not just redundantly, that large. Reaching it costs
-	// resolved values for the modules beyond it, which are still scanned as
-	// written — strictly better than the scan dying and reporting nothing.
-	defaultMaxInstantiated = 200000
+	// instantiate, counted over the whole scan rather than per root: the documents
+	// an instantiated resource turns into are retained until the scan ends. A cap
+	// that resets per root bounds no total at all, because a repository can hold
+	// any number of roots and a pod runs several scans concurrently (four by
+	// default), each with its own evaluator.
+	defaultMaxInstantiated = 150000
 )
 
 // ErrModuleNotEvaluated reports that a module was skipped rather than evaluated,
@@ -162,6 +162,20 @@ func (e *Evaluator) NotEvaluatedDirs() []string {
 // disables it.
 func (e *Evaluator) SetMaxInstantiated(n int) { e.maxInstantiated = n }
 
+// MaxInstantiated reports the per-scan instantiation budget.
+func MaxInstantiated() int { return defaultMaxInstantiated }
+
+// InstantiatedCount reports how many module resources have been charged against
+// the scan-wide retained-document budget.
+func (e *Evaluator) InstantiatedCount() int { return e.instantiated }
+
+// RestoreInstantiatedCount rolls back charges from a root whose evaluation failed
+// after descendants were counted but before any documents were emitted.
+func (e *Evaluator) RestoreInstantiatedCount(n int) {
+	e.instantiated = n
+	e.budgetExceeded = e.maxInstantiated > 0 && e.instantiated >= e.maxInstantiated
+}
+
 func (e *Evaluator) parseDir(dir, packageRoot string) ([]*hclsyntax.Body, error) {
 	key := filepath.Clean(dir) + "\x00" + filepath.Clean(packageRoot)
 
@@ -220,7 +234,11 @@ func (e *Evaluator) EvaluateModule(
 	}
 	visiting := map[string]bool{}
 	allVisited := map[string]bool{}
+	instantiatedBefore := e.instantiated
 	resources, outputs, err = e.evaluate(ctx, abs, "", inputs, "", nil, 0, visiting, allVisited)
+	if err != nil {
+		e.RestoreInstantiatedCount(instantiatedBefore)
+	}
 	return resources, outputs, allVisited, err
 }
 
@@ -247,7 +265,7 @@ func (e *Evaluator) evaluate(
 		inputs:      canonicalInputsKey(inputs),
 	}
 	if resources, outputs, hit, err := e.reuseCachedEvaluation(
-		ctx, cacheKey, dir, addr, chain, allVisited,
+		ctx, cacheKey, dir, addr, chain, depth, allVisited,
 	); hit {
 		return resources, outputs, err
 	}
@@ -327,7 +345,7 @@ func (e *Evaluator) evaluate(
 		}
 	}
 	e.cacheCompletedEvaluation(
-		cacheKey, skippedBefore, resources, outputs, visitedDirs, addr, len(chain),
+		cacheKey, skippedBefore, resources, outputs, visitedDirs, addr, len(chain), depth,
 	)
 
 	return resources, outputs, nil
@@ -349,6 +367,7 @@ func (e *Evaluator) evaluationStop(
 		return e.skipEvaluation(dir)
 	}
 	if e.instantiationBudgetExhausted() {
+		e.reportInstantiationBudgetExceeded(ctx, *e.currentInstantiationCount())
 		return e.skipEvaluation(dir)
 	}
 	return nil
@@ -359,6 +378,7 @@ func (e *Evaluator) reuseCachedEvaluation(
 	key evalCacheKey,
 	dir, addr string,
 	chain []CallSite,
+	depth int,
 	allVisited map[string]bool,
 ) (
 	resources []ResolvedResource,
@@ -370,9 +390,14 @@ func (e *Evaluator) reuseCachedEvaluation(
 	if !ok {
 		return nil, nil, false, nil
 	}
+	if entry.evalDepth > depth {
+		return nil, nil, false, nil
+	}
 	if e.prepassDepth == 0 || entry.baseAddr != addr || entry.baseChainLen != len(chain) {
-		if !e.chargeInstantiationBudget(ctx, len(entry.resources)) {
-			return nil, nil, true, e.skipEvaluation(dir)
+		if charge := moduleResourceCount(entry.resources); charge > 0 {
+			if !e.chargeInstantiationBudget(ctx, charge) {
+				return nil, nil, true, e.skipEvaluation(dir)
+			}
 		}
 	}
 	for _, visited := range entry.visitedDirs {
@@ -414,7 +439,10 @@ func (e *Evaluator) evaluateRootResources(
 	resources, complete := e.rootResourcesWithRefPasses(
 		resourceBlocks, localExprs, evalCtx, addr, chain,
 	)
-	if !complete || !e.chargeInstantiationBudget(ctx, len(resources)) {
+	if !complete {
+		return nil, e.skipEvaluation(dir)
+	}
+	if addr != "" && !e.chargeInstantiationBudget(ctx, len(resources)) {
 		return nil, e.skipEvaluation(dir)
 	}
 	return resources, nil
@@ -428,9 +456,15 @@ func (e *Evaluator) cacheCompletedEvaluation(
 	visitedDirs []string,
 	addr string,
 	chainLen int,
+	depth int,
 ) {
 	if e.skipped != skippedBefore {
 		return
+	}
+	for i := range resources {
+		if resources[i].ExpansionTruncated {
+			return
+		}
 	}
 	e.cache[key] = &evalCacheEntry{
 		resources:    resources,
@@ -438,7 +472,18 @@ func (e *Evaluator) cacheCompletedEvaluation(
 		visitedDirs:  visitedDirs,
 		baseAddr:     addr,
 		baseChainLen: chainLen,
+		evalDepth:    depth,
 	}
+}
+
+func moduleResourceCount(resources []ResolvedResource) int {
+	n := 0
+	for i := range resources {
+		if resources[i].ModuleAddress != "" {
+			n++
+		}
+	}
+	return n
 }
 
 func (e *Evaluator) chargeInstantiationBudget(ctx context.Context, n int) bool {
@@ -496,12 +541,15 @@ func (e *Evaluator) instantiationBudgetExhausted() bool {
 // can leave the modules it did not reach to be scanned as written.
 func (e *Evaluator) BudgetExceeded() bool { return e.budgetExceeded }
 
-// ResetInstantiationBudget clears per-root instantiation counters so one large
-// root cannot consume the quota for every subsequent root in a monorepo.
-func (e *Evaluator) ResetInstantiationBudget() {
-	e.instantiated = 0
+// ResetSpeculativeBudget clears the counter for speculative sibling evaluation at
+// a root boundary. That work is discarded once the root it belongs to is done.
+//
+// The count of resources actually instantiated is deliberately not reset. Those
+// become documents that live until the scan ends, so their bound has to span the
+// scan; resetting it per root is what left the total unbounded when several scans
+// ran concurrently on one pod.
+func (e *Evaluator) ResetSpeculativeBudget() {
 	e.prepassInstantiated = 0
-	e.budgetExceeded = false
 }
 
 func (e *Evaluator) applySiblingModulePrepass(


### PR DESCRIPTION
## Summary

Production OOM kills happened because the instantiation budget was handed back at every root boundary. Each concurrent scan on a pod gets its own evaluator, and with `MaxConcurrentAnalyze` at four by default, four scans each holding a fresh 200k-resource allowance could exceed the 40 GiB container limit.

This change keeps the budget for the whole scan: only the speculative sibling prepass counter resets per root, since that work is discarded with the root it belongs to. The cap moves from 200,000 to 150,000 resources per scan.

## Test plan

- [x] `TestInstantiationBudget_SpansRootsRatherThanResettingPerRoot`
- [x] `TestInstantiationBudget_BoundsTotalAcrossManyRoots` — 40 roots against a budget of 500; fails without the fix (1,280 instantiated)
- [x] `go test ./pkg/parser/terraform/tfeval ./pkg/engine -count=1`
- [x] `golangci-lint run -c .golangci.yml` clean on changed packages

## Blast radius

Terraform local module evaluation only, gated by `k9-iac-enable-local-module-eval`.