### PR TITLE
[K9CODESEC-5297] Extend Terraform module graph and CLI for hosted preprocessing

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -93,13 +93,13 @@ var scanAction = &cli.Command{
 			Name:   "x-local-module-eval",
 			Hidden: true,
 			Usage: "(experimental) resolve Terraform local module variables before scanning; " +
-				"independent of --terraform-modules-mode",
+				"independent of --terraform-modules",
 			Value: false,
 		},
 		&cli.StringFlag{
-			Name:  "terraform-modules-mode",
-			Usage: "Terraform module resolution mode: off, offline, or fetch",
-			Value: string(scan.TerraformModulesModeOff),
+			Name:  "terraform-modules",
+			Usage: "enable remote Terraform module resolution: off or on",
+			Value: string(scan.TerraformModulesOff),
 		},
 		&cli.StringFlag{
 			Name:  "terraform-modules-manifest",
@@ -107,7 +107,7 @@ var scanAction = &cli.Command{
 		},
 		&cli.StringSliceFlag{
 			Name:  "module-allowed-hosts",
-			Usage: "host allowed for Terraform module downloads in fetch mode",
+			Usage: "host allowed for Terraform module downloads when --terraform-modules=on",
 			Value: []string{},
 		},
 		&cli.IntFlag{
@@ -351,24 +351,16 @@ func runScan(ctx context.Context, c *cli.Command) error {
 	if err := validateReportFormats(reportFormats); err != nil {
 		return errorWithExitCode(err, constants.InvalidConfigErrorCode)
 	}
-	moduleMode, err := scan.ParseTerraformModulesMode(c.String("terraform-modules-mode"))
+	modulesSetting, err := scan.ParseTerraformModules(c.String("terraform-modules"))
 	if err != nil {
 		return errorWithExitCode(err, constants.InvalidConfigErrorCode)
 	}
-	if moduleMode == scan.TerraformModulesModeOff &&
+	if modulesSetting == scan.TerraformModulesOff &&
 		(c.String("terraform-modules-manifest") != "" ||
 			len(c.StringSlice("module-allowed-hosts")) > 0 ||
 			c.String("module-cache-dir") != "") {
 		return errorWithExitCode(
-			errors.New("terraform module resolver options require --terraform-modules-mode=offline or fetch"),
-			constants.InvalidConfigErrorCode,
-		)
-	}
-	if moduleMode == scan.TerraformModulesModeOffline &&
-		(len(c.StringSlice("module-allowed-hosts")) > 0 ||
-			c.String("module-cache-dir") != "") {
-		return errorWithExitCode(
-			errors.New("network and cache options require --terraform-modules-mode=fetch"),
+			errors.New("terraform module resolver options require --terraform-modules=on"),
 			constants.InvalidConfigErrorCode,
 		)
 	}
@@ -418,7 +410,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		Config:                      *cfg,
 		ShouldScanTfPlans:           c.Bool("x-terraform-plan"),
 		DisableRuleIsolation:        c.Bool("x-disable-rule-isolation"),
-		TerraformModulesMode:        moduleMode,
+		TerraformModules:            modulesSetting,
 		RemoteModulesManifestPath:   c.String("terraform-modules-manifest"),
 		RemoteModulesHostAllowlist:  c.StringSlice("module-allowed-hosts"),
 		ModuleMaxDepth:              c.Int("terraform-modules-max-depth"),
@@ -746,17 +738,17 @@ func selectPlatforms(platforms []string) []string {
 	return out
 }
 
-func localModuleEvalEnabled(legacyLocalModuleEval bool, modulesMode scan.TerraformModulesMode) bool {
-	return legacyLocalModuleEval || modulesMode != scan.TerraformModulesModeOff
+func localModuleEvalEnabled(legacyLocalModuleEval bool, modulesSetting scan.TerraformModulesSetting) bool {
+	return legacyLocalModuleEval || modulesSetting != scan.TerraformModulesOff
 }
 
 func getFeatureFlagEvaluator(c *cli.Command) featureflags.FlagEvaluator {
-	moduleMode, _ := scan.ParseTerraformModulesMode(c.String("terraform-modules-mode"))
+	modulesSetting, _ := scan.ParseTerraformModules(c.String("terraform-modules"))
 	overrides := map[string]bool{
 		featureflags.IaCEnableKicsParallelFileParsing: c.Bool("x-parallelparsing"),
 		featureflags.IacEnableLocalModuleEval: localModuleEvalEnabled(
 			c.Bool("x-local-module-eval"),
-			moduleMode,
+			modulesSetting,
 		),
 	}
 	return featureflags.NewLocalEvaluatorWithOverrides(overrides)

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -411,6 +411,7 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		ShouldScanTfPlans:           c.Bool("x-terraform-plan"),
 		DisableRuleIsolation:        c.Bool("x-disable-rule-isolation"),
 		TerraformModules:            modulesSetting,
+		NetworkIsolation:            offlineBundlePath != "",
 		RemoteModulesManifestPath:   c.String("terraform-modules-manifest"),
 		RemoteModulesHostAllowlist:  c.StringSlice("module-allowed-hosts"),
 		ModuleMaxDepth:              c.Int("terraform-modules-max-depth"),

--- a/cmd/scanner/scan_test.go
+++ b/cmd/scanner/scan_test.go
@@ -193,7 +193,7 @@ func TestTerraformModuleFlagsUseAuthoritativeMode(t *testing.T) {
 		}
 	}
 
-	require.True(t, names["terraform-modules-mode"])
+	require.True(t, names["terraform-modules"])
 	require.True(t, names["terraform-modules-manifest"])
 	require.True(t, names["module-resolution-timeout"])
 	require.True(t, names["module-cache-dir"])
@@ -207,38 +207,32 @@ func TestLocalModuleEvalEnabled(t *testing.T) {
 	tests := []struct {
 		name       string
 		legacyFlag bool
-		mode       scan.TerraformModulesMode
+		setting    scan.TerraformModulesSetting
 		want       bool
 	}{
 		{
 			name:       "default prod path keeps local eval without module pre-scan mode",
 			legacyFlag: true,
-			mode:       scan.TerraformModulesModeOff,
+			setting:    scan.TerraformModulesOff,
 			want:       true,
 		},
 		{
 			name:       "mode off without legacy flag disables local eval",
 			legacyFlag: false,
-			mode:       scan.TerraformModulesModeOff,
+			setting:    scan.TerraformModulesOff,
 			want:       false,
 		},
 		{
-			name:       "offline mode enables local eval for remote resolution",
+			name:       "on mode enables local eval for remote resolution",
 			legacyFlag: false,
-			mode:       scan.TerraformModulesModeOffline,
-			want:       true,
-		},
-		{
-			name:       "fetch mode enables local eval for remote resolution",
-			legacyFlag: false,
-			mode:       scan.TerraformModulesModeFetch,
+			setting:    scan.TerraformModulesOn,
 			want:       true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, localModuleEvalEnabled(tt.legacyFlag, tt.mode))
+			assert.Equal(t, tt.want, localModuleEvalEnabled(tt.legacyFlag, tt.setting))
 		})
 	}
 }

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -619,7 +619,7 @@ func shouldInstantiateLocalModules(platforms []string, files model.FileMetadatas
 	for _, platform := range platforms {
 		if strings.EqualFold(platform, "Terraform") {
 			for _, file := range files {
-				if file != nil && isTerraformFile(file.FilePath) {
+				if file != nil && tfmodules.IsTerraformConfigPath(file.FilePath) {
 					return true
 				}
 			}

--- a/pkg/engine/module_resolve.go
+++ b/pkg/engine/module_resolve.go
@@ -85,7 +85,7 @@ func (c *Inspector) instantiateLocalModules(
 	}
 	rootDirs := newRootIndex(res.rootDirs)
 	for _, f := range files {
-		if f == nil || !isTerraformFile(f.FilePath) {
+		if f == nil || !tfmodules.IsTerraformConfigPath(f.FilePath) {
 			continue
 		}
 		if replaced := res.suppressed[f.ID]; len(replaced) > 0 {
@@ -136,7 +136,7 @@ func declaresTargetedResource(files model.FileMetadatas, targets *ruleTargets) b
 		return true
 	}
 	for _, f := range files {
-		if f == nil || !isTerraformFile(f.FilePath) {
+		if f == nil || !tfmodules.IsTerraformConfigPath(f.FilePath) {
 			continue
 		}
 		resources, ok := asStringMap(f.Document["resource"])
@@ -1008,7 +1008,7 @@ func indexTerraformFiles(ctx context.Context, files model.FileMetadatas, repoPat
 	filesByDir = make(map[string][]*model.FileMetadata)
 	dirsWithTf = make(map[string]bool)
 	for _, f := range files {
-		if f == nil || !isTerraformFile(f.FilePath) {
+		if f == nil || !tfmodules.IsTerraformConfigPath(f.FilePath) {
 			continue
 		}
 		abs := absPath(f.FilePath, repoPath)
@@ -1045,8 +1045,4 @@ func absPath(p, base string) string {
 		return filepath.Clean(p)
 	}
 	return filepath.Clean(filepath.Join(base, p))
-}
-
-func isTerraformFile(path string) bool {
-	return strings.HasSuffix(strings.ToLower(path), ".tf")
 }

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -167,30 +167,75 @@ func (s *FileSystemSourceProvider) AddUnfilteredPaths(paths []string) {
 	}
 }
 
-// TerraformFiles returns the sorted list of .tf file paths covered by this provider,
-// used by the module graph-walker to discover module call sites before scanning.
+// TerraformFiles returns Terraform config paths used for module discovery before
+// scanning: native .tf files plus .tf.json files (still classified as .json for
+// the scan pipeline).
 func (s *FileSystemSourceProvider) TerraformFiles(ctx context.Context) ([]string, error) {
-	extensions := model.Extensions{".tf": {}}
+	hclExtensions := model.Extensions{".tf": {}}
+	jsonExtensions := model.Extensions{".json": {}}
+	seen := make(map[string]struct{})
 	var files []string
+	add := func(path string) {
+		norm := filepath.ToSlash(path)
+		if _, ok := seen[norm]; ok {
+			return
+		}
+		seen[norm] = struct{}{}
+		files = append(files, norm)
+	}
+
 	for _, scanPath := range s.paths {
 		fileInfo, err := os.Stat(scanPath)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to open path")
 		}
 		if !fileInfo.IsDir() {
-			if shouldSkip, _, _ := s.checkConditions(ctx, fileInfo, extensions, scanPath, nil); shouldSkip {
-				continue
+			if shouldSkip, _, _ := s.checkConditions(ctx, fileInfo, hclExtensions, scanPath, nil); !shouldSkip {
+				add(scanPath)
 			}
-			files = append(files, filepath.ToSlash(scanPath))
+			if strings.HasSuffix(strings.ToLower(scanPath), ".tf.json") {
+				if shouldSkip, _, _ := s.checkConditions(ctx, fileInfo, jsonExtensions, scanPath, nil); !shouldSkip {
+					add(scanPath)
+				}
+			}
 			continue
 		}
-		collected, err := s.collectFiles(ctx, scanPath, unavailableResolverSink, extensions)
+
+		collected, err := s.collectFiles(ctx, scanPath, unavailableResolverSink, hclExtensions)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to collect files")
 		}
-		files = append(files, collected...)
+		for _, path := range collected {
+			add(path)
+		}
+
+		jsonCollected, err := s.collectTerraformJSONModuleFiles(ctx, scanPath)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to collect terraform json module files")
+		}
+		for _, path := range jsonCollected {
+			add(path)
+		}
 	}
+	sort.Strings(files)
 	return files, nil
+}
+
+func (s *FileSystemSourceProvider) collectTerraformJSONModuleFiles(ctx context.Context, scanPath string) ([]string, error) {
+	extensions := model.Extensions{".json": {}}
+	var files []string
+	err := s.walkDirectory(ctx, scanPath, extensions,
+		func(ctx context.Context, path string, resolved *[]string) error {
+			return s.resolveChartDir(ctx, path, unavailableResolverSink, resolved)
+		},
+		func(_ context.Context, path, _ string) error {
+			if !strings.HasSuffix(strings.ToLower(path), ".tf.json") {
+				return nil
+			}
+			files = append(files, strings.ReplaceAll(path, "\\", "/"))
+			return nil
+		})
+	return files, err
 }
 
 func unavailableResolverSink(context.Context, string) ([]string, error) {

--- a/pkg/engine/provider/filesystem_test.go
+++ b/pkg/engine/provider/filesystem_test.go
@@ -802,3 +802,21 @@ func TestIsUnderChartRoot_normalizesSeparators(t *testing.T) {
 	}
 	require.False(t, isUnderChartRoot(`D:/charts/other/templates/svc.yaml`, []string{root}))
 }
+
+func TestTerraformFilesIncludesTfJSON(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`module "a" {}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf.json"), []byte(`{"module":{}}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "data.json"), []byte(`{}`), 0o600))
+
+	provider, err := NewFileSystemSourceProvider(ctx, []string{dir}, nil, nil)
+	require.NoError(t, err)
+
+	files, err := provider.TerraformFiles(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		filepath.ToSlash(filepath.Join(dir, "main.tf")),
+		filepath.ToSlash(filepath.Join(dir, "main.tf.json")),
+	}, files)
+}

--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -123,11 +123,9 @@ type PathParameters struct {
 }
 
 var (
-	queryRegex   = regexp.MustCompile(`\?([\w-]+(=[\w-]*)?(&[\w-]+(=[\w-]*)?)*)?`)
-	urlAuthRegex = regexp.MustCompile(`((ssh|https?)://)(\S+(:\S*)?@).*`)
+	queryRegex         = regexp.MustCompile(`\?([\w-]+(=[\w-]*)?(&[\w-]+(=[\w-]*)?)*)?`)
+	urlAuthRedactRegex = regexp.MustCompile(`((?:ssh|https?)://)(?:\S+(?::\S*)?@)`)
 )
-
-const authGroupPosition = 3
 
 // countNotSuppressed returns the number of non-suppressed files.
 func countNotSuppressed(files []VulnerableFile) int {
@@ -223,14 +221,16 @@ func removeAllURLCredentials(pathExtractionMap map[string]ExtractedPathObject) [
 	return sanitizedScannedPaths
 }
 
-func removeURLCredentials(url string) string {
-	authGroup := ""
-	groups := urlAuthRegex.FindStringSubmatch(url)
-	// credentials are present in the URL
-	if len(groups) > authGroupPosition {
-		authGroup = groups[authGroupPosition]
+// RedactURLCredentials strips embedded userinfo from every ssh/http(s) URL in s.
+func RedactURLCredentials(s string) string {
+	if s == "" {
+		return ""
 	}
-	return strings.Replace(url, authGroup, "", 1)
+	return urlAuthRedactRegex.ReplaceAllString(s, "${1}")
+}
+
+func removeURLCredentials(url string) string {
+	return RedactURLCredentials(url)
 }
 
 func cloneModuleAttributionSummary(attr *ModuleAttribution) *ModuleAttribution {

--- a/pkg/model/summary_test.go
+++ b/pkg/model/summary_test.go
@@ -225,6 +225,13 @@ func TestRemoveURLCredentials(t *testing.T) {
 			},
 			want: "https://test.git.com:8080/test",
 		},
+		{
+			name: "test_redacts_credentials_in_error_message",
+			args: args{
+				url: "clone failed for git::https://user:secret@example.com/repo.git",
+			},
+			want: "clone failed for git::https://example.com/repo.git",
+		},
 	}
 	for _, tt := range tests {
 		require.Equal(t, tt.want, removeURLCredentials(tt.args.url))

--- a/pkg/parser/terraform/modules/config_json.go
+++ b/pkg/parser/terraform/modules/config_json.go
@@ -1,0 +1,158 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package tfmodules
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func extractJSONFile(content []byte) (*fileExtract, error) {
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(content, &root); err != nil {
+		return nil, fmt.Errorf("decoding Terraform JSON: %w", err)
+	}
+	extract := &fileExtract{}
+	if raw, ok := root["locals"]; ok {
+		extract.locals = stringMapFromJSON(raw)
+	}
+	if raw, ok := root["variable"]; ok {
+		extract.vars = variableDefaultsFromJSON(raw)
+	}
+	if raw, ok := root["module"]; ok {
+		modules, err := moduleBlocksFromJSON(raw)
+		if err != nil {
+			return nil, err
+		}
+		extract.modules = modules
+	}
+	return extract, nil
+}
+
+func moduleBlocksFromJSON(raw json.RawMessage) ([]moduleBlockExtract, error) {
+	var blocks map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return nil, fmt.Errorf("decoding module blocks: %w", err)
+	}
+	modules := make([]moduleBlockExtract, 0, len(blocks))
+	for name, body := range blocks {
+		source, version, err := moduleSourceVersionFromJSON(body)
+		if err != nil {
+			return nil, fmt.Errorf("module %q: %w", name, err)
+		}
+		mod := moduleBlockExtract{
+			name: name,
+			// JSON configuration has no source positions; callers treat line 1 as the declaration anchor.
+			defLine:    1,
+			defEndLine: 1,
+		}
+		if source != "" {
+			mod.source = jsonStringToModuleExpr(source)
+		}
+		if version != "" {
+			mod.version = jsonStringToModuleExpr(version)
+		}
+		modules = append(modules, mod)
+	}
+	return modules, nil
+}
+
+func moduleSourceVersionFromJSON(raw json.RawMessage) (source, version string, err error) {
+	var attrs map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &attrs); err != nil {
+		return "", "", fmt.Errorf("decoding module attributes: %w", err)
+	}
+	if rawSource, ok := attrs["source"]; ok {
+		source, err = decodeJSONString(rawSource)
+		if err != nil {
+			return "", "", fmt.Errorf("source: %w", err)
+		}
+	}
+	if rawVersion, ok := attrs["version"]; ok {
+		version, err = decodeJSONString(rawVersion)
+		if err != nil {
+			return "", "", fmt.Errorf("version: %w", err)
+		}
+	}
+	return source, version, nil
+}
+
+func variableDefaultsFromJSON(raw json.RawMessage) map[string]string {
+	var blocks map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return nil
+	}
+	defaults := make(map[string]string, len(blocks))
+	for name, body := range blocks {
+		var attrs map[string]json.RawMessage
+		if err := json.Unmarshal(body, &attrs); err != nil {
+			continue
+		}
+		rawDefault, ok := attrs["default"]
+		if !ok {
+			continue
+		}
+		value, err := decodeJSONString(rawDefault)
+		if err != nil || value == "" {
+			continue
+		}
+		defaults[name] = value
+	}
+	return defaults
+}
+
+func stringMapFromJSON(raw json.RawMessage) map[string]string {
+	var values map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, rawValue := range values {
+		value, err := decodeJSONString(rawValue)
+		if err != nil || value == "" {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func decodeJSONString(raw json.RawMessage) (string, error) {
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+func stringLiteralExpr(value string) hclsyntax.Expression {
+	return &hclsyntax.LiteralValueExpr{
+		Val:      cty.StringVal(value),
+		SrcRange: hcl.Range{Start: hcl.Pos{Line: 1, Column: 1}, End: hcl.Pos{Line: 1, Column: 1}},
+	}
+}
+
+func jsonStringToModuleExpr(value string) hclsyntax.Expression {
+	if !strings.Contains(value, "${") {
+		return stringLiteralExpr(value)
+	}
+	expr, diags := hclsyntax.ParseExpression(
+		[]byte(strconv.Quote(value)),
+		"main.tf.json",
+		hcl.Pos{Line: 1, Column: 1},
+	)
+	if diags.HasErrors() {
+		return stringLiteralExpr(value)
+	}
+	return expr
+}

--- a/pkg/parser/terraform/modules/config_json_test.go
+++ b/pkg/parser/terraform/modules/config_json_test.go
@@ -1,0 +1,109 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package tfmodules
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTerraformConfigPath(t *testing.T) {
+	require.True(t, IsTerraformConfigPath("main.tf"))
+	require.True(t, IsTerraformConfigPath("stack/main.tf.json"))
+	require.False(t, IsTerraformConfigPath("terraform.tfvars"))
+	require.False(t, IsTerraformConfigPath("prod.auto.tfvars"))
+	require.False(t, IsTerraformConfigPath("README.md"))
+}
+
+func TestParseTerraformModules_TFJSON(t *testing.T) {
+	files := model.FileMetadatas{{
+		FilePath: "main.tf.json",
+		OriginalData: `{
+  "module": {
+    "bucket": {
+      "source": "registry.example.com/acme/bucket/aws",
+      "version": "1.2.3"
+    }
+  }
+}`,
+	}}
+	modules, err := ParseTerraformModules(context.Background(), vfs.DiskFS{}, files, 0)
+	require.NoError(t, err)
+	require.Len(t, modules, 1)
+	var module ParsedModule
+	for key := range modules {
+		module = modules[key]
+		break
+	}
+	require.Equal(t, "bucket", module.Name)
+	require.Equal(t, "registry.example.com/acme/bucket/aws", module.Source)
+	require.Equal(t, "1.2.3", module.Version)
+	require.Equal(t, "registry", module.SourceType)
+}
+
+func TestParseTerraformModules_TFJSONResolvesVariableInterpolation(t *testing.T) {
+	files := model.FileMetadatas{{
+		FilePath: "main.tf.json",
+		OriginalData: `{
+  "variable": {
+    "module_source": {
+      "default": "registry.example.com/acme/bucket/aws"
+    }
+  },
+  "module": {
+    "bucket": {
+      "source": "${var.module_source}",
+      "version": "1.2.3"
+    }
+  }
+}`,
+	}}
+	modules, err := ParseTerraformModules(context.Background(), vfs.DiskFS{}, files, 0)
+	require.NoError(t, err)
+	require.Len(t, modules, 1)
+	var module ParsedModule
+	for key := range modules {
+		module = modules[key]
+		break
+	}
+	require.Equal(t, "registry.example.com/acme/bucket/aws", module.Source)
+}
+
+func TestLoadTFFilesFromDir_IncludesTFJSON(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "main.tf.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"module":{"bucket":{"source":"x"}}}`), 0o600))
+	files, err := LoadTFFilesFromDir(root, "")
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, filepath.Clean(path), files[0].FilePath)
+}
+
+func TestParseTerraformModulesFromFiles_TFJSONOnDisk(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "main.tf.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{
+  "module": {
+    "bucket": {
+      "source": "registry.example.com/acme/bucket/aws",
+      "version": "1.2.3"
+    }
+  }
+}`), 0o600))
+	files, err := LoadTFFilesFromDir(root, "")
+	require.NoError(t, err)
+	allowed := map[string]bool{files[0].FilePath: true}
+	modules, err := ParseTerraformModulesFromFiles(context.Background(), nil, files, allowed)
+	require.NoError(t, err)
+	require.Len(t, modules, 1)
+}

--- a/pkg/parser/terraform/modules/config_path.go
+++ b/pkg/parser/terraform/modules/config_path.go
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package tfmodules
+
+import "strings"
+
+// IsTerraformJSONPath reports whether path uses Terraform's JSON configuration syntax.
+func IsTerraformJSONPath(path string) bool {
+	return strings.HasSuffix(strings.ToLower(path), ".tf.json")
+}
+
+// IsTerraformHCLPath reports whether path is a native Terraform HCL configuration file.
+func IsTerraformHCLPath(path string) bool {
+	lower := strings.ToLower(path)
+	return strings.HasSuffix(lower, ".tf") && !IsTerraformJSONPath(path) && !strings.HasSuffix(lower, ".tfvars")
+}
+
+// IsTerraformConfigPath reports whether path may declare Terraform modules.
+func IsTerraformConfigPath(path string) bool {
+	return IsTerraformHCLPath(path) || IsTerraformJSONPath(path)
+}

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -42,6 +42,9 @@ type Request struct {
 
 type ResolvedModule struct {
 	CallerRoot        string
+	CallerFile        string
+	CallerLine        int
+	CallerEndLine     int
 	Source            string
 	Version           string
 	ResolvedVersion   string
@@ -57,6 +60,7 @@ type ResolvedModule struct {
 type Result struct {
 	ScanPaths            []string
 	Modules              []ResolvedModule
+	Failures             []ResolutionFailure
 	SourceMappings       map[string]string
 	BudgetEvents         []BudgetEvent
 	BaselineParseBytes   int64
@@ -72,6 +76,17 @@ type BudgetEvent struct {
 	Maximum      int64
 	Measured     int64
 	SheddingRank int
+}
+
+type ResolutionFailure struct {
+	CallerRoot    string
+	CallerFile    string
+	CallerLine    int
+	CallerEndLine int
+	Source        string
+	Version       string
+	Name          string
+	Reason        string
 }
 
 type resolvedEntry struct {
@@ -91,6 +106,7 @@ type walkerSnapshot struct {
 	sourceMappings map[string]string
 	cleanups       []func()
 	budgetEvents   []BudgetEvent
+	failures       []ResolutionFailure
 }
 
 type visitedSet struct {
@@ -110,6 +126,7 @@ type resultCollector struct {
 	sourceMappings map[string]string
 	cleanups       []func()
 	budgetEvents   []BudgetEvent
+	failures       []ResolutionFailure
 }
 
 type moduleParseCache struct {
@@ -210,6 +227,7 @@ func Resolve(ctx context.Context, request *Request) Result {
 	shedToTotalLimit(&snapshot, budget, moduleMaximum, enforceAdmission)
 	result.ScanPaths = snapshot.paths
 	result.Modules = snapshot.modules
+	result.Failures = snapshot.failures
 	result.SourceMappings = snapshot.sourceMappings
 	result.BudgetEvents = snapshot.budgetEvents
 	result.BaselineParseBytes = baselineBytes
@@ -221,6 +239,19 @@ func Resolve(ctx context.Context, request *Request) Result {
 		left, right := result.Modules[i], result.Modules[j]
 		return strings.Join([]string{left.CallerRoot, left.Source, left.Version, left.Name}, "\x00") <
 			strings.Join([]string{right.CallerRoot, right.Source, right.Version, right.Name}, "\x00")
+	})
+	sort.Slice(result.Failures, func(i, j int) bool {
+		left, right := result.Failures[i], result.Failures[j]
+		if left.CallerFile != right.CallerFile {
+			return left.CallerFile < right.CallerFile
+		}
+		if left.CallerLine != right.CallerLine {
+			return left.CallerLine < right.CallerLine
+		}
+		if left.Source != right.Source {
+			return left.Source < right.Source
+		}
+		return left.Name < right.Name
 	})
 	sort.Slice(result.BudgetEvents, func(i, j int) bool {
 		left, right := result.BudgetEvents[i], result.BudgetEvents[j]
@@ -388,6 +419,9 @@ func (c *resultCollector) addResolvedModule(
 	defer c.mu.Unlock()
 	c.modules = append(c.modules, ResolvedModule{
 		CallerRoot:        moduleCallRoot(mod),
+		CallerFile:        mod.FileName,
+		CallerLine:        mod.DefLine,
+		CallerEndLine:     mod.DefEndLine,
 		Source:            mod.Source,
 		Version:           mod.Version,
 		ResolvedVersion:   resolution.ResolvedVersion,
@@ -425,6 +459,24 @@ func (c *resultCollector) addBudgetEvent(source string, budgetErr *resolver.Budg
 	})
 }
 
+func (c *resultCollector) addResolutionFailure(mod *tfmodules.ParsedModule, err error) {
+	if mod == nil || err == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.failures = append(c.failures, ResolutionFailure{
+		CallerRoot:    moduleCallRoot(mod),
+		CallerFile:    mod.FileName,
+		CallerLine:    mod.DefLine,
+		CallerEndLine: mod.DefEndLine,
+		Source:        mod.Source,
+		Version:       mod.Version,
+		Name:          mod.Name,
+		Reason:        err.Error(),
+	})
+}
+
 func (c *resultCollector) snapshot() walkerSnapshot {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -438,6 +490,7 @@ func (c *resultCollector) snapshot() walkerSnapshot {
 		sourceMappings: sourceMappings,
 		cleanups:       append([]func(){}, c.cleanups...),
 		budgetEvents:   append([]BudgetEvent(nil), c.budgetEvents...),
+		failures:       append([]ResolutionFailure(nil), c.failures...),
 	}
 }
 
@@ -578,7 +631,7 @@ func (w *walker) seedGroups(
 ) (seedGroups, repositoryGroups map[string]map[string]bool) {
 	allowedByDir := make(map[string]map[string]bool)
 	for _, path := range discoveryPaths {
-		if !isTerraformFile(path) {
+		if !tfmodules.IsTerraformConfigPath(path) {
 			continue
 		}
 		path = filepath.Clean(path)
@@ -596,7 +649,7 @@ func (w *walker) seedGroups(
 			continue
 		}
 		if !info.IsDir() {
-			if !isTerraformFile(path) {
+			if !tfmodules.IsTerraformConfigPath(path) {
 				continue
 			}
 			dir := filepath.Dir(path)
@@ -718,6 +771,8 @@ func (w *walker) traverseRemoteModules(
 		if hit {
 			if cached.err == nil && cached.res.LocalPath != "" {
 				w.results.addResolvedModule(&mod, cached.res, parentPackageRoot, depth+1)
+			} else if cached.err != nil && ctx.Err() == nil {
+				w.results.addResolutionFailure(&mod, cached.err)
 			}
 			continue
 		}
@@ -871,6 +926,11 @@ func (w *walker) traverseRemoteModuleGroup(
 	contextLogger.Debug().Msgf("Fetching remote Terraform module %q", representative.Source)
 	resolution, shared, err := w.resolveRemote(ctx, representative)
 	if err != nil {
+		if ctx.Err() == nil {
+			for _, mod := range group.callers {
+				w.results.addResolutionFailure(mod, err)
+			}
+		}
 		if !shared {
 			contextLogger.Debug().Err(err).
 				Msgf("Failed to resolve remote Terraform module %q", representative.Source)
@@ -949,10 +1009,6 @@ func flatTerraformFilePaths(ctx context.Context, dir, packageRoot string) []stri
 		}
 	}
 	return paths
-}
-
-func isTerraformFile(path string) bool {
-	return strings.HasSuffix(strings.ToLower(path), ".tf")
 }
 
 func canonicalGitModuleSource(moduleSource string) string {

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
@@ -470,10 +471,10 @@ func (c *resultCollector) addResolutionFailure(mod *tfmodules.ParsedModule, err 
 		CallerFile:    mod.FileName,
 		CallerLine:    mod.DefLine,
 		CallerEndLine: mod.DefEndLine,
-		Source:        mod.Source,
+		Source:        model.RedactURLCredentials(mod.Source),
 		Version:       mod.Version,
 		Name:          mod.Name,
-		Reason:        err.Error(),
+		Reason:        model.RedactURLCredentials(err.Error()),
 	})
 }
 

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -1004,8 +1004,12 @@ func terraformWorkspaceRoot(fileName string) string {
 func remoteResolveIdentity(mod *tfmodules.ParsedModule) string {
 	sourceType, _ := tfmodules.DetectModuleSourceType(mod.Source)
 	if sourceType == sourceTypeRegistry {
-		return terraformWorkspaceRoot(mod.FileName) + "\x00" + strings.TrimSpace(mod.Source) + "\x00" +
+		identity := terraformWorkspaceRoot(mod.FileName) + "\x00" + strings.TrimSpace(mod.Source) + "\x00" +
 			strings.TrimSpace(mod.Version)
+		if strings.TrimSpace(mod.Version) == "" {
+			identity += "\x00" + strings.TrimSpace(mod.Name)
+		}
+		return identity
 	}
 	if key, ok := resolver.GitModuleResolveKey(mod.Source, mod.Version); ok {
 		return key

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -981,20 +981,36 @@ func moduleCallRoot(mod *tfmodules.ParsedModule) string {
 	return filepath.Clean(filepath.Dir(mod.FileName))
 }
 
+// terraformWorkspaceRoot finds the nearest ancestor directory containing
+// .terraform/modules/modules.json, matching DotTerraformResolver lookup scope.
+func terraformWorkspaceRoot(fileName string) string {
+	if fileName == "" {
+		return "."
+	}
+	clean := filepath.Clean(filepath.Dir(fileName))
+	fallback := clean
+	for {
+		if _, err := os.Stat(filepath.Join(clean, ".terraform", "modules", "modules.json")); err == nil {
+			return clean
+		}
+		parent := filepath.Dir(clean)
+		if parent == clean {
+			return fallback
+		}
+		clean = parent
+	}
+}
+
 func remoteResolveIdentity(mod *tfmodules.ParsedModule) string {
 	sourceType, _ := tfmodules.DetectModuleSourceType(mod.Source)
-	if sourceType == sourceTypeRegistry && mod.Version == "" {
-		return callKey(moduleCallRoot(mod), mod.Source, mod.Version, mod.Name)
+	if sourceType == sourceTypeRegistry {
+		return terraformWorkspaceRoot(mod.FileName) + "\x00" + strings.TrimSpace(mod.Source) + "\x00" +
+			strings.TrimSpace(mod.Version)
 	}
 	if key, ok := resolver.GitModuleResolveKey(mod.Source, mod.Version); ok {
 		return key
 	}
 	return canonicalGitModuleSource(mod.Source) + "\x00" + strings.TrimSpace(mod.Version)
-}
-
-func callKey(root, source, version, name string) string {
-	return filepath.Clean(root) + "\x00" + strings.TrimSpace(source) + "\x00" +
-		strings.TrimSpace(version) + "\x00" + strings.TrimSpace(name)
 }
 
 func flatTerraformFilePaths(ctx context.Context, dir, packageRoot string) []string {

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
@@ -250,13 +250,13 @@ func TestRegistryResolveIdentity(t *testing.T) {
 		Name:     "helper_b",
 	}
 
-	require.Equal(t, remoteResolveIdentity(sameA), remoteResolveIdentity(sameB))
+	require.NotEqual(t, remoteResolveIdentity(sameA), remoteResolveIdentity(sameB))
 	require.NotEqual(t, remoteResolveIdentity(sameA), remoteResolveIdentity(otherWorkspace))
 	require.NotEqual(t, remoteResolveIdentity(sameA), remoteResolveIdentity(pinned))
 	require.NotEqual(t, remoteResolveIdentity(uninitA), remoteResolveIdentity(uninitB))
 }
 
-func TestResolveDedupesUnpinnedRegistryModulesWithinWorkspace(t *testing.T) {
+func TestResolveResolvesUnpinnedRegistryModulesSeparatelyByCallName(t *testing.T) {
 	t.Parallel()
 
 	base := t.TempDir()
@@ -284,7 +284,7 @@ resource "aws_iam_role" "this" {}
 		MaxDepth: 2,
 	})
 
-	require.Equal(t, 1, tracker.callCount(source))
+	require.Equal(t, 2, tracker.callCount(source))
 	require.Len(t, result.Modules, 2)
 	require.Equal(t, []string{filepath.Join(moduleDir, "main.tf")}, result.ScanPaths)
 }

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
@@ -1021,6 +1021,29 @@ func TestResolveReportsResolutionFailure(t *testing.T) {
 	require.Contains(t, result.Failures[0].Reason, "unknown source")
 }
 
+func TestResolveReportsRedactedResolutionFailureCredentials(t *testing.T) {
+	source := "git::https://user:secret@example.com/modules/vpc.git"
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(fmt.Sprintf(`
+module "vpc" {
+  source = %q
+}
+`, source)), 0o644))
+
+	result := Resolve(t.Context(), &Request{
+		RootPaths:      []string{root},
+		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
+		Resolver:       mapResolver{bySource: map[string]resolver.Resolution{}},
+		MaxDepth:       2,
+	})
+
+	require.Len(t, result.Failures, 1)
+	require.NotContains(t, result.Failures[0].Source, "user:secret@")
+	require.Contains(t, result.Failures[0].Source, "example.com/modules/vpc.git")
+	require.NotContains(t, result.Failures[0].Reason, "user:secret@")
+	require.Contains(t, result.Failures[0].Reason, "example.com/modules/vpc.git")
+}
+
 func TestResolveReturnsPartialResultWhenPhaseDeadlineExpires(t *testing.T) {
 	root, _ := writeModuleGraphFixture(t)
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
@@ -177,6 +177,9 @@ func TestResolveAssemblesModuleMetadataAndPaths(t *testing.T) {
 	}, result.SourceMappings)
 	require.Equal(t, []ResolvedModule{{
 		CallerRoot:      root,
+		CallerFile:      filepath.Join(root, "main.tf"),
+		CallerLine:      2,
+		CallerEndLine:   5,
 		Source:          "git::https://git@github.com/acme/network.git//modules/vpc?ref=v1",
 		Version:         "1.2.3",
 		Name:            "network",
@@ -218,6 +221,9 @@ resource "aws_s3_bucket" "this" {}
 	}, result.SourceMappings)
 	require.Equal(t, []ResolvedModule{{
 		CallerRoot:      root,
+		CallerFile:      filepath.Join(root, "main.tf"),
+		CallerLine:      2,
+		CallerEndLine:   5,
 		Source:          "cloud-inventory/bucket/aws",
 		Version:         "~> 9.0",
 		ResolvedVersion: "9.1.0",
@@ -866,6 +872,20 @@ module "extra" {
 	require.Contains(t, result.ScanPaths, filepath.Join(selected, "main.tf"))
 	require.Contains(t, result.ScanPaths, filepath.Join(shared, "main.tf"))
 	require.Contains(t, result.ScanPaths, filepath.Join(extra, "main.tf"))
+}
+
+func TestResolveReportsResolutionFailure(t *testing.T) {
+	root, _ := writeModuleGraphFixture(t)
+	result := Resolve(t.Context(), &Request{
+		RootPaths:      []string{root},
+		DiscoveryPaths: []string{filepath.Join(root, "main.tf")},
+		Resolver:       mapResolver{bySource: map[string]resolver.Resolution{}},
+		MaxDepth:       2,
+	})
+	require.Empty(t, result.Modules)
+	require.Len(t, result.Failures, 1)
+	require.Equal(t, "network", result.Failures[0].Name)
+	require.Contains(t, result.Failures[0].Reason, "unknown source")
 }
 
 func TestResolveReturnsPartialResultWhenPhaseDeadlineExpires(t *testing.T) {

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
@@ -190,6 +190,139 @@ func TestResolveAssemblesModuleMetadataAndPaths(t *testing.T) {
 	}}, result.Modules)
 }
 
+func writeTerraformModulesManifest(t *testing.T, root string) {
+	t.Helper()
+	dir := filepath.Join(root, ".terraform", "modules")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "modules.json"), []byte(`{"Modules":[]}`), 0o644))
+}
+
+func writeRegistryModuleCaller(t *testing.T, dir, moduleName, source string) string {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, "main.tf")
+	require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(`
+module %q {
+  source = %q
+}
+`, moduleName, source)), 0o644))
+	return path
+}
+
+func TestRegistryResolveIdentity(t *testing.T) {
+	t.Parallel()
+
+	source := "terraform-registry.us1.ddbuild.io/cloud-inventory/iam-helper/aws"
+	base := t.TempDir()
+	workspace := filepath.Join(base, "workspace")
+	writeTerraformModulesManifest(t, workspace)
+	writeTerraformModulesManifest(t, filepath.Join(base, "other"))
+
+	sameA := &tfmodules.ParsedModule{
+		FileName: filepath.Join(workspace, "a", "main.tf"),
+		Source:   source,
+		Name:     "helper_a",
+	}
+	sameB := &tfmodules.ParsedModule{
+		FileName: filepath.Join(workspace, "b", "main.tf"),
+		Source:   source,
+		Name:     "helper_b",
+	}
+	otherWorkspace := &tfmodules.ParsedModule{
+		FileName: filepath.Join(base, "other", "main.tf"),
+		Source:   source,
+		Name:     "helper_c",
+	}
+	pinned := &tfmodules.ParsedModule{
+		FileName: sameA.FileName,
+		Source:   "cloud-inventory/bucket/aws",
+		Version:  "~> 9.0",
+		Name:     "bucket",
+	}
+	uninitA := &tfmodules.ParsedModule{
+		FileName: filepath.Join("/repo", "a", "main.tf"),
+		Source:   source,
+		Name:     "helper_a",
+	}
+	uninitB := &tfmodules.ParsedModule{
+		FileName: filepath.Join("/repo", "b", "main.tf"),
+		Source:   source,
+		Name:     "helper_b",
+	}
+
+	require.Equal(t, remoteResolveIdentity(sameA), remoteResolveIdentity(sameB))
+	require.NotEqual(t, remoteResolveIdentity(sameA), remoteResolveIdentity(otherWorkspace))
+	require.NotEqual(t, remoteResolveIdentity(sameA), remoteResolveIdentity(pinned))
+	require.NotEqual(t, remoteResolveIdentity(uninitA), remoteResolveIdentity(uninitB))
+}
+
+func TestResolveDedupesUnpinnedRegistryModulesWithinWorkspace(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	workspace := filepath.Join(base, "workspace")
+	writeTerraformModulesManifest(t, workspace)
+
+	source := "terraform-registry.us1.ddbuild.io/cloud-inventory/iam-helper/aws"
+	moduleDir := filepath.Join(base, "module")
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte(`
+resource "aws_iam_role" "this" {}
+`), 0o644))
+
+	tracker := &trackingResolver{
+		bySource: map[string]resolver.Resolution{source: {LocalPath: moduleDir}},
+		calls:    make(map[string]int),
+	}
+	result := Resolve(t.Context(), &Request{
+		RootPaths: []string{base},
+		DiscoveryPaths: []string{
+			writeRegistryModuleCaller(t, filepath.Join(workspace, "a"), "helper_a", source),
+			writeRegistryModuleCaller(t, filepath.Join(workspace, "b"), "helper_b", source),
+		},
+		Resolver: tracker,
+		MaxDepth: 2,
+	})
+
+	require.Equal(t, 1, tracker.callCount(source))
+	require.Len(t, result.Modules, 2)
+	require.Equal(t, []string{filepath.Join(moduleDir, "main.tf")}, result.ScanPaths)
+}
+
+func TestResolveSeparatesUnpinnedRegistryModulesByWorkspace(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	workspaceA := filepath.Join(base, "a")
+	workspaceB := filepath.Join(base, "b")
+	writeTerraformModulesManifest(t, workspaceA)
+	writeTerraformModulesManifest(t, workspaceB)
+
+	source := "terraform-registry.us1.ddbuild.io/cloud-inventory/iam-helper/aws"
+	moduleDir := filepath.Join(base, "module")
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte(`
+resource "aws_iam_role" "this" {}
+`), 0o644))
+
+	tracker := &trackingResolver{
+		bySource: map[string]resolver.Resolution{source: {LocalPath: moduleDir}},
+		calls:    make(map[string]int),
+	}
+	result := Resolve(t.Context(), &Request{
+		RootPaths: []string{base},
+		DiscoveryPaths: []string{
+			writeRegistryModuleCaller(t, workspaceA, "helper_a", source),
+			writeRegistryModuleCaller(t, workspaceB, "helper_b", source),
+		},
+		Resolver: tracker,
+		MaxDepth: 2,
+	})
+
+	require.Equal(t, 2, tracker.callCount(source))
+	require.Len(t, result.Modules, 2)
+}
+
 func TestResolveThreadsRegistryIdentity(t *testing.T) {
 	base := t.TempDir()
 	root := filepath.Join(base, "root")

--- a/pkg/parser/terraform/modules/modules.go
+++ b/pkg/parser/terraform/modules/modules.go
@@ -86,10 +86,6 @@ func resolveModulePath(source, rootDir string) string {
 	return filepath.Clean(filepath.Join(rootDir, clean))
 }
 
-func isTerraformFile(filePath string) bool {
-	return strings.HasSuffix(strings.ToLower(filePath), ".tf")
-}
-
 const (
 	stringLocal                 = "local"
 	stringUnknown               = "unknown"
@@ -196,6 +192,17 @@ func extractForContent(cache *sync.Map, content, filePath string) (*fileExtract,
 	if cached, ok := cache.Load(key); ok {
 		return cached.(*fileExtract), nil
 	}
+	if IsTerraformJSONPath(filePath) {
+		extract, err := extractJSONFile([]byte(content))
+		if err != nil {
+			return nil, hcl.Diagnostics{{
+				Severity: hcl.DiagError,
+				Summary:  err.Error(),
+			}}
+		}
+		cache.Store(key, extract)
+		return extract, nil
+	}
 	hclFile, diags := hclsyntax.ParseConfig([]byte(content), filePath, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
 		return nil, diags
@@ -222,7 +229,7 @@ func groupTerraformFilesByDir(files model.FileMetadatas) []dirFiles {
 	var groups []dirFiles
 	indexByDir := make(map[string]int)
 	for _, file := range files {
-		if file == nil || !isTerraformFile(file.FilePath) {
+		if file == nil || !IsTerraformConfigPath(file.FilePath) {
 			continue
 		}
 		dir := filepath.Dir(file.FilePath)
@@ -320,7 +327,7 @@ func parseDirModules(
 		}
 		extract, diags := extractForContent(extracts, getFileContent(file), file.FilePath)
 		if diags.HasErrors() {
-			contextLogger.Warn().Msgf("Skipping file %s due to HCL parse errors: %s", file.FilePath, diags.Error())
+			contextLogger.Warn().Msgf("Skipping file %s due to parse errors: %s", file.FilePath, diags.Error())
 			continue
 		}
 		if extract == nil {
@@ -923,7 +930,7 @@ func generateEquivalentMap(ctx context.Context, fsys vfs.FS, modulePath string) 
 		if entry.IsDir() {
 			continue
 		}
-		if !isTerraformFile(entry.Name()) {
+		if !IsTerraformHCLPath(entry.Name()) {
 			continue
 		}
 		path := filepath.Join(modulePath, entry.Name())
@@ -1043,9 +1050,10 @@ func ParseTerraformModulesFromFiles(
 	return parseModulesByDir(ctx, fsys, files, allowedFiles, 0)
 }
 
-// LoadTFFilesFromDir returns FileMetadata for top-level .tf files in dir (no recursion —
-// a Terraform module is a single directory). When packageRoot is non-empty, symlinked .tf
-// files are included only when their targets stay within the package root.
+// LoadTFFilesFromDir returns FileMetadata for top-level Terraform configuration
+// files (.tf and .tf.json) in dir (no recursion — a Terraform module is a single
+// directory). When packageRoot is non-empty, symlinked config files are included
+// only when their targets stay within the package root.
 func LoadTFFilesFromDir(dir, packageRoot string) (model.FileMetadatas, error) {
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
@@ -1078,7 +1086,7 @@ func ScannableTerraformPath(entry fs.DirEntry, dir, packageRoot string) (string,
 		return "", false
 	}
 	name := entry.Name()
-	if !strings.HasSuffix(strings.ToLower(name), ".tf") {
+	if !IsTerraformConfigPath(name) {
 		return "", false
 	}
 	candidate := filepath.Join(dir, name)

--- a/pkg/parser/terraform/modules/modules_test.go
+++ b/pkg/parser/terraform/modules/modules_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/require"
@@ -1067,4 +1068,28 @@ func TestGetProviderFromResourceType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateEquivalentMapIgnoresTerraformJSON(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+resource "aws_s3_bucket" "example" {
+  bucket = var.name
+}
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.tf.json"), []byte(`{
+  "resource": {
+    "aws_s3_bucket": {
+      "json": {
+        "bucket": "${var.other}"
+      }
+    }
+  }
+}`), 0o600))
+
+	equivalent, err := generateEquivalentMap(ctx, vfs.DiskFS{}, dir)
+	require.NoError(t, err)
+	require.Contains(t, equivalent, "aws")
+	require.Contains(t, equivalent["aws"].Inputs, "bucket")
 }

--- a/pkg/parser/terraform/modules/resolver/confinement.go
+++ b/pkg/parser/terraform/modules/resolver/confinement.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
 
 type resolvedPathCacheKey struct{}
@@ -116,7 +118,9 @@ func pathEscapesDir(rel string) bool {
 	return rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator))
 }
 
-// ScannableTerraformPath reports whether a directory entry is a .tf file that can be read.
+// ScannableTerraformPath reports whether a directory entry is an HCL .tf file that
+// the main Terraform parser can scan. JSON configuration is handled separately for
+// module discovery but is not yet emitted in module scan paths.
 // Regular files are accepted. Symlinks are accepted only when their target is a regular
 // file confined within packageRoot (or dir when packageRoot is empty).
 func ScannableTerraformPath(ctx context.Context, entry fs.DirEntry, dir, packageRoot string) (path string, ok bool) {
@@ -124,7 +128,7 @@ func ScannableTerraformPath(ctx context.Context, entry fs.DirEntry, dir, package
 		return "", false
 	}
 	name := entry.Name()
-	if !strings.HasSuffix(strings.ToLower(name), ".tf") {
+	if !tfmodules.IsTerraformHCLPath(name) {
 		return "", false
 	}
 	candidate := filepath.Join(dir, name)

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -24,21 +24,20 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type TerraformModulesMode string
+type TerraformModulesSetting string
 
 const (
-	TerraformModulesModeOff     TerraformModulesMode = "off"
-	TerraformModulesModeOffline TerraformModulesMode = "offline"
-	TerraformModulesModeFetch   TerraformModulesMode = "fetch"
+	TerraformModulesOff TerraformModulesSetting = "off"
+	TerraformModulesOn  TerraformModulesSetting = "on"
 )
 
-func ParseTerraformModulesMode(value string) (TerraformModulesMode, error) {
-	mode := TerraformModulesMode(value)
-	switch mode {
-	case TerraformModulesModeOff, TerraformModulesModeOffline, TerraformModulesModeFetch:
-		return mode, nil
+func ParseTerraformModules(value string) (TerraformModulesSetting, error) {
+	setting := TerraformModulesSetting(value)
+	switch setting {
+	case TerraformModulesOff, TerraformModulesOn:
+		return setting, nil
 	default:
-		return "", fmt.Errorf("invalid Terraform modules mode %q: expected off, offline, or fetch", value)
+		return "", fmt.Errorf("invalid --terraform-modules value %q: expected off or on", value)
 	}
 }
 
@@ -87,7 +86,7 @@ type Parameters struct {
 	ShouldScanTfPlans           bool
 	DisableRuleIsolation        bool
 	UseRulesCache               bool
-	TerraformModulesMode        TerraformModulesMode
+	TerraformModules            TerraformModulesSetting
 	RemoteModulesManifestPath   string
 	RemoteModulesHostAllowlist  []string
 	// ModuleMaxDepth caps the BFS depth of the remote-module graph walker (0 disables traversal entirely).
@@ -201,7 +200,7 @@ func GetDefaultParameters(ctx context.Context, rootPath string) (*Parameters, co
 		MaxFileSizeFlag:             5,
 		UseOldSeverities:            false,
 		MaxResolverDepth:            15,
-		TerraformModulesMode:        TerraformModulesModeOff,
+		TerraformModules:            TerraformModulesOff,
 		ModuleMaxDepth:              DefaultRemoteModuleMaxDepth,
 		ModuleFetchTimeout:          30 * time.Second,
 		MaxModuleBytesTotal:         DefaultRemoteModuleMaxTotalBytes,

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -87,8 +87,10 @@ type Parameters struct {
 	DisableRuleIsolation        bool
 	UseRulesCache               bool
 	TerraformModules            TerraformModulesSetting
-	RemoteModulesManifestPath   string
-	RemoteModulesHostAllowlist  []string
+	// NetworkIsolation disables outbound module fetchers so scans stay offline.
+	NetworkIsolation           bool
+	RemoteModulesManifestPath  string
+	RemoteModulesHostAllowlist []string
 	// ModuleMaxDepth caps the BFS depth of the remote-module graph walker (0 disables traversal entirely).
 	ModuleMaxDepth          int
 	ModuleFetchTimeout      time.Duration

--- a/pkg/scan/client_test.go
+++ b/pkg/scan/client_test.go
@@ -8,15 +8,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseTerraformModulesMode(t *testing.T) {
-	for _, value := range []string{"off", "offline", "fetch"} {
-		mode, err := ParseTerraformModulesMode(value)
+func TestParseTerraformModules(t *testing.T) {
+	for _, value := range []string{"off", "on"} {
+		setting, err := ParseTerraformModules(value)
 		require.NoError(t, err)
-		require.Equal(t, TerraformModulesMode(value), mode)
+		require.Equal(t, TerraformModulesSetting(value), setting)
 	}
 
-	_, err := ParseTerraformModulesMode("online")
-	require.ErrorContains(t, err, "expected off, offline, or fetch")
+	for _, value := range []string{"offline", "fetch", "online"} {
+		_, err := ParseTerraformModules(value)
+		require.ErrorContains(t, err, "expected off or on")
+	}
 }
 
 func Test_Client(t *testing.T) {

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -82,6 +82,14 @@ func (c *Client) resolveTerraformModulesForScan(
 			Int("shedding_rank", event.SheddingRank).
 			Msg("Terraform module excluded by resource budget")
 	}
+	for _, failure := range result.Failures {
+		contextLogger.Warn().
+			Str("module_source", failure.Source).
+			Str("module_name", failure.Name).
+			Str("caller_root", failure.CallerRoot).
+			Str("reason", failure.Reason).
+			Msg("Terraform module resolution failed")
+	}
 	if len(result.ScanPaths) > 0 {
 		contextLogger.Info().Msgf("Adding %d remote module file(s) to scan", len(result.ScanPaths))
 	}

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -61,10 +61,8 @@ func (c *Client) resolveTerraformModulesForScan(
 		return nil, nil, nil, nil, err
 	}
 
-	if c.ScanParams.TerraformModulesMode == TerraformModulesModeFetch {
+	if c.ScanParams.TerraformModules == TerraformModulesOn {
 		contextLogger.Info().Msg("Resolving remote Terraform modules...")
-	} else {
-		contextLogger.Debug().Msg("Resolving Terraform modules from local, manifest, or .terraform/modules sources only")
 	}
 
 	result := c.resolveTerraformModuleGraph(resolveCtx, extractedPaths.Path, moduleDiscoveryPaths, baselinePaths, chain)
@@ -181,8 +179,7 @@ func (c *Client) moduleResolutionContext(ctx context.Context) (context.Context, 
 }
 
 func (c *Client) shouldPreScanTerraformModules(_ []string) bool {
-	mode := c.ScanParams.TerraformModulesMode
-	return mode == TerraformModulesModeOffline || mode == TerraformModulesModeFetch
+	return c.ScanParams.TerraformModules == TerraformModulesOn
 }
 
 func (c *Client) buildModuleResolverChain(
@@ -203,7 +200,7 @@ func (c *Client) buildModuleResolverChain(
 		resolvers = append(resolvers, tfresolver.NewPrefetchedResolver(manifest))
 	}
 
-	if c.ScanParams.TerraformModulesMode != TerraformModulesModeFetch {
+	if c.ScanParams.TerraformModules != TerraformModulesOn {
 		return tfresolver.NewChainResolver(resolvers...), nil
 	}
 

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -200,7 +200,7 @@ func (c *Client) buildModuleResolverChain(
 		resolvers = append(resolvers, tfresolver.NewPrefetchedResolver(manifest))
 	}
 
-	if c.ScanParams.TerraformModules != TerraformModulesOn {
+	if c.ScanParams.TerraformModules != TerraformModulesOn || c.ScanParams.NetworkIsolation {
 		return tfresolver.NewChainResolver(resolvers...), nil
 	}
 

--- a/pkg/scan/remote_modules_test.go
+++ b/pkg/scan/remote_modules_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	engineprovider "github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
@@ -43,33 +44,37 @@ func TestRemoteModulesDisabledByDefault(t *testing.T) {
 
 	params := remoteModuleScanParams(root)
 	params.RemoteModulesManifestPath = manifestPath
-	params.TerraformModulesMode = TerraformModulesModeOff
+	params.TerraformModules = TerraformModulesOff
 
 	results := executeRemoteModuleScan(t, params)
 	require.Empty(t, results.Results)
 }
 
-func TestOfflineModeBuildsOnlyDiskResolvers(t *testing.T) {
-	client := &Client{ScanParams: &Parameters{TerraformModulesMode: TerraformModulesModeOffline}}
+func TestOnModeBuildsNetworkResolvers(t *testing.T) {
+	client := &Client{ScanParams: &Parameters{TerraformModules: TerraformModulesOn}}
 
 	chain, err := client.buildModuleResolverChain(t.Context(), []string{t.TempDir()})
 	require.NoError(t, err)
 
 	resolvers := reflect.ValueOf(chain).Elem().FieldByName("resolvers")
-	require.Equal(t, 2, resolvers.Len())
+	require.GreaterOrEqual(t, resolvers.Len(), 4)
+	foundNetwork := false
 	for i := 0; i < resolvers.Len(); i++ {
 		resolverType := resolvers.Index(i).Elem().Type().String()
-		require.NotContains(t, resolverType, "GoGetter")
-		require.NotContains(t, resolverType, "BareGit")
-		require.NotContains(t, resolverType, "LocalGitRef")
+		if strings.Contains(resolverType, "GoGetter") ||
+			strings.Contains(resolverType, "BareGit") ||
+			strings.Contains(resolverType, "LocalGitRef") {
+			foundNetwork = true
+		}
 	}
+	require.True(t, foundNetwork)
 }
 
-func TestOfflineModeRejectsMalformedManifest(t *testing.T) {
+func TestOnModeRejectsMalformedManifest(t *testing.T) {
 	manifestPath := filepath.Join(t.TempDir(), "modules.json")
 	require.NoError(t, os.WriteFile(manifestPath, []byte(`{"schema_version":1}`), 0o644))
 	client := &Client{ScanParams: &Parameters{
-		TerraformModulesMode:      TerraformModulesModeOffline,
+		TerraformModules:      TerraformModulesOn,
 		RemoteModulesManifestPath: manifestPath,
 	}}
 
@@ -82,7 +87,7 @@ func TestRemoteModulesManifestEnablesModuleInstantiation(t *testing.T) {
 	moduleDir, manifestPath := writeRemoteModuleFixture(t, root)
 
 	params := remoteModuleScanParams(root)
-	params.TerraformModulesMode = TerraformModulesModeOffline
+	params.TerraformModules = TerraformModulesOn
 	params.RemoteModulesManifestPath = manifestPath
 
 	results := executeRemoteModuleScan(t, params)
@@ -144,10 +149,10 @@ resource "aws_vpc" "this" {
 	})
 
 	legacyParams := remoteModuleScanParams(root)
-	legacyParams.TerraformModulesMode = TerraformModulesModeOffline
+	legacyParams.TerraformModules = TerraformModulesOn
 	legacyParams.RemoteModulesManifestPath = legacyPath
 	v1Params := remoteModuleScanParams(root)
-	v1Params.TerraformModulesMode = TerraformModulesModeOffline
+	v1Params.TerraformModules = TerraformModulesOn
 	v1Params.RemoteModulesManifestPath = v1Path
 
 	legacy := executeRemoteModuleScan(t, legacyParams)
@@ -181,7 +186,7 @@ func TestRemoteModuleMaxDepthZeroDisablesTraversal(t *testing.T) {
 	_, manifestPath := writeRemoteModuleFixture(t, root)
 
 	params := remoteModuleScanParams(root)
-	params.TerraformModulesMode = TerraformModulesModeOffline
+	params.TerraformModules = TerraformModulesOn
 	params.RemoteModulesManifestPath = manifestPath
 	params.ModuleMaxDepth = 0
 

--- a/pkg/scan/remote_modules_test.go
+++ b/pkg/scan/remote_modules_test.go
@@ -70,6 +70,25 @@ func TestOnModeBuildsNetworkResolvers(t *testing.T) {
 	require.True(t, foundNetwork)
 }
 
+func TestOnModeSkipsNetworkResolversWhenNetworkIsolated(t *testing.T) {
+	client := &Client{ScanParams: &Parameters{
+		TerraformModules: TerraformModulesOn,
+		NetworkIsolation: true,
+	}}
+
+	chain, err := client.buildModuleResolverChain(t.Context(), []string{t.TempDir()})
+	require.NoError(t, err)
+
+	resolvers := reflect.ValueOf(chain).Elem().FieldByName("resolvers")
+	require.Equal(t, 2, resolvers.Len())
+	for i := 0; i < resolvers.Len(); i++ {
+		resolverType := resolvers.Index(i).Elem().Type().String()
+		require.NotContains(t, resolverType, "GoGetter")
+		require.NotContains(t, resolverType, "BareGit")
+		require.NotContains(t, resolverType, "LocalGitRef")
+	}
+}
+
 func TestOnModeRejectsMalformedManifest(t *testing.T) {
 	manifestPath := filepath.Join(t.TempDir(), "modules.json")
 	require.NoError(t, os.WriteFile(manifestPath, []byte(`{"schema_version":1}`), 0o644))


### PR DESCRIPTION
## Motivation

Hosted Terraform module preprocessing needs richer module-graph output, `.tf.json` support, and a simpler scan CLI before workers can orchestrate public fetch and trusted staging.

Related ticket: [K9CODESEC-5297](https://datadoghq.atlassian.net/browse/K9CODESEC-5297)

## Changes

**Module discovery and parsing**

Classify Terraform HCL and JSON config paths, parse module declarations from `.tf.json`, and include JSON files in module discovery while keeping HCL-only scan paths unchanged.

**Module graph**

Expose caller declaration metadata and structured resolution failures, and dedupe public registry resolution by Terraform workspace root, source, and version.

**Scan CLI**

Replace the unreleased `--terraform-modules-mode off|offline|fetch` tri-state with `--terraform-modules off|on`.

## Author Checklist

1. I have reviewed my own PR.
2. I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
3. All new and existing tests pass.
4. I have tested my changes on staging (if applicable).
5. I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/parser/terraform/modules/... ./pkg/scan ./pkg/engine -count=1`
2. `go test -race ./pkg/parser/terraform/modules/modulegraph ./pkg/scan -count=1`
3. `make build && ./bin/datadog-iac-scanner scan -p <terraform-fixture> -t Terraform --terraform-modules=on` and confirm remote module paths are added to the scan workspace.

## Impact

Datadog IaC Scanner Terraform module resolution and scan CLI only. No rule assets or SARIF schema changes.

## Additional Notes

Follow-up work for the sandbox `prepare-modules` protocol and worker staging loop is tracked separately ([K9CODESEC-5298](https://datadoghq.atlassian.net/browse/K9CODESEC-5298)).

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-5297]: https://datadoghq.atlassian.net/browse/K9CODESEC-5297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[K9CODESEC-5298]: https://datadoghq.atlassian.net/browse/K9CODESEC-5298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ