### PR TITLE
Add phase-attributed peak RSS telemetry for scan OOM investigation

### DIFF
--- a/internal/memwatch/memwatch.go
+++ b/internal/memwatch/memwatch.go
@@ -1,0 +1,95 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+// Package memwatch records the process peak resident set size together with the
+// scan phase it was reached in.
+package memwatch
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rs/zerolog"
+)
+
+const (
+	PhaseStartup        = "startup"
+	PhaseAnalyzePaths   = "analyze_paths"
+	PhaseModuleResolve  = "remote_module_resolve"
+	PhaseGetQueries     = "get_queries"
+	PhasePrepareSources = "prepare_sources"
+	PhaseModuleEval     = "local_module_eval"
+	PhaseStartScan      = "start_scan"
+	PhaseGenerateReport = "generate_report"
+)
+
+type watcherKey struct{}
+
+type Watcher struct {
+	mu        sync.Mutex
+	logger    zerolog.Logger
+	sampleRSS func() (uint64, bool)
+	peakBytes uint64
+	peakPhase string
+	stopped   bool
+}
+
+func Start(ctx context.Context, log *zerolog.Logger) (context.Context, *Watcher) {
+	w := &Watcher{
+		logger:    *log,
+		sampleRSS: peakRSSBytes,
+	}
+	w.sample(PhaseStartup)
+	return context.WithValue(ctx, watcherKey{}, w), w
+}
+
+func Sample(ctx context.Context, phase string) {
+	if w, ok := ctx.Value(watcherKey{}).(*Watcher); ok {
+		w.sample(phase)
+	}
+}
+
+func (w *Watcher) Peak() (bytes uint64, phase string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.peakBytes, w.peakPhase
+}
+
+func (w *Watcher) Stop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.stopped {
+		return
+	}
+	w.stopped = true
+
+	if w.peakBytes == 0 {
+		return
+	}
+
+	w.logger.Info().
+		Uint64("peak_rss_bytes", w.peakBytes).
+		Str("peak_rss_phase", w.peakPhase).
+		Msg("memwatch: peak resident memory summary")
+}
+
+func (w *Watcher) sample(phase string) {
+	current, ok := w.sampleRSS()
+	if !ok {
+		return
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.stopped {
+		return
+	}
+	if current > w.peakBytes {
+		w.peakBytes = current
+		w.peakPhase = phase
+	}
+}

--- a/internal/memwatch/memwatch_test.go
+++ b/internal/memwatch/memwatch_test.go
@@ -1,0 +1,111 @@
+package memwatch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func requirePeakRSSSampling(t *testing.T) {
+	t.Helper()
+	if _, ok := peakRSSBytes(); !ok {
+		t.Skip("peak RSS sampling is unsupported on this platform")
+	}
+}
+
+func TestWatcherLogsSummary(t *testing.T) {
+	requirePeakRSSSampling(t)
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs).Level(zerolog.InfoLevel)
+
+	ctx, w := Start(context.Background(), &logger)
+	Sample(ctx, PhaseStartScan)
+	w.Stop()
+
+	out := logs.String()
+	if !strings.Contains(out, "memwatch: peak resident memory summary") {
+		t.Fatalf("expected summary log, got %q", out)
+	}
+
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &entry); err != nil {
+		t.Fatalf("unmarshal summary log: %v", err)
+	}
+	phase, ok := entry["peak_rss_phase"].(string)
+	if !ok || phase == "" {
+		t.Fatalf("expected peak_rss_phase in summary, got %q", out)
+	}
+	if _, ok := entry["peak_rss_bytes"].(float64); !ok {
+		t.Fatalf("expected peak_rss_bytes in summary, got %q", out)
+	}
+}
+
+func TestSampleKeepsLargestPeakAndItsPhase(t *testing.T) {
+	values := []uint64{100, 300, 200}
+	w := &Watcher{
+		logger: zerolog.Nop(),
+		sampleRSS: func() (uint64, bool) {
+			value := values[0]
+			values = values[1:]
+			return value, true
+		},
+	}
+	ctx := context.WithValue(context.Background(), watcherKey{}, w)
+
+	Sample(ctx, PhaseAnalyzePaths)
+	Sample(ctx, PhaseModuleResolve)
+	Sample(ctx, PhaseStartScan)
+
+	peak, phase := w.Peak()
+	if peak != 300 || phase != PhaseModuleResolve {
+		t.Fatalf("Peak() = (%d, %q), want (300, %q)", peak, phase, PhaseModuleResolve)
+	}
+}
+
+func TestWatchersKeepIndependentPeaks(t *testing.T) {
+	first := &Watcher{
+		logger:    zerolog.Nop(),
+		sampleRSS: func() (uint64, bool) { return 100, true },
+	}
+	second := &Watcher{
+		logger:    zerolog.Nop(),
+		sampleRSS: func() (uint64, bool) { return 200, true },
+	}
+	firstCtx := context.WithValue(context.Background(), watcherKey{}, first)
+	secondCtx := context.WithValue(context.Background(), watcherKey{}, second)
+
+	Sample(firstCtx, PhaseAnalyzePaths)
+	Sample(secondCtx, PhaseModuleResolve)
+
+	firstPeak, firstPhase := first.Peak()
+	secondPeak, secondPhase := second.Peak()
+	if firstPeak != 100 || firstPhase != PhaseAnalyzePaths {
+		t.Fatalf("first Peak() = (%d, %q)", firstPeak, firstPhase)
+	}
+	if secondPeak != 200 || secondPhase != PhaseModuleResolve {
+		t.Fatalf("second Peak() = (%d, %q)", secondPeak, secondPhase)
+	}
+}
+
+func TestSampleWithoutWatcherIsNoop(t *testing.T) {
+	Sample(context.Background(), PhaseStartScan)
+}
+
+func TestUnsupportedSamplerLeavesPeakEmpty(t *testing.T) {
+	w := &Watcher{
+		logger:    zerolog.Nop(),
+		sampleRSS: func() (uint64, bool) { return 0, false },
+	}
+	ctx := context.WithValue(context.Background(), watcherKey{}, w)
+
+	Sample(ctx, PhaseStartup)
+
+	peak, phase := w.Peak()
+	if peak != 0 || phase != "" {
+		t.Fatalf("Peak() = (%d, %q), want (0, empty)", peak, phase)
+	}
+}

--- a/internal/memwatch/peakrss_unit_darwin.go
+++ b/internal/memwatch/peakrss_unit_darwin.go
@@ -1,0 +1,11 @@
+//go:build darwin
+
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package memwatch
+
+const maxrssUnitBytes = 1

--- a/internal/memwatch/peakrss_unit_linux.go
+++ b/internal/memwatch/peakrss_unit_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package memwatch
+
+const maxrssUnitBytes = 1024

--- a/internal/memwatch/peakrss_unix.go
+++ b/internal/memwatch/peakrss_unix.go
@@ -1,0 +1,23 @@
+//go:build linux || darwin
+
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package memwatch
+
+import "syscall"
+
+func peakRSSBytes() (uint64, bool) {
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		return 0, false
+	}
+	if ru.Maxrss < 0 {
+		return 0, false
+	}
+
+	return uint64(ru.Maxrss) * maxrssUnitBytes, true
+}

--- a/internal/memwatch/peakrss_unsupported.go
+++ b/internal/memwatch/peakrss_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin
+
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package memwatch
+
+func peakRSSBytes() (uint64, bool) {
+	return 0, false
+}

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/memwatch"
 	"github.com/DataDog/datadog-iac-scanner/internal/pathutil"
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
 	"github.com/DataDog/datadog-iac-scanner/pkg/detector"
@@ -488,6 +489,7 @@ func (c *Inspector) Inspect(
 		c.flagEvaluator.EvaluateWithOrg(featureflags.IacEnableLocalModuleEval) {
 		targets := ruleTargetedResourceTypes(queries, c.terraformRuleLibraries()...)
 		moduleDocs, syntheticFiles, moduleExtras = c.instantiateLocalModules(ctx, files, targets)
+		memwatch.Sample(ctx, memwatch.PhaseModuleEval)
 	}
 
 	// Must run after module mutations (which suppress module bodies in place).

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/memwatch"
 	"github.com/DataDog/datadog-iac-scanner/internal/storage"
 	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
 	"github.com/DataDog/datadog-iac-scanner/pkg/config"
@@ -252,6 +253,8 @@ func (c *Client) Scan(ctx context.Context) (*Results, error) {
 func (c *Client) PerformScan(ctx context.Context) (ScanMetadata, error) {
 	contextLogger := logger.FromContext(ctx)
 	c.ScanStartTime = time.Now()
+	ctx, watcher := memwatch.Start(ctx, &contextLogger)
+	defer watcher.Stop()
 
 	scanResults, err := c.executeScan(ctx)
 
@@ -266,6 +269,10 @@ func (c *Client) PerformScan(ctx context.Context) (ScanMetadata, error) {
 		contextLogger.Err(postScanError)
 		return ScanMetadata{}, postScanError
 	}
+
+	peakBytes, peakPhase := watcher.Peak()
+	scanMetadata.PeakRSSBytes = peakBytes
+	scanMetadata.PeakRSSPhase = peakPhase
 
 	return scanMetadata, nil
 }

--- a/pkg/scan/metadata.go
+++ b/pkg/scan/metadata.go
@@ -17,6 +17,10 @@ type ScanMetadata struct {
 	Stats ScanStats
 	// RuleStats contains statistics about rules.
 	RuleStats RuleStats
+	// PeakRSSBytes is the scanner process high-water resident set size.
+	PeakRSSBytes uint64 `json:",omitempty"`
+	// PeakRSSPhase is the scan phase in which PeakRSSBytes was reached.
+	PeakRSSPhase string `json:",omitempty"`
 }
 
 type ScanStats struct {

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -139,7 +139,6 @@ func (c *Client) postScan(ctx context.Context, scanResults *Results) (ScanMetada
 
 	handler, exitCode := consoleHelpers.ResultsExitCode(&summary)
 	if handler.ShowError("results") && exitCode != 0 {
-		memwatch.Sample(ctx, memwatch.PhaseGenerateReport)
 		os.Exit(exitCode)
 	}
 

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	consoleHelpers "github.com/DataDog/datadog-iac-scanner/internal/console/helpers"
+	"github.com/DataDog/datadog-iac-scanner/internal/memwatch"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine/provider"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -128,6 +129,7 @@ func (c *Client) postScan(ctx context.Context, scanResults *Results) (ScanMetada
 		scanResults.Files.Combine(ctx, c.ScanParams.LineInfoPayload),
 		c.Printer); err != nil {
 		contextLogger.Err(err).Msgf("failed to resolve outputs %v", err)
+		memwatch.Sample(ctx, memwatch.PhaseGenerateReport)
 		return metadata, err
 	}
 
@@ -137,11 +139,13 @@ func (c *Client) postScan(ctx context.Context, scanResults *Results) (ScanMetada
 
 	handler, exitCode := consoleHelpers.ResultsExitCode(&summary)
 	if handler.ShowError("results") && exitCode != 0 {
+		memwatch.Sample(ctx, memwatch.PhaseGenerateReport)
 		os.Exit(exitCode)
 	}
 
 	// generate metadata payload
 	metadata = c.generateMetadata(scanResults, c.ScanStartTime, endTime)
+	memwatch.Sample(ctx, memwatch.PhaseGenerateReport)
 
 	return metadata, nil
 }

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -10,6 +10,7 @@ package scan
 import (
 	"context"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/memwatch"
 	"github.com/DataDog/datadog-iac-scanner/internal/metrics"
 	"github.com/DataDog/datadog-iac-scanner/pkg/datadog"
 	"github.com/DataDog/datadog-iac-scanner/pkg/engine"
@@ -64,6 +65,7 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		extractedPaths = provider.ExtractedPath{Path: c.inMemoryPaths}
 	} else {
 		paths, fp, err := c.prepareAndAnalyzePaths(ctx)
+		memwatch.Sample(ctx, memwatch.PhaseAnalyzePaths)
 		if err != nil {
 			contextLogger.Err(err).Msgf("failed to prepare and analyze paths %v", err)
 			return nil, err
@@ -88,6 +90,7 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 	moduleCleanup, remoteModulePaths, remoteSourceDirs, remoteModuleProvenance, err := c.resolveTerraformModulesForScan(
 		ctx, paramsPlatforms, &extractedPaths, baselinePaths,
 	)
+	memwatch.Sample(ctx, memwatch.PhaseModuleResolve)
 	if err != nil {
 		return nil, err
 	}
@@ -129,6 +132,7 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		c.ScanParams.UseRulesCache,
 	)
 	metrics.Metric.Stop()
+	memwatch.Sample(ctx, memwatch.PhaseGetQueries)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/DataDog/datadog-iac-scanner/internal/memwatch"
 	"github.com/DataDog/datadog-iac-scanner/internal/metrics"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
@@ -34,6 +35,7 @@ func PrepareAndScan(
 		flagEvaluator.EvaluateWithOrgAndEnv(featureflags.IaCEnableKicsParallelFileParsing) {
 		err := runner.PrepareSharedWalk(ctx, fsp, services, scanID, openAPIResolveReferences, maxResolverDepth)
 		metrics.Metric.Stop()
+		memwatch.Sample(ctx, memwatch.PhasePrepareSources)
 		if err != nil {
 			return err
 		}
@@ -61,12 +63,15 @@ func PrepareAndScan(
 	select {
 	case <-ctx.Done():
 		metrics.Metric.Stop()
+		memwatch.Sample(ctx, memwatch.PhasePrepareSources)
 		return ctx.Err()
 	case <-wgDone:
 		metrics.Metric.Stop()
+		memwatch.Sample(ctx, memwatch.PhasePrepareSources)
 		return StartScan(ctx, scanID, services)
 	case err := <-errCh:
 		metrics.Metric.Stop()
+		memwatch.Sample(ctx, memwatch.PhasePrepareSources)
 		return err
 	}
 }
@@ -74,6 +79,7 @@ func PrepareAndScan(
 // StartScan will run concurrent scans by parser
 func StartScan(ctx context.Context, scanID string, services serviceSlice) error {
 	defer metrics.Metric.Stop()
+	defer memwatch.Sample(ctx, memwatch.PhaseStartScan)
 	metrics.Metric.Start("start_scan")
 	contextLogger := logger.FromContext(ctx)
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Motivation

Large Terraform module instantiation scans can push the scanner subprocess past pod memory limits. We need production telemetry that ties peak resident memory to scan phases before rolling out local module evaluation more broadly.

## Changes

**memwatch**

Add a context-scoped helper that samples `getrusage` Maxrss when scan phases complete and logs one info summary with `peak_rss_bytes` and `peak_rss_phase`.

**Scan pipeline**

Record completed phase samples throughout the CLI scan lifecycle and write `PeakRSSBytes` and `PeakRSSPhase` into scan metadata so consumers do not need to parse scanner logs.

## QA Instruction

1. `go test -race ./internal/memwatch/... ./pkg/engine/... ./pkg/scan/... ./pkg/scanner/...`
2. `make build`
3. `./bin/datadog-iac-scanner scan -p test/fixtures/test_terraform -o /tmp/iac-out -t Terraform --metadata-path /tmp/iac-meta.json --log-level info`
4. Confirm the info log contains `memwatch: peak resident memory summary` and `/tmp/iac-meta.json` includes `PeakRSSBytes` and `PeakRSSPhase`.

## Blast Radius

CLI scan subprocess logging and metadata output only. The watcher is scoped to the scan context, and server scans without a watcher remain unaffected. No rule or finding behavior changes.

## Additional Notes

I submit this contribution under the Apache-2.0 license.