### PR TITLE
docs(readme): document macOS Intel and Apple Silicon archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This project was forked from [Checkmarx KICS](https://github.com/Checkmarx/kics)
 
 Visit the [releases](https://github.com/DataDog/datadog-iac-scanner/releases) page and download the binary archive for your operating system and architecture.
 
-* For Linux, choose the latest `datadog-iac-scanner_X.Y.Z_linux_amd64.tar.gz` (x86_64) or `datadog-iac-scanner_X.Y.Z_linux_arm64.tar.gz` (ARM64) file.
-* For macOS, choose the latest `datadog-iac-scanner_X.Y.Z_darwin_amd64.tar.gz` (Intel) or `datadog-iac-scanner_X.Y.Z_darwin_arm64.tar.gz` (Apple Silicon) file.
-* For Windows, choose the latest `datadog-iac-scanner_X.Y.Z_windows_amd64.zip` file.
+* For Linux, choose the latest `datadog-iac-scanner_linux_amd64.tar.gz` (x86_64) or `datadog-iac-scanner_linux_arm64.tar.gz` (ARM64) file.
+* For macOS, choose the latest `datadog-iac-scanner_darwin_amd64.tar.gz` (Intel) or `datadog-iac-scanner_darwin_arm64.tar.gz` (Apple Silicon) file.
+* For Windows, choose the latest `datadog-iac-scanner_windows_amd64.zip` file.
 
 ### Building from source
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project was forked from [Checkmarx KICS](https://github.com/Checkmarx/kics)
 Visit the [releases](https://github.com/DataDog/datadog-iac-scanner/releases) page and download the binary archive for your operating system and architecture.
 
 * For Linux, choose the latest `datadog-iac-scanner_X.Y.Z_linux_amd64.tar.gz` (x86_64) or `datadog-iac-scanner_X.Y.Z_linux_arm64.tar.gz` (ARM64) file.
-* For macOS, choose the latest `datadog-iac-scanner_X.Y.Z_darwin_arm64.tar.gz` file. Intel hardware is not supported.
+* For macOS, choose the latest `datadog-iac-scanner_X.Y.Z_darwin_amd64.tar.gz` (Intel) or `datadog-iac-scanner_X.Y.Z_darwin_arm64.tar.gz` (Apple Silicon) file.
 * For Windows, choose the latest `datadog-iac-scanner_X.Y.Z_windows_amd64.zip` file.
 
 ### Building from source


### PR DESCRIPTION
## Motivation

The install docs still said Intel Macs were unsupported, even though releases now ship `darwin_amd64`. Archive filenames also included a version placeholder that GoReleaser does not emit.

## Changes

- Documented the `darwin_amd64` (Intel) archive alongside `darwin_arm64` (Apple Silicon) in the install instructions
- Removed the outdated note that Intel hardware is not supported
- Aligned Linux, macOS, and Windows archive names with GoReleaser's unversioned `name_template` (for example `datadog-iac-scanner_darwin_amd64.tar.gz`)

## Additional Notes

I submit this contribution under the Apache-2.0 license.