### PR TITLE
Downgrade Terraform sibling vars/locals resolution noise to debug

### DIFF
--- a/pkg/parser/terraform/variables.go
+++ b/pkg/parser/terraform/variables.go
@@ -180,8 +180,9 @@ func getInputVariables(
 	for _, tfFile := range tfFiles {
 		vars, locals, err := getInputVariablesAndLocalsFromFile(fsys, tfFile)
 		if err != nil {
-			contextLogger.Error().Msgf("Error getting default values and locals from %s", tfFile)
-			contextLogger.Err(err)
+			// Non-fatal: a sibling may be unreadable (broken symlink, partial
+			// MemFS push) or invalid HCL (testdata). Match getDataSourcePolicy.
+			contextLogger.Debug().Err(err).Msgf("Skipping default values and locals from %s", tfFile)
 			continue
 		}
 		mergeMaps(variablesMap, vars)
@@ -202,8 +203,7 @@ func getInputVariables(
 	for _, tfVarsFile := range tfVarsFiles {
 		vars, errInput := getInputVariablesFromFile(fsys, tfVarsFile)
 		if errInput != nil {
-			contextLogger.Error().Msgf("Error getting values from %s", tfVarsFile)
-			contextLogger.Err(errInput)
+			contextLogger.Warn().Err(errInput).Msgf("Skipping values from %s", tfVarsFile)
 			continue
 		}
 		mergeMaps(variablesMap, vars)
@@ -223,8 +223,7 @@ func getInputVariables(
 		if _, err := fsys.Stat(terraformVarsPath); err == nil {
 			vars, errInput := getInputVariablesFromFile(fsys, terraformVarsPath)
 			if errInput != nil {
-				contextLogger.Error().Msgf("Error getting values from %s", terraformVarsPath)
-				contextLogger.Err(errInput)
+				contextLogger.Error().Err(errInput).Msgf("Error getting values from %s", terraformVarsPath)
 			} else {
 				mergeMaps(variablesMap, vars)
 			}


### PR DESCRIPTION
## Motivation

When resolving Terraform `var`/`local` context, the parser globs every sibling `*.tf` file in the directory. Unreadable files (broken symlinks, partial MemFS pushes) or invalid HCL in siblings that are not the file being scanned were logged at `ERR`, producing hundreds of thousands of noisy logs per day on large repos like dd-source. These failures are non-fatal and already handled the same way at debug level in `getDataSourcePolicy`.

## Changes

**Terraform parser**

Sibling `.tf` and `.tfvars` read/parse failures during variable/locals enrichment now log at debug (`Skipping default values and locals from ...`) instead of error. Scan behavior is unchanged; files that are actually being parsed still surface parse failures through the normal runner sink.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/parser/terraform -run TestGetInputVariables -count=1`
2. Scan a dd-source module dir with a broken `common.tf` symlink and confirm no `ERR Error getting default values and locals` lines at default log level.

## Blast Radius

DataDog IaC Scanner only. Affects Terraform variable/locals resolution logging; no change to findings or scan output.

## Additional Notes

I submit this contribution under the Apache-2.0 license.