### PR TITLE
[K9CODESEC-5298] Add sandbox module preparation protocol

### DIFF
--- a/cmd/scanner/list_modules.go
+++ b/cmd/scanner/list_modules.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
@@ -108,7 +107,7 @@ func walkTerraformDiscoveryRoot(walkRoot string, seen map[string]bool, files *mo
 			}
 			return nil
 		}
-		if entry.Type()&fs.ModeSymlink != 0 || !strings.HasSuffix(strings.ToLower(entry.Name()), ".tf") {
+		if entry.Type()&fs.ModeSymlink != 0 || !tfmodules.IsTerraformConfigPath(path) {
 			return nil
 		}
 		clean := filepath.Clean(path)

--- a/cmd/scanner/list_modules_test.go
+++ b/cmd/scanner/list_modules_test.go
@@ -57,6 +57,31 @@ func TestWriteModuleEntriesEmitsJSONArray(t *testing.T) {
 	require.Equal(t, "vpc", entries[0].Name)
 }
 
+func TestModuleEntriesFromPathsListsTerraformJSONDeclarations(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf.json"), []byte(`{
+  "module": {
+    "vpc": {
+      "source": "terraform-aws-modules/vpc/aws",
+      "version": "5.0.0"
+    }
+  }
+}`), 0o644))
+
+	entries, err := moduleEntriesFromPaths(t.Context(), []string{root}, false)
+	require.NoError(t, err)
+	require.Equal(t, []tfmodules.ListModuleEntry{{
+		Name:          "vpc",
+		Source:        "terraform-aws-modules/vpc/aws",
+		Version:       "5.0.0",
+		SourceType:    "registry",
+		RegistryScope: "public",
+		FileName:      "main.tf.json",
+		DefLine:       1,
+		DefEndLine:    1,
+	}}, entries)
+}
+
 func TestModuleEntriesFromPathsFollowsSymlinkedRoot(t *testing.T) {
 	base := t.TempDir()
 	root := filepath.Join(base, "repo")

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -37,6 +37,7 @@ func main() {
 			listPlatformsAction,
 			listQueriesAction,
 			listModulesAction,
+			prepareModulesAction,
 			showConfigAction,
 			testRulesAction,
 			serveAction,

--- a/cmd/scanner/prepare_modules.go
+++ b/cmd/scanner/prepare_modules.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/moduleprepare"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+	"github.com/DataDog/datadog-iac-scanner/pkg/scan"
+	cli "github.com/urfave/cli/v3"
+)
+
+const privateDirectoryMode = 0o750
+
+var prepareModulesAction = &cli.Command{
+	Name:  "prepare-modules",
+	Usage: "Prepares a staged Terraform module graph without network access",
+	Flags: []cli.Flag{
+		&cli.StringSliceFlag{
+			Name:     "path",
+			Aliases:  []string{"p"},
+			Usage:    "Terraform files or directories to inspect",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "module-root",
+			Usage:    "task-scoped root containing staged module artifacts",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "output-response",
+			Usage:    "path to the module preparation response",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "output-manifest",
+			Usage:    "path to the final manifest written after complete resolution",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:  "staged-modules",
+			Usage: "JSON descriptor for staged module archives and directories",
+		},
+		&cli.BoolFlag{
+			Name:  "staged-only",
+			Usage: "disable all outbound module resolvers",
+			Value: true,
+		},
+		&cli.IntFlag{
+			Name:  "terraform-modules-max-depth",
+			Usage: "maximum remote module graph depth",
+			Value: scan.DefaultRemoteModuleMaxDepth,
+		},
+		&cli.IntFlag{
+			Name:  "terraform-modules-max-count",
+			Usage: "maximum number of remote module calls in one graph",
+			Value: scan.DefaultRemoteModuleMaxModules,
+		},
+		&cli.DurationFlag{
+			Name:  "module-resolution-timeout",
+			Usage: "timeout for one module preparation phase",
+			Value: scan.DefaultModuleResolutionTimeout,
+		},
+		&cli.Int64Flag{
+			Name:  "terraform-modules-max-bytes",
+			Usage: "maximum aggregate bytes admitted from remote modules",
+			Value: scan.DefaultRemoteModuleMaxTotalBytes,
+		},
+		&cli.Int64Flag{
+			Name:  "terraform-modules-max-package-bytes",
+			Usage: "maximum expanded bytes admitted from one module package",
+			Value: scan.DefaultRemoteModuleMaxPackageBytes,
+		},
+		&cli.Int64Flag{
+			Name:  "terraform-modules-max-file-bytes",
+			Usage: "maximum expanded size of one module file",
+			Value: scan.DefaultRemoteModuleMaxFileBytes,
+		},
+		&cli.IntFlag{
+			Name:  "terraform-modules-max-package-files",
+			Usage: "maximum file count in one module package",
+			Value: scan.DefaultRemoteModuleMaxPackageFiles,
+		},
+		&cli.Int64Flag{
+			Name:  "terraform-modules-max-parse-bytes",
+			Usage: "target bytes admitted for repository and module parsing",
+		},
+	},
+	Action: prepareModules,
+}
+
+func prepareModules(ctx context.Context, command *cli.Command) error {
+	if !command.Bool("staged-only") {
+		return fmt.Errorf("prepare-modules requires --staged-only")
+	}
+	moduleRoot, err := prepareModuleRoot(command.String("module-root"))
+	if err != nil {
+		return err
+	}
+	limits := resolver.ResourceLimits{
+		MaxPackageBytes: command.Int64("terraform-modules-max-package-bytes"),
+		MaxFileBytes:    command.Int64("terraform-modules-max-file-bytes"),
+		MaxPackageFiles: command.Int("terraform-modules-max-package-files"),
+		MaxTotalBytes:   command.Int64("terraform-modules-max-bytes"),
+	}
+	stagedManifestPath, cleanup, err := prepareStagedModuleManifest(
+		ctx,
+		command.String("staged-modules"),
+		moduleRoot,
+		limits,
+	)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	files, roots, err := loadModuleDiscoveryFiles(command.StringSlice("path"))
+	if err != nil {
+		return err
+	}
+	discoveryPaths := make([]string, 0, len(files))
+	for _, file := range files {
+		if file != nil {
+			discoveryPaths = append(discoveryPaths, file.FilePath)
+		}
+	}
+	params := &scan.Parameters{
+		TerraformModules:          scan.TerraformModulesOn,
+		NetworkIsolation:          true,
+		RemoteModulesManifestPath: stagedManifestPath,
+		ModuleMaxDepth:            command.Int("terraform-modules-max-depth"),
+		ModuleMaxModules:          command.Int("terraform-modules-max-count"),
+		MaxModuleBytesTotal:       limits.MaxTotalBytes,
+		MaxModulePackageBytes:     limits.MaxPackageBytes,
+		MaxModuleFileBytes:        limits.MaxFileBytes,
+		MaxModulePackageFiles:     limits.MaxPackageFiles,
+		MaxModuleParseBytes:       command.Int64("terraform-modules-max-parse-bytes"),
+		ModuleResolutionTimeout:   command.Duration("module-resolution-timeout"),
+	}
+	result, err := scan.PrepareTerraformModules(ctx, params, roots, discoveryPaths)
+	if err != nil {
+		return err
+	}
+	defer result.Cleanup()
+	_, err = moduleprepare.WriteResult(
+		ctx,
+		command.String("output-response"),
+		command.String("output-manifest"),
+		moduleRoot,
+		roots,
+		&result,
+		command.Int("terraform-modules-max-count"),
+	)
+	return err
+}
+
+func prepareStagedModuleManifest(
+	ctx context.Context,
+	stagedModulesPath string,
+	moduleRoot string,
+	limits resolver.ResourceLimits,
+) (manifestPath string, cleanup func(), err error) {
+	if stagedModulesPath == "" {
+		return "", func() {}, nil
+	}
+	temp, err := os.CreateTemp(moduleRoot, ".staged-modules-*.json")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("creating staged module manifest: %w", err)
+	}
+	manifestPath = temp.Name()
+	cleanup = func() { _ = os.Remove(manifestPath) }
+	if err := temp.Close(); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("closing staged module manifest: %w", err)
+	}
+	if err := os.Remove(manifestPath); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("preparing staged module manifest: %w", err)
+	}
+	if err := moduleprepare.WriteStagedManifest(ctx, stagedModulesPath, manifestPath, moduleRoot, limits); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	return manifestPath, cleanup, nil
+}
+
+func prepareModuleRoot(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolving module root: %w", err)
+	}
+	if err := os.MkdirAll(absolute, privateDirectoryMode); err != nil {
+		return "", fmt.Errorf("creating module root: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("resolving module root: %w", err)
+	}
+	return resolved, nil
+}

--- a/cmd/scanner/prepare_modules_test.go
+++ b/cmd/scanner/prepare_modules_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/moduleprepare"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+	"github.com/stretchr/testify/require"
+	cli "github.com/urfave/cli/v3"
+)
+
+func TestPrepareModulesConvergesFromRequestToStagedArchive(t *testing.T) {
+	repositoryRoot := t.TempDir()
+	source := "terraform-aws-modules/vpc/aws//modules/vpc"
+	require.NoError(t, os.WriteFile(filepath.Join(repositoryRoot, "main.tf"), []byte(`
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws//modules/vpc"
+  version = "5.4.0"
+}
+`), 0o600))
+	moduleRoot := t.TempDir()
+	firstResponsePath := filepath.Join(moduleRoot, "first-response.json")
+	manifestPath := filepath.Join(moduleRoot, "manifest.json")
+
+	require.NoError(t, runPrepareModulesCommand(t.Context(), []string{
+		"prepare-modules",
+		"--path", repositoryRoot,
+		"--module-root", moduleRoot,
+		"--output-response", firstResponsePath,
+		"--output-manifest", manifestPath,
+	}))
+	first := readPrepareResponse(t, firstResponsePath)
+	require.Equal(t, moduleprepare.StatusRequiresStaging, first.Status)
+	require.Len(t, first.Requests, 1)
+	require.NoFileExists(t, manifestPath)
+
+	archivePath := filepath.Join(moduleRoot, "incoming", "vpc.zip")
+	writeModuleZip(t, archivePath, "vpc-commit/modules/vpc/main.tf", `resource "test" "vpc" {}`)
+	staged := moduleprepare.StagedModules{
+		SchemaVersion: moduleprepare.ResponseSchemaVersion,
+		Modules: []moduleprepare.StagedModule{{
+			RequestID:        first.Requests[0].RequestID,
+			Source:           source,
+			RequestedVersion: "5.4.0",
+			ResolvedVersion:  "5.4.0",
+			Kind:             moduleprepare.StagedKindArchive,
+			ArtifactPath:     "incoming/vpc.zip",
+			ArchiveFormat:    "zip",
+			TransportDigest:  moduleFileDigest(t, archivePath),
+			Declarations:     first.Requests[0].Declarations,
+		}},
+	}
+	stagedData, err := json.Marshal(staged)
+	require.NoError(t, err)
+	stagedPath := filepath.Join(moduleRoot, "staged.json")
+	require.NoError(t, os.WriteFile(stagedPath, stagedData, 0o600))
+	secondResponsePath := filepath.Join(moduleRoot, "second-response.json")
+
+	require.NoError(t, runPrepareModulesCommand(t.Context(), []string{
+		"prepare-modules",
+		"--path", repositoryRoot,
+		"--module-root", moduleRoot,
+		"--output-response", secondResponsePath,
+		"--output-manifest", manifestPath,
+		"--staged-modules", stagedPath,
+	}))
+	second := readPrepareResponse(t, secondResponsePath)
+	require.Equal(t, moduleprepare.StatusComplete, second.Status)
+	require.Empty(t, second.Requests)
+	require.Equal(t, filepath.ToSlash(manifestPath), second.ManifestPath)
+	manifest, err := resolver.LoadManifest(t.Context(), manifestPath)
+	require.NoError(t, err)
+	require.Len(t, manifest.Entries, 1)
+}
+
+func runPrepareModulesCommand(ctx context.Context, args []string) error {
+	command := &cli.Command{
+		Name:   prepareModulesAction.Name,
+		Flags:  prepareModulesAction.Flags,
+		Action: prepareModules,
+	}
+	return command.Run(ctx, args)
+}
+
+func readPrepareResponse(t *testing.T, path string) moduleprepare.Response {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var response moduleprepare.Response
+	require.NoError(t, json.Unmarshal(data, &response))
+	return response
+}
+
+func writeModuleZip(t *testing.T, path, name, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	writer := zip.NewWriter(file)
+	entry, err := writer.Create(name)
+	require.NoError(t, err)
+	_, err = entry.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	require.NoError(t, file.Close())
+}
+
+func moduleFileDigest(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -35,6 +35,7 @@ type Request struct {
 	DiscoveryPaths  []string
 	Resolver        resolver.Resolver
 	MaxDepth        int
+	MaxModules      int
 	ResourceLimits  resolver.ResourceLimits
 	BaselinePaths   []string
 	TotalParseBytes int64
@@ -66,6 +67,7 @@ type Result struct {
 	BudgetEvents         []BudgetEvent
 	BaselineParseBytes   int64
 	ModuleAdmissionBytes int64
+	ModuleLimitReached   bool
 	TimedOut             bool
 	Cleanup              func()
 }
@@ -164,6 +166,8 @@ type walker struct {
 	acquisitionBytes int64
 	acquisitionBase  int64
 	maxDepth         int
+	maxModules       int
+	moduleCount      int
 	fsys             vfs.FS
 }
 
@@ -204,22 +208,14 @@ func Resolve(ctx context.Context, request *Request) Result {
 		admissionBytes:   moduleMaximum,
 		acquisitionBytes: acquisitionAllowance(moduleMaximum),
 		maxDepth:         request.MaxDepth,
+		maxModules:       request.MaxModules,
 		fsys:             request.FS,
 	}
 	if enforceAdmission {
 		w.acquisitionBase = budget.TotalUsage().Bytes
 	}
 	seedGroups, repositoryGroups := w.seedGroups(ctx, request.RootPaths, request.DiscoveryPaths)
-
-	g, gCtx := errgroup.WithContext(ctx)
-	g.SetLimit(max(1, runtime.GOMAXPROCS(0)*seedGroupConcurrencyFactor))
-	for seedDir, allowedFiles := range seedGroups {
-		g.Go(func() error {
-			w.traverse(gCtx, seedDir, allowedFiles, repositoryGroups, 0, "")
-			return nil
-		})
-	}
-	_ = g.Wait()
+	w.traverseSeedGroups(ctx, seedGroups, repositoryGroups)
 	if enforceAdmission {
 		w.expandAdmittedPackages(ctx, moduleMaximum)
 	}
@@ -233,6 +229,12 @@ func Resolve(ctx context.Context, request *Request) Result {
 	result.BudgetEvents = snapshot.budgetEvents
 	result.BaselineParseBytes = baselineBytes
 	result.ModuleAdmissionBytes = moduleMaximum
+	for _, event := range result.BudgetEvents {
+		if event.Limit == "module_count" {
+			result.ModuleLimitReached = true
+			break
+		}
+	}
 	result.TimedOut = errors.Is(ctx.Err(), context.DeadlineExceeded)
 
 	sort.Strings(result.ScanPaths)
@@ -273,6 +275,33 @@ func Resolve(ctx context.Context, request *Request) Result {
 	return result
 }
 
+func (w *walker) traverseSeedGroups(
+	ctx context.Context,
+	seedGroups map[string]map[string]bool,
+	repositoryGroups map[string]map[string]bool,
+) {
+	if w.maxModules > 0 {
+		seedDirs := make([]string, 0, len(seedGroups))
+		for seedDir := range seedGroups {
+			seedDirs = append(seedDirs, seedDir)
+		}
+		sort.Strings(seedDirs)
+		for _, seedDir := range seedDirs {
+			w.traverse(ctx, seedDir, seedGroups[seedDir], repositoryGroups, 0, "")
+		}
+		return
+	}
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(max(1, runtime.GOMAXPROCS(0)*seedGroupConcurrencyFactor))
+	for seedDir, allowedFiles := range seedGroups {
+		g.Go(func() error {
+			w.traverse(gCtx, seedDir, allowedFiles, repositoryGroups, 0, "")
+			return nil
+		})
+	}
+	_ = g.Wait()
+}
+
 func (w *walker) expandAdmittedPackages(ctx context.Context, maximum int64) {
 	var deferred []pendingTraversal
 	for {
@@ -295,22 +324,35 @@ func (w *walker) expandAdmittedPackages(ctx context.Context, maximum int64) {
 		}
 		deferred = rejected
 
-		g, gCtx := errgroup.WithContext(ctx)
-		g.SetLimit(max(1, resolver.FetchConcurrency))
-		for _, traversal := range admitted {
-			g.Go(func() error {
+		if w.maxModules > 0 {
+			for _, traversal := range admitted {
 				w.traverse(
-					gCtx,
+					ctx,
 					traversal.seed,
 					nil,
 					traversal.repoAllowedDirs,
 					traversal.depth,
 					traversal.packageRoot,
 				)
-				return nil
-			})
+			}
+		} else {
+			g, gCtx := errgroup.WithContext(ctx)
+			g.SetLimit(max(1, resolver.FetchConcurrency))
+			for _, traversal := range admitted {
+				g.Go(func() error {
+					w.traverse(
+						gCtx,
+						traversal.seed,
+						nil,
+						traversal.repoAllowedDirs,
+						traversal.depth,
+						traversal.packageRoot,
+					)
+					return nil
+				})
+			}
+			_ = g.Wait()
 		}
-		_ = g.Wait()
 	}
 }
 
@@ -717,7 +759,7 @@ func (w *walker) traverse(
 		return
 	}
 
-	for key := range mods {
+	for _, key := range orderedModuleKeys(mods) {
 		mod := mods[key]
 		if !mod.IsLocal || mod.AbsSource == "" {
 			continue
@@ -808,6 +850,59 @@ func acquisitionAllowance(maximum int64) int64 {
 	return maximum * acquisitionOvershootFactor
 }
 
+type remoteAcquisition struct {
+	group *remoteModuleGroup
+	lease *resolver.AcquisitionLease
+}
+
+func (w *walker) remoteAcquisitionBatchSize() int {
+	if w.maxModules > 0 && !w.deferExpansion {
+		return 1
+	}
+	return max(1, resolver.FetchConcurrency)
+}
+
+func (w *walker) collectRemoteAcquisitionBatch(
+	ctx context.Context,
+	groups map[string]*remoteModuleGroup,
+	ids []string,
+	start, size int,
+) []remoteAcquisition {
+	batch := make([]remoteAcquisition, 0, size)
+	for _, id := range ids[start:min(start+size, len(ids))] {
+		if w.maxModules > 0 && w.moduleCount >= w.maxModules {
+			break
+		}
+		lease, ok := w.acquireAcquisition(ctx, len(batch) == 0)
+		if !ok {
+			break
+		}
+		batch = append(batch, remoteAcquisition{group: groups[id], lease: lease})
+		if w.maxModules > 0 {
+			w.moduleCount++
+		}
+	}
+	return batch
+}
+
+func (w *walker) runRemoteAcquisitionBatch(
+	ctx context.Context,
+	batch []remoteAcquisition,
+	repoAllowedDirs map[string]map[string]bool,
+	depth, limit int,
+) {
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(limit)
+	for _, item := range batch {
+		g.Go(func() error {
+			defer item.lease.Release()
+			w.traverseRemoteModuleGroup(gCtx, item.group, repoAllowedDirs, depth, item.lease)
+			return nil
+		})
+	}
+	_ = g.Wait()
+}
+
 // acquireRemoteModuleGroups fetches a frontier in deterministically ordered
 // batches, stopping once the frontier has fetched past its allowance. Without
 // this the whole frontier is fetched before admission gets to reject anything,
@@ -823,42 +918,31 @@ func (w *walker) acquireRemoteModuleGroups(
 		w.recordUnacquiredGroups(groups, ids)
 		return
 	}
-	size := max(1, resolver.FetchConcurrency)
+	size := w.remoteAcquisitionBatchSize()
 	for start := 0; start < len(ids); {
-		type acquisition struct {
-			group *remoteModuleGroup
-			lease *resolver.AcquisitionLease
+		if w.maxModules > 0 && w.moduleCount >= w.maxModules {
+			w.recordModuleLimit(groups, ids[start:])
+			return
 		}
-		batch := make([]acquisition, 0, size)
-		end := min(start+size, len(ids))
-		for _, id := range ids[start:end] {
-			lease, ok := w.acquireAcquisition(ctx, len(batch) == 0)
-			if !ok {
-				break
-			}
-			batch = append(batch, acquisition{group: groups[id], lease: lease})
-		}
+		batch := w.collectRemoteAcquisitionBatch(ctx, groups, ids, start, size)
 		if len(batch) == 0 {
 			if ctx.Err() == nil {
 				w.recordUnacquiredGroups(groups, ids[start:])
 			}
 			return
 		}
-
-		g, gCtx := errgroup.WithContext(ctx)
-		g.SetLimit(size)
-		for _, item := range batch {
-			g.Go(func() error {
-				defer item.lease.Release()
-				w.traverseRemoteModuleGroup(
-					gCtx, item.group, repoAllowedDirs, depth, item.lease,
-				)
-				return nil
-			})
-		}
-		_ = g.Wait()
+		w.runRemoteAcquisitionBatch(ctx, batch, repoAllowedDirs, depth, size)
 		start += len(batch)
 	}
+}
+
+func orderedModuleKeys(modules map[string]tfmodules.ParsedModule) []string {
+	keys := make([]string, 0, len(modules))
+	for key := range modules {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // orderedGroupIDs gives the frontier a stable order so that when acquisition
@@ -904,6 +988,17 @@ func (w *walker) recordUnacquiredGroups(groups map[string]*remoteModuleGroup, id
 			Limit:    "module_bytes_total",
 			Maximum:  w.admissionBytes,
 			Measured: measured,
+		})
+	}
+}
+
+func (w *walker) recordModuleLimit(groups map[string]*remoteModuleGroup, ids []string) {
+	for _, id := range ids {
+		w.results.addBudgetEvent(groups[id].representative.Source, &resolver.BudgetExceededError{
+			Gate:     "graph",
+			Limit:    "module_count",
+			Maximum:  int64(w.maxModules),
+			Measured: int64(w.moduleCount + len(ids)),
 		})
 	}
 }

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -43,6 +43,7 @@ type Request struct {
 }
 
 type ResolvedModule struct {
+	RequestID         string
 	CallerRoot        string
 	CallerFile        string
 	CallerLine        int
@@ -82,6 +83,7 @@ type BudgetEvent struct {
 }
 
 type ResolutionFailure struct {
+	RequestID     string
 	CallerRoot    string
 	CallerFile    string
 	CallerLine    int
@@ -461,6 +463,7 @@ func (c *resultCollector) addResolvedModule(
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.modules = append(c.modules, ResolvedModule{
+		RequestID:         resolver.ParsedModuleCallID(mod),
 		CallerRoot:        moduleCallRoot(mod),
 		CallerFile:        mod.FileName,
 		CallerLine:        mod.DefLine,
@@ -509,6 +512,7 @@ func (c *resultCollector) addResolutionFailure(mod *tfmodules.ParsedModule, err 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.failures = append(c.failures, ResolutionFailure{
+		RequestID:     resolver.ParsedModuleCallID(mod),
 		CallerRoot:    moduleCallRoot(mod),
 		CallerFile:    mod.FileName,
 		CallerLine:    mod.DefLine,

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
@@ -176,6 +176,14 @@ func TestResolveAssemblesModuleMetadataAndPaths(t *testing.T) {
 		moduleDir: "git::https://github.com/acme/network//modules/vpc?ref=v1",
 	}, result.SourceMappings)
 	require.Equal(t, []ResolvedModule{{
+		RequestID: resolver.ModuleCallID(
+			filepath.Join(root, "main.tf"),
+			2,
+			5,
+			"network",
+			"git::https://git@github.com/acme/network.git//modules/vpc?ref=v1",
+			"1.2.3",
+		),
 		CallerRoot:      root,
 		CallerFile:      filepath.Join(root, "main.tf"),
 		CallerLine:      2,
@@ -400,6 +408,14 @@ resource "aws_s3_bucket" "this" {}
 		moduleDir: "registry.terraform.io/cloud-inventory/bucket/aws@9.1.0",
 	}, result.SourceMappings)
 	require.Equal(t, []ResolvedModule{{
+		RequestID: resolver.ModuleCallID(
+			filepath.Join(root, "main.tf"),
+			2,
+			5,
+			"bucket",
+			"cloud-inventory/bucket/aws",
+			"~> 9.0",
+		),
 		CallerRoot:      root,
 		CallerFile:      filepath.Join(root, "main.tf"),
 		CallerLine:      2,

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
@@ -190,6 +190,53 @@ func TestResolveAssemblesModuleMetadataAndPaths(t *testing.T) {
 	}}, result.Modules)
 }
 
+func TestResolveAppliesModuleCountLimitDeterministically(t *testing.T) {
+	root := t.TempDir()
+	sources := []string{
+		"example.com/acme/a/aws",
+		"example.com/acme/b/aws",
+		"example.com/acme/c/aws",
+	}
+	caller := filepath.Join(root, "main.tf")
+	require.NoError(t, os.WriteFile(caller, []byte(`
+module "c" { source = "example.com/acme/c/aws" }
+module "a" { source = "example.com/acme/a/aws" }
+module "b" { source = "example.com/acme/b/aws" }
+`), 0o644))
+	resolutions := make(map[string]resolver.Resolution, len(sources))
+	for _, source := range sources {
+		dir := filepath.Join(root, filepath.Base(filepath.Dir(source)))
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "outputs.tf"), []byte("output \"x\" {}"), 0o644))
+		resolutions[source] = resolver.Resolution{LocalPath: dir, PackageRoot: dir}
+	}
+
+	for range 5 {
+		result := Resolve(t.Context(), &Request{
+			RootPaths:      []string{root},
+			DiscoveryPaths: []string{caller},
+			Resolver:       mapResolver{bySource: resolutions},
+			MaxDepth:       2,
+			MaxModules:     2,
+			ResourceLimits: resolver.ResourceLimits{
+				MaxPackageBytes: 10_000,
+				MaxFileBytes:    1_000,
+				MaxPackageFiles: 10,
+				MaxTotalBytes:   100_000,
+			},
+		})
+
+		require.True(t, result.ModuleLimitReached)
+		require.Equal(t, []string{sources[0], sources[1]}, []string{
+			result.Modules[0].Source,
+			result.Modules[1].Source,
+		})
+		require.Len(t, result.BudgetEvents, 1)
+		require.Equal(t, "module_count", result.BudgetEvents[0].Limit)
+		require.Equal(t, sources[2], result.BudgetEvents[0].Source)
+	}
+}
+
 func writeTerraformModulesManifest(t *testing.T, root string) {
 	t.Helper()
 	dir := filepath.Join(root, ".terraform", "modules")

--- a/pkg/parser/terraform/modules/moduleprepare/prepare.go
+++ b/pkg/parser/terraform/modules/moduleprepare/prepare.go
@@ -79,15 +79,27 @@ func WriteResult(
 		return Response{}, err
 	}
 	response := buildResponse(entries, result, maxResponseEntries)
+	// Encode the response first so we know it's within bounds before touching the manifest.
+	responseData, err := encodeResponse(&response)
+	if err != nil {
+		return Response{}, err
+	}
 	if response.Status == StatusComplete {
 		if err := resolver.WriteManifest(ctx, manifestPath, moduleRoot, entries); err != nil {
 			return Response{}, err
 		}
 		response.ManifestPath = filepath.ToSlash(manifestPath)
+		// Re-encode with manifest path now included.
+		responseData, err = encodeResponse(&response)
+		if err != nil {
+			// Manifest was written; remove it to leave no stale artifact.
+			_ = removeStaleManifest(manifestPath)
+			return Response{}, err
+		}
 	} else if err := removeStaleManifest(manifestPath); err != nil {
 		return Response{}, err
 	}
-	if err := writeResponse(responsePath, &response); err != nil {
+	if err := writeResponseBytes(responsePath, responseData); err != nil {
 		return Response{}, err
 	}
 	return response, nil
@@ -389,15 +401,19 @@ func removeStaleManifest(path string) error {
 	return nil
 }
 
-func writeResponse(path string, response *Response) error {
+func encodeResponse(response *Response) ([]byte, error) {
 	data, err := json.MarshalIndent(response, "", "  ")
 	if err != nil {
-		return fmt.Errorf("encoding module preparation response: %w", err)
+		return nil, fmt.Errorf("encoding module preparation response: %w", err)
 	}
 	data = append(data, '\n')
 	if len(data) > maxResponseBytes {
-		return fmt.Errorf("module preparation response exceeds %d bytes", maxResponseBytes)
+		return nil, fmt.Errorf("module preparation response exceeds %d bytes", maxResponseBytes)
 	}
+	return data, nil
+}
+
+func writeResponseBytes(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, privateDirectoryMode); err != nil {
 		return fmt.Errorf("creating response directory: %w", err)

--- a/pkg/parser/terraform/modules/moduleprepare/prepare.go
+++ b/pkg/parser/terraform/modules/moduleprepare/prepare.go
@@ -1,0 +1,426 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package moduleprepare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/modulegraph"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+)
+
+const (
+	ResponseSchemaVersion = 1
+	StatusComplete        = "complete"
+	StatusRequiresStaging = "requires_staging"
+	StatusIncomplete      = "incomplete"
+
+	privateDirectoryMode = 0o750
+	privateFileMode      = 0o600
+	maxResponseBytes     = 16 * 1024 * 1024
+)
+
+type Response struct {
+	SchemaVersion   int                       `json:"schema_version"`
+	Status          string                    `json:"status"`
+	ManifestPath    string                    `json:"manifest_path,omitempty"`
+	Modules         []resolver.ManifestModule `json:"modules"`
+	Requests        []resolver.ManifestModule `json:"requests,omitempty"`
+	OmittedModules  int                       `json:"omitted_modules,omitempty"`
+	OmittedRequests int                       `json:"omitted_requests,omitempty"`
+	Termination     Termination               `json:"termination"`
+}
+
+type Termination struct {
+	TimedOut            bool          `json:"timed_out"`
+	ModuleLimitReached  bool          `json:"module_limit_reached"`
+	BudgetEvents        []BudgetEvent `json:"budget_events,omitempty"`
+	OmittedBudgetEvents int           `json:"omitted_budget_events,omitempty"`
+}
+
+type BudgetEvent struct {
+	Source   string `json:"source"`
+	Gate     string `json:"gate"`
+	Limit    string `json:"limit"`
+	Maximum  int64  `json:"maximum"`
+	Measured int64  `json:"measured"`
+}
+
+func WriteResult(
+	ctx context.Context,
+	responsePath string,
+	manifestPath string,
+	moduleRoot string,
+	repositoryRoots []string,
+	result *modulegraph.Result,
+	maxResponseEntries int,
+) (Response, error) {
+	if result == nil {
+		return Response{}, fmt.Errorf("module graph result is required")
+	}
+	if strings.TrimSpace(responsePath) == "" || strings.TrimSpace(manifestPath) == "" {
+		return Response{}, fmt.Errorf("response and manifest paths are required")
+	}
+	if filepath.Clean(responsePath) == filepath.Clean(manifestPath) {
+		return Response{}, fmt.Errorf("response and manifest paths must be distinct")
+	}
+	entries, err := manifestEntries(ctx, moduleRoot, repositoryRoots, result)
+	if err != nil {
+		return Response{}, err
+	}
+	response := buildResponse(entries, result, maxResponseEntries)
+	if response.Status == StatusComplete {
+		if err := resolver.WriteManifest(ctx, manifestPath, moduleRoot, entries); err != nil {
+			return Response{}, err
+		}
+		response.ManifestPath = filepath.ToSlash(manifestPath)
+	} else if err := removeStaleManifest(manifestPath); err != nil {
+		return Response{}, err
+	}
+	if err := writeResponse(responsePath, &response); err != nil {
+		return Response{}, err
+	}
+	return response, nil
+}
+
+func buildResponse(
+	entries []resolver.ManifestModule,
+	result *modulegraph.Result,
+	maxResponseEntries int,
+) Response {
+	response := Response{
+		SchemaVersion: ResponseSchemaVersion,
+		Status:        StatusComplete,
+		Termination: Termination{
+			TimedOut:           result.TimedOut,
+			ModuleLimitReached: result.ModuleLimitReached,
+		},
+	}
+	var modules []resolver.ManifestModule
+	var requests []resolver.ManifestModule
+	for index := range entries {
+		if entries[index].Status == resolver.ManifestStatusUnresolved {
+			requests = append(requests, entries[index])
+		} else {
+			modules = append(modules, entries[index])
+		}
+	}
+	response.Modules, response.OmittedModules = limitManifestEntries(modules, maxResponseEntries)
+	response.Requests, response.OmittedRequests = limitManifestEntries(requests, maxResponseEntries)
+	sort.Slice(response.Requests, func(left, right int) bool {
+		return response.Requests[left].RequestID < response.Requests[right].RequestID
+	})
+
+	events := make([]BudgetEvent, 0, len(result.BudgetEvents))
+	for _, event := range result.BudgetEvents {
+		events = append(events, BudgetEvent{
+			Source:   model.RedactURLCredentials(event.Source),
+			Gate:     event.Gate,
+			Limit:    event.Limit,
+			Maximum:  event.Maximum,
+			Measured: event.Measured,
+		})
+	}
+	sort.Slice(events, func(left, right int) bool {
+		a, b := events[left], events[right]
+		if a.Source != b.Source {
+			return a.Source < b.Source
+		}
+		if a.Gate != b.Gate {
+			return a.Gate < b.Gate
+		}
+		if a.Limit != b.Limit {
+			return a.Limit < b.Limit
+		}
+		if a.Maximum != b.Maximum {
+			return a.Maximum < b.Maximum
+		}
+		return a.Measured < b.Measured
+	})
+	if maxResponseEntries > 0 && len(events) > maxResponseEntries {
+		response.Termination.OmittedBudgetEvents = len(events) - maxResponseEntries
+		events = events[:maxResponseEntries]
+	}
+	response.Termination.BudgetEvents = events
+
+	switch {
+	case result.TimedOut || result.ModuleLimitReached || len(result.BudgetEvents) > 0:
+		response.Status = StatusIncomplete
+	case len(requests) > 0:
+		response.Status = StatusRequiresStaging
+	}
+	return response
+}
+
+func manifestEntries(
+	ctx context.Context,
+	moduleRoot string,
+	repositoryRoots []string,
+	result *modulegraph.Result,
+) ([]resolver.ManifestModule, error) {
+	resolvedRoot, err := filepath.Abs(moduleRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolving module root: %w", err)
+	}
+	resolvedRoot, err = filepath.EvalSymlinks(resolvedRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolving module root: %w", err)
+	}
+	roots, err := resolvedRoots(repositoryRoots)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]resolver.ManifestModule, 0, len(result.Modules)+len(result.Failures))
+	digests := make(map[string]string)
+	for index := range result.Modules {
+		module := &result.Modules[index]
+		packageRoot, err := relativePathWithinRoot(ctx, resolvedRoot, module.PackageRoot)
+		if err != nil {
+			return nil, fmt.Errorf("module %q package root: %w", module.Source, err)
+		}
+		localPath, err := relativePathWithinRoot(ctx, resolvedRoot, module.LocalPath)
+		if err != nil {
+			return nil, fmt.Errorf("module %q local path: %w", module.Source, err)
+		}
+		digest := digests[module.PackageRoot]
+		if digest == "" {
+			digest, err = resolver.ComputePackageDigest(ctx, module.PackageRoot)
+			if err != nil {
+				return nil, fmt.Errorf("module %q digest: %w", module.Source, err)
+			}
+			digests[module.PackageRoot] = digest
+		}
+		descriptor := resolver.DescribeModuleSource(module.Source, module.Version)
+		safeSource := model.RedactURLCredentials(module.Source)
+		requestID := module.RequestID
+		if requestID == "" {
+			requestID = resolver.ModuleCallID(
+				module.CallerFile,
+				module.CallerLine,
+				module.CallerEndLine,
+				module.Name,
+				module.Source,
+				module.Version,
+			)
+		}
+		entries = append(entries, resolver.ManifestModule{
+			RequestID:        requestID,
+			AcquisitionKey:   resolver.ModuleAcquisitionKey(module.Source, module.Version),
+			Source:           safeSource,
+			NormalizedSource: descriptor.NormalizedSource,
+			CanonicalSource:  model.RedactURLCredentials(module.CanonicalSource),
+			SourceType:       descriptor.SourceType,
+			SourceCategory:   descriptor.SourceCategory,
+			RegistryScope:    descriptor.RegistryScope,
+			RequestedVersion: descriptor.RequestedVersion,
+			RequestedRef:     descriptor.RequestedRef,
+			Subdirectory:     descriptor.Subdirectory,
+			ResolvedVersion:  module.ResolvedVersion,
+			ResolvedRef:      module.ResolvedRef,
+			ContentDigest:    digest,
+			PackageRoot:      packageRoot,
+			LocalPath:        localPath,
+			Status:           resolver.ManifestStatusResolved,
+			Declarations: []resolver.ManifestDeclaration{
+				resolvedDeclaration(module, result.Modules, roots, resolvedRoot),
+			},
+		})
+	}
+
+	for index := range result.Failures {
+		failure := &result.Failures[index]
+		descriptor := resolver.DescribeModuleSource(failure.Source, failure.Version)
+		safeSource := model.RedactURLCredentials(failure.Source)
+		requestID := failure.RequestID
+		if requestID == "" {
+			requestID = resolver.ModuleCallID(
+				failure.CallerFile,
+				failure.CallerLine,
+				failure.CallerEndLine,
+				failure.Name,
+				failure.Source,
+				failure.Version,
+			)
+		}
+		entries = append(entries, resolver.ManifestModule{
+			RequestID:        requestID,
+			AcquisitionKey:   resolver.ModuleAcquisitionKey(failure.Source, failure.Version),
+			Source:           safeSource,
+			NormalizedSource: descriptor.NormalizedSource,
+			SourceType:       descriptor.SourceType,
+			SourceCategory:   descriptor.SourceCategory,
+			RegistryScope:    descriptor.RegistryScope,
+			RequestedVersion: descriptor.RequestedVersion,
+			RequestedRef:     descriptor.RequestedRef,
+			Subdirectory:     descriptor.Subdirectory,
+			Status:           resolver.ManifestStatusUnresolved,
+			Failure:          failure.Reason,
+			Declarations: []resolver.ManifestDeclaration{{
+				Filename:     relativeDeclarationPath(failure.CallerFile, roots, resolvedRoot),
+				LineStart:    failure.CallerLine,
+				LineEnd:      failure.CallerEndLine,
+				ModuleName:   failure.Name,
+				CallerModule: callerModuleForFile(failure.CallerFile, result.Modules),
+			}},
+		})
+	}
+	sort.Slice(entries, func(left, right int) bool {
+		return entries[left].RequestID < entries[right].RequestID
+	})
+	return entries, nil
+}
+
+func resolvedDeclaration(
+	module *modulegraph.ResolvedModule,
+	all []modulegraph.ResolvedModule,
+	repositoryRoots []string,
+	moduleRoot string,
+) resolver.ManifestDeclaration {
+	return resolver.ManifestDeclaration{
+		Filename:     relativeDeclarationPath(module.CallerFile, repositoryRoots, moduleRoot),
+		LineStart:    module.CallerLine,
+		LineEnd:      module.CallerEndLine,
+		ModuleName:   module.Name,
+		CallerModule: callerModuleForPackage(module.ParentPackageRoot, all),
+	}
+}
+
+func callerModuleForFile(path string, modules []modulegraph.ResolvedModule) string {
+	bestLength := -1
+	caller := ""
+	for index := range modules {
+		module := &modules[index]
+		relative, err := filepath.Rel(module.LocalPath, path)
+		if err != nil || !filepath.IsLocal(relative) || len(module.LocalPath) <= bestLength {
+			continue
+		}
+		bestLength = len(module.LocalPath)
+		caller = module.CanonicalSource
+	}
+	return caller
+}
+
+func callerModuleForPackage(packageRoot string, modules []modulegraph.ResolvedModule) string {
+	if packageRoot == "" {
+		return ""
+	}
+	for index := range modules {
+		if filepath.Clean(modules[index].PackageRoot) == filepath.Clean(packageRoot) {
+			return modules[index].CanonicalSource
+		}
+	}
+	return ""
+}
+
+func relativeDeclarationPath(path string, repositoryRoots []string, moduleRoot string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	for _, root := range append(repositoryRoots, moduleRoot) {
+		relative, err := filepath.Rel(root, path)
+		if err == nil && filepath.IsLocal(relative) {
+			return filepath.ToSlash(relative)
+		}
+	}
+	return filepath.ToSlash(filepath.Base(path))
+}
+
+func resolvedRoots(paths []string) ([]string, error) {
+	roots := make([]string, 0, len(paths))
+	for _, path := range paths {
+		absolute, err := filepath.Abs(path)
+		if err != nil {
+			return nil, fmt.Errorf("resolving repository root %q: %w", path, err)
+		}
+		resolved, err := filepath.EvalSymlinks(absolute)
+		if err != nil {
+			return nil, fmt.Errorf("resolving repository root %q: %w", path, err)
+		}
+		roots = append(roots, resolved)
+	}
+	sort.Strings(roots)
+	return roots, nil
+}
+
+func relativePathWithinRoot(ctx context.Context, root, path string) (string, error) {
+	if _, err := resolver.ResolvePathWithinRoot(ctx, root, path); err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	relative, err := filepath.Rel(root, resolved)
+	if err != nil || !filepath.IsLocal(relative) {
+		return "", fmt.Errorf("path %q is outside module root %q", path, root)
+	}
+	return filepath.ToSlash(relative), nil
+}
+
+func limitManifestEntries(
+	entries []resolver.ManifestModule,
+	maximum int,
+) (limited []resolver.ManifestModule, omitted int) {
+	if maximum <= 0 || len(entries) <= maximum {
+		limited = make([]resolver.ManifestModule, len(entries))
+		copy(limited, entries)
+		return limited, 0
+	}
+	limited = make([]resolver.ManifestModule, maximum)
+	copy(limited, entries[:maximum])
+	return limited, len(entries) - maximum
+}
+
+func removeStaleManifest(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing stale module manifest: %w", err)
+	}
+	return nil
+}
+
+func writeResponse(path string, response *Response) error {
+	data, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding module preparation response: %w", err)
+	}
+	data = append(data, '\n')
+	if len(data) > maxResponseBytes {
+		return fmt.Errorf("module preparation response exceeds %d bytes", maxResponseBytes)
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, privateDirectoryMode); err != nil {
+		return fmt.Errorf("creating response directory: %w", err)
+	}
+	temp, err := os.CreateTemp(dir, ".module-response-*.json")
+	if err != nil {
+		return fmt.Errorf("creating temporary response: %w", err)
+	}
+	tempPath := temp.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+	if err := temp.Chmod(privateFileMode); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("setting response permissions: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("writing response: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("closing response: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("replacing response: %w", err)
+	}
+	return nil
+}

--- a/pkg/parser/terraform/modules/moduleprepare/prepare_test.go
+++ b/pkg/parser/terraform/modules/moduleprepare/prepare_test.go
@@ -1,0 +1,144 @@
+package moduleprepare
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/modulegraph"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteResultEmitsGenericCallScopedRequestsWithoutManifest(t *testing.T) {
+	repositoryRoot := t.TempDir()
+	callerA := filepath.Join(repositoryRoot, "a", "main.tf")
+	callerB := filepath.Join(repositoryRoot, "b", "main.tf")
+	require.NoError(t, os.MkdirAll(filepath.Dir(callerA), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(callerB), 0o755))
+	require.NoError(t, os.WriteFile(callerA, []byte("module"), 0o600))
+	require.NoError(t, os.WriteFile(callerB, []byte("module"), 0o600))
+
+	moduleRoot := t.TempDir()
+	responsePath := filepath.Join(moduleRoot, "response.json")
+	manifestPath := filepath.Join(moduleRoot, "manifest.json")
+	require.NoError(t, os.WriteFile(manifestPath, []byte("stale"), 0o600))
+	source := "terraform-aws-modules/vpc/aws"
+	result := modulegraph.Result{
+		Failures: []modulegraph.ResolutionFailure{
+			{
+				RequestID:     resolver.ModuleCallID(callerA, 1, 3, "vpc_a", source, ""),
+				CallerFile:    callerA,
+				CallerLine:    1,
+				CallerEndLine: 3,
+				Source:        source,
+				Name:          "vpc_a",
+				Reason:        "not found in staged modules",
+			},
+			{
+				RequestID:     resolver.ModuleCallID(callerB, 1, 3, "vpc_b", source, ""),
+				CallerFile:    callerB,
+				CallerLine:    1,
+				CallerEndLine: 3,
+				Source:        source,
+				Name:          "vpc_b",
+				Reason:        "not found in staged modules",
+			},
+		},
+	}
+
+	response, err := WriteResult(
+		t.Context(),
+		responsePath,
+		manifestPath,
+		moduleRoot,
+		[]string{repositoryRoot},
+		&result,
+		10,
+	)
+	require.NoError(t, err)
+	require.Equal(t, StatusRequiresStaging, response.Status)
+	require.Empty(t, response.ManifestPath)
+	require.Len(t, response.Requests, 2)
+	require.NotEqual(t, response.Requests[0].RequestID, response.Requests[1].RequestID)
+	require.Equal(t, response.Requests[0].AcquisitionKey, response.Requests[1].AcquisitionKey)
+	_, err = os.Stat(manifestPath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	data, err := os.ReadFile(responsePath)
+	require.NoError(t, err)
+	var persisted Response
+	require.NoError(t, json.Unmarshal(data, &persisted))
+	require.Equal(t, response.Status, persisted.Status)
+	require.Equal(t, response.Modules, persisted.Modules)
+	require.Equal(t, response.Requests, persisted.Requests)
+}
+
+func TestWriteResultPublishesManifestOnlyWhenComplete(t *testing.T) {
+	repositoryRoot := t.TempDir()
+	caller := filepath.Join(repositoryRoot, "main.tf")
+	require.NoError(t, os.WriteFile(caller, []byte("module"), 0o600))
+	moduleRoot := t.TempDir()
+	packageRoot := filepath.Join(moduleRoot, "packages", "module")
+	require.NoError(t, os.MkdirAll(packageRoot, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(packageRoot, "main.tf"), []byte("resource"), 0o600))
+	source := "terraform-aws-modules/vpc/aws"
+	requestID := resolver.ModuleCallID(caller, 1, 3, "vpc", source, "~> 5.0")
+	result := modulegraph.Result{
+		Modules: []modulegraph.ResolvedModule{{
+			RequestID:       requestID,
+			CallerFile:      caller,
+			CallerLine:      1,
+			CallerEndLine:   3,
+			Source:          source,
+			Version:         "~> 5.0",
+			ResolvedVersion: "5.4.0",
+			Name:            "vpc",
+			LocalPath:       packageRoot,
+			PackageRoot:     packageRoot,
+		}},
+	}
+	responsePath := filepath.Join(moduleRoot, "response.json")
+	manifestPath := filepath.Join(moduleRoot, "manifest.json")
+
+	response, err := WriteResult(
+		t.Context(),
+		responsePath,
+		manifestPath,
+		moduleRoot,
+		[]string{repositoryRoot},
+		&result,
+		10,
+	)
+	require.NoError(t, err)
+	require.Equal(t, StatusComplete, response.Status)
+	require.Equal(t, filepath.ToSlash(manifestPath), response.ManifestPath)
+	manifest, err := resolver.LoadManifest(t.Context(), manifestPath)
+	require.NoError(t, err)
+	require.Contains(t, manifest.Modules, requestID)
+}
+
+func TestWriteResultBoundsBudgetEvents(t *testing.T) {
+	moduleRoot := t.TempDir()
+	result := modulegraph.Result{
+		BudgetEvents: []modulegraph.BudgetEvent{
+			{Source: "a", Gate: "graph", Limit: "module_count", Maximum: 1, Measured: 2},
+			{Source: "b", Gate: "graph", Limit: "module_count", Maximum: 1, Measured: 3},
+			{Source: "c", Gate: "graph", Limit: "module_count", Maximum: 1, Measured: 4},
+		},
+	}
+	response, err := WriteResult(
+		t.Context(),
+		filepath.Join(moduleRoot, "response.json"),
+		filepath.Join(moduleRoot, "manifest.json"),
+		moduleRoot,
+		nil,
+		&result,
+		2,
+	)
+	require.NoError(t, err)
+	require.Equal(t, StatusIncomplete, response.Status)
+	require.Len(t, response.Termination.BudgetEvents, 2)
+	require.Equal(t, 1, response.Termination.OmittedBudgetEvents)
+}

--- a/pkg/parser/terraform/modules/moduleprepare/staged.go
+++ b/pkg/parser/terraform/modules/moduleprepare/staged.go
@@ -1,0 +1,381 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package moduleprepare
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+)
+
+const (
+	StagedKindArchive   = "archive"
+	StagedKindDirectory = "directory"
+
+	maxStagedInputBytes = 16 * 1024 * 1024
+)
+
+type StagedModules struct {
+	SchemaVersion int            `json:"schema_version"`
+	Modules       []StagedModule `json:"modules"`
+}
+
+type StagedModule struct {
+	RequestID        string                         `json:"request_id"`
+	Source           string                         `json:"source"`
+	RequestedVersion string                         `json:"requested_version,omitempty"`
+	ResolvedVersion  string                         `json:"resolved_version,omitempty"`
+	ResolvedRef      string                         `json:"resolved_ref,omitempty"`
+	CanonicalSource  string                         `json:"canonical_source,omitempty"`
+	Kind             string                         `json:"kind"`
+	ArtifactPath     string                         `json:"artifact_path,omitempty"`
+	ArchiveFormat    string                         `json:"archive_format,omitempty"`
+	TransportDigest  string                         `json:"transport_digest,omitempty"`
+	PackagePath      string                         `json:"package_path,omitempty"`
+	Declarations     []resolver.ManifestDeclaration `json:"declarations"`
+}
+
+func WriteStagedManifest(
+	ctx context.Context,
+	inputPath string,
+	outputPath string,
+	moduleRoot string,
+	limits resolver.ResourceLimits,
+) error {
+	input, err := readStagedModules(inputPath)
+	if err != nil {
+		return err
+	}
+	root, err := filepath.Abs(moduleRoot)
+	if err != nil {
+		return fmt.Errorf("resolving module root: %w", err)
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return fmt.Errorf("resolving module root: %w", err)
+	}
+	entries, err := materializeStagedModules(ctx, root, input.Modules, limits)
+	if err != nil {
+		return err
+	}
+	return resolver.WriteManifest(ctx, outputPath, root, entries)
+}
+
+func readStagedModules(path string) (StagedModules, error) {
+	file, err := os.Open(path) //nolint:gosec
+	if err != nil {
+		return StagedModules{}, fmt.Errorf("reading staged modules: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	data, err := io.ReadAll(io.LimitReader(file, maxStagedInputBytes+1))
+	if err != nil {
+		return StagedModules{}, fmt.Errorf("reading staged modules: %w", err)
+	}
+	if len(data) > maxStagedInputBytes {
+		return StagedModules{}, fmt.Errorf("staged modules exceeds %d bytes", maxStagedInputBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var input StagedModules
+	if err := decoder.Decode(&input); err != nil {
+		return StagedModules{}, fmt.Errorf("parsing staged modules: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return StagedModules{}, fmt.Errorf("parsing staged modules: trailing JSON content")
+	}
+	if input.SchemaVersion != ResponseSchemaVersion {
+		return StagedModules{}, fmt.Errorf("unsupported staged modules schema_version %d", input.SchemaVersion)
+	}
+	if input.Modules == nil {
+		return StagedModules{}, fmt.Errorf("staged modules must contain a modules array")
+	}
+	return input, nil
+}
+
+func materializeStagedModules(
+	ctx context.Context,
+	root string,
+	modules []StagedModule,
+	limits resolver.ResourceLimits,
+) ([]resolver.ManifestModule, error) {
+	entries := make([]resolver.ManifestModule, 0, len(modules))
+	seen := make(map[string]bool, len(modules))
+	for index := range modules {
+		staged := &modules[index]
+		staged.RequestID = strings.TrimSpace(staged.RequestID)
+		staged.Source = strings.TrimSpace(staged.Source)
+		if staged.RequestID == "" {
+			return nil, fmt.Errorf("modules[%d].request_id is required", index)
+		}
+		if seen[staged.RequestID] {
+			return nil, fmt.Errorf("modules[%d].request_id %q is duplicated", index, staged.RequestID)
+		}
+		seen[staged.RequestID] = true
+		if staged.Source == "" {
+			return nil, fmt.Errorf("modules[%d].source is required", index)
+		}
+		packageRoot, err := materializeStagedModule(ctx, root, staged, limits)
+		if err != nil {
+			return nil, fmt.Errorf("modules[%d]: %w", index, err)
+		}
+		if err := validateStagedPackage(ctx, packageRoot, limits); err != nil {
+			return nil, fmt.Errorf("modules[%d].package: %w", index, err)
+		}
+		contentDigest, err := resolver.ComputePackageDigest(ctx, packageRoot)
+		if err != nil {
+			return nil, fmt.Errorf("modules[%d].content_digest: %w", index, err)
+		}
+		descriptor := resolver.DescribeModuleSource(staged.Source, staged.RequestedVersion)
+		localPath := packageRoot
+		if descriptor.Subdirectory != "" {
+			localPath = filepath.Join(packageRoot, filepath.FromSlash(descriptor.Subdirectory))
+		}
+		if _, err := resolver.ResolvePathWithinRoot(ctx, packageRoot, localPath); err != nil {
+			return nil, fmt.Errorf("modules[%d].subdirectory: %w", index, err)
+		}
+		relativePackageRoot, err := relativePathWithinRoot(ctx, root, packageRoot)
+		if err != nil {
+			return nil, fmt.Errorf("modules[%d].package: %w", index, err)
+		}
+		relativeLocalPath, err := relativePathWithinRoot(ctx, root, localPath)
+		if err != nil {
+			return nil, fmt.Errorf("modules[%d].subdirectory: %w", index, err)
+		}
+		entries = append(entries, resolver.ManifestModule{
+			RequestID:        staged.RequestID,
+			AcquisitionKey:   resolver.ModuleAcquisitionKey(staged.Source, staged.RequestedVersion),
+			Source:           staged.Source,
+			NormalizedSource: descriptor.NormalizedSource,
+			CanonicalSource:  staged.CanonicalSource,
+			SourceType:       descriptor.SourceType,
+			SourceCategory:   descriptor.SourceCategory,
+			RegistryScope:    descriptor.RegistryScope,
+			RequestedVersion: descriptor.RequestedVersion,
+			RequestedRef:     descriptor.RequestedRef,
+			Subdirectory:     descriptor.Subdirectory,
+			ResolvedVersion:  strings.TrimSpace(staged.ResolvedVersion),
+			ResolvedRef:      strings.TrimSpace(staged.ResolvedRef),
+			ContentDigest:    contentDigest,
+			PackageRoot:      relativePackageRoot,
+			LocalPath:        relativeLocalPath,
+			Status:           resolver.ManifestStatusResolved,
+			Declarations:     staged.Declarations,
+		})
+	}
+	return entries, nil
+}
+
+func materializeStagedModule(
+	ctx context.Context,
+	root string,
+	staged *StagedModule,
+	limits resolver.ResourceLimits,
+) (string, error) {
+	switch staged.Kind {
+	case StagedKindDirectory:
+		if staged.ArtifactPath != "" || staged.ArchiveFormat != "" || staged.TransportDigest != "" {
+			return "", fmt.Errorf("directory staging accepts package_path only")
+		}
+		return stagedPath(ctx, root, staged.PackagePath)
+	case StagedKindArchive:
+		if staged.PackagePath != "" {
+			return "", fmt.Errorf("archive staging does not accept package_path")
+		}
+		return materializeArchive(ctx, root, staged, limits)
+	default:
+		return "", fmt.Errorf("kind must be %q or %q", StagedKindArchive, StagedKindDirectory)
+	}
+}
+
+func materializeArchive(
+	ctx context.Context,
+	root string,
+	staged *StagedModule,
+	limits resolver.ResourceLimits,
+) (string, error) {
+	artifactPath, err := stagedFilePath(ctx, root, staged.ArtifactPath)
+	if err != nil {
+		return "", fmt.Errorf("artifact_path: %w", err)
+	}
+	rawDigest, err := verifyTransportDigest(ctx, artifactPath, staged.TransportDigest, limits.MaxPackageBytes)
+	if err != nil {
+		return "", err
+	}
+	packagesRoot := filepath.Join(root, "packages")
+	if err := os.MkdirAll(packagesRoot, privateDirectoryMode); err != nil {
+		return "", fmt.Errorf("creating staged packages root: %w", err)
+	}
+	destination := filepath.Join(packagesRoot, strings.TrimPrefix(rawDigest, "sha256:"))
+	if info, statErr := os.Stat(destination); statErr == nil && info.IsDir() {
+		return normalizedPackageRoot(destination)
+	}
+	temp, err := os.MkdirTemp(packagesRoot, ".extract-")
+	if err != nil {
+		return "", fmt.Errorf("creating staged package directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(temp) }()
+	if err := resolver.ExtractModuleArchive(ctx, artifactPath, temp, staged.ArchiveFormat, limits); err != nil {
+		return "", fmt.Errorf("extracting module archive: %w", err)
+	}
+	relativePackageRoot, err := normalizedPackageRootRelative(temp)
+	if err != nil {
+		return "", err
+	}
+	if err := os.Rename(temp, destination); err != nil {
+		if info, statErr := os.Stat(destination); statErr != nil || !info.IsDir() {
+			return "", fmt.Errorf("publishing staged package: %w", err)
+		}
+		return normalizedPackageRoot(destination)
+	}
+	return filepath.Join(destination, relativePackageRoot), nil
+}
+
+func verifyTransportDigest(
+	ctx context.Context,
+	path string,
+	expected string,
+	maximumBytes int64,
+) (string, error) {
+	expected = strings.ToLower(strings.TrimSpace(expected))
+	if !strings.HasPrefix(expected, "sha256:") {
+		return "", fmt.Errorf("transport_digest must use sha256")
+	}
+	rawHex := strings.TrimPrefix(expected, "sha256:")
+	if len(rawHex) != sha256.Size*2 {
+		return "", fmt.Errorf("transport_digest must contain a SHA-256 digest")
+	}
+	if _, err := hex.DecodeString(rawHex); err != nil {
+		return "", fmt.Errorf("transport_digest must contain a SHA-256 digest")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("reading staged archive: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("staged archive must be a regular file")
+	}
+	if maximumBytes > 0 && info.Size() > maximumBytes {
+		return "", &resolver.BudgetExceededError{
+			Gate:     "staging",
+			Limit:    "archive_bytes",
+			Maximum:  maximumBytes,
+			Measured: info.Size(),
+		}
+	}
+	file, err := os.Open(path) //nolint:gosec
+	if err != nil {
+		return "", fmt.Errorf("opening staged archive: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, &contextReader{ctx: ctx, reader: file}); err != nil {
+		return "", fmt.Errorf("hashing staged archive: %w", err)
+	}
+	actual := "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+	if actual != expected {
+		return "", fmt.Errorf("transport_digest mismatch: got %q, computed %q", expected, actual)
+	}
+	return actual, nil
+}
+
+func stagedPath(ctx context.Context, root, relative string) (string, error) {
+	if relative == "" || !filepath.IsLocal(relative) {
+		return "", fmt.Errorf("must be a non-empty relative path")
+	}
+	path := filepath.Join(root, filepath.FromSlash(relative))
+	if _, err := resolver.ResolvePathWithinRoot(ctx, root, path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func stagedFilePath(ctx context.Context, root, relative string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if relative == "" || !filepath.IsLocal(relative) {
+		return "", fmt.Errorf("must be a non-empty relative path")
+	}
+	path, err := filepath.EvalSymlinks(filepath.Join(root, filepath.FromSlash(relative)))
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil || !filepath.IsLocal(rel) {
+		return "", fmt.Errorf("path escapes module root")
+	}
+	return path, nil
+}
+
+func normalizedPackageRoot(root string) (string, error) {
+	relative, err := normalizedPackageRootRelative(root)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, relative), nil
+}
+
+func normalizedPackageRootRelative(root string) (string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return "", fmt.Errorf("reading extracted module: %w", err)
+	}
+	if len(entries) == 0 {
+		return "", fmt.Errorf("module archive is empty")
+	}
+	if len(entries) == 1 && entries[0].IsDir() {
+		return entries[0].Name(), nil
+	}
+	return ".", nil
+}
+
+func validateStagedPackage(ctx context.Context, root string, limits resolver.ResourceLimits) error {
+	counter := resolver.NewResourceBudget(limits).NewPackageCounter()
+	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if filepath.Clean(path) == filepath.Clean(root) {
+				return nil
+			}
+			return counter.AddEntry(0)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("package entry %q is not a regular file", path)
+		}
+		return counter.AddEntry(info.Size())
+	})
+}
+
+type contextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r *contextReader) Read(buffer []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(buffer)
+}

--- a/pkg/parser/terraform/modules/moduleprepare/staged_test.go
+++ b/pkg/parser/terraform/modules/moduleprepare/staged_test.go
@@ -1,0 +1,262 @@
+package moduleprepare
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteStagedManifestExtractsAndVerifiesArchive(t *testing.T) {
+	moduleRoot := t.TempDir()
+	archivePath := filepath.Join(moduleRoot, "incoming", "module.zip")
+	writeZip(t, archivePath, map[string]string{
+		"module-commit/modules/vpc/main.tf": `resource "test" "vpc" {}`,
+	})
+	digest := fileSHA256(t, archivePath)
+	caller := filepath.Join(t.TempDir(), "main.tf")
+	source := "git::https://github.com/acme/module.git//modules/vpc?ref=v1"
+	requestID := resolver.ModuleCallID(caller, 1, 3, "vpc", source, "")
+	inputPath := writeStagedInput(t, moduleRoot, StagedModules{
+		SchemaVersion: ResponseSchemaVersion,
+		Modules: []StagedModule{{
+			RequestID:       requestID,
+			Source:          source,
+			ResolvedRef:     "0123456789012345678901234567890123456789",
+			Kind:            StagedKindArchive,
+			ArtifactPath:    "incoming/module.zip",
+			ArchiveFormat:   "zip",
+			TransportDigest: digest,
+			Declarations: []resolver.ManifestDeclaration{{
+				Filename:   "main.tf",
+				LineStart:  1,
+				LineEnd:    3,
+				ModuleName: "vpc",
+			}},
+		}},
+	})
+	manifestPath := filepath.Join(moduleRoot, "staged.json")
+
+	err := WriteStagedManifest(t.Context(), inputPath, manifestPath, moduleRoot, testLimits())
+	require.NoError(t, err)
+	manifest, err := resolver.LoadManifest(t.Context(), manifestPath)
+	require.NoError(t, err)
+	resolution, err := resolver.NewPrefetchedResolver(manifest).Resolve(
+		t.Context(),
+		&tfmodules.ParsedModule{
+			FileName:   caller,
+			DefLine:    1,
+			DefEndLine: 3,
+			Name:       "vpc",
+			Source:     source,
+		},
+	)
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(resolution.LocalPath, "main.tf"))
+	require.Equal(t, "0123456789012345678901234567890123456789", resolution.ResolvedRef)
+}
+
+func TestWriteStagedManifestRejectsTransportDigestMismatch(t *testing.T) {
+	moduleRoot := t.TempDir()
+	archivePath := filepath.Join(moduleRoot, "module.zip")
+	writeZip(t, archivePath, map[string]string{"main.tf": "resource"})
+	inputPath := writeStagedInput(t, moduleRoot, StagedModules{
+		SchemaVersion: ResponseSchemaVersion,
+		Modules: []StagedModule{{
+			RequestID:       "request",
+			Source:          "terraform-aws-modules/vpc/aws",
+			Kind:            StagedKindArchive,
+			ArtifactPath:    "module.zip",
+			ArchiveFormat:   "zip",
+			TransportDigest: "sha256:" + strings.Repeat("0", 64),
+			Declarations: []resolver.ManifestDeclaration{{
+				Filename:   "main.tf",
+				LineStart:  1,
+				LineEnd:    3,
+				ModuleName: "vpc",
+			}},
+		}},
+	})
+
+	err := WriteStagedManifest(
+		t.Context(),
+		inputPath,
+		filepath.Join(moduleRoot, "manifest.json"),
+		moduleRoot,
+		testLimits(),
+	)
+	require.ErrorContains(t, err, "transport_digest mismatch")
+}
+
+func TestWriteStagedManifestPreservesDuplicateUnversionedCalls(t *testing.T) {
+	moduleRoot := t.TempDir()
+	packagePath := filepath.Join(moduleRoot, "packages", "shared")
+	require.NoError(t, os.MkdirAll(packagePath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(packagePath, "main.tf"), []byte("resource"), 0o600))
+	source := "terraform-aws-modules/vpc/aws"
+	first := &tfmodules.ParsedModule{
+		FileName:   filepath.Join("/workspace", "a", "main.tf"),
+		DefLine:    1,
+		DefEndLine: 3,
+		Name:       "vpc_a",
+		Source:     source,
+	}
+	second := &tfmodules.ParsedModule{
+		FileName:   filepath.Join("/workspace", "b", "main.tf"),
+		DefLine:    1,
+		DefEndLine: 3,
+		Name:       "vpc_b",
+		Source:     source,
+	}
+	inputPath := writeStagedInput(t, moduleRoot, StagedModules{
+		SchemaVersion: ResponseSchemaVersion,
+		Modules: []StagedModule{
+			stagedDirectory(first, "packages/shared"),
+			stagedDirectory(second, "packages/shared"),
+		},
+	})
+	manifestPath := filepath.Join(moduleRoot, "manifest.json")
+
+	require.NoError(t, WriteStagedManifest(
+		t.Context(),
+		inputPath,
+		manifestPath,
+		moduleRoot,
+		testLimits(),
+	))
+	manifest, err := resolver.LoadManifest(t.Context(), manifestPath)
+	require.NoError(t, err)
+	require.Len(t, manifest.Modules, 2)
+	for _, module := range []*tfmodules.ParsedModule{first, second} {
+		_, err := resolver.NewPrefetchedResolver(manifest).Resolve(t.Context(), module)
+		require.NoError(t, err)
+	}
+}
+
+func TestWriteStagedManifestEnforcesFileLimitForDirectory(t *testing.T) {
+	moduleRoot := t.TempDir()
+	packagePath := filepath.Join(moduleRoot, "package")
+	require.NoError(t, os.MkdirAll(packagePath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(packagePath, "main.tf"), []byte("content"), 0o600))
+	module := &tfmodules.ParsedModule{
+		FileName:   filepath.Join("/workspace", "main.tf"),
+		DefLine:    1,
+		DefEndLine: 3,
+		Name:       "vpc",
+		Source:     "terraform-aws-modules/vpc/aws",
+	}
+	inputPath := writeStagedInput(t, moduleRoot, StagedModules{
+		SchemaVersion: ResponseSchemaVersion,
+		Modules:       []StagedModule{stagedDirectory(module, "package")},
+	})
+	limits := testLimits()
+	limits.MaxFileBytes = 3
+
+	err := WriteStagedManifest(
+		t.Context(),
+		inputPath,
+		filepath.Join(moduleRoot, "manifest.json"),
+		moduleRoot,
+		limits,
+	)
+	var budgetErr *resolver.BudgetExceededError
+	require.ErrorAs(t, err, &budgetErr)
+	require.Equal(t, "file_bytes", budgetErr.Limit)
+}
+
+func TestWriteStagedManifestRejectsArchiveEscape(t *testing.T) {
+	moduleRoot := t.TempDir()
+	archivePath := filepath.Join(moduleRoot, "module.zip")
+	writeZip(t, archivePath, map[string]string{"../outside.tf": "content"})
+	inputPath := writeStagedInput(t, moduleRoot, StagedModules{
+		SchemaVersion: ResponseSchemaVersion,
+		Modules: []StagedModule{{
+			RequestID:       "request",
+			Source:          "terraform-aws-modules/vpc/aws",
+			Kind:            StagedKindArchive,
+			ArtifactPath:    "module.zip",
+			ArchiveFormat:   "zip",
+			TransportDigest: fileSHA256(t, archivePath),
+			Declarations: []resolver.ManifestDeclaration{{
+				Filename:   "main.tf",
+				LineStart:  1,
+				LineEnd:    3,
+				ModuleName: "vpc",
+			}},
+		}},
+	})
+
+	err := WriteStagedManifest(
+		t.Context(),
+		inputPath,
+		filepath.Join(moduleRoot, "manifest.json"),
+		moduleRoot,
+		testLimits(),
+	)
+	require.ErrorContains(t, err, "not a local path")
+	require.NoFileExists(t, filepath.Join(filepath.Dir(moduleRoot), "outside.tf"))
+}
+
+func stagedDirectory(module *tfmodules.ParsedModule, packagePath string) StagedModule {
+	return StagedModule{
+		RequestID:   resolver.ParsedModuleCallID(module),
+		Source:      module.Source,
+		Kind:        StagedKindDirectory,
+		PackagePath: packagePath,
+		Declarations: []resolver.ManifestDeclaration{{
+			Filename:   filepath.Base(module.FileName),
+			LineStart:  module.DefLine,
+			LineEnd:    module.DefEndLine,
+			ModuleName: module.Name,
+		}},
+	}
+}
+
+func testLimits() resolver.ResourceLimits {
+	return resolver.ResourceLimits{
+		MaxPackageBytes: 1024 * 1024,
+		MaxFileBytes:    1024 * 1024,
+		MaxPackageFiles: 100,
+	}
+}
+
+func writeStagedInput(t *testing.T, root string, input StagedModules) string {
+	t.Helper()
+	data, err := json.Marshal(input)
+	require.NoError(t, err)
+	path := filepath.Join(root, "staged-input.json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func writeZip(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	writer := zip.NewWriter(file)
+	for name, content := range files {
+		entry, err := writer.Create(name)
+		require.NoError(t, err)
+		_, err = entry.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close())
+	require.NoError(t, file.Close())
+}
+
+func fileSHA256(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/pkg/parser/terraform/modules/resolver/gogetter.go
+++ b/pkg/parser/terraform/modules/resolver/gogetter.go
@@ -632,7 +632,7 @@ func validateGetterSourceTransport(source string) error {
 	switch scheme {
 	case httpScheme, httpsScheme, "file":
 		return nil
-	case "ssh", "git", "s3", "gcs", "hg":
+	case "ssh", sourceTypeGit, "s3", "gcs", "hg":
 		return &tfmodules.UnresolvedError{
 			Reason: fmt.Sprintf("module transport %q is disabled because destination policy cannot be enforced", scheme),
 		}

--- a/pkg/parser/terraform/modules/resolver/manifest_write.go
+++ b/pkg/parser/terraform/modules/resolver/manifest_write.go
@@ -95,7 +95,7 @@ func encodeManifest(relativeRoot string, entries []ManifestModule) ([]byte, erro
 		if a.RequestedVersion != b.RequestedVersion {
 			return a.RequestedVersion < b.RequestedVersion
 		}
-		return a.ID < b.ID
+		return a.RequestID < b.RequestID
 	})
 
 	data, err := json.MarshalIndent(struct {

--- a/pkg/parser/terraform/modules/resolver/manifest_write.go
+++ b/pkg/parser/terraform/modules/resolver/manifest_write.go
@@ -1,0 +1,141 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+const (
+	manifestDirectoryMode = 0o750
+	manifestFileMode      = 0o600
+)
+
+// WriteManifest writes and validates a versioned module manifest atomically.
+func WriteManifest(ctx context.Context, path, root string, entries []ManifestModule) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	manifestPath, manifestDir, relativeRoot, err := resolveManifestWritePaths(path, root)
+	if err != nil {
+		return err
+	}
+	data, err := encodeManifest(relativeRoot, entries)
+	if err != nil {
+		return err
+	}
+	return writeValidatedManifest(ctx, manifestPath, manifestDir, data)
+}
+
+func resolveManifestWritePaths(
+	path, root string,
+) (manifestPath, manifestDir, relativeRoot string, err error) {
+	manifestPath, err = filepath.Abs(path)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolving manifest path: %w", err)
+	}
+	manifestDir = filepath.Dir(manifestPath)
+	if err := os.MkdirAll(manifestDir, manifestDirectoryMode); err != nil {
+		return "", "", "", fmt.Errorf("creating manifest directory: %w", err)
+	}
+	resolvedManifestDir, err := filepath.EvalSymlinks(manifestDir)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolving manifest directory: %w", err)
+	}
+	moduleRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolving module root: %w", err)
+	}
+	moduleRoot, err = filepath.EvalSymlinks(moduleRoot)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolving module root: %w", err)
+	}
+	relativeRoot, err = filepath.Rel(resolvedManifestDir, moduleRoot)
+	if err != nil || !filepath.IsLocal(relativeRoot) {
+		return "", "", "", fmt.Errorf(
+			"module root %q must be relative to manifest directory %q",
+			moduleRoot,
+			resolvedManifestDir,
+		)
+	}
+	return manifestPath, manifestDir, relativeRoot, nil
+}
+
+func encodeManifest(relativeRoot string, entries []ManifestModule) ([]byte, error) {
+	sortedEntries := append([]ManifestModule(nil), entries...)
+	for i := range sortedEntries {
+		sortedEntries[i].Declarations = append([]ManifestDeclaration(nil), sortedEntries[i].Declarations...)
+		sort.Slice(sortedEntries[i].Declarations, func(left, right int) bool {
+			a, b := sortedEntries[i].Declarations[left], sortedEntries[i].Declarations[right]
+			if a.CallerModule != b.CallerModule {
+				return a.CallerModule < b.CallerModule
+			}
+			if a.Filename != b.Filename {
+				return a.Filename < b.Filename
+			}
+			if a.LineStart != b.LineStart {
+				return a.LineStart < b.LineStart
+			}
+			return a.ModuleName < b.ModuleName
+		})
+	}
+	sort.Slice(sortedEntries, func(left, right int) bool {
+		a, b := sortedEntries[left], sortedEntries[right]
+		if a.Source != b.Source {
+			return a.Source < b.Source
+		}
+		if a.RequestedVersion != b.RequestedVersion {
+			return a.RequestedVersion < b.RequestedVersion
+		}
+		return a.ID < b.ID
+	})
+
+	data, err := json.MarshalIndent(struct {
+		SchemaVersion int              `json:"schema_version"`
+		Root          string           `json:"root"`
+		Modules       []ManifestModule `json:"modules"`
+	}{
+		SchemaVersion: ManifestSchemaVersion,
+		Root:          filepath.ToSlash(relativeRoot),
+		Modules:       sortedEntries,
+	}, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encoding manifest: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func writeValidatedManifest(ctx context.Context, manifestPath, manifestDir string, data []byte) error {
+	temp, err := os.CreateTemp(manifestDir, ".modules-*.json")
+	if err != nil {
+		return fmt.Errorf("creating temporary manifest: %w", err)
+	}
+	tempPath := temp.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+	if err := temp.Chmod(manifestFileMode); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("setting manifest permissions: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("writing temporary manifest: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("closing temporary manifest: %w", err)
+	}
+	if _, err := LoadManifest(ctx, tempPath); err != nil {
+		return fmt.Errorf("validating generated manifest: %w", err)
+	}
+	if err := os.Rename(tempPath, manifestPath); err != nil {
+		return fmt.Errorf("replacing manifest: %w", err)
+	}
+	return nil
+}

--- a/pkg/parser/terraform/modules/resolver/module_identity.go
+++ b/pkg/parser/terraform/modules/resolver/module_identity.go
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+)
+
+func ModuleCallID(
+	callerFile string,
+	lineStart int,
+	lineEnd int,
+	moduleName string,
+	source string,
+	version string,
+) string {
+	return digestIdentity(
+		filepath.Clean(callerFile),
+		fmt.Sprint(lineStart),
+		fmt.Sprint(lineEnd),
+		strings.TrimSpace(moduleName),
+		strings.TrimSpace(source),
+		strings.TrimSpace(version),
+	)
+}
+
+func ParsedModuleCallID(module *tfmodules.ParsedModule) string {
+	if module == nil {
+		return ""
+	}
+	return ModuleCallID(
+		module.FileName,
+		module.DefLine,
+		module.DefEndLine,
+		module.Name,
+		module.Source,
+		module.Version,
+	)
+}
+
+func ModuleAcquisitionKey(source, version string) string {
+	descriptor := DescribeModuleSource(source, version)
+	identitySource := descriptor.NormalizedSource
+	if descriptor.SourceType != sourceTypeRegistry && descriptor.SourceType != sourceTypeGit {
+		identitySource = strings.TrimSpace(source)
+	}
+	return digestIdentity(
+		descriptor.SourceType,
+		identitySource,
+		descriptor.RequestedVersion,
+		descriptor.RequestedRef,
+	)
+}
+
+func digestIdentity(values ...string) string {
+	hasher := sha256.New()
+	for _, value := range values {
+		_, _ = hasher.Write([]byte(value))
+		_, _ = hasher.Write([]byte{0})
+	}
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+}

--- a/pkg/parser/terraform/modules/resolver/module_identity.go
+++ b/pkg/parser/terraform/modules/resolver/module_identity.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -28,7 +29,7 @@ func ModuleCallID(
 		fmt.Sprint(lineStart),
 		fmt.Sprint(lineEnd),
 		strings.TrimSpace(moduleName),
-		strings.TrimSpace(source),
+		redactSourceCredentials(source),
 		strings.TrimSpace(version),
 	)
 }
@@ -68,4 +69,26 @@ func digestIdentity(values ...string) string {
 		_, _ = hasher.Write([]byte{0})
 	}
 	return "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+}
+
+// redactSourceCredentials strips embedded userinfo from git-getter source strings.
+func redactSourceCredentials(source string) string {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return ""
+	}
+	// Strip "scheme::" getter prefix so the underlying URL can be parsed.
+	stripped := source
+	if idx := strings.Index(source, "::"); idx >= 0 {
+		stripped = source[idx+2:]
+	}
+	u, err := url.Parse(stripped)
+	if err != nil || u.User == nil {
+		return source
+	}
+	u.User = nil
+	if idx := strings.Index(source, "::"); idx >= 0 {
+		return source[:idx+2] + u.String()
+	}
+	return u.String()
 }

--- a/pkg/parser/terraform/modules/resolver/module_identity_test.go
+++ b/pkg/parser/terraform/modules/resolver/module_identity_test.go
@@ -31,3 +31,22 @@ func TestModuleIdentitiesSeparateCallsAndDeduplicateAcquisition(t *testing.T) {
 		ModuleAcquisitionKey(second.Source, second.Version),
 	)
 }
+
+func TestModuleCallIDStripsCredentials(t *testing.T) {
+	withCredentials := &tfmodules.ParsedModule{
+		FileName:   filepath.Join("/repo", "main.tf"),
+		DefLine:    1,
+		DefEndLine: 3,
+		Name:       "vpc",
+		Source:     "git::https://token:secret@github.com/acme/network.git?ref=v1",
+	}
+	withoutCredentials := &tfmodules.ParsedModule{
+		FileName:   withCredentials.FileName,
+		DefLine:    withCredentials.DefLine,
+		DefEndLine: withCredentials.DefEndLine,
+		Name:       withCredentials.Name,
+		Source:     "git::https://github.com/acme/network.git?ref=v1",
+	}
+
+	require.Equal(t, ParsedModuleCallID(withCredentials), ParsedModuleCallID(withoutCredentials))
+}

--- a/pkg/parser/terraform/modules/resolver/module_identity_test.go
+++ b/pkg/parser/terraform/modules/resolver/module_identity_test.go
@@ -1,0 +1,33 @@
+package resolver
+
+import (
+	"path/filepath"
+	"testing"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModuleIdentitiesSeparateCallsAndDeduplicateAcquisition(t *testing.T) {
+	first := &tfmodules.ParsedModule{
+		FileName:   filepath.Join("/repo", "a", "main.tf"),
+		DefLine:    1,
+		DefEndLine: 3,
+		Name:       "vpc_a",
+		Source:     "git::https://github.com/acme/network.git//modules/a?ref=v1",
+	}
+	second := &tfmodules.ParsedModule{
+		FileName:   filepath.Join("/repo", "b", "main.tf"),
+		DefLine:    1,
+		DefEndLine: 3,
+		Name:       "vpc_b",
+		Source:     "git::https://github.com/acme/network.git//modules/b?ref=v1",
+	}
+
+	require.NotEqual(t, ParsedModuleCallID(first), ParsedModuleCallID(second))
+	require.Equal(
+		t,
+		ModuleAcquisitionKey(first.Source, first.Version),
+		ModuleAcquisitionKey(second.Source, second.Version),
+	)
+}

--- a/pkg/parser/terraform/modules/resolver/prefetched.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched.go
@@ -401,7 +401,7 @@ func (r *PrefetchedResolver) validateEntry(mod *tfmodules.ParsedModule, entry *M
 		return &tfmodules.UnresolvedError{Reason: entry.Failure}
 	}
 	if r.manifest.SchemaVersion == ManifestSchemaVersion &&
-		strings.TrimSpace(entry.Source) != strings.TrimSpace(mod.Source) {
+		strings.TrimSpace(entry.Source) != redactSourceCredentials(mod.Source) {
 		return &tfmodules.UnresolvedError{
 			Reason: fmt.Sprintf("module %q not found in manifest", mod.Source),
 		}

--- a/pkg/parser/terraform/modules/resolver/prefetched.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched.go
@@ -23,6 +23,7 @@ const (
 )
 
 type ManifestEntry struct {
+	Source           string `json:"source,omitempty"`
 	LocalPath        string `json:"local_path"`
 	PackageRoot      string `json:"package_root,omitempty"`
 	Version          string `json:"version,omitempty"`
@@ -43,7 +44,8 @@ type Manifest struct {
 }
 
 type ManifestModule struct {
-	ID               string                `json:"id,omitempty"`
+	RequestID        string                `json:"request_id,omitempty"`
+	AcquisitionKey   string                `json:"acquisition_key,omitempty"`
 	Source           string                `json:"source"`
 	NormalizedSource string                `json:"normalized_source,omitempty"`
 	CanonicalSource  string                `json:"canonical_source,omitempty"`
@@ -58,7 +60,6 @@ type ManifestModule struct {
 	ContentDigest    string                `json:"content_digest,omitempty"`
 	PackageRoot      string                `json:"package_root,omitempty"`
 	LocalPath        string                `json:"local_path,omitempty"`
-	StagingRoute     string                `json:"staging_route,omitempty"`
 	Status           string                `json:"status"`
 	Failure          string                `json:"failure,omitempty"`
 	Declarations     []ManifestDeclaration `json:"declarations"`
@@ -172,11 +173,15 @@ func (m *Manifest) addV1Entry(ctx context.Context, module *ManifestModule) error
 	if err := validateManifestDeclarations(module.Declarations); err != nil {
 		return err
 	}
-	key := manifestModuleKey(module.Source, strings.TrimSpace(module.RequestedVersion))
+	key := strings.TrimSpace(module.RequestID)
+	if key == "" {
+		key = manifestModuleKey(module.Source, strings.TrimSpace(module.RequestedVersion))
+	}
 	if _, exists := m.Modules[key]; exists {
 		return fmt.Errorf("duplicate module %q", key)
 	}
 	entry := ManifestEntry{
+		Source:           module.Source,
 		RequestedVersion: strings.TrimSpace(module.RequestedVersion),
 		ResolvedVersion:  strings.TrimSpace(module.ResolvedVersion),
 		ResolvedRef:      strings.TrimSpace(module.ResolvedRef),
@@ -316,22 +321,14 @@ func (r *PrefetchedResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedM
 	if mod.IsLocal {
 		return Resolution{}, &tfmodules.UnresolvedError{Reason: "local modules are handled by LocalResolver"}
 	}
-	entry, ok := r.manifest.Modules[manifestModuleKey(mod.Source, mod.Version)]
-	if !ok {
-		entry, ok = r.manifest.Modules[mod.Source]
-	}
+	entry, ok := r.entryForModule(mod)
 	if !ok {
 		return Resolution{}, &tfmodules.UnresolvedError{
 			Reason: fmt.Sprintf("module %q not found in manifest", mod.Source),
 		}
 	}
-	if entry.Status == ManifestStatusUnresolved {
-		return Resolution{}, &tfmodules.UnresolvedError{Reason: entry.Failure}
-	}
-	if entry.RequestedVersion != "" && mod.Version != "" && entry.RequestedVersion != mod.Version {
-		return Resolution{}, &tfmodules.UnresolvedError{
-			Reason: fmt.Sprintf("module %q version %q not found in manifest", mod.Source, mod.Version),
-		}
+	if err := r.validateEntry(mod, &entry); err != nil {
+		return Resolution{}, err
 	}
 	return ConfineResolution(ctx, Resolution{
 		LocalPath:       entry.LocalPath,
@@ -339,6 +336,89 @@ func (r *PrefetchedResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedM
 		ResolvedVersion: firstNonEmpty(entry.ResolvedVersion, entry.Version),
 		ResolvedRef:     entry.ResolvedRef,
 	})
+}
+
+func (r *PrefetchedResolver) entryForModule(mod *tfmodules.ParsedModule) (ManifestEntry, bool) {
+	var entry ManifestEntry
+	var ok bool
+	if r.manifest.SchemaVersion == ManifestSchemaVersion {
+		entry, ok = r.manifest.Modules[ParsedModuleCallID(mod)]
+		if !ok {
+			entry, ok = r.portableV1Entry(mod)
+		}
+		if !ok {
+			entry, ok = r.manifest.Modules[manifestModuleKey(mod.Source, mod.Version)]
+		}
+	} else {
+		entry, ok = r.manifest.Modules[manifestModuleKey(mod.Source, mod.Version)]
+	}
+	if !ok && r.manifest.SchemaVersion != ManifestSchemaVersion {
+		entry, ok = r.manifest.Modules[mod.Source]
+	}
+	return entry, ok
+}
+
+func (r *PrefetchedResolver) portableV1Entry(mod *tfmodules.ParsedModule) (ManifestEntry, bool) {
+	var matched ManifestEntry
+	matchCount := 0
+	for index := range r.manifest.Entries {
+		module := &r.manifest.Entries[index]
+		if strings.TrimSpace(module.Source) != strings.TrimSpace(mod.Source) ||
+			strings.TrimSpace(module.RequestedVersion) != strings.TrimSpace(mod.Version) ||
+			!declarationMatchesModule(module.Declarations, mod) {
+			continue
+		}
+		key := strings.TrimSpace(module.RequestID)
+		if key == "" {
+			key = manifestModuleKey(module.Source, module.RequestedVersion)
+		}
+		entry, exists := r.manifest.Modules[key]
+		if !exists {
+			continue
+		}
+		matched = entry
+		matchCount++
+	}
+	return matched, matchCount == 1
+}
+
+func declarationMatchesModule(declarations []ManifestDeclaration, mod *tfmodules.ParsedModule) bool {
+	filename := filepath.ToSlash(filepath.Clean(mod.FileName))
+	for _, declaration := range declarations {
+		declarationPath := filepath.ToSlash(filepath.Clean(declaration.Filename))
+		if declaration.ModuleName == mod.Name &&
+			declaration.LineStart == mod.DefLine &&
+			declaration.LineEnd == mod.DefEndLine &&
+			(filename == declarationPath || strings.HasSuffix(filename, "/"+declarationPath)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *PrefetchedResolver) validateEntry(mod *tfmodules.ParsedModule, entry *ManifestEntry) error {
+	if entry.Status == ManifestStatusUnresolved {
+		return &tfmodules.UnresolvedError{Reason: entry.Failure}
+	}
+	if r.manifest.SchemaVersion == ManifestSchemaVersion &&
+		strings.TrimSpace(entry.Source) != strings.TrimSpace(mod.Source) {
+		return &tfmodules.UnresolvedError{
+			Reason: fmt.Sprintf("module %q not found in manifest", mod.Source),
+		}
+	}
+	if r.manifest.SchemaVersion == ManifestSchemaVersion &&
+		strings.TrimSpace(entry.RequestedVersion) != strings.TrimSpace(mod.Version) {
+		return &tfmodules.UnresolvedError{
+			Reason: fmt.Sprintf("module %q version %q not found in manifest", mod.Source, mod.Version),
+		}
+	}
+	if r.manifest.SchemaVersion != ManifestSchemaVersion &&
+		entry.RequestedVersion != "" && mod.Version != "" && entry.RequestedVersion != mod.Version {
+		return &tfmodules.UnresolvedError{
+			Reason: fmt.Sprintf("module %q version %q not found in manifest", mod.Source, mod.Version),
+		}
+	}
+	return nil
 }
 
 func firstNonEmpty(values ...string) string {

--- a/pkg/parser/terraform/modules/resolver/prefetched.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched.go
@@ -18,8 +18,8 @@ import (
 
 const (
 	ManifestSchemaVersion    = 1
-	manifestStatusResolved   = "resolved"
-	manifestStatusUnresolved = "unresolved"
+	ManifestStatusResolved   = "resolved"
+	ManifestStatusUnresolved = "unresolved"
 )
 
 type ManifestEntry struct {
@@ -45,25 +45,31 @@ type Manifest struct {
 type ManifestModule struct {
 	ID               string                `json:"id,omitempty"`
 	Source           string                `json:"source"`
+	NormalizedSource string                `json:"normalized_source,omitempty"`
 	CanonicalSource  string                `json:"canonical_source,omitempty"`
 	SourceType       string                `json:"source_type,omitempty"`
+	SourceCategory   string                `json:"source_category,omitempty"`
 	RegistryScope    string                `json:"registry_scope,omitempty"`
 	RequestedVersion string                `json:"requested_version,omitempty"`
+	RequestedRef     string                `json:"requested_ref,omitempty"`
+	Subdirectory     string                `json:"subdirectory,omitempty"`
 	ResolvedVersion  string                `json:"resolved_version,omitempty"`
 	ResolvedRef      string                `json:"resolved_ref,omitempty"`
 	ContentDigest    string                `json:"content_digest,omitempty"`
 	PackageRoot      string                `json:"package_root,omitempty"`
 	LocalPath        string                `json:"local_path,omitempty"`
+	StagingRoute     string                `json:"staging_route,omitempty"`
 	Status           string                `json:"status"`
 	Failure          string                `json:"failure,omitempty"`
 	Declarations     []ManifestDeclaration `json:"declarations"`
 }
 
 type ManifestDeclaration struct {
-	Filename   string `json:"filename"`
-	LineStart  int    `json:"line_start"`
-	LineEnd    int    `json:"line_end"`
-	ModuleName string `json:"module_name"`
+	Filename     string `json:"filename"`
+	LineStart    int    `json:"line_start"`
+	LineEnd      int    `json:"line_end"`
+	ModuleName   string `json:"module_name"`
+	CallerModule string `json:"caller_module,omitempty"`
 }
 
 type manifestEnvelope struct {
@@ -112,7 +118,7 @@ func loadLegacyManifest(envelope manifestEnvelope) (*Manifest, error) {
 		entry := modules[key]
 		entry.RequestedVersion = entry.Version
 		entry.ResolvedVersion = entry.Version
-		entry.Status = manifestStatusResolved
+		entry.Status = ManifestStatusResolved
 		modules[key] = entry
 	}
 	return &Manifest{Dir: envelope.Dir, Modules: modules}, nil
@@ -179,7 +185,7 @@ func (m *Manifest) addV1Entry(ctx context.Context, module *ManifestModule) error
 		Origin:           module.SourceType,
 	}
 	switch module.Status {
-	case manifestStatusResolved:
+	case ManifestStatusResolved:
 		if err := m.resolveV1Paths(ctx, module, &entry); err != nil {
 			return err
 		}
@@ -193,7 +199,7 @@ func (m *Manifest) addV1Entry(ctx context.Context, module *ManifestModule) error
 		if !strings.EqualFold(module.ContentDigest, digest) {
 			return fmt.Errorf("content_digest mismatch: got %q, computed %q", module.ContentDigest, digest)
 		}
-	case manifestStatusUnresolved:
+	case ManifestStatusUnresolved:
 		if strings.TrimSpace(module.Failure) == "" {
 			return fmt.Errorf("failure is required for an unresolved module")
 		}
@@ -253,7 +259,7 @@ func (m *Manifest) validate(ctx context.Context) error {
 	}
 	for src := range m.Modules {
 		entry := m.Modules[src]
-		if entry.Status == manifestStatusUnresolved {
+		if entry.Status == ManifestStatusUnresolved {
 			continue
 		}
 		if !filepath.IsAbs(entry.LocalPath) {
@@ -319,7 +325,7 @@ func (r *PrefetchedResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedM
 			Reason: fmt.Sprintf("module %q not found in manifest", mod.Source),
 		}
 	}
-	if entry.Status == manifestStatusUnresolved {
+	if entry.Status == ManifestStatusUnresolved {
 		return Resolution{}, &tfmodules.UnresolvedError{Reason: entry.Failure}
 	}
 	if entry.RequestedVersion != "" && mod.Version != "" && entry.RequestedVersion != mod.Version {

--- a/pkg/parser/terraform/modules/resolver/prefetched_test.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched_test.go
@@ -142,6 +142,86 @@ func TestLoadManifestV1PreservesUnresolvedStatus(t *testing.T) {
 	require.ErrorContains(t, err, "credentials_unavailable")
 }
 
+func TestPrefetchedResolverRequiresExactVersionForV1Entry(t *testing.T) {
+	dir := t.TempDir()
+	moduleDir := filepath.Join(dir, "modules", "vpc")
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("resource"), 0o600))
+	digest, err := ComputePackageDigest(t.Context(), moduleDir)
+	require.NoError(t, err)
+	caller := filepath.Join(dir, "repo", "main.tf")
+	versioned := &tfmodules.ParsedModule{
+		FileName:   caller,
+		DefLine:    1,
+		DefEndLine: 3,
+		Name:       "vpc",
+		Source:     "terraform-aws-modules/vpc/aws",
+		Version:    "5.0.0",
+	}
+	manifestPath := filepath.Join(dir, "manifest.json")
+	writeManifestJSON(t, manifestPath, map[string]any{
+		"schema_version": ManifestSchemaVersion,
+		"root":           "modules",
+		"modules": []map[string]any{{
+			"request_id":     ParsedModuleCallID(versioned),
+			"source":         versioned.Source,
+			"local_path":     "vpc",
+			"content_digest": digest,
+			"status":         ManifestStatusResolved,
+			"declarations": []map[string]any{{
+				"filename":    "main.tf",
+				"line_start":  1,
+				"line_end":    3,
+				"module_name": "vpc",
+			}},
+		}},
+	})
+	manifest, err := LoadManifest(t.Context(), manifestPath)
+	require.NoError(t, err)
+
+	_, err = NewPrefetchedResolver(manifest).Resolve(t.Context(), versioned)
+	require.ErrorContains(t, err, "version")
+}
+
+func TestPrefetchedResolverMatchesCallAfterWorkspaceMoves(t *testing.T) {
+	dir := t.TempDir()
+	moduleDir := filepath.Join(dir, "modules", "vpc")
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("resource"), 0o600))
+	digest, err := ComputePackageDigest(t.Context(), moduleDir)
+	require.NoError(t, err)
+	source := "terraform-aws-modules/vpc/aws"
+	manifestPath := filepath.Join(dir, "manifest.json")
+	writeManifestJSON(t, manifestPath, map[string]any{
+		"schema_version": ManifestSchemaVersion,
+		"root":           "modules",
+		"modules": []map[string]any{{
+			"request_id":     ModuleCallID("/old/repo/main.tf", 1, 3, "vpc", source, ""),
+			"source":         source,
+			"local_path":     "vpc",
+			"content_digest": digest,
+			"status":         ManifestStatusResolved,
+			"declarations": []map[string]any{{
+				"filename":    "repo/main.tf",
+				"line_start":  1,
+				"line_end":    3,
+				"module_name": "vpc",
+			}},
+		}},
+	})
+	manifest, err := LoadManifest(t.Context(), manifestPath)
+	require.NoError(t, err)
+
+	_, err = NewPrefetchedResolver(manifest).Resolve(t.Context(), &tfmodules.ParsedModule{
+		FileName:   "/new/repo/main.tf",
+		DefLine:    1,
+		DefEndLine: 3,
+		Name:       "vpc",
+		Source:     source,
+	})
+	require.NoError(t, err)
+}
+
 func TestLoadManifestV1RejectsDigestMismatch(t *testing.T) {
 	dir := t.TempDir()
 	moduleDir := filepath.Join(dir, "modules", "vpc")

--- a/pkg/parser/terraform/modules/resolver/source_descriptor.go
+++ b/pkg/parser/terraform/modules/resolver/source_descriptor.go
@@ -1,0 +1,77 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+)
+
+type SourceDescriptor struct {
+	NormalizedSource string
+	SourceType       string
+	SourceCategory   string
+	RegistryScope    string
+	RequestedVersion string
+	RequestedRef     string
+	Subdirectory     string
+}
+
+func DescribeModuleSource(source, version string) SourceDescriptor {
+	source = strings.TrimSpace(source)
+	version = strings.TrimSpace(version)
+	sourceType, registryScope := tfmodules.DetectModuleSourceType(source)
+	descriptor := SourceDescriptor{
+		NormalizedSource: source,
+		SourceType:       sourceType,
+		SourceCategory:   sourceType,
+		RegistryScope:    registryScope,
+		RequestedVersion: version,
+	}
+
+	if address, err := tfmodules.ParseRegistryModuleSource(source); err == nil {
+		address.Subdir, descriptor.Subdirectory = "", filepath.ToSlash(address.Subdir)
+		descriptor.NormalizedSource = address.String()
+		descriptor.SourceCategory = registryScope + "_registry"
+		return descriptor
+	}
+	if repoURL, subdir, ref, ok := parseGitGetterSource(source); ok {
+		descriptor.NormalizedSource = normalizeGitRepoURL(repoURL)
+		descriptor.SourceType = sourceTypeGit
+		descriptor.SourceCategory = sourceTypeGit
+		descriptor.RequestedRef = ref
+		descriptor.Subdirectory = filepath.ToSlash(subdir)
+		return descriptor
+	}
+
+	getterSource := source
+	getterType := ""
+	if index := strings.Index(getterSource, "::"); index >= 0 {
+		getterType = strings.ToLower(getterSource[:index])
+		getterSource = getterSource[index+2:]
+	}
+	parsed, err := url.Parse(getterSource)
+	if err != nil || parsed.Scheme == "" {
+		return descriptor
+	}
+	descriptor.SourceType = strings.ToLower(parsed.Scheme)
+	if getterType != "" {
+		descriptor.SourceType = getterType
+	}
+	descriptor.SourceCategory = descriptor.SourceType
+	descriptor.RequestedRef = parsed.Query().Get("ref")
+	parsed.RawQuery = ""
+	if index := strings.Index(parsed.Path, "//"); index >= 0 {
+		descriptor.Subdirectory = filepath.ToSlash(parsed.Path[index+2:])
+		parsed.Path = parsed.Path[:index]
+	}
+	parsed.Host = strings.ToLower(parsed.Host)
+	descriptor.NormalizedSource = parsed.String()
+	return descriptor
+}

--- a/pkg/parser/terraform/modules/resolver/source_descriptor_test.go
+++ b/pkg/parser/terraform/modules/resolver/source_descriptor_test.go
@@ -1,0 +1,66 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescribeModuleSource(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		version string
+		want    SourceDescriptor
+	}{
+		{
+			name:    "public registry subdirectory",
+			source:  "terraform-aws-modules/vpc/aws//modules/vpc-endpoints",
+			version: "~> 5.0",
+			want: SourceDescriptor{
+				NormalizedSource: "registry.terraform.io/terraform-aws-modules/vpc/aws",
+				SourceType:       "registry",
+				SourceCategory:   "public_registry",
+				RegistryScope:    "public",
+				RequestedVersion: "~> 5.0",
+				Subdirectory:     "modules/vpc-endpoints",
+			},
+		},
+		{
+			name:   "private registry",
+			source: "registry.example.com/acme/network/aws",
+			want: SourceDescriptor{
+				NormalizedSource: "registry.example.com/acme/network/aws",
+				SourceType:       "registry",
+				SourceCategory:   "private_registry",
+				RegistryScope:    "private",
+			},
+		},
+		{
+			name:   "git ref and subdirectory",
+			source: "git::https://github.com/acme/network.git//modules/vpc?ref=v1.2.3",
+			want: SourceDescriptor{
+				NormalizedSource: "github.com/acme/network",
+				SourceType:       "git",
+				SourceCategory:   "git",
+				RequestedRef:     "v1.2.3",
+				Subdirectory:     "modules/vpc",
+			},
+		},
+		{
+			name:   "object storage",
+			source: "s3::https://s3.amazonaws.com/example/module.zip",
+			want: SourceDescriptor{
+				NormalizedSource: "https://s3.amazonaws.com/example/module.zip",
+				SourceType:       "s3",
+				SourceCategory:   "s3",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, DescribeModuleSource(test.source, test.version))
+		})
+	}
+}

--- a/pkg/parser/terraform/modules/resolver/staged_archive.go
+++ b/pkg/parser/terraform/modules/resolver/staged_archive.go
@@ -1,0 +1,54 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const stagedArchiveUmask = 0o077
+
+// ExtractModuleArchive expands a staged module archive with the resolver's package limits.
+func ExtractModuleArchive(
+	ctx context.Context,
+	sourcePath string,
+	destinationPath string,
+	format string,
+	limits ResourceLimits,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	format = strings.ToLower(strings.TrimPrefix(strings.TrimSpace(format), "."))
+	if !isDirectoryArchiveFormat(format) {
+		return fmt.Errorf("unsupported module archive format %q", format)
+	}
+	decompressor := limitedDecompressors(limits, limits.MaxPackageBytes)[format]
+	if decompressor == nil {
+		return fmt.Errorf("unsupported module archive format %q", format)
+	}
+	if err := decompressor.Decompress(destinationPath, sourcePath, true, stagedArchiveUmask); err != nil {
+		_ = os.RemoveAll(destinationPath)
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		_ = os.RemoveAll(destinationPath)
+		return err
+	}
+	return nil
+}
+
+func isDirectoryArchiveFormat(format string) bool {
+	switch format {
+	case "tar", "tar.bz2", "tar.gz", "tar.xz", "tar.zst", "tbz2", "tgz", "txz", "tzst", "zip":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -44,6 +44,7 @@ func ParseTerraformModules(value string) (TerraformModulesSetting, error) {
 
 const (
 	DefaultRemoteModuleMaxDepth        = 8
+	DefaultRemoteModuleMaxModules      = 1024
 	DefaultRemoteModuleMaxTotalBytes   = tfresolver.DefaultMaxTotalBytes
 	DefaultRemoteModuleMaxPackageBytes = tfresolver.DefaultMaxPackageBytes
 	DefaultRemoteModuleMaxFileBytes    = tfresolver.DefaultMaxFileBytes
@@ -94,6 +95,7 @@ type Parameters struct {
 	RemoteModulesHostAllowlist []string
 	// ModuleMaxDepth caps the BFS depth of the remote-module graph walker (0 disables traversal entirely).
 	ModuleMaxDepth          int
+	ModuleMaxModules        int
 	ModuleFetchTimeout      time.Duration
 	MaxModuleBytesTotal     int64
 	MaxModulePackageBytes   int64

--- a/pkg/scan/module_prepare.go
+++ b/pkg/scan/module_prepare.go
@@ -1,0 +1,45 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package scan
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/modulegraph"
+	tfresolver "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+)
+
+func PrepareTerraformModules(
+	ctx context.Context,
+	params *Parameters,
+	rootPaths []string,
+	discoveryPaths []string,
+) (modulegraph.Result, error) {
+	if params == nil {
+		return modulegraph.Result{}, fmt.Errorf("scan parameters are required")
+	}
+	if !params.NetworkIsolation {
+		return modulegraph.Result{}, fmt.Errorf("module preparation requires network isolation")
+	}
+	client := &Client{
+		ScanParams: params,
+		fsys:       vfs.DiskFS{},
+	}
+	resolveCtx, cancel := client.moduleResolutionContext(ctx)
+	defer cancel()
+	resolvers := []tfresolver.Resolver{tfresolver.LocalResolver{}}
+	if params.RemoteModulesManifestPath != "" {
+		manifest, err := tfresolver.LoadManifest(resolveCtx, params.RemoteModulesManifestPath)
+		if err != nil {
+			return modulegraph.Result{}, err
+		}
+		resolvers = append(resolvers, tfresolver.NewPrefetchedResolver(manifest))
+	}
+	chain := tfresolver.NewChainResolver(resolvers...)
+	return client.resolveTerraformModuleGraph(resolveCtx, rootPaths, discoveryPaths, nil, chain), nil
+}

--- a/pkg/scan/module_prepare_test.go
+++ b/pkg/scan/module_prepare_test.go
@@ -1,0 +1,12 @@
+package scan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareTerraformModulesRequiresNetworkIsolation(t *testing.T) {
+	_, err := PrepareTerraformModules(t.Context(), &Parameters{}, nil, nil)
+	require.ErrorContains(t, err, "requires network isolation")
+}

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -80,7 +80,8 @@ func (c *Client) resolveTerraformModulesForScan(
 			Int("shedding_rank", event.SheddingRank).
 			Msg("Terraform module excluded by resource budget")
 	}
-	for _, failure := range result.Failures {
+	for index := range result.Failures {
+		failure := &result.Failures[index]
 		contextLogger.Warn().
 			Str("module_source", failure.Source).
 			Str("module_name", failure.Name).

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -148,6 +148,7 @@ func (c *Client) resolveTerraformModuleGraph(
 		DiscoveryPaths: discoveryPaths,
 		Resolver:       moduleResolver,
 		MaxDepth:       c.ScanParams.ModuleMaxDepth,
+		MaxModules:     c.ScanParams.ModuleMaxModules,
 		ResourceLimits: tfresolver.ResourceLimits{
 			MaxPackageBytes: packageBytes,
 			MaxFileBytes:    fileBytes,


### PR DESCRIPTION
## Motivation

Hosted remote Terraform module scans need a machine-readable sandbox phase that discovers module declarations, resolves public sources into a task-scoped cache, accepts already-staged private repositories, and writes a validated manifest for the final scan. This adds that prepare boundary in the scanner so the trusted worker can orchestrate repeated sandbox commands without parsing Terraform configuration itself.

Related ticket: [K9CODESEC-5298](https://datadoghq.atlassian.net/browse/K9CODESEC-5298)

## Changes

**CLI**

Add `prepare-modules`, which emits stable JSON with `complete`, `requires_staging`, or `incomplete` status plus normalized module entries and worker staging requests.

**Module preparation**

Add `moduleprepare` to build manifest v1 entries with source descriptors, declaration locations, confinement checks, and content digests. Staged private packs can be supplied via JSON or an existing manifest.

**Resolver and graph**

Add validated manifest writes, source descriptors, and deterministic module-graph limits so preparation reruns converge on the same task cache.

## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/parser/terraform/modules/moduleprepare ./pkg/parser/terraform/modules/resolver ./pkg/parser/terraform/modules/modulegraph ./pkg/scan ./cmd/scanner -count=1`
2. `make build`
3. Run `prepare-modules` against a small Terraform repo with `--module-root` and `--output-manifest`, and confirm the JSON status and generated manifest load with `LoadManifest`.

## Blast Radius

This affects the scanner CLI and Terraform module resolution path only. It does not change scan findings, Terrapin lifecycle, or SCI authorization.

## Additional Notes

Private git link minting (5304) and hosted orchestration (5299) remain follow-up work; this PR defines the sandbox protocol boundary only.

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-5298]: https://datadoghq.atlassian.net/browse/K9CODESEC-5298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ