### PR TITLE
Fix panic when Terraform certificate_body is not a string

### DIFF
--- a/pkg/parser/terraform/certificate_body_test.go
+++ b/pkg/parser/terraform/certificate_body_test.go
@@ -1,0 +1,73 @@
+package terraform
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+	"github.com/rs/zerolog"
+)
+
+func TestCertificateBodyNonStringDoesNotPanicDuringResourceProcessing(t *testing.T) {
+	t.Run("literal bool", func(t *testing.T) {
+		content := `resource "aws_api_gateway_domain_name" "example" {
+  certificate_body = true
+  domain_name      = "api.example.com"
+}`
+		assertNoRecoveredPanic(t, content, "main.tf")
+	})
+
+	t.Run("variable resolved to bool via tfvars", func(t *testing.T) {
+		dir := t.TempDir()
+		mainTF := `variable "cert" {
+  type    = bool
+  default = true
+}
+resource "aws_acm_certificate" "example" {
+  certificate_body = var.cert
+}`
+		if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(mainTF), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "terraform.tfvars"), []byte("cert = true\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		var logBuf bytes.Buffer
+		ctx := zerolog.New(&logBuf).WithContext(context.Background())
+		parser := NewDefaultWithParams(vfs.DiskFS{}, "", model.SCIInfo{})
+		path := filepath.Join(dir, "main.tf")
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, _, err = parser.Parse(ctx, content, path, true, 15)
+		if err != nil {
+			t.Fatalf("parse returned error: %v", err)
+		}
+		if bytes.Contains(logBuf.Bytes(), []byte("Recovered from panic")) {
+			t.Fatalf("unexpected recovered panic in logs: %q", logBuf.String())
+		}
+	})
+}
+
+func assertNoRecoveredPanic(t *testing.T, content, path string) {
+	t.Helper()
+
+	var logBuf bytes.Buffer
+	ctx := zerolog.New(&logBuf).WithContext(context.Background())
+	parser := NewDefault()
+
+	_, _, _, _, err := parser.Parse(ctx, []byte(content), path, true, 15)
+	if err != nil {
+		t.Fatalf("parse returned error: %v", err)
+	}
+	if bytes.Contains(logBuf.Bytes(), []byte("Recovered from panic")) {
+		t.Fatalf("unexpected recovered panic in logs: %q", logBuf.String())
+	}
+}

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pkg/errors"
+	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 	"golang.org/x/sync/singleflight"
 )
@@ -141,6 +142,9 @@ func processElements(ctx context.Context, elements model.Document, path string) 
 			content := utils.CheckCertificate(value)
 			processContent(ctx, elements, content, path)
 		case ctyjson.SimpleJSONValue:
+			if value.Type() != cty.String {
+				continue
+			}
 			content := utils.CheckCertificate(value.AsString())
 			processContent(ctx, elements, content, path)
 		}


### PR DESCRIPTION
## Motivation

Terraform parsing could panic with `not a string` when post-processing resources whose `certificate_body` attribute resolved to a non-string cty value (for example a bool from tfvars). The panic was recovered, but it produced error logs and skipped certificate enrichment for the affected file.

## Changes

**Terraform parser**

Before calling `AsString()` on a `certificate_body` `SimpleJSONValue`, verify the underlying cty type is string. Non-string values are skipped because certificate enrichment only applies to PEM content.

**Tests**

Added regression coverage for literal bool and tfvars-resolved bool `certificate_body` values.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/parser/terraform -run TestCertificateBodyNonString -count=1 -v`
2. Confirm no `Recovered from panic during process of resources` log appears when scanning Terraform with non-string `certificate_body` values.

## Impact

CLI Terraform parsing only. Certificate metadata enrichment is unchanged for string PEM values; non-string values are ignored as before they should have been.

I submit this contribution under the Apache-2.0 license.