### PR TITLE
[K9CODESEC-5298] Add worker-side Terraform module preparation for offline hosted scans

### DIFF
--- a/pkg/parser/terraform/modules/modulegraph/admission.go
+++ b/pkg/parser/terraform/modules/modulegraph/admission.go
@@ -6,10 +6,12 @@
 package modulegraph
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 )
@@ -101,6 +103,26 @@ func shedToTotalLimit(
 
 	roots := packageRootsBySpecificity(nodes)
 	snapshot.paths = filterPathsByPackages(snapshot.paths, roots, accepted)
+	for i := range snapshot.modules {
+		module := &snapshot.modules[i]
+		if accepted[filepath.Clean(module.PackageRoot)] {
+			continue
+		}
+		snapshot.failures = append(snapshot.failures, ResolutionFailure{
+			CallerRoot:        module.CallerRoot,
+			CallerFile:        module.CallerFile,
+			CallerPackageRoot: module.ParentPackageRoot,
+			CallerLine:        module.CallerLine,
+			CallerEndLine:     module.CallerEndLine,
+			Source:            model.RedactURLCredentials(module.Source),
+			Version:           module.Version,
+			Name:              module.Name,
+			Reason: fmt.Sprintf(
+				"module package rejected: pre-parse admission exceeds module_bytes_total limit %d",
+				maximum,
+			),
+		})
+	}
 	snapshot.modules = filterModulesByPackages(snapshot.modules, accepted)
 	for localPath := range snapshot.sourceMappings {
 		if !pathOwnedByAcceptedPackage(localPath, roots, accepted) {

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph.go
@@ -80,14 +80,15 @@ type BudgetEvent struct {
 }
 
 type ResolutionFailure struct {
-	CallerRoot    string
-	CallerFile    string
-	CallerLine    int
-	CallerEndLine int
-	Source        string
-	Version       string
-	Name          string
-	Reason        string
+	CallerRoot        string
+	CallerFile        string
+	CallerPackageRoot string
+	CallerLine        int
+	CallerEndLine     int
+	Source            string
+	Version           string
+	Name              string
+	Reason            string
 }
 
 type resolvedEntry struct {
@@ -460,21 +461,24 @@ func (c *resultCollector) addBudgetEvent(source string, budgetErr *resolver.Budg
 	})
 }
 
-func (c *resultCollector) addResolutionFailure(mod *tfmodules.ParsedModule, err error) {
+func (c *resultCollector) addResolutionFailure(
+	mod *tfmodules.ParsedModule, callerPackageRoot string, err error,
+) {
 	if mod == nil || err == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.failures = append(c.failures, ResolutionFailure{
-		CallerRoot:    moduleCallRoot(mod),
-		CallerFile:    mod.FileName,
-		CallerLine:    mod.DefLine,
-		CallerEndLine: mod.DefEndLine,
-		Source:        model.RedactURLCredentials(mod.Source),
-		Version:       mod.Version,
-		Name:          mod.Name,
-		Reason:        model.RedactURLCredentials(err.Error()),
+		CallerRoot:        moduleCallRoot(mod),
+		CallerFile:        mod.FileName,
+		CallerPackageRoot: callerPackageRoot,
+		CallerLine:        mod.DefLine,
+		CallerEndLine:     mod.DefEndLine,
+		Source:            model.RedactURLCredentials(mod.Source),
+		Version:           mod.Version,
+		Name:              mod.Name,
+		Reason:            model.RedactURLCredentials(err.Error()),
 	})
 }
 
@@ -773,7 +777,7 @@ func (w *walker) traverseRemoteModules(
 			if cached.err == nil && cached.res.LocalPath != "" {
 				w.results.addResolvedModule(&mod, cached.res, parentPackageRoot, depth+1)
 			} else if cached.err != nil && ctx.Err() == nil {
-				w.results.addResolutionFailure(&mod, cached.err)
+				w.results.addResolutionFailure(&mod, parentPackageRoot, cached.err)
 			}
 			continue
 		}
@@ -839,7 +843,9 @@ func (w *walker) acquireRemoteModuleGroups(
 			batch = append(batch, acquisition{group: groups[id], lease: lease})
 		}
 		if len(batch) == 0 {
-			if ctx.Err() == nil {
+			if err := ctx.Err(); err != nil {
+				w.recordFailedGroups(groups, ids[start:], err)
+			} else {
 				w.recordUnacquiredGroups(groups, ids[start:])
 			}
 			return
@@ -858,6 +864,14 @@ func (w *walker) acquireRemoteModuleGroups(
 		}
 		_ = g.Wait()
 		start += len(batch)
+	}
+}
+
+func (w *walker) recordFailedGroups(groups map[string]*remoteModuleGroup, ids []string, err error) {
+	for _, id := range ids {
+		for _, mod := range groups[id].callers {
+			w.results.addResolutionFailure(mod, groups[id].parentPackageRoot, err)
+		}
 	}
 }
 
@@ -899,12 +913,19 @@ func (w *walker) acquireAcquisition(
 func (w *walker) recordUnacquiredGroups(groups map[string]*remoteModuleGroup, ids []string) {
 	measured := w.budget.TotalUsage().Bytes
 	for _, id := range ids {
-		w.results.addBudgetEvent(groups[id].representative.Source, &resolver.BudgetExceededError{
+		group := groups[id]
+		budgetErr := &resolver.BudgetExceededError{
 			Gate:     "acquisition",
 			Limit:    "module_bytes_total",
 			Maximum:  w.admissionBytes,
 			Measured: measured,
-		})
+		}
+		w.results.addBudgetEvent(group.representative.Source, budgetErr)
+		for _, mod := range group.callers {
+			w.results.addResolutionFailure(mod, group.parentPackageRoot, &tfmodules.UnresolvedError{
+				Reason: "module package rejected: " + budgetErr.Error(),
+			})
+		}
 	}
 }
 
@@ -927,10 +948,8 @@ func (w *walker) traverseRemoteModuleGroup(
 	contextLogger.Debug().Msgf("Fetching remote Terraform module %q", representative.Source)
 	resolution, shared, err := w.resolveRemote(ctx, representative)
 	if err != nil {
-		if ctx.Err() == nil {
-			for _, mod := range group.callers {
-				w.results.addResolutionFailure(mod, err)
-			}
+		for _, mod := range group.callers {
+			w.results.addResolutionFailure(mod, group.parentPackageRoot, err)
 		}
 		if !shared {
 			contextLogger.Debug().Err(err).

--- a/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
+++ b/pkg/parser/terraform/modules/modulegraph/modulegraph_test.go
@@ -572,6 +572,9 @@ resource "aws_vpc" "transitive" {}
 	require.Equal(t, "example.com/acme/transitive/aws", result.BudgetEvents[0].Source)
 	require.Equal(t, "pre_parse_admission", result.BudgetEvents[0].Gate)
 	require.Equal(t, 1, result.BudgetEvents[0].SheddingRank)
+	require.Len(t, result.Failures, 1)
+	require.Equal(t, "example.com/acme/transitive/aws", result.Failures[0].Source)
+	require.Contains(t, result.Failures[0].Reason, "pre-parse admission")
 }
 
 func TestResolveDoesNotTraverseDescendantsOfShedPackage(t *testing.T) {
@@ -1147,6 +1150,10 @@ func TestResolveStopsAcquiringFrontierPastAllowance(t *testing.T) {
 		}
 	}
 	require.Equal(t, count-acquired, unacquired)
+	require.Len(t, result.Failures, count-len(result.Modules))
+	for _, failure := range result.Failures {
+		require.Contains(t, failure.Reason, "module_bytes_total")
+	}
 }
 
 func TestShedToTotalLimitBreaksTiesDeterministically(t *testing.T) {

--- a/pkg/parser/terraform/modules/moduleprepare/artifact.go
+++ b/pkg/parser/terraform/modules/moduleprepare/artifact.go
@@ -1,0 +1,397 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package moduleprepare
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/modulegraph"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+)
+
+const (
+	artifactDirectoryPermissions = 0o750
+	artifactFileModeMask         = 0o750
+)
+
+type stagedPackage struct {
+	originalRoot string
+	digest       string
+	relativeRoot string
+}
+
+type materializer struct {
+	artifactRoot string
+	packages     map[string]stagedPackage
+	packageRoots []string
+}
+
+type manifestGroup struct {
+	source           string
+	requestedVersion string
+	sourceType       string
+	registryScope    string
+	resolved         []modulegraph.ResolvedModule
+	failures         []modulegraph.ResolutionFailure
+	declarations     []resolver.ManifestDeclaration
+}
+
+func newMaterializer(
+	ctx context.Context,
+	artifactRoot string,
+	modules []modulegraph.ResolvedModule,
+	failures []modulegraph.ResolutionFailure,
+) (*materializer, error) {
+	if err := os.MkdirAll(filepath.Join(artifactRoot, manifestRoot), artifactDirectoryPermissions); err != nil {
+		return nil, fmt.Errorf("creating module artifact root: %w", err)
+	}
+	m := &materializer{
+		artifactRoot: artifactRoot,
+		packages:     make(map[string]stagedPackage),
+	}
+	addPackage := func(packageRoot string) error {
+		if packageRoot == "" {
+			return nil
+		}
+		root := filepath.Clean(packageRoot)
+		if _, ok := m.packages[root]; ok {
+			return nil
+		}
+		digest, err := resolver.ComputePackageDigest(ctx, root)
+		if err != nil {
+			return fmt.Errorf("digesting module package %q: %w", root, err)
+		}
+		m.packages[root] = stagedPackage{
+			originalRoot: root,
+			digest:       digest,
+			relativeRoot: strings.TrimPrefix(digest, "sha256:"),
+		}
+		m.packageRoots = append(m.packageRoots, root)
+		return nil
+	}
+	for i := range modules {
+		if err := addPackage(modules[i].PackageRoot); err != nil {
+			return nil, err
+		}
+	}
+	for i := range failures {
+		if err := addPackage(failures[i].CallerPackageRoot); err != nil {
+			return nil, err
+		}
+	}
+	sort.Slice(m.packageRoots, func(i, j int) bool {
+		if len(m.packageRoots[i]) != len(m.packageRoots[j]) {
+			return len(m.packageRoots[i]) > len(m.packageRoots[j])
+		}
+		return m.packageRoots[i] < m.packageRoots[j]
+	})
+	return m, nil
+}
+
+func buildManifestModules(
+	ctx context.Context,
+	repositoryRoot string,
+	graphResult *modulegraph.Result,
+	materializer *materializer,
+) ([]resolver.ManifestModule, error) {
+	groups := make(map[string]*manifestGroup)
+	for i := range graphResult.Modules {
+		module := graphResult.Modules[i]
+		declaration, err := materializer.declaration(repositoryRoot, module.CallerFile, module.Name, module.CallerLine, module.CallerEndLine)
+		if err != nil {
+			return nil, err
+		}
+		group := manifestGroupFor(groups, module.Source, module.Version, declaration)
+		group.resolved = append(group.resolved, module)
+		if group.sourceType == "" {
+			group.sourceType, group.registryScope = sourceIdentity(module.Source, module.ResolvedRef)
+		}
+		group.declarations = append(group.declarations, declaration)
+	}
+	for i := range graphResult.Failures {
+		failure := graphResult.Failures[i]
+		declaration, err := materializer.declaration(
+			repositoryRoot,
+			failure.CallerFile,
+			failure.Name,
+			failure.CallerLine,
+			failure.CallerEndLine,
+		)
+		if err != nil {
+			return nil, err
+		}
+		group := manifestGroupFor(groups, failure.Source, failure.Version, declaration)
+		group.failures = append(group.failures, failure)
+		if group.sourceType == "" {
+			group.sourceType, group.registryScope = sourceIdentity(failure.Source, "")
+		}
+		group.declarations = append(group.declarations, declaration)
+	}
+
+	keys := make([]string, 0, len(groups))
+	for key := range groups {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	entries := make([]resolver.ManifestModule, 0, len(keys))
+	for _, key := range keys {
+		entry, err := materializer.buildEntry(ctx, groups[key])
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+func manifestGroupFor(
+	groups map[string]*manifestGroup,
+	source, version string,
+	declaration resolver.ManifestDeclaration,
+) *manifestGroup {
+	source = strings.TrimSpace(model.RedactURLCredentials(source))
+	version = strings.TrimSpace(version)
+	key := strings.Join([]string{
+		source,
+		version,
+		declaration.Filename,
+		declaration.ModuleName,
+		fmt.Sprintf("%d", declaration.LineStart),
+	}, "\x00")
+	if groups[key] == nil {
+		groups[key] = &manifestGroup{
+			source:           source,
+			requestedVersion: version,
+		}
+	}
+	return groups[key]
+}
+
+func (m *materializer) buildEntry(ctx context.Context, group *manifestGroup) (resolver.ManifestModule, error) {
+	entry := resolver.ManifestModule{
+		Source:           group.source,
+		SourceType:       group.sourceType,
+		RegistryScope:    group.registryScope,
+		RequestedVersion: group.requestedVersion,
+		Declarations:     uniqueDeclarations(group.declarations),
+	}
+	if len(group.failures) > 0 {
+		entry.Status = resolver.ManifestStatusUnresolved
+		entry.Failure = joinedFailureReasons(group.failures)
+		return entry, nil
+	}
+	if len(group.resolved) == 0 {
+		entry.Status = resolver.ManifestStatusUnresolved
+		entry.Failure = "module was not resolved"
+		return entry, nil
+	}
+
+	first := group.resolved[0]
+	packageInfo := m.packages[filepath.Clean(first.PackageRoot)]
+	selectedPath, err := relativeSelectedPath(&first)
+	if err != nil {
+		return resolver.ManifestModule{}, err
+	}
+	for i := 1; i < len(group.resolved); i++ {
+		module := group.resolved[i]
+		otherPackage := m.packages[filepath.Clean(module.PackageRoot)]
+		otherSelected, relErr := relativeSelectedPath(&module)
+		if relErr != nil {
+			return resolver.ManifestModule{}, relErr
+		}
+		if packageInfo.digest != otherPackage.digest ||
+			filepath.Clean(selectedPath) != filepath.Clean(otherSelected) ||
+			first.ResolvedVersion != module.ResolvedVersion ||
+			first.ResolvedRef != module.ResolvedRef {
+			entry.Status = resolver.ManifestStatusUnresolved
+			entry.Failure = "module resolved inconsistently across declarations"
+			return entry, nil
+		}
+	}
+	if err := m.stagePackage(ctx, packageInfo); err != nil {
+		return resolver.ManifestModule{}, err
+	}
+
+	entry.CanonicalSource = model.RedactURLCredentials(first.CanonicalSource)
+	entry.ResolvedVersion = first.ResolvedVersion
+	entry.ResolvedRef = first.ResolvedRef
+	entry.ContentDigest = packageInfo.digest
+	entry.PackageRoot = packageInfo.relativeRoot
+	entry.LocalPath = filepath.ToSlash(filepath.Join(packageInfo.relativeRoot, selectedPath))
+	entry.Status = resolver.ManifestStatusResolved
+	return entry, nil
+}
+
+func (m *materializer) stagePackage(ctx context.Context, pkg stagedPackage) error {
+	destination := filepath.Join(m.artifactRoot, manifestRoot, filepath.FromSlash(pkg.relativeRoot))
+	if _, err := os.Stat(destination); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("checking staged module package: %w", err)
+	}
+	temp, err := os.MkdirTemp(filepath.Join(m.artifactRoot, manifestRoot), ".package-")
+	if err != nil {
+		return fmt.Errorf("creating temporary package directory: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(temp)
+	}()
+	if err := copyPackage(ctx, pkg.originalRoot, temp); err != nil {
+		return fmt.Errorf("staging module package: %w", err)
+	}
+	if err := os.Rename(temp, destination); err != nil {
+		if _, statErr := os.Stat(destination); statErr == nil {
+			return nil
+		}
+		return fmt.Errorf("publishing module package: %w", err)
+	}
+	return nil
+}
+
+func (m *materializer) declaration(
+	repositoryRoot, filename, moduleName string, lineStart, lineEnd int,
+) (resolver.ManifestDeclaration, error) {
+	filename = filepath.Clean(filename)
+	if relative, ok := relativeWithin(repositoryRoot, filename); ok {
+		return newDeclaration(relative, moduleName, lineStart, lineEnd), nil
+	}
+	for _, root := range m.packageRoots {
+		pkg := m.packages[root]
+		if relative, ok := relativeWithin(pkg.originalRoot, filename); ok {
+			return newDeclaration(filepath.Join(pkg.relativeRoot, relative), moduleName, lineStart, lineEnd), nil
+		}
+	}
+	return resolver.ManifestDeclaration{}, fmt.Errorf("module declaration %q is outside the repository and resolved packages", filename)
+}
+
+func newDeclaration(filename, moduleName string, lineStart, lineEnd int) resolver.ManifestDeclaration {
+	return resolver.ManifestDeclaration{
+		Filename:   filepath.ToSlash(filename),
+		LineStart:  lineStart,
+		LineEnd:    lineEnd,
+		ModuleName: moduleName,
+	}
+}
+
+func sourceIdentity(source, resolvedRef string) (sourceType, registryScope string) {
+	sourceType, registryScope = tfmodules.DetectModuleSourceType(source)
+	if sourceType == "unknown" && resolvedRef != "" {
+		sourceType = "git"
+	}
+	return sourceType, registryScope
+}
+
+func relativeSelectedPath(module *modulegraph.ResolvedModule) (string, error) {
+	relative, ok := relativeWithin(module.PackageRoot, module.LocalPath)
+	if !ok {
+		return "", fmt.Errorf("module path %q is outside package root %q", module.LocalPath, module.PackageRoot)
+	}
+	if relative == "." {
+		return "", nil
+	}
+	return relative, nil
+}
+
+func relativeWithin(root, path string) (string, bool) {
+	relative, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	return relative, err == nil && !pathEscapes(relative)
+}
+
+func uniqueDeclarations(declarations []resolver.ManifestDeclaration) []resolver.ManifestDeclaration {
+	sort.Slice(declarations, func(i, j int) bool {
+		left, right := declarations[i], declarations[j]
+		if left.Filename != right.Filename {
+			return left.Filename < right.Filename
+		}
+		if left.LineStart != right.LineStart {
+			return left.LineStart < right.LineStart
+		}
+		return left.ModuleName < right.ModuleName
+	})
+	output := declarations[:0]
+	for _, declaration := range declarations {
+		if len(output) == 0 || output[len(output)-1] != declaration {
+			output = append(output, declaration)
+		}
+	}
+	return output
+}
+
+func joinedFailureReasons(failures []modulegraph.ResolutionFailure) string {
+	reasons := make(map[string]struct{}, len(failures))
+	for i := range failures {
+		reason := strings.TrimSpace(model.RedactURLCredentials(failures[i].Reason))
+		if reason != "" {
+			reasons[reason] = struct{}{}
+		}
+	}
+	ordered := make([]string, 0, len(reasons))
+	for reason := range reasons {
+		ordered = append(ordered, reason)
+	}
+	sort.Strings(ordered)
+	return strings.Join(ordered, "; ")
+}
+
+func copyPackage(ctx context.Context, source, destination string) error {
+	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destination, relative)
+		if entry.Type()&fs.ModeSymlink != 0 {
+			return fmt.Errorf("symlink %q is not allowed in a module package", path)
+		}
+		if entry.IsDir() {
+			return os.MkdirAll(target, artifactDirectoryPermissions)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("non-regular file %q is not allowed in a module package", path)
+		}
+		return copyRegularFile(path, target, info.Mode().Perm())
+	})
+}
+
+func copyRegularFile(source, destination string, mode fs.FileMode) error {
+	input, err := os.Open(source) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	// destination is derived from an owned artifact root and a walked relative path.
+	output, err := os.OpenFile( //nolint:gosec
+		destination,
+		os.O_WRONLY|os.O_CREATE|os.O_EXCL,
+		mode&artifactFileModeMask,
+	)
+	if err != nil {
+		return errors.Join(err, input.Close())
+	}
+	_, copyErr := io.Copy(output, input)
+	inputCloseErr := input.Close()
+	closeErr := output.Close()
+	return errors.Join(copyErr, inputCloseErr, closeErr)
+}

--- a/pkg/parser/terraform/modules/moduleprepare/prepare.go
+++ b/pkg/parser/terraform/modules/moduleprepare/prepare.go
@@ -1,0 +1,355 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+// Package moduleprepare materializes Terraform modules for a later offline scan.
+package moduleprepare
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/modulegraph"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+)
+
+const (
+	DefaultMaxDepth          = 8
+	DefaultResolutionTimeout = 5 * time.Minute
+	DefaultFetchTimeout      = 30 * time.Second
+	manifestFilename         = "modules.json"
+	manifestRoot             = "modules"
+)
+
+type Config struct {
+	RepositoryRoot string
+	// ArtifactDir is published atomically and must not already exist.
+	ArtifactDir    string
+	DiscoveryPaths []string
+	// Resolver replaces the standard resolver chain when set.
+	Resolver resolver.Resolver
+	// AdditionalResolvers run before the standard network resolvers.
+	AdditionalResolvers []resolver.Resolver
+	HostAllowlist       []string
+	CacheDir            string
+	MaxCacheBytes       int64
+	// MaxDepth caps remote-module traversal depth. nil uses DefaultMaxDepth; explicit zero disables traversal.
+	MaxDepth          *int
+	FetchTimeout      time.Duration
+	ResolutionTimeout time.Duration
+	ResourceLimits    resolver.ResourceLimits
+	TotalParseBytes   int64
+	FS                vfs.FS
+}
+
+type Result struct {
+	ManifestPath string
+	Modules      []resolver.ManifestModule
+	Failures     []modulegraph.ResolutionFailure
+	BudgetEvents []modulegraph.BudgetEvent
+	TimedOut     bool
+}
+
+// Prepare resolves a staged repository's module graph into an offline scan artifact.
+func Prepare(ctx context.Context, config *Config) (Result, error) {
+	var output Result
+	if err := validateConfig(config); err != nil {
+		return output, err
+	}
+	repositoryRoot, artifactDir, err := validatePaths(config.RepositoryRoot, config.ArtifactDir)
+	if err != nil {
+		return output, err
+	}
+	discoveryPaths, err := configuredDiscoveryPaths(
+		ctx,
+		repositoryRoot,
+		config.DiscoveryPaths,
+		config.CacheDir,
+	)
+	if err != nil {
+		return output, err
+	}
+
+	moduleResolver := config.Resolver
+	if moduleResolver == nil {
+		moduleResolver, err = resolver.NewDefaultChain(ctx, &resolver.DefaultChainConfig{
+			DiscoveryPaths: discoveryPaths,
+			Additional:     config.AdditionalResolvers,
+			FetchRemote:    true,
+			FetchTimeout:   defaultDuration(config.FetchTimeout, DefaultFetchTimeout),
+			HostAllowlist:  config.HostAllowlist,
+			CacheRoot:      config.CacheDir,
+			MaxCacheBytes:  config.MaxCacheBytes,
+		})
+		if err != nil {
+			return output, fmt.Errorf("building module resolver: %w", err)
+		}
+	}
+
+	resolveCtx, cancel := resolutionContext(ctx, config.ResolutionTimeout)
+	defer cancel()
+	graphResult := modulegraph.Resolve(resolveCtx, &modulegraph.Request{
+		RootPaths:       []string{repositoryRoot},
+		DiscoveryPaths:  discoveryPaths,
+		Resolver:        moduleResolver,
+		MaxDepth:        configuredMaxDepth(config.MaxDepth),
+		ResourceLimits:  defaultResourceLimits(config.ResourceLimits),
+		BaselinePaths:   discoveryPaths,
+		TotalParseBytes: config.TotalParseBytes,
+		FS:              config.FS,
+	})
+	defer graphResult.Cleanup()
+
+	output.Failures = graphResult.Failures
+	output.BudgetEvents = redactedBudgetEvents(graphResult.BudgetEvents)
+	output.TimedOut = graphResult.TimedOut
+	if err := ctx.Err(); err != nil {
+		return output, err
+	}
+
+	tempArtifact, err := os.MkdirTemp(filepath.Dir(artifactDir), "."+filepath.Base(artifactDir)+"-")
+	if err != nil {
+		return output, fmt.Errorf("creating temporary module artifact: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tempArtifact)
+	}()
+
+	materializer, err := newMaterializer(ctx, tempArtifact, graphResult.Modules, graphResult.Failures)
+	if err != nil {
+		return output, err
+	}
+	output.Modules, err = buildManifestModules(ctx, repositoryRoot, &graphResult, materializer)
+	if err != nil {
+		return output, err
+	}
+	tempManifest := filepath.Join(tempArtifact, manifestFilename)
+	if err := resolver.WriteManifest(ctx, tempManifest, manifestRoot, output.Modules); err != nil {
+		return output, err
+	}
+	if _, err := os.Stat(artifactDir); !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			return output, fmt.Errorf("artifact directory %q already exists", artifactDir)
+		}
+		return output, fmt.Errorf("checking artifact directory: %w", err)
+	}
+	if err := publishArtifact(tempArtifact, artifactDir); err != nil {
+		return output, fmt.Errorf("publishing module artifact: %w", err)
+	}
+	output.ManifestPath = filepath.Join(artifactDir, manifestFilename)
+	return output, nil
+}
+
+func configuredDiscoveryPaths(
+	ctx context.Context, root string, configured []string, cacheDir string,
+) ([]string, error) {
+	paths := append([]string(nil), configured...)
+	if len(paths) == 0 {
+		var err error
+		paths, err = discoverTerraformFiles(ctx, root, effectiveCacheDir(cacheDir))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return normalizeDiscoveryPaths(root, paths)
+}
+
+func effectiveCacheDir(configured string) string {
+	if strings.TrimSpace(configured) != "" {
+		return configured
+	}
+	root, _ := resolver.DefaultModuleCacheRoot()
+	return root
+}
+
+func redactedBudgetEvents(events []modulegraph.BudgetEvent) []modulegraph.BudgetEvent {
+	output := append([]modulegraph.BudgetEvent(nil), events...)
+	for i := range output {
+		output[i].Source = model.RedactURLCredentials(output[i].Source)
+	}
+	return output
+}
+
+func validateConfig(config *Config) error {
+	if config == nil {
+		return fmt.Errorf("configuration is required")
+	}
+	if config.MaxDepth != nil && *config.MaxDepth < 0 {
+		return fmt.Errorf("maximum depth must not be negative")
+	}
+	if config.FetchTimeout < 0 {
+		return fmt.Errorf("fetch timeout must not be negative")
+	}
+	if config.ResolutionTimeout < 0 {
+		return fmt.Errorf("resolution timeout must not be negative")
+	}
+	return nil
+}
+
+func validatePaths(repositoryRoot, artifactDir string) (root, artifact string, err error) {
+	if strings.TrimSpace(repositoryRoot) == "" {
+		return "", "", fmt.Errorf("repository root is required")
+	}
+	if strings.TrimSpace(artifactDir) == "" {
+		return "", "", fmt.Errorf("artifact directory is required")
+	}
+	root, err = filepath.Abs(repositoryRoot)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving repository root: %w", err)
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving repository root: %w", err)
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		return "", "", fmt.Errorf("checking repository root: %w", err)
+	}
+	if !info.IsDir() {
+		return "", "", fmt.Errorf("repository root must be a directory")
+	}
+	artifact, err = filepath.Abs(artifactDir)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving artifact directory: %w", err)
+	}
+	if root == filepath.Clean(artifact) {
+		return "", "", fmt.Errorf("artifact directory must differ from repository root")
+	}
+	if _, err := os.Stat(artifact); !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			return "", "", fmt.Errorf("artifact directory %q already exists", artifact)
+		}
+		return "", "", fmt.Errorf("checking artifact directory: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(artifact), artifactDirectoryPermissions); err != nil {
+		return "", "", fmt.Errorf("creating artifact parent directory: %w", err)
+	}
+	return root, filepath.Clean(artifact), nil
+}
+
+func discoverTerraformFiles(ctx context.Context, root, excludedDir string) ([]string, error) {
+	if strings.TrimSpace(excludedDir) != "" {
+		excludedDir, _ = filepath.Abs(excludedDir)
+		if resolved, err := filepath.EvalSymlinks(excludedDir); err == nil {
+			excludedDir = resolved
+		}
+	}
+	var paths []string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if excludedDir != "" && filepath.Clean(path) == filepath.Clean(excludedDir) {
+				return fs.SkipDir
+			}
+			if entry.Type()&fs.ModeSymlink != 0 {
+				return fs.SkipDir
+			}
+			name := strings.ToLower(entry.Name())
+			if path != root && (name == ".git" || strings.HasPrefix(name, ".terra")) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if entry.Type().IsRegular() && tfmodules.IsTerraformConfigPath(path) {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("discovering Terraform files: %w", err)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func normalizeDiscoveryPaths(root string, paths []string) ([]string, error) {
+	normalized := make([]string, 0, len(paths))
+	seen := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		absolute := path
+		if !filepath.IsAbs(absolute) {
+			absolute = filepath.Join(root, absolute)
+		}
+		absolute, err := filepath.Abs(absolute)
+		if err != nil {
+			return nil, fmt.Errorf("resolving discovery path %q: %w", path, err)
+		}
+		resolved, err := filepath.EvalSymlinks(absolute)
+		if err != nil {
+			return nil, fmt.Errorf("resolving discovery path %q: %w", path, err)
+		}
+		relative, err := filepath.Rel(root, resolved)
+		if err != nil || pathEscapes(relative) {
+			return nil, fmt.Errorf("discovery path %q is outside repository root", path)
+		}
+		info, err := os.Stat(resolved)
+		if err != nil {
+			return nil, fmt.Errorf("checking discovery path %q: %w", path, err)
+		}
+		if !info.Mode().IsRegular() || !tfmodules.IsTerraformConfigPath(resolved) {
+			return nil, fmt.Errorf("discovery path %q is not a Terraform configuration file", path)
+		}
+		if _, ok := seen[resolved]; ok {
+			continue
+		}
+		seen[resolved] = struct{}{}
+		normalized = append(normalized, resolved)
+	}
+	sort.Strings(normalized)
+	return normalized, nil
+}
+
+func resolutionContext(ctx context.Context, configured time.Duration) (context.Context, context.CancelFunc) {
+	timeout := defaultDuration(configured, DefaultResolutionTimeout)
+	return context.WithTimeout(ctx, timeout)
+}
+
+func defaultDuration(value, fallback time.Duration) time.Duration {
+	if value == 0 {
+		return fallback
+	}
+	return value
+}
+
+func configuredMaxDepth(depth *int) int {
+	if depth == nil {
+		return DefaultMaxDepth
+	}
+	return *depth
+}
+
+func defaultResourceLimits(limits resolver.ResourceLimits) resolver.ResourceLimits {
+	if limits.MaxTotalBytes == 0 {
+		limits.MaxTotalBytes = resolver.DefaultMaxTotalBytes
+	}
+	if limits.MaxPackageBytes == 0 {
+		limits.MaxPackageBytes = resolver.DefaultMaxPackageBytes
+	}
+	if limits.MaxFileBytes == 0 {
+		limits.MaxFileBytes = resolver.DefaultMaxFileBytes
+	}
+	if limits.MaxPackageFiles == 0 {
+		limits.MaxPackageFiles = resolver.DefaultMaxPackageFiles
+	}
+	return limits
+}
+
+func pathEscapes(relative string) bool {
+	return relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator))
+}

--- a/pkg/parser/terraform/modules/moduleprepare/prepare_test.go
+++ b/pkg/parser/terraform/modules/moduleprepare/prepare_test.go
@@ -1,0 +1,501 @@
+package moduleprepare
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules/resolver"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareBuildsRecursiveArtifactWithInjectedPrivateResolver(t *testing.T) {
+	root := t.TempDir()
+	parentSource := "git::https://git.example/acme/parent.git?ref=v1.0.0"
+	childSource := "git::https://git.example/acme/child.git?ref=v2.0.0"
+	writeFile(t, filepath.Join(root, "main.tf"), `
+module "parent" {
+  source = "`+parentSource+`"
+}
+`)
+
+	sourceRoot := t.TempDir()
+	parentPackage := filepath.Join(sourceRoot, "parent")
+	childPackage := filepath.Join(sourceRoot, "child")
+	writeFile(t, filepath.Join(parentPackage, "main.tf"), `
+module "child" {
+  source = "`+childSource+`"
+}
+resource "aws_vpc" "parent" {}
+`)
+	writeFile(t, filepath.Join(childPackage, "main.tf"), `resource "aws_subnet" "child" {}`)
+
+	privateResolver := &fixtureResolver{packages: map[string]string{
+		parentSource: parentPackage,
+		childSource:  childPackage,
+	}}
+	artifactDir := filepath.Join(t.TempDir(), "prepared")
+	result, err := Prepare(t.Context(), &Config{
+		RepositoryRoot:      root,
+		ArtifactDir:         artifactDir,
+		AdditionalResolvers: []resolver.Resolver{privateResolver},
+		HostAllowlist:       []string{"git.example"},
+		CacheDir:            filepath.Join(t.TempDir(), "cache"),
+	})
+	require.NoError(t, err)
+	require.False(t, result.TimedOut)
+	require.Empty(t, result.Failures)
+	require.Len(t, result.Modules, 2)
+	require.Equal(t, 2, privateResolver.cleanupCount())
+
+	manifest, err := resolver.LoadManifest(t.Context(), result.ManifestPath)
+	require.NoError(t, err)
+	parentResolution, err := resolver.NewPrefetchedResolver(manifest).Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source: parentSource,
+	})
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(parentResolution.LocalPath, "main.tf"))
+	childResolution, err := resolver.NewPrefetchedResolver(manifest).Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source: childSource,
+	})
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(childResolution.LocalPath, "main.tf"))
+	var childEntry resolver.ManifestModule
+	for _, entry := range manifest.Entries {
+		if entry.Source == childSource {
+			childEntry = entry
+		}
+	}
+	require.Contains(t, childEntry.Declarations[0].Filename, filepath.Base(parentResolution.PackageRoot))
+}
+
+func TestPrepareKeepsUnresolvedModulesWithoutDroppingResolvedModules(t *testing.T) {
+	root := t.TempDir()
+	goodSource := "git::https://git.example/acme/good.git?ref=v1"
+	badSource := "git::https://git.example/acme/missing.git?ref=v1"
+	writeFile(t, filepath.Join(root, "main.tf"), `
+module "good" {
+  source = "`+goodSource+`"
+}
+module "missing" {
+  source = "`+badSource+`"
+}
+`)
+	goodPackage := filepath.Join(t.TempDir(), "good")
+	writeFile(t, filepath.Join(goodPackage, "main.tf"), `resource "aws_vpc" "good" {}`)
+
+	artifactDir := filepath.Join(t.TempDir(), "prepared")
+	result, err := Prepare(t.Context(), &Config{
+		RepositoryRoot: root,
+		ArtifactDir:    artifactDir,
+		DiscoveryPaths: []string{"main.tf"},
+		Resolver: &fixtureResolver{
+			packages: map[string]string{goodSource: goodPackage},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Failures, 1)
+	require.Len(t, result.Modules, 2)
+
+	manifest, err := resolver.LoadManifest(t.Context(), result.ManifestPath)
+	require.NoError(t, err)
+	prefetched := resolver.NewPrefetchedResolver(manifest)
+	_, err = prefetched.Resolve(t.Context(), &tfmodules.ParsedModule{Source: goodSource})
+	require.NoError(t, err)
+	_, err = prefetched.Resolve(t.Context(), &tfmodules.ParsedModule{Source: badSource})
+	require.ErrorContains(t, err, "fixture has no package")
+
+	var resolved, unresolved int
+	for _, entry := range manifest.Entries {
+		switch entry.Status {
+		case "resolved":
+			resolved++
+		case "unresolved":
+			unresolved++
+		}
+	}
+	require.Equal(t, 1, resolved)
+	require.Equal(t, 1, unresolved)
+}
+
+func TestPrepareArtifactManifestRejectsTamperedPackage(t *testing.T) {
+	root := t.TempDir()
+	source := "git::https://git.example/acme/module.git?ref=v1"
+	writeFile(t, filepath.Join(root, "main.tf"), `
+module "example" {
+  source = "`+source+`"
+}
+`)
+	modulePackage := filepath.Join(t.TempDir(), "module")
+	writeFile(t, filepath.Join(modulePackage, "main.tf"), `resource "aws_vpc" "example" {}`)
+	artifactDir := filepath.Join(t.TempDir(), "prepared")
+	result, err := Prepare(t.Context(), &Config{
+		RepositoryRoot: root,
+		ArtifactDir:    artifactDir,
+		Resolver: &fixtureResolver{
+			packages: map[string]string{source: modulePackage},
+		},
+	})
+	require.NoError(t, err)
+
+	manifest, err := resolver.LoadManifest(t.Context(), result.ManifestPath)
+	require.NoError(t, err)
+	require.Len(t, manifest.Entries, 1)
+	resolution, err := resolver.NewPrefetchedResolver(manifest).Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source: source,
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(resolution.LocalPath, "main.tf"),
+		[]byte(`resource "aws_vpc" "tampered" {}`),
+		0o644,
+	))
+	_, err = resolver.LoadManifest(t.Context(), result.ManifestPath)
+	require.ErrorContains(t, err, "content_digest mismatch")
+}
+
+func TestPreparePreservesSelectedSubdirectoryWithinPackage(t *testing.T) {
+	root := t.TempDir()
+	source := "git::https://git.example/acme/network.git//modules/vpc?ref=v1"
+	writeFile(t, filepath.Join(root, "main.tf"), `
+module "vpc" {
+  source = "`+source+`"
+}
+`)
+	modulePackage := filepath.Join(t.TempDir(), "network")
+	selected := filepath.Join(modulePackage, "modules", "vpc")
+	writeFile(t, filepath.Join(selected, "main.tf"), `resource "aws_vpc" "example" {}`)
+	writeFile(t, filepath.Join(modulePackage, "modules", "shared", "variables.tf"), `variable "name" {}`)
+
+	artifactDir := filepath.Join(t.TempDir(), "prepared")
+	result, err := Prepare(t.Context(), &Config{
+		RepositoryRoot: root,
+		ArtifactDir:    artifactDir,
+		Resolver: &fixtureResolver{
+			packages: map[string]string{source: modulePackage},
+			selected: map[string]string{source: selected},
+		},
+	})
+	require.NoError(t, err)
+	manifest, err := resolver.LoadManifest(t.Context(), result.ManifestPath)
+	require.NoError(t, err)
+	resolution, err := resolver.NewPrefetchedResolver(manifest).Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source: source,
+	})
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(resolution.PackageRoot, "modules", "vpc"), resolution.LocalPath)
+	require.FileExists(t, filepath.Join(resolution.PackageRoot, "modules", "shared", "variables.tf"))
+}
+
+func TestPreparePreservesDistinctUnversionedRegistryCalls(t *testing.T) {
+	root := t.TempDir()
+	source := "registry.example.com/acme/network/aws"
+	for _, name := range []string{"first", "second"} {
+		writeFile(t, filepath.Join(root, name, "main.tf"), `
+module "`+name+`" {
+  source = "`+source+`"
+}
+`)
+		writeFile(t, filepath.Join(root, name, ".terraform", "modules", "modules.json"), `{}`)
+	}
+	firstPackage := filepath.Join(t.TempDir(), "first")
+	secondPackage := filepath.Join(t.TempDir(), "second")
+	writeFile(t, filepath.Join(firstPackage, "main.tf"), `resource "aws_vpc" "first" {}`)
+	writeFile(t, filepath.Join(secondPackage, "main.tf"), `resource "aws_vpc" "second" {}`)
+
+	artifactDir := filepath.Join(t.TempDir(), "prepared")
+	result, err := Prepare(t.Context(), &Config{
+		RepositoryRoot: root,
+		ArtifactDir:    artifactDir,
+		Resolver: &fixtureResolver{byName: map[string]string{
+			"first":  firstPackage,
+			"second": secondPackage,
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Modules, 2)
+
+	manifest, err := resolver.LoadManifest(t.Context(), result.ManifestPath)
+	require.NoError(t, err)
+	for _, name := range []string{"first", "second"} {
+		resolution, resolveErr := resolver.NewPrefetchedResolver(manifest).Resolve(
+			t.Context(),
+			&tfmodules.ParsedModule{
+				Source:   source,
+				Name:     name,
+				FileName: filepath.Join(root, name, "main.tf"),
+				DefLine:  2,
+			},
+		)
+		require.NoError(t, resolveErr)
+		content, readErr := os.ReadFile(filepath.Join(resolution.LocalPath, "main.tf"))
+		require.NoError(t, readErr)
+		require.Contains(t, string(content), `"`+name+`"`)
+	}
+}
+
+func TestPrepareRedactsSourceCredentialsWithoutBreakingLookup(t *testing.T) {
+	root := t.TempDir()
+	source := "git::https://user:token@git.example/acme/module.git?ref=v1"
+	writeFile(t, filepath.Join(root, "main.tf"), `
+module "example" {
+  source = "`+source+`"
+}
+`)
+	modulePackage := filepath.Join(t.TempDir(), "module")
+	writeFile(t, filepath.Join(modulePackage, "main.tf"), `resource "aws_vpc" "example" {}`)
+	artifactDir := filepath.Join(t.TempDir(), "prepared")
+	result, err := Prepare(t.Context(), &Config{
+		RepositoryRoot: root,
+		ArtifactDir:    artifactDir,
+		Resolver: &fixtureResolver{
+			packages: map[string]string{source: modulePackage},
+		},
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(result.ManifestPath)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "user:token")
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	manifest, err := resolver.LoadManifest(t.Context(), result.ManifestPath)
+	require.NoError(t, err)
+	_, err = resolver.NewPrefetchedResolver(manifest).Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source: source,
+	})
+	require.NoError(t, err)
+}
+
+func TestPreparePublishesPartialManifestOnResolutionTimeout(t *testing.T) {
+	root := t.TempDir()
+	source := "git::https://git.example/acme/slow.git?ref=v1"
+	writeFile(t, filepath.Join(root, "main.tf"), `
+module "slow" {
+  source = "`+source+`"
+}
+`)
+	artifactDir := filepath.Join(t.TempDir(), "prepared")
+	result, err := Prepare(t.Context(), &Config{
+		RepositoryRoot:    root,
+		ArtifactDir:       artifactDir,
+		Resolver:          blockingResolver{},
+		ResolutionTimeout: 10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	require.True(t, result.TimedOut)
+	require.Len(t, result.Failures, 1)
+
+	manifest, err := resolver.LoadManifest(t.Context(), result.ManifestPath)
+	require.NoError(t, err)
+	require.Len(t, manifest.Entries, 1)
+	require.Equal(t, "unresolved", manifest.Entries[0].Status)
+	require.Contains(t, manifest.Entries[0].Failure, context.DeadlineExceeded.Error())
+}
+
+func TestPrepareRecordsModulesRemovedByAdmission(t *testing.T) {
+	root := t.TempDir()
+	parentSource := "registry.example.com/acme/parent/aws"
+	childSource := "git::https://user:token@git.example/acme/child.git?ref=v1"
+	writeFile(t, filepath.Join(root, "main.tf"), `
+module "parent" {
+  source = "`+parentSource+`"
+}
+`)
+	parentPackage := filepath.Join(t.TempDir(), "parent")
+	childPackage := filepath.Join(t.TempDir(), "child")
+	writeFile(t, filepath.Join(parentPackage, "main.tf"), `
+module "child" {
+  source = "`+childSource+`"
+}
+resource "aws_vpc" "parent" {}
+`)
+	writeFile(t, filepath.Join(childPackage, "main.tf"), `resource "aws_subnet" "child" {}`)
+	parentUsage, err := resolver.MeasurePackage(t.Context(), parentPackage, resolver.ResourceLimits{})
+	require.NoError(t, err)
+
+	artifactDir := filepath.Join(t.TempDir(), "prepared")
+	result, err := Prepare(t.Context(), &Config{
+		RepositoryRoot: root,
+		ArtifactDir:    artifactDir,
+		Resolver: &fixtureResolver{packages: map[string]string{
+			parentSource: parentPackage,
+			childSource:  childPackage,
+		}},
+		ResourceLimits: resolver.ResourceLimits{
+			MaxTotalBytes: parentUsage.Bytes,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.BudgetEvents, 1)
+	require.NotContains(t, result.BudgetEvents[0].Source, "user:token")
+
+	manifest, err := resolver.LoadManifest(t.Context(), result.ManifestPath)
+	require.NoError(t, err)
+	require.Len(t, manifest.Entries, 2)
+	var unresolved int
+	for _, entry := range manifest.Entries {
+		if entry.Status == resolver.ManifestStatusUnresolved {
+			unresolved++
+			require.Contains(t, entry.Failure, "pre-parse admission")
+		}
+	}
+	require.Equal(t, 1, unresolved)
+}
+
+func TestPrepareMaxDepthZeroDisablesTraversal(t *testing.T) {
+	root := t.TempDir()
+	source := "git::https://git.example/acme/module.git?ref=v1"
+	writeFile(t, filepath.Join(root, "main.tf"), `
+module "example" {
+  source = "`+source+`"
+}
+`)
+	modulePackage := filepath.Join(t.TempDir(), "module")
+	writeFile(t, filepath.Join(modulePackage, "main.tf"), `resource "aws_vpc" "example" {}`)
+	resolverCalled := false
+	depth := 0
+	artifactDir := filepath.Join(t.TempDir(), "prepared")
+	result, err := Prepare(t.Context(), &Config{
+		RepositoryRoot: root,
+		ArtifactDir:    artifactDir,
+		MaxDepth:       &depth,
+		Resolver: &fixtureResolver{
+			packages: map[string]string{source: modulePackage},
+			onResolve: func() {
+				resolverCalled = true
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, resolverCalled)
+	require.Empty(t, result.Modules)
+	require.Empty(t, result.Failures)
+}
+
+func TestPrepareWritesValidEmptyManifest(t *testing.T) {
+	artifactDir := filepath.Join(t.TempDir(), "prepared")
+	result, err := Prepare(t.Context(), &Config{
+		RepositoryRoot: t.TempDir(),
+		ArtifactDir:    artifactDir,
+		Resolver:       &fixtureResolver{},
+	})
+	require.NoError(t, err)
+	manifest, err := resolver.LoadManifest(t.Context(), result.ManifestPath)
+	require.NoError(t, err)
+	require.Empty(t, manifest.Entries)
+}
+
+func TestPrepareIgnoresTerraformCacheDirectoriesDuringDiscovery(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".terraform", "modules", "cached", "main.tf"), `
+module "cached" {
+  source = "git::https://git.example/acme/cached.git?ref=v1"
+}
+`)
+	cacheDir := filepath.Join(root, "worker-cache")
+	writeFile(t, filepath.Join(cacheDir, "modules", "cached", "main.tf"), `
+module "worker_cached" {
+  source = "git::https://git.example/acme/worker-cached.git?ref=v1"
+}
+`)
+	artifactDir := filepath.Join(t.TempDir(), "prepared")
+	result, err := Prepare(t.Context(), &Config{
+		RepositoryRoot: root,
+		ArtifactDir:    artifactDir,
+		CacheDir:       cacheDir,
+		Resolver:       &fixtureResolver{},
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.Modules)
+}
+
+func TestPrepareDoesNotReplaceExistingArtifact(t *testing.T) {
+	root := t.TempDir()
+	artifactDir := t.TempDir()
+	sentinel := filepath.Join(artifactDir, "sentinel")
+	writeFile(t, sentinel, "keep")
+
+	_, err := Prepare(t.Context(), &Config{
+		RepositoryRoot: root,
+		ArtifactDir:    artifactDir,
+		Resolver:       &fixtureResolver{},
+	})
+	require.ErrorContains(t, err, "already exists")
+	require.FileExists(t, sentinel)
+}
+
+func TestPublishArtifactDoesNotReplaceDestination(t *testing.T) {
+	parent := t.TempDir()
+	first := filepath.Join(parent, "first")
+	second := filepath.Join(parent, "second")
+	destination := filepath.Join(parent, "published")
+	writeFile(t, filepath.Join(first, "marker"), "first")
+	writeFile(t, filepath.Join(second, "marker"), "second")
+
+	require.NoError(t, publishArtifact(first, destination))
+	require.Error(t, publishArtifact(second, destination))
+	content, err := os.ReadFile(filepath.Join(destination, "marker"))
+	require.NoError(t, err)
+	require.Equal(t, "first", string(content))
+}
+
+type fixtureResolver struct {
+	packages  map[string]string
+	selected  map[string]string
+	byName    map[string]string
+	onResolve func()
+	mu        sync.Mutex
+	cleanups  int
+}
+
+func (r *fixtureResolver) Resolve(_ context.Context, module *tfmodules.ParsedModule) (resolver.Resolution, error) {
+	if r.onResolve != nil {
+		r.onResolve()
+	}
+	root, ok := r.packages[module.Source]
+	if named := r.byName[module.Name]; named != "" {
+		root, ok = named, true
+	}
+	if !ok {
+		return resolver.Resolution{}, &tfmodules.UnresolvedError{Reason: "fixture has no package"}
+	}
+	localPath := root
+	if selected := r.selected[module.Source]; selected != "" {
+		localPath = selected
+	}
+	return resolver.Resolution{
+		LocalPath:   localPath,
+		PackageRoot: root,
+		ResolvedRef: "fixture-ref",
+		Cleanup: func() {
+			r.mu.Lock()
+			r.cleanups++
+			r.mu.Unlock()
+		},
+	}, nil
+}
+
+func (r *fixtureResolver) cleanupCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.cleanups
+}
+
+type blockingResolver struct{}
+
+func (blockingResolver) Resolve(ctx context.Context, _ *tfmodules.ParsedModule) (resolver.Resolution, error) {
+	<-ctx.Done()
+	return resolver.Resolution{}, ctx.Err()
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}

--- a/pkg/parser/terraform/modules/moduleprepare/publish_darwin.go
+++ b/pkg/parser/terraform/modules/moduleprepare/publish_darwin.go
@@ -1,0 +1,15 @@
+//go:build darwin
+
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package moduleprepare
+
+import "golang.org/x/sys/unix"
+
+func publishArtifact(source, destination string) error {
+	return unix.RenamexNp(source, destination, unix.RENAME_EXCL)
+}

--- a/pkg/parser/terraform/modules/moduleprepare/publish_linux.go
+++ b/pkg/parser/terraform/modules/moduleprepare/publish_linux.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package moduleprepare
+
+import "golang.org/x/sys/unix"
+
+func publishArtifact(source, destination string) error {
+	return unix.Renameat2(
+		unix.AT_FDCWD,
+		source,
+		unix.AT_FDCWD,
+		destination,
+		unix.RENAME_NOREPLACE,
+	)
+}

--- a/pkg/parser/terraform/modules/moduleprepare/publish_other.go
+++ b/pkg/parser/terraform/modules/moduleprepare/publish_other.go
@@ -1,0 +1,15 @@
+//go:build !linux && !darwin && !windows
+
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package moduleprepare
+
+import "os"
+
+func publishArtifact(source, destination string) error {
+	return os.Rename(source, destination)
+}

--- a/pkg/parser/terraform/modules/moduleprepare/publish_windows.go
+++ b/pkg/parser/terraform/modules/moduleprepare/publish_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package moduleprepare
+
+import "os"
+
+func publishArtifact(source, destination string) error {
+	return os.Rename(source, destination)
+}

--- a/pkg/parser/terraform/modules/resolver/default_chain.go
+++ b/pkg/parser/terraform/modules/resolver/default_chain.go
@@ -1,0 +1,130 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+)
+
+type DefaultChainConfig struct {
+	DiscoveryPaths []string
+	Manifest       *Manifest
+	Additional     []Resolver
+	FetchRemote    bool
+	FetchTimeout   time.Duration
+	HostAllowlist  []string
+	CacheRoot      string
+	MaxCacheBytes  int64
+}
+
+// NewDefaultChain builds the standard local, prefetched, injected, git, and registry resolver chain.
+func NewDefaultChain(ctx context.Context, config *DefaultChainConfig) (*ChainResolver, error) {
+	if config == nil {
+		config = &DefaultChainConfig{}
+	}
+	contextLogger := logger.FromContext(ctx)
+	roots := TerraformRootDirs(config.DiscoveryPaths)
+	resolvers := []Resolver{
+		LocalResolver{},
+		&DotTerraformResolver{RootDirs: roots},
+	}
+	if config.Manifest != nil {
+		resolvers = append(resolvers, NewPrefetchedResolver(config.Manifest))
+	}
+	for _, additional := range config.Additional {
+		if additional != nil {
+			resolvers = append(resolvers, additional)
+		}
+	}
+	if !config.FetchRemote {
+		return NewChainResolver(resolvers...), nil
+	}
+
+	getterConfig := NewGoGetterConfig()
+	if config.FetchTimeout > 0 {
+		getterConfig.FetchTimeout = config.FetchTimeout
+	}
+	getterConfig.HostAllowlist = append([]string(nil), config.HostAllowlist...)
+
+	cacheRoot := strings.TrimSpace(config.CacheRoot)
+	if cacheRoot == "" {
+		var err error
+		cacheRoot, err = DefaultModuleCacheRoot()
+		if err != nil {
+			contextLogger.Warn().Err(err).
+				Msg("Remote module cache root unavailable; cache limits will not be enforced")
+		}
+	}
+	maxCacheBytes := config.MaxCacheBytes
+	if maxCacheBytes == 0 {
+		maxCacheBytes = DefaultMaxCacheBytes
+	}
+	var budget *ModuleCacheBudget
+	if cacheRoot != "" {
+		var err error
+		budget, err = NewModuleCacheBudget(cacheRoot, maxCacheBytes)
+		if err != nil {
+			contextLogger.Warn().Err(err).
+				Msg("Remote module cache budget unavailable; cache limits will not be enforced")
+		}
+	}
+
+	git := NewBareGitResolver(ModuleCacheSubdir(cacheRoot, CacheSubdirGitBare), config.HostAllowlist...)
+	git.Budget = budget
+	getterConfig.Git = git
+	localGit := NewLocalGitRefResolver(roots, ModuleCacheSubdir(cacheRoot, CacheSubdirGitLocal))
+	localGit.Budget = budget
+	resolvers = append(resolvers, localGit, git)
+
+	cache, err := NewModuleCacheWithDir(ModuleCacheSubdir(cacheRoot, CacheSubdirModules), budget)
+	if err != nil {
+		contextLogger.Warn().Err(err).
+			Msg("Module disk cache unavailable; fetched modules will not be cached")
+	} else {
+		getterConfig.Cache = cache
+	}
+	resolvers = append(resolvers, NewGoGetterResolver(getterConfig))
+	return NewChainResolver(resolvers...), nil
+}
+
+// TerraformRootDirs returns the Terraform workspace root for each distinct discovery path.
+func TerraformRootDirs(paths []string) []string {
+	seen := make(map[string]bool, len(paths))
+	roots := make([]string, 0, len(paths))
+	for _, path := range paths {
+		root := terraformRootDir(path)
+		if root == "" || seen[root] {
+			continue
+		}
+		seen[root] = true
+		roots = append(roots, root)
+	}
+	return roots
+}
+
+func terraformRootDir(path string) string {
+	info, err := os.Stat(path)
+	if err == nil && !info.IsDir() {
+		path = filepath.Dir(path)
+	}
+	clean := filepath.Clean(path)
+	for {
+		if _, err := os.Stat(filepath.Join(clean, ".terraform", "modules", "modules.json")); err == nil {
+			return clean
+		}
+		parent := filepath.Dir(clean)
+		if parent == clean {
+			return filepath.Clean(path)
+		}
+		clean = parent
+	}
+}

--- a/pkg/parser/terraform/modules/resolver/manifest_write.go
+++ b/pkg/parser/terraform/modules/resolver/manifest_write.go
@@ -1,0 +1,88 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package resolver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+const (
+	manifestDirectoryPermissions = 0o750
+	manifestFilePermissions      = 0o640
+)
+
+type manifestV1 struct {
+	SchemaVersion int              `json:"schema_version"`
+	Root          string           `json:"root"`
+	Modules       []ManifestModule `json:"modules"`
+}
+
+// WriteManifest writes and validates a versioned prefetched-module manifest atomically.
+func WriteManifest(ctx context.Context, path, root string, modules []ManifestModule) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	path = filepath.Clean(path)
+	if root == "" || !filepath.IsLocal(root) {
+		return fmt.Errorf("manifest root must be a non-empty relative path")
+	}
+
+	ordered := append(make([]ManifestModule, 0, len(modules)), modules...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].Source != ordered[j].Source {
+			return ordered[i].Source < ordered[j].Source
+		}
+		if ordered[i].RequestedVersion != ordered[j].RequestedVersion {
+			return ordered[i].RequestedVersion < ordered[j].RequestedVersion
+		}
+		return ordered[i].ID < ordered[j].ID
+	})
+	data, err := json.MarshalIndent(manifestV1{
+		SchemaVersion: ManifestSchemaVersion,
+		Root:          filepath.ToSlash(root),
+		Modules:       ordered,
+	}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling manifest: %w", err)
+	}
+	data = append(data, '\n')
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, manifestDirectoryPermissions); err != nil {
+		return fmt.Errorf("creating manifest directory: %w", err)
+	}
+	temp, err := os.CreateTemp(dir, ".modules-*.json")
+	if err != nil {
+		return fmt.Errorf("creating temporary manifest: %w", err)
+	}
+	tempPath := temp.Name()
+	defer func() {
+		_ = os.Remove(tempPath)
+	}()
+	if err := temp.Chmod(manifestFilePermissions); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("setting manifest permissions: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("writing temporary manifest: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("closing temporary manifest: %w", err)
+	}
+	if _, err := LoadManifest(ctx, tempPath); err != nil {
+		return fmt.Errorf("validating generated manifest: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("publishing manifest: %w", err)
+	}
+	return nil
+}

--- a/pkg/parser/terraform/modules/resolver/prefetched.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched.go
@@ -13,13 +13,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
 )
 
 const (
 	ManifestSchemaVersion    = 1
-	manifestStatusResolved   = "resolved"
-	manifestStatusUnresolved = "unresolved"
+	ManifestStatusResolved   = "resolved"
+	ManifestStatusUnresolved = "unresolved"
 )
 
 type ManifestEntry struct {
@@ -35,11 +36,18 @@ type ManifestEntry struct {
 }
 
 type Manifest struct {
-	SchemaVersion int                      `json:"schema_version,omitempty"`
-	Root          string                   `json:"root,omitempty"`
-	Dir           string                   `json:"dir,omitempty"`
-	Modules       map[string]ManifestEntry `json:"modules,omitempty"`
-	Entries       []ManifestModule         `json:"-"`
+	SchemaVersion   int                      `json:"schema_version,omitempty"`
+	Root            string                   `json:"root,omitempty"`
+	Dir             string                   `json:"dir,omitempty"`
+	Modules         map[string]ManifestEntry `json:"modules,omitempty"`
+	Entries         []ManifestModule         `json:"-"`
+	candidates      map[string][]manifestCandidate
+	verifiedDigests map[string]string
+}
+
+type manifestCandidate struct {
+	entry        ManifestEntry
+	declarations []ManifestDeclaration
 }
 
 type ManifestModule struct {
@@ -112,7 +120,7 @@ func loadLegacyManifest(envelope manifestEnvelope) (*Manifest, error) {
 		entry := modules[key]
 		entry.RequestedVersion = entry.Version
 		entry.ResolvedVersion = entry.Version
-		entry.Status = manifestStatusResolved
+		entry.Status = ManifestStatusResolved
 		modules[key] = entry
 	}
 	return &Manifest{Dir: envelope.Dir, Modules: modules}, nil
@@ -141,11 +149,13 @@ func loadManifestV1(ctx context.Context, manifestPath string, envelope manifestE
 		return nil, fmt.Errorf("modules must be an array")
 	}
 	manifest := &Manifest{
-		SchemaVersion: ManifestSchemaVersion,
-		Root:          root,
-		Dir:           root,
-		Modules:       make(map[string]ManifestEntry, len(entries)),
-		Entries:       entries,
+		SchemaVersion:   ManifestSchemaVersion,
+		Root:            root,
+		Dir:             root,
+		Modules:         make(map[string]ManifestEntry, len(entries)),
+		Entries:         entries,
+		candidates:      make(map[string][]manifestCandidate, len(entries)),
+		verifiedDigests: make(map[string]string),
 	}
 	for i := range manifest.Entries {
 		if err := manifest.addV1Entry(ctx, &manifest.Entries[i]); err != nil {
@@ -167,9 +177,6 @@ func (m *Manifest) addV1Entry(ctx context.Context, module *ManifestModule) error
 		return err
 	}
 	key := manifestModuleKey(module.Source, strings.TrimSpace(module.RequestedVersion))
-	if _, exists := m.Modules[key]; exists {
-		return fmt.Errorf("duplicate module %q", key)
-	}
 	entry := ManifestEntry{
 		RequestedVersion: strings.TrimSpace(module.RequestedVersion),
 		ResolvedVersion:  strings.TrimSpace(module.ResolvedVersion),
@@ -179,29 +186,58 @@ func (m *Manifest) addV1Entry(ctx context.Context, module *ManifestModule) error
 		Origin:           module.SourceType,
 	}
 	switch module.Status {
-	case manifestStatusResolved:
+	case ManifestStatusResolved:
 		if err := m.resolveV1Paths(ctx, module, &entry); err != nil {
 			return err
 		}
 		if module.ContentDigest == "" {
 			return fmt.Errorf("content_digest is required for a resolved module")
 		}
-		digest, err := ComputePackageDigest(ctx, entry.PackageRoot)
-		if err != nil {
-			return fmt.Errorf("computing content digest: %w", err)
+		digest, verified := m.verifiedDigests[entry.PackageRoot]
+		if !verified {
+			var err error
+			digest, err = ComputePackageDigest(ctx, entry.PackageRoot)
+			if err != nil {
+				return fmt.Errorf("computing content digest: %w", err)
+			}
+			m.verifiedDigests[entry.PackageRoot] = digest
 		}
 		if !strings.EqualFold(module.ContentDigest, digest) {
 			return fmt.Errorf("content_digest mismatch: got %q, computed %q", module.ContentDigest, digest)
 		}
-	case manifestStatusUnresolved:
+	case ManifestStatusUnresolved:
 		if strings.TrimSpace(module.Failure) == "" {
 			return fmt.Errorf("failure is required for an unresolved module")
 		}
 	default:
 		return fmt.Errorf("status must be resolved or unresolved")
 	}
-	m.Modules[key] = entry
+	for i := range m.candidates[key] {
+		if declarationsOverlap(m.candidates[key][i].declarations, module.Declarations) {
+			return fmt.Errorf("duplicate module declaration for %q", key)
+		}
+	}
+	m.candidates[key] = append(m.candidates[key], manifestCandidate{
+		entry:        entry,
+		declarations: append([]ManifestDeclaration(nil), module.Declarations...),
+	})
+	if _, exists := m.Modules[key]; !exists {
+		m.Modules[key] = entry
+	}
 	return nil
+}
+
+func declarationsOverlap(left, right []ManifestDeclaration) bool {
+	for _, first := range left {
+		for _, second := range right {
+			if first.Filename == second.Filename &&
+				first.ModuleName == second.ModuleName &&
+				first.LineStart == second.LineStart {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (m *Manifest) resolveV1Paths(ctx context.Context, module *ManifestModule, entry *ManifestEntry) error {
@@ -253,7 +289,7 @@ func (m *Manifest) validate(ctx context.Context) error {
 	}
 	for src := range m.Modules {
 		entry := m.Modules[src]
-		if entry.Status == manifestStatusUnresolved {
+		if entry.Status == ManifestStatusUnresolved {
 			continue
 		}
 		if !filepath.IsAbs(entry.LocalPath) {
@@ -310,7 +346,18 @@ func (r *PrefetchedResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedM
 	if mod.IsLocal {
 		return Resolution{}, &tfmodules.UnresolvedError{Reason: "local modules are handled by LocalResolver"}
 	}
-	entry, ok := r.manifest.Modules[manifestModuleKey(mod.Source, mod.Version)]
+	key := manifestModuleKey(mod.Source, mod.Version)
+	if candidates := r.manifest.candidates[key]; len(candidates) > 0 {
+		entry, err := selectManifestCandidate(mod, candidates)
+		if err != nil {
+			return Resolution{}, err
+		}
+		return resolveManifestEntry(ctx, mod, entry)
+	}
+	entry, ok := r.manifest.Modules[key]
+	if !ok {
+		entry, ok = r.manifest.Modules[legacyManifestModuleKey(mod.Source, mod.Version)]
+	}
 	if !ok {
 		entry, ok = r.manifest.Modules[mod.Source]
 	}
@@ -319,7 +366,58 @@ func (r *PrefetchedResolver) Resolve(ctx context.Context, mod *tfmodules.ParsedM
 			Reason: fmt.Sprintf("module %q not found in manifest", mod.Source),
 		}
 	}
-	if entry.Status == manifestStatusUnresolved {
+	return resolveManifestEntry(ctx, mod, &entry)
+}
+
+func selectManifestCandidate(
+	mod *tfmodules.ParsedModule, candidates []manifestCandidate,
+) (*ManifestEntry, error) {
+	if len(candidates) == 1 {
+		return &candidates[0].entry, nil
+	}
+	matches := make([]*ManifestEntry, 0, len(candidates))
+	bestSpecificity := -1
+	for i := range candidates {
+		candidateSpecificity := -1
+		for _, declaration := range candidates[i].declarations {
+			if declarationMatchesModule(declaration, mod) {
+				candidateSpecificity = max(candidateSpecificity, len(filepath.Clean(declaration.Filename)))
+			}
+		}
+		switch {
+		case candidateSpecificity > bestSpecificity:
+			bestSpecificity = candidateSpecificity
+			matches = []*ManifestEntry{&candidates[i].entry}
+		case candidateSpecificity >= 0 && candidateSpecificity == bestSpecificity:
+			matches = append(matches, &candidates[i].entry)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	reason := fmt.Sprintf("module %q declaration not found in manifest", mod.Source)
+	if len(matches) > 1 {
+		reason = fmt.Sprintf("module %q declaration is ambiguous in manifest", mod.Source)
+	}
+	return nil, &tfmodules.UnresolvedError{Reason: reason}
+}
+
+func declarationMatchesModule(declaration ManifestDeclaration, mod *tfmodules.ParsedModule) bool {
+	if declaration.ModuleName != mod.Name {
+		return false
+	}
+	if mod.DefLine > 0 && declaration.LineStart != mod.DefLine {
+		return false
+	}
+	filename := filepath.ToSlash(filepath.Clean(mod.FileName))
+	declared := filepath.ToSlash(filepath.Clean(declaration.Filename))
+	return filename == declared || strings.HasSuffix(filename, "/"+declared)
+}
+
+func resolveManifestEntry(
+	ctx context.Context, mod *tfmodules.ParsedModule, entry *ManifestEntry,
+) (Resolution, error) {
+	if entry.Status == ManifestStatusUnresolved {
 		return Resolution{}, &tfmodules.UnresolvedError{Reason: entry.Failure}
 	}
 	if entry.RequestedVersion != "" && mod.Version != "" && entry.RequestedVersion != mod.Version {
@@ -345,6 +443,11 @@ func firstNonEmpty(values ...string) string {
 }
 
 func manifestModuleKey(source, version string) string {
+	source = model.RedactURLCredentials(source)
+	return legacyManifestModuleKey(source, version)
+}
+
+func legacyManifestModuleKey(source, version string) string {
 	if version == "" {
 		return source
 	}

--- a/pkg/parser/terraform/modules/resolver/prefetched_test.go
+++ b/pkg/parser/terraform/modules/resolver/prefetched_test.go
@@ -142,6 +142,68 @@ func TestLoadManifestV1PreservesUnresolvedStatus(t *testing.T) {
 	require.ErrorContains(t, err, "credentials_unavailable")
 }
 
+func TestPrefetchedResolverChoosesMostSpecificDeclaration(t *testing.T) {
+	dir := t.TempDir()
+	packageRoot := filepath.Join(dir, "modules", "package")
+	rootSelection := filepath.Join(packageRoot, "root")
+	nestedSelection := filepath.Join(packageRoot, "nested")
+	require.NoError(t, os.MkdirAll(rootSelection, 0o755))
+	require.NoError(t, os.MkdirAll(nestedSelection, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(rootSelection, "main.tf"), []byte("root"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(nestedSelection, "main.tf"), []byte("nested"), 0o644))
+	digest, err := ComputePackageDigest(t.Context(), packageRoot)
+	require.NoError(t, err)
+
+	source := "registry.example.com/acme/shared/aws"
+	manifestPath := filepath.Join(dir, "modules.json")
+	writeManifestJSON(t, manifestPath, map[string]any{
+		"schema_version": ManifestSchemaVersion,
+		"root":           "modules",
+		"modules": []map[string]any{
+			{
+				"source":         source,
+				"package_root":   "package",
+				"local_path":     "package/root",
+				"content_digest": digest,
+				"status":         ManifestStatusResolved,
+				"declarations": []map[string]any{{
+					"filename":    "main.tf",
+					"line_start":  1,
+					"line_end":    3,
+					"module_name": "shared",
+				}},
+			},
+			{
+				"source":         source,
+				"package_root":   "package",
+				"local_path":     "package/nested",
+				"content_digest": digest,
+				"status":         ManifestStatusResolved,
+				"declarations": []map[string]any{{
+					"filename":    "parent/main.tf",
+					"line_start":  1,
+					"line_end":    3,
+					"module_name": "shared",
+				}},
+			},
+		},
+	})
+
+	manifest, err := LoadManifest(t.Context(), manifestPath)
+	require.NoError(t, err)
+	prefetched := NewPrefetchedResolver(manifest)
+	rootResult, err := prefetched.Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source: source, Name: "shared", FileName: "/repo/main.tf", DefLine: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, rootSelection, rootResult.LocalPath)
+	nestedResult, err := prefetched.Resolve(t.Context(), &tfmodules.ParsedModule{
+		Source: source, Name: "shared", FileName: "/repo/parent/main.tf", DefLine: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, nestedSelection, nestedResult.LocalPath)
+}
+
 func TestLoadManifestV1RejectsDigestMismatch(t *testing.T) {
 	dir := t.TempDir()
 	moduleDir := filepath.Join(dir, "modules", "vpc")
@@ -277,11 +339,11 @@ func TestLoadManifestRespectsCancelledContext(t *testing.T) {
 		"schema_version": ManifestSchemaVersion,
 		"root":           "modules",
 		"modules": []map[string]any{{
-			"source":           "terraform-aws-modules/vpc/aws",
-			"package_root":     "vpc-package",
-			"local_path":       "vpc-package/modules/vpc",
-			"content_digest":   digest,
-			"status":           "resolved",
+			"source":         "terraform-aws-modules/vpc/aws",
+			"package_root":   "vpc-package",
+			"local_path":     "vpc-package/modules/vpc",
+			"content_digest": digest,
+			"status":         "resolved",
 			"declarations": []map[string]any{{
 				"filename":    "infra/main.tf",
 				"line_start":  12,

--- a/pkg/scan/remote_modules.go
+++ b/pkg/scan/remote_modules.go
@@ -7,8 +7,6 @@ package scan
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -80,7 +78,8 @@ func (c *Client) resolveTerraformModulesForScan(
 			Int("shedding_rank", event.SheddingRank).
 			Msg("Terraform module excluded by resource budget")
 	}
-	for _, failure := range result.Failures {
+	for i := range result.Failures {
+		failure := &result.Failures[i]
 		contextLogger.Warn().
 			Str("module_source", failure.Source).
 			Str("module_name", failure.Name).
@@ -185,112 +184,29 @@ func (c *Client) shouldPreScanTerraformModules(_ []string) bool {
 func (c *Client) buildModuleResolverChain(
 	ctx context.Context, moduleDiscoveryPaths []string,
 ) (*tfresolver.ChainResolver, error) {
-	contextLogger := logger.FromContext(ctx)
-
-	resolvers := []tfresolver.Resolver{
-		tfresolver.LocalResolver{},
-		&tfresolver.DotTerraformResolver{RootDirs: dotTerraformRootDirs(moduleDiscoveryPaths)},
-	}
-
+	var manifest *tfresolver.Manifest
 	if c.ScanParams.RemoteModulesManifestPath != "" {
-		manifest, err := tfresolver.LoadManifest(ctx, c.ScanParams.RemoteModulesManifestPath)
+		var err error
+		manifest, err = tfresolver.LoadManifest(ctx, c.ScanParams.RemoteModulesManifestPath)
 		if err != nil {
 			return nil, err
 		}
-		resolvers = append(resolvers, tfresolver.NewPrefetchedResolver(manifest))
 	}
-
-	if c.ScanParams.TerraformModules != TerraformModulesOn || c.ScanParams.NetworkIsolation {
-		return tfresolver.NewChainResolver(resolvers...), nil
-	}
-
-	ggCfg := tfresolver.NewGoGetterConfig()
-	if t := c.ScanParams.ModuleFetchTimeout; t > 0 {
-		ggCfg.FetchTimeout = t
-	}
-	ggCfg.HostAllowlist = c.ScanParams.RemoteModulesHostAllowlist
 
 	cacheBytes := c.ScanParams.MaxModuleCacheBytes
 	if cacheBytes == 0 {
 		cacheBytes = DefaultRemoteModuleMaxCacheBytes
 	}
-
-	var (
-		cacheRoot string
-		budget    *tfresolver.ModuleCacheBudget
-	)
-	cacheRoot = strings.TrimSpace(c.ScanParams.RemoteModulesCacheDir)
-	if cacheRoot == "" {
-		var rootErr error
-		cacheRoot, rootErr = tfresolver.DefaultModuleCacheRoot()
-		if rootErr != nil {
-			contextLogger.Warn().Err(rootErr).Msg("Remote module cache root unavailable; cache limits will not be enforced")
-		}
-	}
-	if cacheRoot != "" {
-		var budgetErr error
-		budget, budgetErr = tfresolver.NewModuleCacheBudget(cacheRoot, cacheBytes)
-		if budgetErr != nil {
-			contextLogger.Warn().Err(budgetErr).Msg("Remote module cache budget unavailable; cache limits will not be enforced")
-		}
-	}
-
-	gitCacheDir := tfresolver.ModuleCacheSubdir(cacheRoot, tfresolver.CacheSubdirGitBare)
-	localCacheDir := tfresolver.ModuleCacheSubdir(cacheRoot, tfresolver.CacheSubdirGitLocal)
-	git := tfresolver.NewBareGitResolver(gitCacheDir, c.ScanParams.RemoteModulesHostAllowlist...)
-	git.Budget = budget
-	ggCfg.Git = git
-	localGit := tfresolver.NewLocalGitRefResolver(dotTerraformRootDirs(moduleDiscoveryPaths), localCacheDir)
-	localGit.Budget = budget
-	resolvers = append(resolvers, localGit, git)
-
-	moduleCacheDir := tfresolver.ModuleCacheSubdir(cacheRoot, tfresolver.CacheSubdirModules)
-	cache, err := tfresolver.NewModuleCacheWithDir(moduleCacheDir, budget)
-	if err != nil {
-		contextLogger.Warn().Err(err).Msg("Module disk cache unavailable; fetched modules will not be cached")
-	} else {
-		ggCfg.Cache = cache
-	}
-
-	resolvers = append(resolvers, tfresolver.NewGoGetterResolver(ggCfg))
-	return tfresolver.NewChainResolver(resolvers...), nil
-}
-
-func dotTerraformRootDirs(paths []string) []string {
-	seen := make(map[string]bool, len(paths))
-	roots := make([]string, 0, len(paths))
-	for _, p := range paths {
-		root := terraformRootDir(p)
-		if root == "" || seen[root] {
-			continue
-		}
-		seen[root] = true
-		roots = append(roots, root)
-	}
-	return roots
-}
-
-func terraformRootDir(path string) string {
-	info, err := os.Stat(path)
-	if err == nil && !info.IsDir() {
-		path = filepath.Dir(path)
-	}
-	clean := filepath.Clean(path)
-	for {
-		if hasTerraformModulesManifest(clean) {
-			return clean
-		}
-		parent := filepath.Dir(clean)
-		if parent == clean {
-			return filepath.Clean(path)
-		}
-		clean = parent
-	}
-}
-
-func hasTerraformModulesManifest(dir string) bool {
-	_, err := os.Stat(filepath.Join(dir, ".terraform", "modules", "modules.json"))
-	return err == nil
+	return tfresolver.NewDefaultChain(ctx, &tfresolver.DefaultChainConfig{
+		DiscoveryPaths: moduleDiscoveryPaths,
+		Manifest:       manifest,
+		FetchRemote: c.ScanParams.TerraformModules == TerraformModulesOn &&
+			!c.ScanParams.NetworkIsolation,
+		FetchTimeout:  c.ScanParams.ModuleFetchTimeout,
+		HostAllowlist: c.ScanParams.RemoteModulesHostAllowlist,
+		CacheRoot:     c.ScanParams.RemoteModulesCacheDir,
+		MaxCacheBytes: cacheBytes,
+	})
 }
 
 func platformsIncludeTerraform(platforms []string) bool {

--- a/pkg/scan/remote_modules_test.go
+++ b/pkg/scan/remote_modules_test.go
@@ -93,7 +93,7 @@ func TestOnModeRejectsMalformedManifest(t *testing.T) {
 	manifestPath := filepath.Join(t.TempDir(), "modules.json")
 	require.NoError(t, os.WriteFile(manifestPath, []byte(`{"schema_version":1}`), 0o644))
 	client := &Client{ScanParams: &Parameters{
-		TerraformModules:      TerraformModulesOn,
+		TerraformModules:          TerraformModulesOn,
 		RemoteModulesManifestPath: manifestPath,
 	}}
 
@@ -218,7 +218,7 @@ func TestDotTerraformRootDirsUsesFileParent(t *testing.T) {
 	file := filepath.Join(root, "main.tf")
 	require.NoError(t, os.WriteFile(file, nil, 0o644))
 
-	require.Equal(t, []string{root}, dotTerraformRootDirs([]string{file}))
+	require.Equal(t, []string{root}, resolver.TerraformRootDirs([]string{file}))
 }
 
 func TestRemoteModuleFilesBypassPrebuiltInventoryFilters(t *testing.T) {


### PR DESCRIPTION
## Motivation

Hosted scans need remote Terraform modules resolved and materialized on the trusted worker before the offline scan sandbox runs. This adds the worker-side preparation library for that flow, as part of the broader remote modules epic.

Related ticket: [K9CODESEC-5298](https://datadoghq.atlassian.net/browse/K9CODESEC-5298)

## Changes

**Resolver and manifest primitives**

Extracted a reusable default resolver chain and atomic manifest writer so both the scanner and the preparation library share the same fetch, cache, and manifest contracts.

**Module graph**

Unresolved module declarations are now preserved when admission limits or resolution timeouts drop packages from the walk, so partial manifests still record what failed.

**Worker preparation library**

New `moduleprepare` package resolves the module graph, stages content-addressed artifacts, writes a digest-verified manifest, and publishes the output atomically per platform. `MaxDepth` uses a pointer so unset keeps the default depth while explicit zero disables traversal, matching scan semantics.

**Scanner integration**

`remote_modules` now builds its resolver chain through the shared helper.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/parser/terraform/modules/... ./pkg/scan/... -count=1`
2. `golangci-lint run -c .golangci.yml --timeout 20m` on changed packages if needed.
3. Confirm `moduleprepare.Prepare` produces a valid `modules.json`, stages packages under digest directories, and records unresolved modules on timeout or admission rejection.

## Blast Radius

Library-only change for now. Affects the Terraform remote-module preparation path and shared resolver/manifest code used by the scanner. No CLI flag or default scan behavior changes until a caller wires this in.

## Additional Notes

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-5298]: https://datadoghq.atlassian.net/browse/K9CODESEC-5298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ