### PR TITLE
[K9CODESEC-5295] Export column ranges in module attribution SARIF

### DIFF
--- a/pkg/engine/module_attribution_sarif_integration_test.go
+++ b/pkg/engine/module_attribution_sarif_integration_test.go
@@ -130,5 +130,7 @@ resource "aws_s3_bucket" "this" {
 	require.Contains(t, string(moduleRaw), `"name":"bucket"`)
 	require.Contains(t, string(moduleRaw), `"source":"modules/bucket"`)
 	require.Contains(t, string(moduleRaw), `"code_location"`)
+	require.Contains(t, string(moduleRaw), `"column_start"`)
+	require.Contains(t, string(moduleRaw), `"column_end"`)
 	require.NotContains(t, string(moduleRaw), `"module_path"`)
 }

--- a/pkg/model/module_attribution.go
+++ b/pkg/model/module_attribution.go
@@ -5,13 +5,13 @@
  */
 package model
 
-// SourceLocation is a filename plus an inclusive line range.
+// SourceLocation is a filename plus an inclusive line/column range.
 type SourceLocation struct {
 	Filename    string `json:"filename,omitempty"`
 	LineStart   int    `json:"line_start,omitempty"`
 	LineEnd     int    `json:"line_end,omitempty"`
-	ColumnStart int    `json:"-"`
-	ColumnEnd   int    `json:"-"`
+	ColumnStart int    `json:"column_start,omitempty"`
+	ColumnEnd   int    `json:"column_end,omitempty"`
 }
 
 // ModulePathHop is one module call on the path to a finding.

--- a/pkg/model/module_attribution_sarif_test.go
+++ b/pkg/model/module_attribution_sarif_test.go
@@ -11,6 +11,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestModuleAttributionForSARIF_IncludesCodeLocationColumns(t *testing.T) {
+	attr := &ModuleAttribution{
+		ModuleCodeLocation: SourceLocation{
+			Filename:    "main.tf",
+			LineStart:   24,
+			LineEnd:     31,
+			ColumnStart: 3,
+			ColumnEnd:   12,
+		},
+		ModulePath: []ModulePathHop{{
+			Name: "wrapper",
+			CodeLocation: SourceLocation{
+				Filename:    "stack/main.tf",
+				LineStart:   2,
+				LineEnd:     4,
+				ColumnStart: 1,
+				ColumnEnd:   2,
+			},
+		}},
+	}
+
+	payload := ModuleAttributionForSARIF(attr)
+	require.Equal(t, 3, payload.ModuleCodeLocation.ColumnStart)
+	require.Equal(t, 12, payload.ModuleCodeLocation.ColumnEnd)
+	require.Equal(t, 1, payload.ModulePath[0].CodeLocation.ColumnStart)
+	require.Equal(t, 2, payload.ModulePath[0].CodeLocation.ColumnEnd)
+}
+
 func TestModuleAttributionForSARIF_RedactsCredentials(t *testing.T) {
 	attr := &ModuleAttribution{
 		Source: "https://user:token@example.com/modules/bucket",

--- a/pkg/report/model/sarif_module_test.go
+++ b/pkg/report/model/sarif_module_test.go
@@ -85,7 +85,9 @@ func TestBuildSarifIssue_ModuleAttribution(t *testing.T) {
 		"code_location": {
 			"filename": "main.tf",
 			"line_start": 2,
-			"line_end": 4
+			"line_end": 4,
+			"column_start": 1,
+			"column_end": 2
 		}
 	}`, string(payload))
 }


### PR DESCRIPTION
## Motivation

Module attribution SARIF already computed column ranges internally, but `SourceLocation` omitted them from JSON (`json:"-"`). As a result, `properties.module.code_location` and each `module_path[]` hop only carried line numbers while top-level `code_location` had full ranges. Downstream intake needs columns on every module `code_location` for precise evidence linking.

Related ticket: [K9CODESEC-5295](https://datadoghq.atlassian.net/browse/K9CODESEC-5295)

## Changes

**SARIF module attribution**

`SourceLocation` now serializes `column_start` and `column_end` in SARIF `properties.module.code_location` and on every `module_path[].code_location` hop. No change to top-level `locations[0]` (already had columns via SARIF region mapping).

**Tests**

Unit test for `ModuleAttributionForSARIF` column propagation on leaf and path hops. Integration test asserts columns appear in emitted SARIF module JSON.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/model/... ./pkg/engine/... -run 'ModuleAttribution|Inspect_ModuleAttribution' -count=1 -v`
2. Scan a fixture with remote/local module attribution and confirm SARIF `properties.module.code_location` and `module_path[].code_location` include `column_start` / `column_end`.

## Blast Radius

Affects SARIF output only when module attribution is present (feature-gated remote module path). JSON report shape unchanged. No CLI flag or rule behavior changes.

## Additional Notes

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-5295]: https://datadoghq.atlassian.net/browse/K9CODESEC-5295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ