### PR TITLE
[K9VULN-17730] Preserve dynamic block labels in module evaluation

### DIFF
--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -48,6 +48,22 @@ DatadogPolicy contains result if {
 }
 `
 
+const dynamicBlockRule = `package datadog
+
+DatadogPolicy contains result if {
+	some name, i
+	instance := input.document[i].resource.google_sql_database_instance[name]
+	instance.settings.dynamic.ip_configuration.content.private_network == "projects/test/global/networks/private"
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "google_sql_database_instance",
+		"resourceName": name,
+		"searchKey": sprintf("google_sql_database_instance[%s].settings.dynamic.ip_configuration", [name]),
+	}
+}
+`
+
 func parseTerraform(t *testing.T, path string) model.FileMetadatas {
 	t.Helper()
 	content, err := os.ReadFile(filepath.Clean(path))
@@ -141,6 +157,63 @@ resource "aws_s3_bucket" "this" {
 	require.Equal(t, "modules/bucket", v.ModuleAttribution.Source)
 	require.Equal(t, "main.tf", v.ModuleAttribution.ModuleCodeLocation.Filename)
 	require.Empty(t, v.ModuleAttribution.ModulePath)
+}
+
+func TestInspect_ModuleEvaluationPreservesDynamicBlockLabels(t *testing.T) {
+	root := t.TempDir()
+	rootDir := filepath.Join(root, "stack")
+	modDir := filepath.Join(root, "modules", "sql")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+
+	rootPath := filepath.Join(rootDir, "main.tf")
+	modPath := filepath.Join(modDir, "main.tf")
+	require.NoError(t, os.WriteFile(rootPath, []byte(`
+module "sql" {
+  source          = "../modules/sql"
+  private_network = "projects/test/global/networks/private"
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(modPath, []byte(`
+variable "private_network" {
+  type = string
+}
+
+resource "google_sql_database_instance" "this" {
+  settings {
+    dynamic "ip_configuration" {
+      for_each = ["enabled"]
+      content {
+        private_network = var.private_network
+      }
+    }
+  }
+}
+`), 0o644))
+
+	var files model.FileMetadatas
+	files = append(files, parseTerraform(t, rootPath)...)
+	files = append(files, parseTerraform(t, modPath)...)
+
+	ins := newTestInspector(t, inspectorOpts{
+		queries: []model.QueryMetadata{{
+			Query:       "dynamic_block_rule",
+			Content:     dynamicBlockRule,
+			InputData:   "{}",
+			Platform:    "terraform",
+			Metadata:    map[string]interface{}{"id": "dynamic-block-rule"},
+			Aggregation: 1,
+		}},
+		repoPath:      root,
+		vb:            DefaultVulnerabilityBuilder,
+		flagEvaluator: moduleEvalEnabled(),
+	})
+
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
+	require.NoError(t, err)
+	require.Len(t, vulns, 1)
+	require.Equal(t, modPath, vulns[0].FileName)
+	require.NotNil(t, vulns[0].ModuleAttribution)
 }
 
 func TestModuleInstantiationSummary_LoggedAtWarnLevel(t *testing.T) {

--- a/pkg/parser/terraform/tfeval/document.go
+++ b/pkg/parser/terraform/tfeval/document.go
@@ -34,9 +34,10 @@ func AttributesToDocument(r *ResolvedResource) map[string]interface{} {
 // back to their reference text. Exactly one field is set, or none when the value
 // cannot be traced back to a specific expression or block.
 type attrSource struct {
-	expr   hclsyntax.Expression // attribute value expression
-	body   *hclsyntax.Body      // body of a single nested block
-	blocks []*hclsyntax.Block   // nested blocks sharing one type
+	expr       hclsyntax.Expression // attribute value expression
+	body       *hclsyntax.Body      // body of a single nested block
+	blocks     []*hclsyntax.Block   // nested blocks sharing one type
+	labelDepth int
 }
 
 func attributesToDocument(attrs map[string]cty.Value, body *hclsyntax.Body) map[string]interface{} {
@@ -117,7 +118,11 @@ func seqElementSources(src attrSource, n int) []attrSource {
 	if len(src.blocks) == n {
 		out := make([]attrSource, n)
 		for i, b := range src.blocks {
-			out[i] = attrSource{body: b.Body}
+			if src.labelDepth >= len(b.Labels) {
+				out[i] = attrSource{body: b.Body}
+			} else {
+				out[i] = attrSource{blocks: []*hclsyntax.Block{b}, labelDepth: src.labelDepth}
+			}
 		}
 		return out
 	}
@@ -135,7 +140,7 @@ func seqElementSources(src attrSource, n int) []attrSource {
 // keys are skipped (keys are always strings in well-formed Terraform).
 func ctyMapToDocument(v cty.Value, src attrSource) map[string]interface{} {
 	body := src.body
-	if body == nil && len(src.blocks) == 1 {
+	if body == nil && len(src.blocks) == 1 && src.labelDepth >= len(src.blocks[0].Labels) {
 		body = src.blocks[0].Body
 	}
 	items := objectConsSources(src.expr)
@@ -153,10 +158,22 @@ func ctyMapToDocument(v cty.Value, src attrSource) map[string]interface{} {
 			es = sourceFor(body, name)
 		case items[name] != nil:
 			es = attrSource{expr: items[name]}
+		case len(src.blocks) > 0:
+			es = labeledBlockSource(src, name)
 		}
 		obj[name] = ctyValueToDocument(ev, es)
 	}
 	return obj
+}
+
+func labeledBlockSource(src attrSource, label string) attrSource {
+	blocks := make([]*hclsyntax.Block, 0, len(src.blocks))
+	for _, block := range src.blocks {
+		if src.labelDepth < len(block.Labels) && block.Labels[src.labelDepth] == label {
+			blocks = append(blocks, block)
+		}
+	}
+	return attrSource{blocks: blocks, labelDepth: src.labelDepth + 1}
 }
 
 // objectConsSources maps the statically known keys of an object constructor to

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -1010,9 +1010,7 @@ func (e *Evaluator) resolveLocals(
 	return resolved
 }
 
-// evalBody evaluates an HCL body into an attribute map. Attributes in skip are
-// omitted. Nested blocks of the same type are always encoded as tuples (including
-// a single block) so the shape matches the canonical Terraform parser output rules expect.
+// evalBody evaluates an HCL body into the shape produced by the Terraform parser.
 func (e *Evaluator) evalBody(
 	body *hclsyntax.Body,
 	ctx *hcl.EvalContext,
@@ -1027,28 +1025,34 @@ func (e *Evaluator) evalBody(
 		out[name] = e.evalExpr(attr.Expr, ctx)
 	}
 
-	grouped := map[string][]cty.Value{}
-	order := make([]string, 0, len(body.Blocks))
 	for _, b := range body.Blocks {
-		if _, seen := grouped[b.Type]; !seen {
-			order = append(order, b.Type)
-		}
-		grouped[b.Type] = append(grouped[b.Type], objectOrEmpty(e.evalBody(b.Body, ctx, nil)))
-	}
-	for _, t := range order {
-		list := grouped[t]
-		// Match how a parsed Terraform file represents nested blocks: a block
-		// written once is an object, and only a repeated one becomes a list.
-		// Rules are written against that shape — `resource.ingress.cidr_blocks`
-		// reads straight through a single block — so a list here would make a
-		// rule quietly stop matching resources that came from a module.
-		if len(list) == 1 {
-			out[t] = list[0]
-			continue
-		}
-		out[t] = cty.TupleVal(list)
+		path := append([]string{b.Type}, b.Labels...)
+		addNestedBlock(out, path, objectOrEmpty(e.evalBody(b.Body, ctx, nil)))
 	}
 	return out
+}
+
+func addNestedBlock(out map[string]cty.Value, path []string, value cty.Value) {
+	key := path[0]
+	if len(path) == 1 {
+		if current, ok := out[key]; ok {
+			if current.Type().IsTupleType() {
+				out[key] = cty.TupleVal(append(current.AsValueSlice(), value))
+			} else {
+				out[key] = cty.TupleVal([]cty.Value{current, value})
+			}
+		} else {
+			out[key] = value
+		}
+		return
+	}
+
+	nested := map[string]cty.Value{}
+	if current, ok := out[key]; ok && current.Type().IsObjectType() {
+		nested = current.AsValueMap()
+	}
+	addNestedBlock(nested, path[1:], value)
+	out[key] = objectOrEmpty(nested)
 }
 
 // evalExpr evaluates an expression, returning unknown on any resolution failure.

--- a/pkg/parser/terraform/tfeval/evaluator_test.go
+++ b/pkg/parser/terraform/tfeval/evaluator_test.go
@@ -1268,6 +1268,29 @@ resource "aws_security_group" "repeated" {
     from_port = 443
   }
 }
+
+resource "google_sql_database_instance" "dynamic" {
+  dynamic "ip_configuration" {
+    for_each = ["private"]
+    content {
+      private_network = var.private_network
+    }
+  }
+
+  dynamic "ip_configuration" {
+    for_each = ["psc"]
+    content {
+      ipv4_enabled = false
+    }
+  }
+
+  dynamic "backup_configuration" {
+    for_each = ["enabled"]
+    content {
+      enabled = true
+    }
+  }
+}
 `,
 	})
 
@@ -1289,6 +1312,29 @@ resource "aws_security_group" "repeated" {
 	if !ingress.Type().IsTupleType() || ingress.LengthInt() != 2 {
 		t.Fatalf("ingress = %s (len %d), want a 2-tuple for a repeated block",
 			ingress.Type().FriendlyName(), ingress.LengthInt())
+	}
+
+	dynamicResource := findResource(t, resources, "google_sql_database_instance", "dynamic")
+	dynamic := dynamicResource.Attributes["dynamic"]
+	if !dynamic.Type().IsObjectType() {
+		t.Fatalf("dynamic = %s, want an object", dynamic.Type().FriendlyName())
+	}
+	ipConfiguration := dynamic.GetAttr("ip_configuration")
+	if !ipConfiguration.Type().IsTupleType() || ipConfiguration.LengthInt() != 2 {
+		t.Fatalf("dynamic.ip_configuration = %s (len %d), want a 2-tuple",
+			ipConfiguration.Type().FriendlyName(), ipConfiguration.LengthInt())
+	}
+	if !dynamic.GetAttr("backup_configuration").Type().IsObjectType() {
+		t.Fatalf("dynamic.backup_configuration = %s, want an object",
+			dynamic.GetAttr("backup_configuration").Type().FriendlyName())
+	}
+
+	doc := AttributesToDocument(&dynamicResource)
+	dynamicDoc := doc["dynamic"].(map[string]interface{})
+	ipConfigurationDoc := dynamicDoc["ip_configuration"].([]interface{})
+	firstContent := ipConfigurationDoc[0].(map[string]interface{})["content"].(map[string]interface{})
+	if got := firstContent["private_network"]; got != "${var.private_network}" {
+		t.Fatalf("private_network = %#v, want source reference", got)
 	}
 }
 

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -729,8 +729,13 @@ func TestAnalyze_RequestLibrariesDoNotCallBackend(t *testing.T) {
 }
 
 func TestAnalyze_LogsFailedQueryCount(t *testing.T) {
+	engine.ResetCompiledQueryCachesForTest()
+	t.Cleanup(engine.ResetCompiledQueryCachesForTest)
+
 	s := newTestServer(t)
 	rule := syntheticRule()
+	rule.ID = "test-terraform-invalid-result"
+	rule.Name = rule.ID
 	rule.RegoQuery = []byte(`package datadog
 
 import rego.v1
@@ -747,7 +752,7 @@ DatadogPolicy contains "invalid-result"`)
 	}
 
 	var logs bytes.Buffer
-	ctx := zerolog.New(&logs).WithContext(t.Context())
+	ctx := zerolog.New(&logs).WithContext(context.Background())
 	out, err := s.analyze(ctx, &req)
 	if err != nil {
 		t.Fatalf("analyze: %v", err)


### PR DESCRIPTION
## Motivation

Local module evaluation dropped Terraform `dynamic` block labels, so resources evaluated from modules exposed `settings.dynamic` instead of `settings.dynamic.ip_configuration`. Rules written against the direct parser shape false-positived when local module resolution was enabled.

Related ticket: [K9VULN-17730](https://datadoghq.atlassian.net/browse/K9VULN-17730)

## Changes

- Nest evaluated blocks by type and labels in `tfeval.evalBody`, matching the direct Terraform parser shape.
- Teach `AttributesToDocument` to trace labeled nested blocks through `labelDepth`.
- Add unit and engine integration coverage for `dynamic "ip_configuration"` inside evaluated modules.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run:

```bash
go test ./pkg/parser/terraform/tfeval ./pkg/engine -run 'TestEvaluateModule_NestedBlockShapeMatchesParser|TestInspect_ModuleEvaluationPreservesDynamicBlockLabels' -count=1
```

Confirm evaluated module resources expose `settings.dynamic.ip_configuration` and rules can match that path with module attribution.

## Blast Radius

This only affects Terraform local-module evaluation output shape. Direct `.tf` parsing is unchanged.

## Additional Notes

Companion rules PR: DataDog/datadog-iac-scanner-default-rules (to follow).

I submit this contribution under the Apache-2.0 license.

[K9VULN-17730]: https://datadoghq.atlassian.net/browse/K9VULN-17730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ