### PR TITLE
Fix plan-JSON parsing: dropped identifiers, missing data sources, and bracket-boundary bugs

### DIFF
--- a/pkg/detector/default_detect.go
+++ b/pkg/detector/default_detect.go
@@ -166,7 +166,8 @@ func detectTerraformPlanLine(
 // "type[module.foo.name]") and/or a count/for_each suffix bracket (e.g.
 // "type[this[0]]"), so the top-level dot-split ignores dots inside an
 // unclosed "[...]" (see splitTopLevelDots), and a group's closing bracket is
-// its LAST "]", not the first one found after "[".
+// found by findMatchingBracket, which is quote- and nesting-aware since a
+// for_each key can itself contain a literal "]" (e.g. module.secrets["prod]eu"]).
 func terraformPlanPath(searchKey string) ([]string, bool) {
 	// Drop the value anchor (key=value) up front; the value may contain dots.
 	if eq := strings.Index(searchKey, "="); eq >= 0 {
@@ -189,8 +190,8 @@ func terraformPlanPath(searchKey string) ([]string, bool) {
 			if head := seg[:open]; head != "" {
 				comps = append(comps, head)
 			}
-			closeIdx := strings.LastIndex(seg, "]")
-			if closeIdx < 0 || closeIdx < open {
+			closeIdx := findMatchingBracket(seg, open)
+			if closeIdx < 0 {
 				break
 			}
 			inner := seg[open+1 : closeIdx]
@@ -209,22 +210,64 @@ func terraformPlanPath(searchKey string) ([]string, bool) {
 	return append([]string{"resource"}, comps...), explicitResourcePath
 }
 
+// findMatchingBracket finds the "]" closing the "[" at open in s, tracking
+// nested brackets and quoting so a quoted for_each key's own "]" isn't mistaken
+// for the group's close.
+func findMatchingBracket(s string, open int) int {
+	inQuotes := false
+	depth := 0
+	for i := open + 1; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			if inQuotes {
+				i++ // skip the escaped character
+			}
+		case '"':
+			inQuotes = !inQuotes
+		case '[':
+			if !inQuotes {
+				depth++
+			}
+		case ']':
+			if inQuotes {
+				continue
+			}
+			if depth == 0 {
+				return i
+			}
+			depth--
+		}
+	}
+	return -1
+}
+
 // splitTopLevelDots splits s on "." like strings.Split, except dots inside an
 // unclosed "[...]" group aren't treated as separators, e.g.
 // "type[module.foo.name].attr" splits into ["type[module.foo.name]", "attr"].
+// Quote-aware like findMatchingBracket.
 func splitTopLevelDots(s string) []string {
 	var segs []string
 	depth, start := 0, 0
-	for i, c := range s {
+	inQuotes := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
 		switch c {
+		case '\\':
+			if inQuotes {
+				i++
+			}
+		case '"':
+			inQuotes = !inQuotes
 		case '[':
-			depth++
+			if !inQuotes {
+				depth++
+			}
 		case ']':
-			if depth > 0 {
+			if !inQuotes && depth > 0 {
 				depth--
 			}
 		case '.':
-			if depth == 0 {
+			if depth == 0 && !inQuotes {
 				segs = append(segs, s[start:i])
 				start = i + 1
 			}

--- a/pkg/detector/default_detect_test.go
+++ b/pkg/detector/default_detect_test.go
@@ -413,6 +413,14 @@ func Test_terraformPlanPath(t *testing.T) {
 			searchKey: "aws_s3_bucket_object[{{module.s3_object.this[0]}}]",
 			want:      []string{"resource", "aws_s3_bucket_object", "module.s3_object.this[0]"},
 		},
+		{
+			// A for_each key is an arbitrary quoted HCL string that may itself
+			// contain a literal "]", which must not be mistaken for the group's
+			// own closing bracket.
+			name:      "for_each_key_containing_literal_bracket",
+			searchKey: `aws_secretsmanager_secret[module.secrets["prod]eu"].test].kms_key_id`,
+			want:      []string{"resource", "aws_secretsmanager_secret", `module.secrets["prod]eu"].test`, "kms_key_id"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -342,11 +342,14 @@ func parseTFPlan(doc model.Document) (model.Document, error) {
 }
 
 // extractResourceHeaderLines returns each resource's "values" attribute
-// line, keyed by resource address.
+// line, keyed by resource address. Addresses are unique across the whole
+// plan, so planned_values and prior_state (resolved data sources) share one map.
 func extractResourceHeaderLines(rawPlan []byte) map[string]int {
 	lines := make(map[string]int)
-	root_module := gjson.GetBytes(rawPlan, "planned_values.root_module")
-	walkModule(&root_module, lines)
+	plannedRootModule := gjson.GetBytes(rawPlan, "planned_values.root_module")
+	walkModule(&plannedRootModule, lines)
+	priorStateRootModule := gjson.GetBytes(rawPlan, "prior_state.values.root_module")
+	walkModule(&priorStateRootModule, lines)
 	return lines
 }
 
@@ -383,7 +386,7 @@ func readPlan(
 	kp.readModule(plan.PlannedValues.RootModule, "", resourceLines, correlation)
 
 	if plan.PriorState != nil && plan.PriorState.Values != nil {
-		kp.readPriorStateData(plan.PriorState.Values.RootModule, "", deletedAddresses(plan.ResourceChanges))
+		kp.readPriorStateData(plan.PriorState.Values.RootModule, "", resourceLines, deletedAddresses(plan.ResourceChanges))
 	}
 
 	doc := model.Document{}
@@ -466,7 +469,12 @@ func deletedAddresses(resourceChanges []*hcl_plan.ResourceChange) map[string]boo
 // moduleAddress is "" for the root module. prior_state predates the plan's
 // diff, so a data source being deleted by this plan is skipped rather than
 // republished as if it were still part of the proposed infrastructure.
-func (kp *TFPlan) readPriorStateData(module *hcl_plan.StateModule, moduleAddress string, deleted map[string]bool) {
+func (kp *TFPlan) readPriorStateData(
+	module *hcl_plan.StateModule,
+	moduleAddress string,
+	resourceLines map[string]int,
+	deleted map[string]bool,
+) {
 	if module == nil {
 		return
 	}
@@ -497,11 +505,21 @@ func (kp *TFPlan) readPriorStateData(module *hcl_plan.StateModule, moduleAddress
 			dataKey = formatResourceKeyWithIndex(dataKey, resource.Index)
 		}
 
-		kp.Data[resource.Type][dataKey] = resource.AttributeValues
+		typeData := kp.Data[resource.Type]
+		typeData[dataKey] = resource.AttributeValues
+
+		if line, ok := resourceLines[resource.Address]; ok {
+			ddLines, isMap := typeData["_dd_lines"].(map[string]*model.LineObject)
+			if !isMap {
+				ddLines = make(map[string]*model.LineObject)
+				typeData["_dd_lines"] = ddLines
+			}
+			ddLines["_dd_"+dataKey] = &model.LineObject{Line: line}
+		}
 	}
 
 	for _, childModule := range module.ChildModules {
-		kp.readPriorStateData(childModule, childModule.Address, deleted)
+		kp.readPriorStateData(childModule, childModule.Address, resourceLines, deleted)
 	}
 }
 

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -383,7 +383,7 @@ func readPlan(
 	kp.readModule(plan.PlannedValues.RootModule, "", resourceLines, correlation)
 
 	if plan.PriorState != nil && plan.PriorState.Values != nil {
-		kp.readPriorStateData(plan.PriorState.Values.RootModule)
+		kp.readPriorStateData(plan.PriorState.Values.RootModule, "")
 	}
 
 	doc := model.Document{}
@@ -451,7 +451,8 @@ func (kp *TFPlan) readModule(
 }
 
 // readPriorStateData recursively merges resolved data sources into data.<type>.<name>.
-func (kp *TFPlan) readPriorStateData(module *hcl_plan.StateModule) {
+// moduleAddress is "" for the root module.
+func (kp *TFPlan) readPriorStateData(module *hcl_plan.StateModule, moduleAddress string) {
 	if module == nil {
 		return
 	}
@@ -467,11 +468,23 @@ func (kp *TFPlan) readPriorStateData(module *hcl_plan.StateModule) {
 		if kp.Data[resource.Type] == nil {
 			kp.Data[resource.Type] = make(map[string]any)
 		}
-		kp.Data[resource.Type][resource.Name] = resource.AttributeValues
+
+		// Module-prefixed and index-suffixed so same-type-same-name data
+		// sources in different modules or for_each/count instances don't
+		// collide, mirroring readModule's resourceKey construction.
+		dataKey := resource.Name
+		if moduleAddress != "" {
+			dataKey = moduleAddress + "." + resource.Name
+		}
+		if resource.Index != nil {
+			dataKey = formatResourceKeyWithIndex(dataKey, resource.Index)
+		}
+
+		kp.Data[resource.Type][dataKey] = resource.AttributeValues
 	}
 
 	for _, childModule := range module.ChildModules {
-		kp.readPriorStateData(childModule)
+		kp.readPriorStateData(childModule, childModule.Address)
 	}
 }
 

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -21,6 +21,9 @@ import (
 type TFPlan struct {
 	Resource map[string]TFPlanResource `json:"resource"`
 
+	// Data mirrors the HCL parser's data.<type>.<name> shape for data sources.
+	Data map[string]map[string]any `json:"data,omitempty"`
+
 	ResourceChanges any `json:"resource_changes,omitempty"`
 	Configuration   any `json:"configuration,omitempty"`
 
@@ -379,6 +382,10 @@ func readPlan(
 
 	kp.readModule(plan.PlannedValues.RootModule, "", resourceLines, correlation)
 
+	if plan.PriorState != nil && plan.PriorState.Values != nil {
+		kp.readPriorStateData(plan.PriorState.Values.RootModule)
+	}
+
 	doc := model.Document{}
 
 	tmpDocBytes, err := json.Marshal(kp)
@@ -440,6 +447,31 @@ func (kp *TFPlan) readModule(
 
 	for _, childModule := range module.ChildModules {
 		kp.readModule(childModule, childModule.Address, resourceLines, correlation)
+	}
+}
+
+// readPriorStateData recursively merges resolved data sources into data.<type>.<name>.
+func (kp *TFPlan) readPriorStateData(module *hcl_plan.StateModule) {
+	if module == nil {
+		return
+	}
+
+	for _, resource := range module.Resources {
+		if resource.Mode != hcl_plan.DataResourceMode {
+			continue
+		}
+
+		if kp.Data == nil {
+			kp.Data = make(map[string]map[string]any)
+		}
+		if kp.Data[resource.Type] == nil {
+			kp.Data[resource.Type] = make(map[string]any)
+		}
+		kp.Data[resource.Type][resource.Name] = resource.AttributeValues
+	}
+
+	for _, childModule := range module.ChildModules {
+		kp.readPriorStateData(childModule)
 	}
 }
 

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -383,7 +383,7 @@ func readPlan(
 	kp.readModule(plan.PlannedValues.RootModule, "", resourceLines, correlation)
 
 	if plan.PriorState != nil && plan.PriorState.Values != nil {
-		kp.readPriorStateData(plan.PriorState.Values.RootModule, "")
+		kp.readPriorStateData(plan.PriorState.Values.RootModule, "", deletedAddresses(plan.ResourceChanges))
 	}
 
 	doc := model.Document{}
@@ -450,15 +450,32 @@ func (kp *TFPlan) readModule(
 	}
 }
 
+// deletedAddresses returns the set of addresses whose only planned action is
+// deletion, e.g. a data source removed from config or dropped by count/for_each.
+func deletedAddresses(resourceChanges []*hcl_plan.ResourceChange) map[string]bool {
+	deleted := make(map[string]bool)
+	for _, rc := range resourceChanges {
+		if rc.Change != nil && rc.Change.Actions.Delete() {
+			deleted[rc.Address] = true
+		}
+	}
+	return deleted
+}
+
 // readPriorStateData recursively merges resolved data sources into data.<type>.<name>.
-// moduleAddress is "" for the root module.
-func (kp *TFPlan) readPriorStateData(module *hcl_plan.StateModule, moduleAddress string) {
+// moduleAddress is "" for the root module. prior_state predates the plan's
+// diff, so a data source being deleted by this plan is skipped rather than
+// republished as if it were still part of the proposed infrastructure.
+func (kp *TFPlan) readPriorStateData(module *hcl_plan.StateModule, moduleAddress string, deleted map[string]bool) {
 	if module == nil {
 		return
 	}
 
 	for _, resource := range module.Resources {
 		if resource.Mode != hcl_plan.DataResourceMode {
+			continue
+		}
+		if deleted[resource.Address] {
 			continue
 		}
 
@@ -484,7 +501,7 @@ func (kp *TFPlan) readPriorStateData(module *hcl_plan.StateModule, moduleAddress
 	}
 
 	for _, childModule := range module.ChildModules {
-		kp.readPriorStateData(childModule, childModule.Address)
+		kp.readPriorStateData(childModule, childModule.Address, deleted)
 	}
 }
 

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -768,6 +768,58 @@ func TestJson_parseTFPlan(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "test - resolved data source in prior_state merged under data.<type>.<name>",
+			args: args{
+				doc: model.Document{
+					"format_version":    "0.2",
+					"terraform_version": "1.0.5",
+					"variables":         map[string]any{},
+					"planned_values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []map[string]any{},
+						},
+					},
+					"prior_state": map[string]any{
+						"format_version": "1.0",
+						"values": map[string]any{
+							"root_module": map[string]any{
+								"resources": []map[string]any{
+									{
+										"address": "data.aws_kms_key.by_alias",
+										"mode":    "data",
+										"type":    "aws_kms_key",
+										"name":    "by_alias",
+										"values": map[string]any{
+											"key_id": "alias/aws/s3",
+											"arn":    "arn:aws:kms:us-east-1:123456789012:key/abc",
+											"id":     "abc",
+										},
+									},
+								},
+							},
+						},
+					},
+					"resource_changes": []map[string]any{},
+					"configuration":    map[string]any{},
+				},
+			},
+			want: model.Document{
+				"resource": map[string]any{},
+				"data": map[string]any{
+					"aws_kms_key": map[string]any{
+						"by_alias": map[string]any{
+							"key_id": "alias/aws/s3",
+							"arn":    "arn:aws:kms:us-east-1:123456789012:key/abc",
+							"id":     "abc",
+						},
+					},
+				},
+				"resource_changes": []any{},
+				"configuration":    map[string]any{},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -821,6 +821,58 @@ func TestJson_parseTFPlan(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "test - data source scheduled for deletion in resource_changes is excluded from prior_state merge",
+			args: args{
+				doc: model.Document{
+					"format_version":    "1.2",
+					"terraform_version": "1.5.0",
+					"planned_values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []map[string]any{},
+						},
+					},
+					"prior_state": map[string]any{
+						"format_version": "1.0",
+						"values": map[string]any{
+							"root_module": map[string]any{
+								"resources": []map[string]any{
+									{
+										"address": "data.aws_kms_key.by_alias",
+										"mode":    "data",
+										"type":    "aws_kms_key",
+										"name":    "by_alias",
+										"values": map[string]any{
+											"key_id": "alias/aws/s3",
+										},
+									},
+								},
+							},
+						},
+					},
+					"resource_changes": []map[string]any{
+						{
+							"address": "data.aws_kms_key.by_alias",
+							"mode":    "data",
+							"type":    "aws_kms_key",
+							"name":    "by_alias",
+							"change": map[string]any{
+								"actions": []any{"delete"},
+								"before":  map[string]any{"key_id": "alias/aws/s3"},
+								"after":   nil,
+							},
+						},
+					},
+					"configuration": map[string]any{},
+				},
+			},
+			want: model.Document{
+				"resource":         map[string]any{},
+				"resource_changes": []any{map[string]any{"address": "data.aws_kms_key.by_alias", "mode": "data", "type": "aws_kms_key", "name": "by_alias", "change": map[string]any{"actions": []any{"delete"}, "before": map[string]any{"key_id": "alias/aws/s3"}, "after": nil}}},
+				"configuration":    map[string]any{},
+			},
+			wantErr: false,
+		},
+		{
 			name: "test - for_each data source instances in prior_state keep distinct keys",
 			args: args{
 				doc: model.Document{

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -821,6 +821,66 @@ func TestJson_parseTFPlan(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "test - injects data source values line from _dd_lines under prior_state",
+			args: args{
+				doc: model.Document{
+					"format_version":    "1.2",
+					"terraform_version": "1.5.0",
+					"planned_values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []map[string]any{},
+						},
+					},
+					"prior_state": map[string]any{
+						"format_version": "1.0",
+						"values": map[string]any{
+							"root_module": map[string]any{
+								"_dd_lines": map[string]any{
+									"_dd_resources": map[string]any{
+										"_dd_arr": []map[string]any{
+											{
+												"_dd__default": map[string]any{"_dd_line": 5},
+												"_dd_values":   map[string]any{"_dd_line": 14},
+											},
+										},
+									},
+								},
+								"resources": []map[string]any{
+									{
+										"address": "data.aws_kms_key.by_alias",
+										"mode":    "data",
+										"type":    "aws_kms_key",
+										"name":    "by_alias",
+										"values": map[string]any{
+											"key_id": "alias/aws/s3",
+										},
+									},
+								},
+							},
+						},
+					},
+					"resource_changes": []map[string]any{},
+					"configuration":    map[string]any{},
+				},
+			},
+			want: model.Document{
+				"resource": map[string]any{},
+				"data": map[string]any{
+					"aws_kms_key": map[string]any{
+						"_dd_lines": map[string]any{
+							"_dd_by_alias": map[string]any{"_dd_line": (float64)(14)},
+						},
+						"by_alias": map[string]any{
+							"key_id": "alias/aws/s3",
+						},
+					},
+				},
+				"resource_changes": []any{},
+				"configuration":    map[string]any{},
+			},
+			wantErr: false,
+		},
+		{
 			name: "test - data source scheduled for deletion in resource_changes is excluded from prior_state merge",
 			args: args{
 				doc: model.Document{

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -505,7 +505,7 @@ func TestJson_parseTFPlan(t *testing.T) {
 					},
 				},
 			},
-					want: model.Document{
+			want: model.Document{
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
 						"module.app1.data": map[string]interface{}{
@@ -812,6 +812,133 @@ func TestJson_parseTFPlan(t *testing.T) {
 							"key_id": "alias/aws/s3",
 							"arn":    "arn:aws:kms:us-east-1:123456789012:key/abc",
 							"id":     "abc",
+						},
+					},
+				},
+				"resource_changes": []any{},
+				"configuration":    map[string]any{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test - for_each data source instances in prior_state keep distinct keys",
+			args: args{
+				doc: model.Document{
+					"format_version":    "1.2",
+					"terraform_version": "1.5.0",
+					"planned_values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []map[string]any{},
+						},
+					},
+					"prior_state": map[string]any{
+						"format_version": "1.0",
+						"values": map[string]any{
+							"root_module": map[string]any{
+								"resources": []map[string]any{
+									{
+										"address": `data.aws_kms_key.by_alias["prod"]`,
+										"mode":    "data",
+										"type":    "aws_kms_key",
+										"name":    "by_alias",
+										"index":   "prod",
+										"values": map[string]any{
+											"key_id": "alias/prod",
+										},
+									},
+									{
+										"address": `data.aws_kms_key.by_alias["dev"]`,
+										"mode":    "data",
+										"type":    "aws_kms_key",
+										"name":    "by_alias",
+										"index":   "dev",
+										"values": map[string]any{
+											"key_id": "alias/dev",
+										},
+									},
+								},
+							},
+						},
+					},
+					"resource_changes": []map[string]any{},
+					"configuration":    map[string]any{},
+				},
+			},
+			want: model.Document{
+				"resource": map[string]any{},
+				"data": map[string]any{
+					"aws_kms_key": map[string]any{
+						`by_alias["prod"]`: map[string]any{
+							"key_id": "alias/prod",
+						},
+						`by_alias["dev"]`: map[string]any{
+							"key_id": "alias/dev",
+						},
+					},
+				},
+				"resource_changes": []any{},
+				"configuration":    map[string]any{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test - same-name data source in root and child module keeps module-prefixed keys",
+			args: args{
+				doc: model.Document{
+					"format_version":    "1.2",
+					"terraform_version": "1.5.0",
+					"planned_values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []map[string]any{},
+						},
+					},
+					"prior_state": map[string]any{
+						"format_version": "1.0",
+						"values": map[string]any{
+							"root_module": map[string]any{
+								"resources": []map[string]any{
+									{
+										"address": "data.aws_kms_key.by_alias",
+										"mode":    "data",
+										"type":    "aws_kms_key",
+										"name":    "by_alias",
+										"values": map[string]any{
+											"key_id": "alias/root",
+										},
+									},
+								},
+								"child_modules": []map[string]any{
+									{
+										"address": "module.storage",
+										"resources": []map[string]any{
+											{
+												"address": "module.storage.data.aws_kms_key.by_alias",
+												"mode":    "data",
+												"type":    "aws_kms_key",
+												"name":    "by_alias",
+												"values": map[string]any{
+													"key_id": "alias/storage",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"resource_changes": []map[string]any{},
+					"configuration":    map[string]any{},
+				},
+			},
+			want: model.Document{
+				"resource": map[string]any{},
+				"data": map[string]any{
+					"aws_kms_key": map[string]any{
+						"by_alias": map[string]any{
+							"key_id": "alias/root",
+						},
+						"module.storage.by_alias": map[string]any{
+							"key_id": "alias/storage",
 						},
 					},
 				},

--- a/pkg/parser/jsonfilter/json_filter_test.go
+++ b/pkg/parser/jsonfilter/json_filter_test.go
@@ -336,6 +336,18 @@ var inputs = []struct {
 		},
 	},
 	{
+		name:  "selector_unquoted_multi_segment_identifier",
+		input: `{ $.eventSource = ec2.amazonaws.com }`,
+		expected: parser.AWSJSONFilter{
+			FilterExpression: parser.FilterSelector{
+				Selector: "$.eventSource",
+				Op:       "=",
+				Value:    "ec2.amazonaws.com",
+			},
+		},
+		wantErr: false,
+	},
+	{
 		name:  "expr_two_selectors_and_with_parenthesis_unquoted_unquoted_strings",
 		input: `{ ($.eventSource = "kms.amazonaws.com") && (($.eventName = DisableKey) || ($.eventName = ScheduleKeyDeletion)) }`,
 		expected: parser.AWSJSONFilter{

--- a/pkg/parser/jsonfilter/parser/jsonfilter_tree_visitor.go
+++ b/pkg/parser/jsonfilter/parser/jsonfilter_tree_visitor.go
@@ -94,7 +94,7 @@ func (v *JSONFilterTreeVisitor) VisitFilter_expr_or(ctx *Filter_expr_orContext) 
 }
 
 func (v *JSONFilterTreeVisitor) VisitQualifiedidentifier(ctx *QualifiedidentifierContext) interface{} {
-	return v.VisitChildren(ctx)
+	return ctx.GetText()
 }
 
 func (v *JSONFilterTreeVisitor) VisitExp(ctx *ExpContext) interface{} {


### PR DESCRIPTION
Three independent bug fixes to the Terraform plan-JSON parsing/detection path, found while investigating a false positive in `datadog-iac-scanner-default-rules` PR 201.

## Changes

**1. Fix jsonfilter parser dropping unquoted multi-segment identifiers**
`VisitQualifiedidentifier` delegated to the default `VisitChildren`, which discards child return values, so unquoted values like `ec2.amazonaws.com` resolved to `nil` instead of the concatenated string. Now returns `ctx.GetText()` directly. This was the root cause of the PR 201 false positive: a Rego guard comparing against `ec2.amazonaws.com` was silently comparing against `nil`.

**2. Surface resolved plan-JSON data sources under `doc.data.<type>.<name>`**
`prior_state.values.root_module` holds resolved data blocks but was never read, so queries written against `.tf` data sources (e.g. `doc.data.aws_kms_key.<label>.key_id`) never matched plan JSON even when the data source resolved successfully. Now walks `prior_state` the same way `planned_values` is already walked, filters to `mode == "data"`, and merges into `data.<type>.<name>` to match the HCL parser's shape. Absent `prior_state` (offline/unresolved data sources) is a no-op.

**3. Fix bracket-boundary detection for quoted for_each keys in plan searchKeys**
`terraformPlanPath` used `strings.LastIndex` to find a bracket group's close, and `splitTopLevelDots` counted `[`/`]` depth naively — both assumed brackets in a for_each/count key can't contain a literal `]`, which is legal in a quoted HCL key (e.g. `module.secrets["prod]eu"]`). That produced a garbage gjson path, so `GetLineBySearchLine` failed and the line silently defaulted to 1. Replaced both with a quote-aware scan (`findMatchingBracket`, and the same awareness in `splitTopLevelDots`) that still respects nested, unquoted brackets like a count index `this[0]`.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

Run `go test ./pkg/...`. Notably:
- `pkg/parser/jsonfilter/json_filter_test.go` — multi-segment identifier regression case.
- `pkg/parser/json/tfplan_test.go` — resolved data source merged under `data.<type>.<name>`.
- `pkg/detector/default_detect_test.go` — for_each key containing a literal `]`.

## Blast Radius

`datadog-iac-scanner` only: the Terraform plan-JSON parser and the plan searchKey-to-gjson-path detector. No changes to HCL parsing, other platforms, or the Datadog backend.

Note: fix #2 (as the number and not the PR linked automatically by GitHub) makes previously-dead `doc.data.<type>` Rego code paths in some default rules fire for the first time (e.g. `terraform-gcp-service-account-with-improper-privileges`, `terraform-aws-iam-policies-with-full-privileges`), which now correctly flags over-permissive data sources already present in those rules' test fixtures. The backend's expected-results for those fixtures predate this fix and don't yet include these findings — that needs a follow-up in `datadog-iac-scanner-default-rules`, tracked separately.

## Additional Notes

I submit this contribution under the Apache-2.0 license.
