### PR TITLE
Fix Terraform scanning and SARIF remediation edge cases

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -367,10 +367,10 @@ func Analyze(ctx context.Context, a *Analyzer) (model.AnalyzedPaths, error) {
 	ignoreFiles := make([]string, 0)
 	projectConfigFiles := make([]string, 0)
 	hasGitIgnoreFile, gitIgnore := shouldConsiderGitIgnoreFile(ctx, a.RepoPath, a.GitIgnoreFileName, a.ExcludeGitIgnore)
-	if a.Exc, err = expandPaths(ctx, a.Exc); err != nil {
+	if a.Exc, err = expandPaths(a.Exc); err != nil {
 		return returnAnalyzedPaths, fmt.Errorf("failed to expand ignore-paths: %w", err)
 	}
-	if a.Only, err = expandPaths(ctx, a.Only); err != nil {
+	if a.Only, err = expandPaths(a.Only); err != nil {
 		return returnAnalyzedPaths, fmt.Errorf("failed to expand only-paths: %w", err)
 	}
 	// get all the files inside the given paths
@@ -1068,13 +1068,13 @@ func getKeysFromTypesFlag(typesFlag []string) []string {
 //   - non-empty input → non-nil output (possibly []string{}): signals "restriction is in
 //     effect", even if all glob patterns matched nothing. Callers must treat a non-nil
 //     empty result as "restrict to zero files", not as "no restriction".
-func expandPaths(ctx context.Context, paths []string) ([]string, error) {
+func expandPaths(paths []string) ([]string, error) {
 	if len(paths) == 0 {
 		return nil, nil
 	}
 	expanded := make([]string, 0, len(paths))
 	for _, p := range paths {
-		exp, err := provider.GetExcludePaths(ctx, p)
+		exp, err := provider.GetExcludePaths(p)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -877,7 +877,7 @@ func (c *Inspector) TransformJsonencodeInPayload(ctx context.Context, value ast.
 			// Check if the string starts with jsonencode or ${jsonencode after trimming
 			trimmed := strings.TrimSpace(str)
 			if strings.HasPrefix(trimmed, "jsonencode(") || strings.HasPrefix(trimmed, "${jsonencode(") {
-				parsed, err := parseJsonencodeHCL(ctx, str)
+				parsed, err := parseJsonencodeHCL(str)
 				if err == nil {
 					return parsed
 				} else {
@@ -1681,41 +1681,28 @@ func (q *QueryLoader) loadSharedQueriesCached(ctx context.Context, queries []mod
 	}
 }
 
-func parseJsonencodeHCL(ctx context.Context, input string) (ast.Value, error) {
-	contextLogger := logger.FromContext(ctx)
+func parseJsonencodeHCL(input string) (ast.Value, error) {
 	input = strings.TrimSpace(input)
 
-	// Remove Terraform interpolation
-	if strings.HasPrefix(input, "${") && strings.HasSuffix(input, "}") {
-		input = strings.TrimPrefix(input, "${")
-		input = strings.TrimSuffix(input, "}")
+	if strings.HasPrefix(input, "${") {
+		if !strings.HasSuffix(input, "}") {
+			return nil, fmt.Errorf("invalid interpolated expression")
+		}
+		input = strings.TrimSuffix(strings.TrimPrefix(input, "${"), "}")
 	}
 
-	// Validate jsonencode(...) format
-	const prefix = "jsonencode("
-	const suffix = ")"
-
-	if !strings.HasPrefix(input, prefix) || !strings.HasSuffix(input, suffix) {
-		err := fmt.Errorf("expected jsonencode(...) format, got: %s", input)
-		contextLogger.Error().Msg(err.Error())
-		return nil, err
-	}
-
-	// Extract inner expression
-	inner := strings.TrimSuffix(strings.TrimPrefix(input, prefix), suffix)
-
-	expr, diags := hclsyntax.ParseExpression([]byte(inner), "inline_expr.hcl", hcl.Pos{Line: 1, Column: 1})
+	expr, diags := hclsyntax.ParseExpression([]byte(input), "inline_expr.hcl", hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
-		err := fmt.Errorf("HCL parse error: %s", diags.Error())
-		contextLogger.Error().Msg(err.Error())
-		return nil, err
+		return nil, fmt.Errorf("HCL parse error: %s", diags.Error())
+	}
+	call, ok := expr.(*hclsyntax.FunctionCallExpr)
+	if !ok || call.Name != "jsonencode" || len(call.Args) != 1 {
+		return nil, fmt.Errorf("expected a standalone jsonencode call")
 	}
 
-	val, err := expressionToAST(expr)
+	val, err := expressionToAST(call.Args[0])
 	if err != nil {
-		err = fmt.Errorf("expression to AST failed: %w", err)
-		contextLogger.Error().Msg(err.Error())
-		return nil, err
+		return nil, fmt.Errorf("expression to AST failed: %w", err)
 	}
 
 	return val, nil

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -6,6 +6,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -404,6 +405,17 @@ func TestInterfaceToPayloadValueMatchesExistingTransformation(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, want.String(), got.String())
+}
+
+func TestTransformJsonencodeInPayloadLeavesSuffixExpressionUnchanged(t *testing.T) {
+	input := ast.String(`${jsonencode(each.value.role_name_patterns)}.exists(r, attribute.aws_role.matches(r))`)
+	var logs bytes.Buffer
+	ctx := zerolog.New(&logs).WithContext(context.Background())
+
+	got := (&Inspector{}).TransformJsonencodeInPayload(ctx, input)
+
+	require.Equal(t, input, got)
+	require.Empty(t, logs.String())
 }
 
 func TestBuildPlatformPayloadsReusesEquivalentFullPayload(t *testing.T) {

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -115,12 +115,10 @@ func (s *FileSystemSourceProvider) addExcluded(ctx context.Context, excludePaths
 }
 
 // GetExcludePaths gets all the files that should be excluded
-func GetExcludePaths(ctx context.Context, pathExpressions string) ([]string, error) {
-	contextLogger := logger.FromContext(ctx)
+func GetExcludePaths(_ context.Context, pathExpressions string) ([]string, error) {
 	if strings.ContainsAny(pathExpressions, "*?[") {
 		info, err := filepathx.Glob(pathExpressions)
 		if err != nil {
-			contextLogger.Error().Msgf("failed to get exclude path %s: %s", pathExpressions, err)
 			return []string{pathExpressions}, nil
 		}
 		return info, nil

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -59,7 +59,7 @@ func NewFileSystemSourceProvider(ctx context.Context, paths, excludes, onlyPaths
 	}
 
 	for _, exclude := range excludes {
-		excludePaths, err := GetExcludePaths(ctx, exclude)
+		excludePaths, err := GetExcludePaths(exclude)
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +77,7 @@ func NewFileSystemSourceProvider(ctx context.Context, paths, excludes, onlyPaths
 	if len(onlyPaths) > 0 {
 		fs.onlyPaths = make([]string, 0)
 		for _, only := range onlyPaths {
-			expanded, err := GetExcludePaths(ctx, only)
+			expanded, err := GetExcludePaths(only)
 			if err != nil {
 				return nil, err
 			}
@@ -115,7 +115,7 @@ func (s *FileSystemSourceProvider) addExcluded(ctx context.Context, excludePaths
 }
 
 // GetExcludePaths gets all the files that should be excluded
-func GetExcludePaths(_ context.Context, pathExpressions string) ([]string, error) {
+func GetExcludePaths(pathExpressions string) ([]string, error) {
 	if strings.ContainsAny(pathExpressions, "*?[") {
 		info, err := filepathx.Glob(pathExpressions)
 		if err != nil {

--- a/pkg/engine/provider/filesystem_test.go
+++ b/pkg/engine/provider/filesystem_test.go
@@ -6,6 +6,7 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/test"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -650,6 +652,18 @@ func TestProvider_getExcludePaths(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestGetExcludePathsTreatsMalformedGlobAsLiteral(t *testing.T) {
+	var logs bytes.Buffer
+	ctx := zerolog.New(&logs).WithContext(context.Background())
+	path := filepath.Join("terraform", "module[production.tf")
+
+	got, err := GetExcludePaths(ctx, path)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{path}, got)
+	require.NotContains(t, logs.String(), `"level":"error"`)
 }
 
 func TestIsUnderResolvedChart(t *testing.T) {

--- a/pkg/engine/provider/filesystem_test.go
+++ b/pkg/engine/provider/filesystem_test.go
@@ -6,7 +6,6 @@
 package provider
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"os"
@@ -19,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/test"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -640,30 +638,27 @@ func TestProvider_getExcludePaths(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "malformed glob treated as literal path",
+			args: args{
+				pathExpressions: filepath.Join("terraform", "module[production.tf"),
+			},
+			want: []string{
+				filepath.Join("terraform", "module[production.tf"),
+			},
+			wantErr: false,
+		},
 	}
 
-	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetExcludePaths(ctx, tt.args.pathExpressions)
+			got, err := GetExcludePaths(tt.args.pathExpressions)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getExcludePaths Error: %v, wantErr: %v", got, tt.wantErr)
 			}
 			require.Equal(t, tt.want, got)
 		})
 	}
-}
-
-func TestGetExcludePathsTreatsMalformedGlobAsLiteral(t *testing.T) {
-	var logs bytes.Buffer
-	ctx := zerolog.New(&logs).WithContext(context.Background())
-	path := filepath.Join("terraform", "module[production.tf")
-
-	got, err := GetExcludePaths(ctx, path)
-
-	require.NoError(t, err)
-	require.Equal(t, []string{path}, got)
-	require.NotContains(t, logs.String(), `"level":"error"`)
 }
 
 func TestIsUnderResolvedChart(t *testing.T) {

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -236,7 +236,7 @@ func (v *converterExprVisitor) VisitConditional(e *hclsyntax.ConditionalExpr) (i
 		Variables: v.c.inputVars,
 		Functions: functions.TerraformFuncs,
 	})
-	if err != nil {
+	if err != nil || !val.IsWhollyKnown() {
 		return v.c.wrapExpr(e)
 	}
 	return ctyjson.SimpleJSONValue{Value: val}, nil
@@ -426,7 +426,7 @@ func (v *converterStringPartVisitor) VisitExprSyntaxError(e *hclsyntax.ExprSynta
 }
 func (v *converterStringPartVisitor) VisitDefault(e hclsyntax.Expression) (string, error) {
 	val, _ := e.Value(&hcl.EvalContext{Variables: v.c.inputVars})
-	if val.Type().FriendlyName() == ctyFriendlyNameString {
+	if val.IsWhollyKnown() && val.Type().FriendlyName() == ctyFriendlyNameString {
 		return val.AsString(), nil
 	}
 	return v.c.wrapExpr(e)
@@ -490,7 +490,7 @@ func (c *converter) tryEvalExpression(expr hclsyntax.Expression) (interface{}, e
 		Variables: c.inputVars,
 		Functions: functions.TerraformFuncs,
 	})
-	if !checkDynamicKnownTypes(val) {
+	if val.IsWhollyKnown() && !checkDynamicKnownTypes(val) {
 		return ctyjson.SimpleJSONValue{Value: val}, nil
 	}
 	return c.wrapExpr(expr)
@@ -501,7 +501,7 @@ func (c *converter) tryEvalToString(expr hclsyntax.Expression) (string, error) {
 		Variables: c.inputVars,
 		Functions: functions.TerraformFuncs,
 	})
-	if val.Type().FriendlyName() == ctyFriendlyNameString {
+	if val.IsWhollyKnown() && val.Type().FriendlyName() == ctyFriendlyNameString {
 		return val.AsString(), nil
 	}
 	return c.wrapExpr(expr)
@@ -549,10 +549,7 @@ func (c *converter) evalFunction(expression hclsyntax.Expression) (interface{}, 
 			return c.wrapExpr(expression)
 		}
 	}
-	if !expressionEvaluated.HasWhollyKnownType() {
-		// in some cases, the expression is evaluated with no error but the type is unknown.
-		// this causes the json marshaling of the Document later on to fail with an error, and the entire scan fails.
-		// Therefore, we prefer to wrap it as a string and continue the scan.
+	if !expressionEvaluated.IsWhollyKnown() {
 		return c.wrapExpr(expression)
 	}
 	return ctyjson.SimpleJSONValue{Value: expressionEvaluated}, nil

--- a/pkg/parser/terraform/converter/default_test.go
+++ b/pkg/parser/terraform/converter/default_test.go
@@ -310,6 +310,35 @@ block "label_one" {
 	}
 }
 
+func TestUnknownValuesRemainSerializable(t *testing.T) {
+	input := `
+block "test" {
+	conditional = var.enabled ? "enabled" : "disabled"
+	function    = upper(var.name)
+	template    = "prefix-${var.name}"
+}
+`
+	file, diags := hclsyntax.ParseConfig([]byte(input), "testFileName", hcl.Pos{Byte: 0, Line: 1, Column: 1})
+	require.False(t, diags.HasErrors(), "parse error: %v", diags)
+
+	body, err := DefaultConverted(context.Background(), file, VariableMap{
+		"var": cty.ObjectVal(map[string]cty.Value{
+			"enabled": cty.UnknownVal(cty.Bool),
+			"name":    cty.UnknownVal(cty.String),
+		}),
+	})
+	require.NoError(t, err)
+	require.NotPanics(t, func() {
+		_, err = json.Marshal(body)
+	})
+	require.NoError(t, err)
+
+	block := body["block"].(model.Document)["test"].(model.Document)
+	require.Equal(t, `${var.enabled ? "enabled" : "disabled"}`, block["conditional"])
+	require.Equal(t, "${upper(var.name)}", block["function"])
+	require.Equal(t, "prefix-${var.name}", block["template"])
+}
+
 func TestRelativeTraversalExpr(t *testing.T) {
 	t.Run("jsondecode_with_traversal_resolves", func(t *testing.T) {
 		input := `

--- a/pkg/parser/terraform/data_source.go
+++ b/pkg/parser/terraform/data_source.go
@@ -419,7 +419,10 @@ func resolveTuple(ctx context.Context, expr hclsyntax.Expression) {
 			striExpr, err := e.ExpToString(ctx, ex)
 
 			if err != nil {
-				contextLogger.Error().Msgf("Error trying to ExpToString: %s", err)
+				if literal, ok := ex.(*hclsyntax.LiteralValueExpr); !ok || !literal.Val.IsNull() {
+					contextLogger.Error().Msgf("Error trying to ExpToString: %s", err)
+				}
+				continue
 			}
 
 			v.Exprs[i] = &hclsyntax.LiteralValueExpr{

--- a/pkg/parser/terraform/data_source_test.go
+++ b/pkg/parser/terraform/data_source_test.go
@@ -6,6 +6,7 @@
 package terraform
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -13,10 +14,32 @@ import (
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 )
+
+func TestResolveTuplePreservesNullValues(t *testing.T) {
+	expr, diagnostics := hclsyntax.ParseExpression(
+		[]byte(`[null, "arn:aws:s3:::example"]`),
+		"policy.tf",
+		hcl.InitialPos,
+	)
+	require.False(t, diagnostics.HasErrors())
+	tuple := expr.(*hclsyntax.TupleConsExpr)
+	var logs bytes.Buffer
+	ctx := zerolog.New(&logs).WithContext(context.Background())
+
+	resolveTuple(ctx, tuple)
+
+	nullExpr := tuple.Exprs[0].(*hclsyntax.LiteralValueExpr)
+	require.True(t, nullExpr.Val.IsNull())
+	require.Equal(t, "arn:aws:s3:::example", tuple.Exprs[1].(*hclsyntax.LiteralValueExpr).Val.AsString())
+	require.Empty(t, logs.String())
+}
 
 func Test_getDataSourcePolicy(t *testing.T) {
 	type args struct {

--- a/pkg/parser/terraform/tfeval/evaluator.go
+++ b/pkg/parser/terraform/tfeval/evaluator.go
@@ -592,7 +592,10 @@ func (e *Evaluator) evaluateLocalModuleBlocks(
 	// (module B referencing module C where C appears later in file order) survive the
 	// first iteration's evalCtx.Variables["module"] update.
 	moduleOutputs = map[string]cty.Value{}
-	if existing, ok := evalCtx.Variables["module"]; ok && existing.Type().IsObjectType() {
+	if existing, ok := evalCtx.Variables["module"]; ok &&
+		existing.IsKnown() &&
+		!existing.IsNull() &&
+		existing.Type().IsObjectType() {
 		for it := existing.ElementIterator(); it.Next(); {
 			k, v := it.Element()
 			moduleOutputs[k.AsString()] = v

--- a/pkg/parser/terraform/tfeval/evaluator_test.go
+++ b/pkg/parser/terraform/tfeval/evaluator_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -920,6 +921,24 @@ func TestCanonicalInputsKey_NullTypeDistinct(t *testing.T) {
 	k2 := canonicalInputsKey(map[string]cty.Value{"x": cty.NullVal(cty.Number)})
 	if k1 == k2 {
 		t.Errorf("null(string) and null(number) produced the same cache key: %q", k1)
+	}
+}
+
+func TestEvaluateLocalModuleBlocksIgnoresNullPreliminaryOutputs(t *testing.T) {
+	evalCtx := &hcl.EvalContext{Variables: map[string]cty.Value{
+		"module": cty.NullVal(cty.EmptyObject),
+	}}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("evaluateLocalModuleBlocks panicked: %v", recovered)
+		}
+	}()
+
+	_, outputs := New().evaluateLocalModuleBlocks(
+		context.Background(), nil, evalCtx, "", "", "", nil, 0, nil, nil,
+	)
+	if len(outputs) != 0 {
+		t.Fatalf("outputs = %#v, want empty", outputs)
 	}
 }
 

--- a/pkg/report/remediations/remediations_helper.go
+++ b/pkg/report/remediations/remediations_helper.go
@@ -189,6 +189,10 @@ func findReplacementTarget(
 	alternatives := parseAlternatives(before)
 	for lineNumber := start; lineNumber <= end; lineNumber++ {
 		line := vuln.FileSource[lineNumber-1]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
+			continue
+		}
 		matches := keyValRegex.FindStringSubmatch(line)
 		if len(matches) < 3 || normalize(matches[1]) != expectedKey {
 			continue

--- a/pkg/report/remediations/remediations_helper.go
+++ b/pkg/report/remediations/remediations_helper.go
@@ -47,9 +47,18 @@ func buildReplacementFix(ctx context.Context, vuln model.VulnerableFile,
 	keyValRegex := regexp.MustCompile(`(?m)["']?(\w+)["']?\s*[:=]\s*(\[.*?\]|".*?"|[^#]+)`)
 	matches := keyValRegex.FindStringSubmatch(vuln.LineWithVulnerability)
 	if len(matches) < 3 {
-		err := fmt.Errorf("could not parse key-value from line: %s", vuln.LineWithVulnerability)
-		contextLogger.Error().Msg(err.Error())
-		return model.SarifFix{}, err
+		line, lineNumber, found := findReplacementTarget(&vuln, before, keyValRegex)
+		if !found {
+			err := fmt.Errorf("could not parse key-value from line: %s", vuln.LineWithVulnerability)
+			contextLogger.Error().Msg(err.Error())
+			return model.SarifFix{}, err
+		}
+		vuln.LineWithVulnerability = line
+		vuln.Line = lineNumber
+		vuln.RemediationLocation.Start.Line = lineNumber
+		vuln.RemediationLocation.End.Line = lineNumber
+		startLocation.Line = lineNumber
+		matches = keyValRegex.FindStringSubmatch(line)
 	}
 
 	key := strings.TrimSpace(matches[1])
@@ -162,6 +171,36 @@ func buildReplacementFix(ctx context.Context, vuln model.VulnerableFile,
 		Line: vuln.Line,
 		Col:  len(vuln.LineWithVulnerability) + 1,
 	}), nil
+}
+
+func findReplacementTarget(
+	vuln *model.VulnerableFile,
+	before string,
+	keyValRegex *regexp.Regexp,
+) (line string, lineNumber int, found bool) {
+	firstAlternative := strings.Split(before, " or ")[0]
+	expectedKey, _ := splitKeyValue(firstAlternative)
+	if expectedKey == "" {
+		return "", 0, false
+	}
+
+	start := max(vuln.BlockLocation.Start.Line, 1)
+	end := min(vuln.BlockLocation.End.Line, len(vuln.FileSource))
+	alternatives := parseAlternatives(before)
+	for lineNumber := start; lineNumber <= end; lineNumber++ {
+		line := vuln.FileSource[lineNumber-1]
+		matches := keyValRegex.FindStringSubmatch(line)
+		if len(matches) < 3 || normalize(matches[1]) != expectedKey {
+			continue
+		}
+		value := normalize(matches[2])
+		for _, alternative := range alternatives {
+			if strings.Contains(value, alternative) {
+				return line, lineNumber, true
+			}
+		}
+	}
+	return "", 0, false
 }
 
 // nolint:gocritic

--- a/pkg/report/remediations/remediations_helper_test.go
+++ b/pkg/report/remediations/remediations_helper_test.go
@@ -25,15 +25,15 @@ func TestTransformToSarifFixE2E(t *testing.T) { //nolint
 					Start: model.ResourceLine{Line: 1, Col: 1},
 					End:   model.ResourceLine{Line: 9, Col: 2},
 				},
-				VulnLines:        nil,
-				ResourceType:     "n/a",
-				ResourceName:     "n/a",
-				SearchKey:        "module[s3_bucket]",
-				SearchLine:       1,
-				SearchValue:      "",
-				Value:            nil,
-				Remediation:      "block_public_acls = true",
-				RemediationType:  "addition",
+				VulnLines:       nil,
+				ResourceType:    "n/a",
+				ResourceName:    "n/a",
+				SearchKey:       "module[s3_bucket]",
+				SearchLine:      1,
+				SearchValue:     "",
+				Value:           nil,
+				Remediation:     "block_public_acls = true",
+				RemediationType: "addition",
 				RemediationLocation: model.ResourceLocation{
 					Start: model.ResourceLine{Line: 8, Col: 2},
 					End:   model.ResourceLine{Line: 8, Col: 2},
@@ -121,6 +121,41 @@ func TestTransformToSarifFix_Removal(t *testing.T) {
 	fix, err := TransformToSarifFix(ctx, vuln, start, end)
 	require.NoError(t, err)
 	require.Equal(t, "", fix.ArtifactChanges[0].Replacements[0].InsertedContent.Text)
+}
+
+func TestTransformToSarifFix_ReplacementFindsAttributeInsideBlock(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "enabled = true", "after": "false"}`,
+		LineWithVulnerability: `module "generic_region" {`,
+		Line:                  1,
+		FileSource: []string{
+			`module "generic_region" {`,
+			"  enabled = true",
+			"}",
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 3, Col: 2},
+		},
+		RemediationLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: 1},
+		},
+	}
+
+	fix, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 26},
+	)
+
+	require.NoError(t, err)
+	replacement := fix.ArtifactChanges[0].Replacements[0]
+	require.Equal(t, 2, replacement.DeletedRegion.StartLine)
+	require.Equal(t, "  enabled = false", replacement.InsertedContent.Text)
 }
 
 func TestTransformToSarifFix_Replacement(t *testing.T) {

--- a/pkg/report/remediations/remediations_helper_test.go
+++ b/pkg/report/remediations/remediations_helper_test.go
@@ -158,6 +158,42 @@ func TestTransformToSarifFix_ReplacementFindsAttributeInsideBlock(t *testing.T) 
 	require.Equal(t, "  enabled = false", replacement.InsertedContent.Text)
 }
 
+func TestTransformToSarifFix_ReplacementFindsAttributeInsideBlockSkipsComments(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "enabled = true", "after": "false"}`,
+		LineWithVulnerability: `module "generic_region" {`,
+		Line:                  1,
+		FileSource: []string{
+			`module "generic_region" {`,
+			"  # enabled = true",
+			"  enabled = true",
+			"}",
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 4, Col: 2},
+		},
+		RemediationLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: 1},
+		},
+	}
+
+	fix, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 26},
+	)
+
+	require.NoError(t, err)
+	replacement := fix.ArtifactChanges[0].Replacements[0]
+	require.Equal(t, 3, replacement.DeletedRegion.StartLine)
+	require.Equal(t, "  enabled = false", replacement.InsertedContent.Text)
+}
+
 func TestTransformToSarifFix_Replacement(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Motivation

Production `iac-scanning` logs showed recurring scanner-side failures that reduce coverage or remediation quality without failing whole scans: `jsonencode` suffix expressions were mis-parsed and logged as errors, null Terraform values could panic module evaluation or spam data-source resolution, unknown Terraform values could make converted documents fail JSON marshaling and skip entire files, literal file paths with bracket characters were treated as malformed globs and logged at error level, and SARIF replacement fixes failed when the vulnerable line pointed at a block header instead of the attribute inside the block.

## Changes

**Query payload preprocessing**

Parse the full HCL expression before expanding `jsonencode(...)` and only transform standalone calls, leaving expressions like `${jsonencode(x)}.exists(...)` unchanged without emitting error logs.

**Terraform evaluation**

Skip `ElementIterator` on null or unknown module output objects during local module evaluation, treat null tuple elements in data-source resolution as expected instead of logging `ExpToString` errors, and preserve unknown conditionals, function results, and template interpolations as source expressions so converted documents remain serializable.

**Path filtering**

When exclude or include path expressions contain glob metacharacters but are not valid glob syntax, fall back to treating the expression as a literal path without emitting scanner errors.

**SARIF remediation**

When replacement fix generation cannot parse the reported vulnerable line, search inside the resource or module block for the matching attribute before giving up.

## Author Checklist

1. [ ] I have reviewed my own PR.
2. [x] I have added or updated relevant unit tests where necessary.
3. [x] All new and existing tests pass.
4. [ ] I have tested my changes on staging, if applicable.
5. [ ] I have updated relevant documentation, if applicable.

## QA Instruction

1. `go test ./pkg/engine -run TestTransformJsonencodeInPayloadLeavesSuffixExpressionUnchanged -count=1`
2. `go test ./pkg/parser/terraform/tfeval -run TestEvaluateLocalModuleBlocksIgnoresNullPreliminaryOutputs -count=1`
3. `go test ./pkg/parser/terraform -run TestResolveTuplePreservesNullValues -count=1`
4. `go test ./pkg/parser/terraform/converter -run TestUnknownValuesRemainSerializable -count=1`
5. `go test ./pkg/engine/provider -run TestGetExcludePathsTreatsMalformedGlobAsLiteral -count=1`
6. `go test ./pkg/report/remediations -run TestTransformToSarifFix_ReplacementFindsAttributeInsideBlock -count=1`
7. `go test ./pkg/... -count=1`
8. `golangci-lint run -c .golangci.yml --timeout 20m ./pkg/...`

## Blast Radius

This affects the Datadog IaC Scanner only: Terraform parsing and evaluation, OPA payload preprocessing, scan path filtering, and SARIF fix generation. Findings are still emitted when expressions cannot be fully evaluated or automatic fixes cannot be attached; these changes reduce false-negative risk and improve remediation attachment for edge-case Terraform configs.

## Additional Notes

The changes are split into five focused commits. Custom-rule `deletion` remediation types remain intentionally unsupported because built-in rules use `removal`, `addition`, and `replacement`.

I submit this contribution under the Apache-2.0 license.