### PR TITLE
Add Least Privilege IaC rule category

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -39,6 +39,7 @@ var (
 		"Supply-Chain":            "CAT013",
 		"Structure and Semantics": "CAT014",
 		"Bill Of Materials":       "CAT015",
+		"Least Privilege":         "CAT016",
 	}
 
 	// AvailablePlatforms - All platforms available

--- a/legacy_config.md
+++ b/legacy_config.md
@@ -61,6 +61,7 @@ The following top-level entries are supported:
 - `Encryption`
 - `Insecure Configurations`
 - `Insecure Defaults`
+- `Least Privilege`
 - `Networking and Firewall`
 - `Observability`
 - `Resource Management`

--- a/pkg/config/config_validation_test.go
+++ b/pkg/config/config_validation_test.go
@@ -52,7 +52,7 @@ func TestParseSeverityValues(t *testing.T) {
 }
 
 func TestParseCategoryValues(t *testing.T) {
-	for _, cat := range []string{"Access Control", "Encryption", "Best Practices"} {
+	for _, cat := range []string{"Access Control", "Encryption", "Best Practices", "Least Privilege"} {
 		require.Contains(t, constants.AvailableCategories, cat, "fixture references removed category")
 	}
 
@@ -63,6 +63,7 @@ func TestParseCategoryValues(t *testing.T) {
 		{"lowercase", "encryption", "Encryption"},
 		{"whitespace and case", `"  access control  "`, "Access Control"},
 		{"multi-word exact", `"Best Practices"`, "Best Practices"},
+		{"least privilege", `"Least Privilege"`, "Least Privilege"},
 	}
 	invalid := []struct {
 		name, input, errFragment string

--- a/pkg/report/model/sonarqube.go
+++ b/pkg/report/model/sonarqube.go
@@ -29,6 +29,7 @@ var categorySonarQubeEquivalence = map[string]string{
 	"Encryption":              "VULNERABILITY",
 	"Insecure Configurations": "CODE_SMELL",
 	"Insecure Defaults":       "CODE_SMELL",
+	"Least Privilege":         "VULNERABILITY",
 	"Networking and Firewall": "VULNERABILITY",
 	"Observability":           "VULNERABILITY",
 	"Resource Management":     "VULNERABILITY",


### PR DESCRIPTION
## Motivation

Add **Least Privilege** as a supported IaC rule category (`CAT016`) for custom rules and repo configuration filtering. Requested via customer feedback for CI/CD and AI-agent over-permission findings.

Slack: https://dd.slack.com/archives/C069XJF7F4L/p1788182857176039

JIRA Ticket

## Changes

- Add `"Least Privilege": "CAT016"` to `AvailableCategories` in `internal/constants/constants.go`
- Document in `legacy_config.md` under `exclude-categories`
- Map to SonarQube `VULNERABILITY` in `pkg/report/model/sonarqube.go`

## Author Checklist

- [x] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [x] I have updated any relevant documentation (if applicable).

## QA Instruction

Verify `ignore-categories: ["Least Privilege"]` parses in `code-security.datadog.yaml` and custom rules can carry the category in SARIF output.

## Blast Radius

DataDog IaC Scanner only — category enum and config validation.

## Additional Notes

Companion changes in dd-source, web-ui, dd-go, schema, and documentation.

I submit this contribution under the Apache-2.0 license.
