### PR TITLE
Add retired CLI flag registry

### DIFF
--- a/cmd/scanner/retired_flags.go
+++ b/cmd/scanner/retired_flags.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+	cli "github.com/urfave/cli/v3"
+)
+
+// Shared retired flags must be removed from both scan and serve in the same change.
+func sharedRetiredFlags() []cli.Flag {
+	return nil
+}
+
+func retiredScanOnlyFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.IntFlag{
+			Name:   "timeout",
+			Hidden: true,
+			Action: retiredFlagAction[int]("timeout"),
+		},
+	}
+}
+
+func retiredServeOnlyFlags() []cli.Flag {
+	return nil
+}
+
+func retiredScanFlags() []cli.Flag {
+	return joinRetiredFlags(retiredScanOnlyFlags())
+}
+
+func retiredServeFlags() []cli.Flag {
+	return joinRetiredFlags(retiredServeOnlyFlags())
+}
+
+func joinRetiredFlags(specific []cli.Flag) []cli.Flag {
+	return append(append([]cli.Flag{}, sharedRetiredFlags()...), specific...)
+}
+
+func retiredFlagAction[T any](name string) func(context.Context, *cli.Command, T) error {
+	return func(ctx context.Context, _ *cli.Command, _ T) error {
+		log.Ctx(ctx).Warn().Str("flag", name).Msg("ignoring retired flag")
+		return nil
+	}
+}

--- a/cmd/scanner/retired_flags.go
+++ b/cmd/scanner/retired_flags.go
@@ -7,6 +7,10 @@ import (
 	cli "github.com/urfave/cli/v3"
 )
 
+const retiredTimeoutUsage = "(DEPRECATED) no longer has any effect; " +
+	"queries run to completion and slow rules are logged instead. " +
+	"This flag will be removed."
+
 // Shared retired flags must be removed from both scan and serve in the same change.
 func sharedRetiredFlags() []cli.Flag {
 	return nil
@@ -14,14 +18,15 @@ func sharedRetiredFlags() []cli.Flag {
 
 func retiredScanOnlyFlags() []cli.Flag {
 	return []cli.Flag{
-		retiredInt("timeout"),
+		retiredInt("timeout", retiredTimeoutUsage),
 	}
 }
 
-func retiredInt(name string) *cli.IntFlag {
+func retiredInt(name, usage string) *cli.IntFlag {
 	return &cli.IntFlag{
 		Name:   name,
 		Hidden: true,
+		Usage:  usage,
 		Action: retiredFlagAction[int](name),
 	}
 }

--- a/cmd/scanner/retired_flags.go
+++ b/cmd/scanner/retired_flags.go
@@ -14,11 +14,15 @@ func sharedRetiredFlags() []cli.Flag {
 
 func retiredScanOnlyFlags() []cli.Flag {
 	return []cli.Flag{
-		&cli.IntFlag{
-			Name:   "timeout",
-			Hidden: true,
-			Action: retiredFlagAction[int]("timeout"),
-		},
+		retiredInt("timeout"),
+	}
+}
+
+func retiredInt(name string) *cli.IntFlag {
+	return &cli.IntFlag{
+		Name:   name,
+		Hidden: true,
+		Action: retiredFlagAction[int](name),
 	}
 }
 

--- a/cmd/scanner/retired_flags_test.go
+++ b/cmd/scanner/retired_flags_test.go
@@ -101,3 +101,19 @@ func TestRetiredFlagsAreHidden(t *testing.T) {
 	assert.Empty(t, (&cli.Command{Flags: retiredScanFlags()}).VisibleFlags())
 	assert.Empty(t, (&cli.Command{Flags: retiredServeFlags()}).VisibleFlags())
 }
+
+func TestUnknownXFlagFailsAtParseTime(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cli.Command{
+		Name:  "scan",
+		Flags: append([]cli.Flag{&cli.StringSliceFlag{Name: "path"}}, retiredScanFlags()...),
+		Action: func(_ context.Context, _ *cli.Command) error {
+			return nil
+		},
+	}
+
+	err := cmd.Run(context.Background(), []string{"scan", "--x-blabla", "1234", "--path", "."})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "flag provided but not defined")
+}

--- a/cmd/scanner/retired_flags_test.go
+++ b/cmd/scanner/retired_flags_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cli "github.com/urfave/cli/v3"
+)
+
+func retiredFlagNames(flags []cli.Flag) []string {
+	names := make([]string, 0, len(flags))
+	for _, flag := range flags {
+		names = append(names, flag.Names()[0])
+	}
+	return names
+}
+
+func TestRetiredTimeoutFlagIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	prev := log.Logger
+	prevLevel := zerolog.GlobalLevel()
+	t.Cleanup(func() {
+		log.Logger = prev
+		zerolog.SetGlobalLevel(prevLevel)
+	})
+	log.Logger = zerolog.New(&buf)
+
+	cmd := &cli.Command{
+		Name: "test",
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "log-format", Value: "json"},
+			&cli.StringFlag{Name: "log-level", Value: "error"},
+		},
+		Before: applyGlobalOptions,
+		Commands: []*cli.Command{
+			{
+				Name:  "scan",
+				Flags: append([]cli.Flag{&cli.StringSliceFlag{Name: "path"}}, retiredScanFlags()...),
+				Action: func(_ context.Context, c *cli.Command) error {
+					assert.Empty(t, c.Args().Slice())
+					return nil
+				},
+			},
+		},
+	}
+
+	require.NoError(t, cmd.Run(context.Background(), []string{
+		"test",
+		"--log-level", "warn",
+		"scan",
+		"--path", "/tmp",
+		"--timeout", "60",
+	}))
+	assert.Contains(t, buf.String(), `"flag":"timeout"`)
+	assert.Contains(t, buf.String(), "ignoring retired flag")
+}
+
+func TestRetiredScanOnlyFlagsAreNotOnServe(t *testing.T) {
+	t.Parallel()
+
+	serve := &cli.Command{Name: "serve", Flags: retiredServeFlags()}
+
+	err := serve.Run(context.Background(), []string{"serve", "--timeout", "60"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "flag provided but not defined")
+}
+
+func TestRetiredFlagComposition(t *testing.T) {
+	t.Parallel()
+
+	shared := retiredFlagNames(sharedRetiredFlags())
+	scanOnly := retiredFlagNames(retiredScanOnlyFlags())
+	serveOnly := retiredFlagNames(retiredServeOnlyFlags())
+	scan := retiredFlagNames(retiredScanFlags())
+	serve := retiredFlagNames(retiredServeFlags())
+
+	for _, name := range shared {
+		assert.Contains(t, scan, name)
+		assert.Contains(t, serve, name)
+	}
+	for _, name := range scanOnly {
+		assert.Contains(t, scan, name)
+		assert.NotContains(t, serve, name)
+	}
+	for _, name := range serveOnly {
+		assert.Contains(t, serve, name)
+		assert.NotContains(t, scan, name)
+	}
+}
+
+func TestRetiredFlagsAreHidden(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, (&cli.Command{Flags: retiredScanFlags()}).VisibleFlags())
+	assert.Empty(t, (&cli.Command{Flags: retiredServeFlags()}).VisibleFlags())
+}

--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -30,7 +30,7 @@ import (
 var scanAction = &cli.Command{
 	Name:  "scan",
 	Usage: "Analyzes the content of a repository",
-	Flags: []cli.Flag{
+	Flags: append([]cli.Flag{
 		&cli.StringSliceFlag{
 			Name:     "path",
 			Aliases:  []string{"p"},
@@ -65,12 +65,6 @@ var scanAction = &cli.Command{
 			Name:  "max-resolver-depth",
 			Usage: "maximum depth that the scanner will resolve files in",
 			Value: 15,
-		},
-		&cli.IntFlag{
-			Name:   "timeout",
-			Usage:  "(DEPRECATED) no longer has any effect; queries run to completion and slow rules are logged instead. This flag will be removed.",
-			Value:  60,
-			Hidden: true,
 		},
 		&cli.StringSliceFlag{
 			Name:  "exclude-queries",
@@ -191,7 +185,7 @@ var scanAction = &cli.Command{
 			Usage: "output report formats (valid: sarif, simple-json)",
 			Value: []string{"sarif"},
 		},
-	},
+	}, retiredScanFlags()...),
 	Action: runScan,
 }
 
@@ -258,11 +252,6 @@ func validateQueriesPaths(paths []string) ([]string, error) {
 
 // nolint:gocyclo
 func runScan(ctx context.Context, c *cli.Command) error {
-	if c.IsSet("timeout") {
-		contextLogger := logger.FromContext(ctx)
-		contextLogger.Warn().Msg(
-			"the --timeout flag is deprecated and no longer has any effect; queries run to completion and slow rules are logged instead")
-	}
 	if c.Args().Len() > 0 {
 		return fmt.Errorf("unexpected arguments: %v", c.Args().Slice())
 	}

--- a/cmd/scanner/serve.go
+++ b/cmd/scanner/serve.go
@@ -13,7 +13,7 @@ import (
 var serveAction = &cli.Command{
 	Name:  "serve",
 	Usage: "Runs a long-lived HTTP server that analyzes IaC files on demand",
-	Flags: []cli.Flag{
+	Flags: append([]cli.Flag{
 		&cli.IntFlag{
 			Name:  "port",
 			Value: 8000,
@@ -69,7 +69,7 @@ var serveAction = &cli.Command{
 			Usage:  "(experimental, will be removed soon) parse pushed files in parallel across CPUs",
 			Value:  true,
 		},
-	},
+	}, retiredServeFlags()...),
 	Action: serve,
 }
 


### PR DESCRIPTION
## Motivation

Hidden `--x-*` flags are internal experimental toggles passed by callers such as iac-scanning. When we remove a flag from the scanner, callers must currently land coordinated changes or the CLI exits with a usage error. This change introduces an explicit retired-flag registry so removed flags can stay registered as hidden no-ops until callers catch up, instead of guessing argv or stripping unknown `x-*` names.

## Changes

**CLI**

Retired flags live in `retired_flags.go`, isolated from active flag definitions. Each entry keeps its original urfave type, is hidden from help, and logs a warn when used. Shared retired flags apply to both `scan` and `serve`; command-specific ones stay scoped (for example scan-only).

As a first example, `--timeout` is moved out of `scan` into the registry. It no longer affects scanning; callers that still pass it get a warn and the command continues.

## QA Instruction

1. `go test ./cmd/scanner -run TestRetired -v -count=1`
2. Build and run: `./bin/datadog-iac-scanner scan -p test/fixtures/test_terraform --timeout 60 --log-level warn` — should succeed with a warn log for `timeout`.
3. Confirm a real typo still fails: `./bin/datadog-iac-scanner scan -p test/fixtures/test_terraform --pathh /tmp`
4. Confirm `--timeout` is not accepted on `serve`: `./bin/datadog-iac-scanner serve --timeout 60` — should fail with a usage error.

## Impact

CLI only. No change to scan results, rules, or the HTTP server.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

I submit this contribution under the Apache-2.0 license.