### PR TITLE
Fix line locations for Helm template wrappers

### DIFF
--- a/pkg/detector/helm/helm_detect.go
+++ b/pkg/detector/helm/helm_detect.go
@@ -114,6 +114,26 @@ func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata
 		}
 	}
 
+	// Helm attributes output from a named template to the file that invoked it.
+	// Include-only wrapper files therefore contain no rendered YAML keys for the
+	// search path to match. Anchor those findings to the invocation that emitted
+	// the resource instead of returning an undetected line.
+	if file.HelmID == "" {
+		if line, col, ok := findHelmTemplateInvocation(lines); ok {
+			adjustedLine := line + 1
+			return model.VulnerabilityLines{
+				Line:                  adjustedLine,
+				VulnLines:             detector.GetAdjacentVulnLines(line, outputLines, lines),
+				LineWithVulnerability: lines[line],
+				ResolvedFile:          file.FilePath,
+				VulnerablilityLocation: model.ResourceLocation{
+					Start: model.ResourceLine{Line: adjustedLine, Col: col},
+					End:   model.ResourceLine{Line: adjustedLine, Col: len(lines[line])},
+				},
+			}
+		}
+	}
+
 	var filePathSplit = strings.Split(file.FilePath, "/")
 	contextLogger.Warn().Msgf("Failed to detect line associated with identified result in file %s", filePathSplit[len(filePathSplit)-1])
 
@@ -122,6 +142,22 @@ func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata
 		VulnLines:    &[]model.CodeLine{},
 		ResolvedFile: file.FilePath,
 	}
+}
+
+func findHelmTemplateInvocation(lines []string) (line, col int, ok bool) {
+	for line, sourceLine := range lines {
+		col = strings.Index(sourceLine, "{{")
+		if col < 0 {
+			continue
+		}
+		action := strings.TrimLeft(sourceLine[col+2:], "- \t")
+		if strings.HasPrefix(action, "include ") ||
+			strings.HasPrefix(action, "template ") ||
+			strings.HasPrefix(action, "tpl ") {
+			return line, col, true
+		}
+	}
+	return 0, 0, false
 }
 
 // removeLines is used to update the vulnerability line after removing the "# KICS_HELM_ID_"

--- a/pkg/detector/helm/helm_detect.go
+++ b/pkg/detector/helm/helm_detect.go
@@ -119,7 +119,7 @@ func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata
 	// search path to match. Anchor those findings to the invocation that emitted
 	// the resource instead of returning an undetected line.
 	if file.HelmID == "" {
-		if line, col, ok := findHelmTemplateInvocation(lines); ok {
+		if line, col, ok := findHelmTemplateInvocation(lines, file.HelmDocIndex); ok {
 			adjustedLine := line + 1
 			return model.VulnerabilityLines{
 				Line:                  adjustedLine,
@@ -144,17 +144,34 @@ func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata
 	}
 }
 
-func findHelmTemplateInvocation(lines []string) (line, col int, ok bool) {
+func findHelmTemplateInvocation(lines []string, documentIndex int) (line, col int, ok bool) {
+	invocationIndex := 0
 	for line, sourceLine := range lines {
-		col = strings.Index(sourceLine, "{{")
-		if col < 0 {
-			continue
-		}
-		action := strings.TrimLeft(sourceLine[col+2:], "- \t")
-		if strings.HasPrefix(action, "include ") ||
-			strings.HasPrefix(action, "template ") ||
-			strings.HasPrefix(action, "tpl ") {
-			return line, col, true
+		for offset := 0; offset < len(sourceLine); {
+			relativeCol := strings.Index(sourceLine[offset:], "{{")
+			if relativeCol < 0 {
+				break
+			}
+			col = offset + relativeCol
+			actionStart := col + len("{{")
+			actionEnd := strings.Index(sourceLine[actionStart:], "}}")
+			if actionEnd < 0 {
+				actionEnd = len(sourceLine)
+				offset = len(sourceLine)
+			} else {
+				actionEnd += actionStart
+				offset = actionEnd + len("}}")
+			}
+
+			action := strings.TrimLeft(sourceLine[actionStart:actionEnd], "- \t")
+			if strings.HasPrefix(action, "include ") ||
+				strings.HasPrefix(action, "template ") ||
+				strings.HasPrefix(action, "tpl ") {
+				if invocationIndex == documentIndex {
+					return line, col, true
+				}
+				invocationIndex++
+			}
 		}
 	}
 	return 0, 0, false

--- a/pkg/detector/helm/helm_detect.go
+++ b/pkg/detector/helm/helm_detect.go
@@ -114,23 +114,21 @@ func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata
 		}
 	}
 
-	// Helm attributes output from a named template to the file that invoked it.
-	// Include-only wrapper files therefore contain no rendered YAML keys for the
-	// search path to match. Anchor those findings to the invocation that emitted
-	// the resource instead of returning an undetected line.
-	if file.HelmID == "" {
-		if line, col, ok := findHelmTemplateInvocation(lines, file.HelmDocIndex); ok {
-			adjustedLine := line + 1
-			return model.VulnerabilityLines{
-				Line:                  adjustedLine,
-				VulnLines:             detector.GetAdjacentVulnLines(line, outputLines, lines),
-				LineWithVulnerability: lines[line],
-				ResolvedFile:          file.FilePath,
-				VulnerablilityLocation: model.ResourceLocation{
-					Start: model.ResourceLine{Line: adjustedLine, Col: col},
-					End:   model.ResourceLine{Line: adjustedLine, Col: len(lines[line])},
-				},
-			}
+	// Helm attributes named-template output to the file that invoked it. The
+	// resolver records the action that actually executed, so wrappers with
+	// conditional or repeated invocations can still point to the right source.
+	invocation := file.HelmInvocation
+	invocationLine := invocation.Line - 1
+	if invocation.Line > 0 && invocationLine < len(lines) {
+		return model.VulnerabilityLines{
+			Line:                  invocation.Line,
+			VulnLines:             detector.GetAdjacentVulnLines(invocationLine, outputLines, lines),
+			LineWithVulnerability: lines[invocationLine],
+			ResolvedFile:          file.FilePath,
+			VulnerablilityLocation: model.ResourceLocation{
+				Start: invocation,
+				End:   model.ResourceLine{Line: invocation.Line, Col: len(lines[invocationLine])},
+			},
 		}
 	}
 
@@ -142,39 +140,6 @@ func (d DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadata
 		VulnLines:    &[]model.CodeLine{},
 		ResolvedFile: file.FilePath,
 	}
-}
-
-func findHelmTemplateInvocation(lines []string, documentIndex int) (line, col int, ok bool) {
-	invocationIndex := 0
-	for line, sourceLine := range lines {
-		for offset := 0; offset < len(sourceLine); {
-			relativeCol := strings.Index(sourceLine[offset:], "{{")
-			if relativeCol < 0 {
-				break
-			}
-			col = offset + relativeCol
-			actionStart := col + len("{{")
-			actionEnd := strings.Index(sourceLine[actionStart:], "}}")
-			if actionEnd < 0 {
-				actionEnd = len(sourceLine)
-				offset = len(sourceLine)
-			} else {
-				actionEnd += actionStart
-				offset = actionEnd + len("}}")
-			}
-
-			action := strings.TrimLeft(sourceLine[actionStart:actionEnd], "- \t")
-			if strings.HasPrefix(action, "include ") ||
-				strings.HasPrefix(action, "template ") ||
-				strings.HasPrefix(action, "tpl ") {
-				if invocationIndex == documentIndex {
-					return line, col, true
-				}
-				invocationIndex++
-			}
-		}
-	}
-	return 0, 0, false
 }
 
 // removeLines is used to update the vulnerability line after removing the "# KICS_HELM_ID_"

--- a/pkg/detector/helm/helm_detect_test.go
+++ b/pkg/detector/helm/helm_detect_test.go
@@ -292,6 +292,40 @@ func TestEngine_detectHelmLine(t *testing.T) { //nolint
 	}
 }
 
+func TestDetectLineFallsBackToIncludeInvocation(t *testing.T) {
+	original := `{{- include "quickwit.metastore.deployment" (dict
+  "root" .
+  "component" "metastore"
+) }}`
+	file := &model.FileMetadata{
+		Kind:              model.KindHELM,
+		FilePath:          "templates/metastore-deployment.yaml",
+		OriginalData:      original,
+		LinesOriginalData: utils.SplitLines(original),
+	}
+
+	got := (DetectKindLine{}).DetectLine(
+		context.Background(), file, "apiVersion=apps/v1.kind=Deployment.spec.template.spec.containers", 1,
+	)
+	want := model.VulnerabilityLines{
+		Line: 1,
+		VulnLines: &[]model.CodeLine{{
+			Position: 1,
+			Line:     `{{- include "quickwit.metastore.deployment" (dict`,
+		}},
+		LineWithVulnerability: `{{- include "quickwit.metastore.deployment" (dict`,
+		ResolvedFile:          "templates/metastore-deployment.yaml",
+		VulnerablilityLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 0},
+			End:   model.ResourceLine{Line: 1, Col: 49},
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("DetectLine() = %#v, want %#v", got, want)
+	}
+}
+
 func TestDetectLastSingleMissingHelmID(t *testing.T) {
 	distances := map[int]int{2: 1, 5: 1}
 	idInfo := map[int]interface{}{0: map[int]int{2: 2}}

--- a/pkg/detector/helm/helm_detect_test.go
+++ b/pkg/detector/helm/helm_detect_test.go
@@ -326,6 +326,46 @@ func TestDetectLineFallsBackToIncludeInvocation(t *testing.T) {
 	}
 }
 
+func TestDetectLineSelectsRenderedDocumentInvocation(t *testing.T) {
+	original := `{{- include "first.resource" . }}
+{{- include "second.resource" . }}`
+	file := &model.FileMetadata{
+		Kind:              model.KindHELM,
+		FilePath:          "templates/resources.yaml",
+		OriginalData:      original,
+		LinesOriginalData: utils.SplitLines(original),
+		HelmDocIndex:      1,
+	}
+
+	got := (DetectKindLine{}).DetectLine(context.Background(), file, "spec.containers", 1)
+
+	if got.Line != 2 {
+		t.Fatalf("DetectLine() line = %d, want second invocation on line 2", got.Line)
+	}
+	if got.LineWithVulnerability != `{{- include "second.resource" . }}` {
+		t.Fatalf("DetectLine() vulnerable line = %q, want second invocation", got.LineWithVulnerability)
+	}
+}
+
+func TestDetectLineInspectsEveryActionOnLine(t *testing.T) {
+	original := `{{- if .Values.enabled }}{{ include "resource" . }}{{- end }}`
+	file := &model.FileMetadata{
+		Kind:              model.KindHELM,
+		FilePath:          "templates/resource.yaml",
+		OriginalData:      original,
+		LinesOriginalData: utils.SplitLines(original),
+	}
+
+	got := (DetectKindLine{}).DetectLine(context.Background(), file, "spec.containers", 1)
+
+	if got.Line != 1 {
+		t.Fatalf("DetectLine() line = %d, want 1", got.Line)
+	}
+	if got.VulnerablilityLocation.Start.Col != 25 {
+		t.Fatalf("DetectLine() column = %d, want include action at column 25", got.VulnerablilityLocation.Start.Col)
+	}
+}
+
 func TestDetectLastSingleMissingHelmID(t *testing.T) {
 	distances := map[int]int{2: 1, 5: 1}
 	idInfo := map[int]interface{}{0: map[int]int{2: 2}}

--- a/pkg/detector/helm/helm_detect_test.go
+++ b/pkg/detector/helm/helm_detect_test.go
@@ -302,6 +302,7 @@ func TestDetectLineFallsBackToIncludeInvocation(t *testing.T) {
 		FilePath:          "templates/metastore-deployment.yaml",
 		OriginalData:      original,
 		LinesOriginalData: utils.SplitLines(original),
+		HelmInvocation:    model.ResourceLine{Line: 1, Col: 0},
 	}
 
 	got := (DetectKindLine{}).DetectLine(
@@ -326,7 +327,7 @@ func TestDetectLineFallsBackToIncludeInvocation(t *testing.T) {
 	}
 }
 
-func TestDetectLineSelectsRenderedDocumentInvocation(t *testing.T) {
+func TestDetectLineUsesExecutedInvocation(t *testing.T) {
 	original := `{{- include "first.resource" . }}
 {{- include "second.resource" . }}`
 	file := &model.FileMetadata{
@@ -334,7 +335,7 @@ func TestDetectLineSelectsRenderedDocumentInvocation(t *testing.T) {
 		FilePath:          "templates/resources.yaml",
 		OriginalData:      original,
 		LinesOriginalData: utils.SplitLines(original),
-		HelmDocIndex:      1,
+		HelmInvocation:    model.ResourceLine{Line: 2, Col: 0},
 	}
 
 	got := (DetectKindLine{}).DetectLine(context.Background(), file, "spec.containers", 1)
@@ -354,6 +355,7 @@ func TestDetectLineInspectsEveryActionOnLine(t *testing.T) {
 		FilePath:          "templates/resource.yaml",
 		OriginalData:      original,
 		LinesOriginalData: utils.SplitLines(original),
+		HelmInvocation:    model.ResourceLine{Line: 1, Col: 25},
 	}
 
 	got := (DetectKindLine{}).DetectLine(context.Background(), file, "spec.containers", 1)

--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -157,6 +157,10 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 	if linesVulne.Line == -1 {
 		logWithFields.Warn().Msgf("Failed to detect line, query response %s", searchKey)
 		linesVulne.Line = 1
+		linesVulne.VulnerablilityLocation = model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: 1},
+		}
 	}
 
 	searchValue := ""

--- a/pkg/engine/vulnerability_builder_test.go
+++ b/pkg/engine/vulnerability_builder_test.go
@@ -415,6 +415,12 @@ func TestDefaultVulnerabilityBuilder(t *testing.T) {
 	for _, tt := range vbTests {
 		insDetector := detector.NewDetectLine(3)
 		t.Run(tt.name, func(t *testing.T) {
+			// Every table case intentionally uses a search key that is absent from
+			// the source, so the builder must return a complete fallback location.
+			tt.want.VulnerabilityLocation = model.ResourceLocation{
+				Start: model.ResourceLine{Line: 1, Col: 1},
+				End:   model.ResourceLine{Line: 1, Col: 1},
+			}
 			got, err := DefaultVulnerabilityBuilder(ctx, tt.args.ctx, tt.args.tracker, tt.args.v, insDetector, tt.useNewVulnerability, testQueryDuration)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("test[%s] DefaultVulnerabilityBuilder() error %v, wantErr %v", tt.name, err, tt.wantErr)

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -171,7 +171,9 @@ type FileMetadata struct {
 	ResolvedFiles     map[string]ResolvedFile
 	LinesOriginalData *[]string
 	IsMinified        bool
-	HelmDocIndex      int // rendered document order within a Helm source file
+	// HelmInvocation identifies the source action that emitted a rendered Helm
+	// resource whose YAML lives in a named template.
+	HelmInvocation ResourceLine
 	// ModuleCallChain: synthetic rows for instantiated local modules; used in SARIF fingerprint (Terraform only).
 	ModuleCallChain string
 	// ModuleAttributions maps resourceType.resourceName to attribution when a synthetic
@@ -333,6 +335,7 @@ type ResolvedHelm struct {
 	OriginalData        []byte
 	SplitID             string
 	SourceDocumentIndex int
+	HelmInvocation      ResourceLine
 	IDInfo              map[int]interface{}
 	IsCRD               bool
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -171,6 +171,7 @@ type FileMetadata struct {
 	ResolvedFiles     map[string]ResolvedFile
 	LinesOriginalData *[]string
 	IsMinified        bool
+	HelmDocIndex      int // rendered document order within a Helm source file
 	// ModuleCallChain: synthetic rows for instantiated local modules; used in SARIF fingerprint (Terraform only).
 	ModuleCallChain string
 	// ModuleAttributions maps resourceType.resourceName to attribution when a synthetic

--- a/pkg/resolver/helm/helm.go
+++ b/pkg/resolver/helm/helm.go
@@ -408,6 +408,7 @@ func makeDeterministic(ch *chart.Chart) *chart.Chart {
 func setID(chartReq *chart.Chart) *chart.Chart {
 	for _, temp := range chartReq.Templates {
 		temp = addID(temp)
+		temp = addHelmInvocationMarkers(temp)
 		if temp != nil {
 			continue
 		}
@@ -425,6 +426,60 @@ func setID(chartReq *chart.Chart) *chart.Chart {
 		}
 	}
 	return chartReq
+}
+
+// addHelmInvocationMarkers instruments action-only wrapper templates so the
+// rendered output retains the source position of the invocation that actually
+// ran. The marker action is inserted immediately before include/template/tpl,
+// which keeps it under the same Helm control flow as the invocation.
+func addHelmInvocationMarkers(file *chart.File) *chart.File {
+	source := string(file.Data)
+	if strings.Contains(source, kicsHelmInvocation) || !isHelmInvocationWrapper(source) {
+		return file
+	}
+
+	var markers []replacement
+	for _, span := range templateActionSpans(source) {
+		actionText := strings.Trim(source[span[0]+len("{{"):span[1]-len("}}")], "- \t\r\n")
+		fields := strings.Fields(actionText)
+		if len(fields) == 0 || !isHelmOutputInvocation(fields[0]) {
+			continue
+		}
+
+		line := strings.Count(source[:span[0]], "\n") + 1
+		lineStart := strings.LastIndexByte(source[:span[0]], '\n') + 1
+		col := span[0] - lineStart
+		marker := fmt.Sprintf("%s%d_%d:\n", kicsHelmInvocation, line, col)
+		markers = append(markers, replacement{
+			start: span[0],
+			end:   span[0],
+			text:  fmt.Sprintf("{{ print %q }}", marker),
+		})
+	}
+
+	sort.Slice(markers, func(i, j int) bool {
+		return markers[i].start > markers[j].start
+	})
+	for _, marker := range markers {
+		source = source[:marker.start] + marker.text + source[marker.end:]
+	}
+	file.Data = []byte(source)
+	return file
+}
+
+func isHelmInvocationWrapper(source string) bool {
+	withoutActions := templateActionRE.ReplaceAllString(source, "")
+	for _, line := range strings.Split(withoutActions, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && !strings.HasPrefix(trimmed, "#") && !isYAMLDocumentBoundary(trimmed) {
+			return false
+		}
+	}
+	return true
+}
+
+func isHelmOutputInvocation(name string) bool {
+	return name == "include" || name == "template" || name == "tpl"
 }
 
 // addID will add auxiliary lines used to detect line

--- a/pkg/resolver/helm/resolver.go
+++ b/pkg/resolver/helm/resolver.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -29,12 +30,19 @@ type splitManifest struct {
 	original            []byte
 	splitID             string
 	sourceDocumentIndex int
+	helmInvocation      model.ResourceLine
 	splitIDMap          map[int]interface{}
 	isCRD               bool
 }
 
 const (
-	kicsHelmID = "# KICS_HELM_ID_"
+	kicsHelmID         = "# KICS_HELM_ID_"
+	kicsHelmInvocation = "# KICS_HELM_INVOCATION_"
+)
+
+var (
+	helmInvocationMarkerPattern = regexp.MustCompile(`^# KICS_HELM_INVOCATION_(\d+)_(\d+):$`)
+	helmInvocationLinePattern   = regexp.MustCompile(`(?m)^[ \t]*# KICS_HELM_INVOCATION_\d+_\d+:[^\r\n]*(?:\r?\n|$)`)
 )
 
 // Resolve will render the passed helm chart and return its content ready for parsing
@@ -69,6 +77,7 @@ func (r *Resolver) Resolve(ctx context.Context, filePath string) (model.Resolved
 			OriginalData:        split.original,
 			SplitID:             split.splitID,
 			SourceDocumentIndex: split.sourceDocumentIndex,
+			HelmInvocation:      split.helmInvocation,
 			IDInfo:              split.splitIDMap,
 			IsCRD:               split.isCRD,
 		})
@@ -138,6 +147,8 @@ func splitManifestYAML(template *release.Release, loadedChart *chart.Chart) (*[]
 		if source == nil {
 			continue
 		}
+		helmInvocation, _ := parseHelmInvocation(splited)
+		splited = helmInvocationLinePattern.ReplaceAllString(splited, "")
 		if err := source.ensureIDMap(); err != nil {
 			return nil, err
 		}
@@ -152,6 +163,7 @@ func splitManifestYAML(template *release.Release, loadedChart *chart.Chart) (*[]
 			original:            source.original,
 			splitID:             splitID,
 			sourceDocumentIndex: sourceDocumentIndex,
+			helmInvocation:      helmInvocation,
 			splitIDMap:          source.idMap,
 			isCRD:               source.isCRD,
 		})
@@ -160,6 +172,7 @@ func splitManifestYAML(template *release.Release, loadedChart *chart.Chart) (*[]
 }
 
 func splitHelmManifest(manifest string) []string {
+	manifest = propagateHelmInvocationMarkers(manifest)
 	manifests := releaseutil.SplitManifests(manifest)
 	keys := make([]string, 0, len(manifests))
 	for key := range manifests {
@@ -172,6 +185,43 @@ func splitHelmManifest(manifest string) []string {
 		splits = append(splits, "\n"+manifests[key]+"\n")
 	}
 	return splits
+}
+
+// propagateHelmInvocationMarkers keeps the executed invocation attached when a
+// single include emits multiple YAML documents. A new Helm source header or a
+// new invocation marker ends the previous marker's scope.
+func propagateHelmInvocationMarkers(manifest string) string {
+	lines := strings.Split(manifest, "\n")
+	result := make([]string, 0, len(lines))
+	activeMarker := ""
+	for index, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "# Source: ") {
+			activeMarker = ""
+		}
+		if helmInvocationMarkerPattern.MatchString(trimmed) {
+			activeMarker = trimmed
+		}
+
+		result = append(result, line)
+		if activeMarker != "" && isYAMLDocumentBoundary(trimmed) &&
+			shouldPropagateHelmInvocation(lines[index+1:]) {
+			result = append(result, activeMarker)
+		}
+	}
+	return strings.Join(result, "\n")
+}
+
+func shouldPropagateHelmInvocation(lines []string) bool {
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		return !strings.HasPrefix(trimmed, "# Source: ") &&
+			!helmInvocationMarkerPattern.MatchString(trimmed)
+	}
+	return false
 }
 
 // parseManifestSource extracts the Helm # Source header from a manifest split.
@@ -207,6 +257,22 @@ func firstHelmMarker(content string) string {
 		return content[lineStart:]
 	}
 	return content[lineStart : index+lineEnd]
+}
+
+func parseHelmInvocation(content string) (model.ResourceLine, bool) {
+	for _, line := range strings.Split(content, "\n") {
+		match := helmInvocationMarkerPattern.FindStringSubmatch(strings.TrimSpace(line))
+		if match == nil {
+			continue
+		}
+		lineNumber, lineErr := strconv.Atoi(match[1])
+		col, colErr := strconv.Atoi(match[2])
+		if lineErr != nil || colErr != nil {
+			return model.ResourceLine{}, false
+		}
+		return model.ResourceLine{Line: lineNumber, Col: col}, true
+	}
+	return model.ResourceLine{}, false
 }
 
 func looksLikeManifest(split string) bool {
@@ -266,7 +332,7 @@ func (s *sourceMetadata) ensureIDMap() error {
 func indexSources(files []*chart.File) map[string]*sourceMetadata {
 	sources := make(map[string]*sourceMetadata, len(files))
 	for _, file := range files {
-		original := file.Data
+		original := stripHelmInvocationActions(file.Data)
 		if bytes.IndexByte(original, '\r') >= 0 {
 			original = bytes.ReplaceAll(original, []byte{'\r'}, nil)
 		}
@@ -276,6 +342,15 @@ func indexSources(files []*chart.File) map[string]*sourceMetadata {
 		}
 	}
 	return sources
+}
+
+func stripHelmInvocationActions(source []byte) []byte {
+	return templateActionRE.ReplaceAllFunc(source, func(action []byte) []byte {
+		if bytes.Contains(action, []byte(kicsHelmInvocation)) {
+			return nil
+		}
+		return action
+	})
 }
 
 func isCRDSourcePath(name string) bool {

--- a/pkg/resolver/helm/resolver_test.go
+++ b/pkg/resolver/helm/resolver_test.go
@@ -195,6 +195,28 @@ kind: ConfigMap
 	require.Contains(t, splits[1], "literal --- separator")
 }
 
+func TestSplitHelmManifestPropagatesInvocationAcrossDocuments(t *testing.T) {
+	manifest := `---
+# Source: chart/templates/resources.yaml
+# KICS_HELM_INVOCATION_5_0:
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: first
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: second
+`
+
+	splits := splitHelmManifest(manifest)
+	require.Len(t, splits, 2)
+	for _, split := range splits {
+		require.Contains(t, split, "# KICS_HELM_INVOCATION_5_0:")
+	}
+}
+
 func Test_parseManifestSource(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -432,6 +454,28 @@ func TestAddID_multiDocumentUsesSourceLineIDs(t *testing.T) {
 
 	require.Contains(t, string(file.Data), "# KICS_HELM_ID_0:\napiVersion: v1")
 	require.Contains(t, string(file.Data), "# KICS_HELM_ID_8:\napiVersion: v1")
+}
+
+func TestAddHelmInvocationMarkersInspectsEveryAction(t *testing.T) {
+	file := &chart.File{Data: []byte(`{{- if .Values.enabled }}{{ include "resource" . }}{{- end }}`)}
+	addHelmInvocationMarkers(file)
+
+	require.Equal(t, 1, strings.Count(string(file.Data), kicsHelmInvocation))
+	require.Contains(t, string(file.Data), "# KICS_HELM_INVOCATION_1_25:")
+}
+
+func TestHelmResolveTracksExecutedConditionalInvocation(t *testing.T) {
+	got, err := (&Resolver{}).Resolve(
+		context.Background(), helmFixturePath(t, "test_helm_conditional_invocations"),
+	)
+	require.NoError(t, err)
+
+	resolved := findResolvedBySuffix(t, got.File, "templates/resources.yaml")
+	require.Contains(t, string(resolved.Content), "resource-b")
+	require.NotContains(t, string(resolved.Content), "resource-a")
+	require.Equal(t, model.ResourceLine{Line: 5, Col: 0}, resolved.HelmInvocation)
+	require.NotContains(t, string(resolved.Content), kicsHelmInvocation)
+	require.NotContains(t, string(resolved.OriginalData), kicsHelmInvocation)
 }
 
 func TestDetectLine_MultiDocumentTemplateUsesSourceLines(t *testing.T) {

--- a/pkg/runner/resolver_sink.go
+++ b/pkg/runner/resolver_sink.go
@@ -114,7 +114,7 @@ func (s *Service) storeResolvedFiles(
 				Kind:              kind,
 				FilePath:          rfile.FileName,
 				HelmID:            rfile.SplitID,
-				HelmDocIndex:      rfile.SourceDocumentIndex,
+				HelmInvocation:    rfile.HelmInvocation,
 				Commands:          cached.commands,
 				IDInfo:            rfile.IDInfo,
 				LinesIgnore:       documents.IgnoreLines,

--- a/pkg/runner/resolver_sink.go
+++ b/pkg/runner/resolver_sink.go
@@ -114,6 +114,7 @@ func (s *Service) storeResolvedFiles(
 				Kind:              kind,
 				FilePath:          rfile.FileName,
 				HelmID:            rfile.SplitID,
+				HelmDocIndex:      rfile.SourceDocumentIndex,
 				Commands:          cached.commands,
 				IDInfo:            rfile.IDInfo,
 				LinesIgnore:       documents.IgnoreLines,

--- a/pkg/runner/resolver_sink_test.go
+++ b/pkg/runner/resolver_sink_test.go
@@ -197,23 +197,23 @@ func TestStoreResolvedFilesKeepsRenderedLineInfoForHelmTemplates(t *testing.T) {
 	require.Equal(t, "api", metadata["name"])
 }
 
-func TestStoreResolvedFilesKeepsHelmSourceDocumentIndex(t *testing.T) {
+func TestStoreResolvedFilesKeepsHelmInvocation(t *testing.T) {
 	ctx := context.Background()
 	service, store := newYAMLResolverSinkService(t, ctx)
 	original := []byte("{{- include \"first.resource\" . }}\n{{- include \"second.resource\" . }}\n")
 	service.storeResolvedFiles(ctx, model.ResolvedFiles{
 		File: []model.ResolvedHelm{
 			{
-				FileName:            "chart/templates/resources.yaml",
-				Content:             []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: first\n"),
-				OriginalData:        original,
-				SourceDocumentIndex: 0,
+				FileName:       "chart/templates/resources.yaml",
+				Content:        []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: first\n"),
+				OriginalData:   original,
+				HelmInvocation: model.ResourceLine{Line: 1, Col: 0},
 			},
 			{
-				FileName:            "chart/templates/resources.yaml",
-				Content:             []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: second\n"),
-				OriginalData:        original,
-				SourceDocumentIndex: 1,
+				FileName:       "chart/templates/resources.yaml",
+				Content:        []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: second\n"),
+				OriginalData:   original,
+				HelmInvocation: model.ResourceLine{Line: 2, Col: 0},
 			},
 		},
 	}, model.KindHELM, "helm-source-document-index", false, 15)
@@ -221,8 +221,8 @@ func TestStoreResolvedFilesKeepsHelmSourceDocumentIndex(t *testing.T) {
 	files, err := store.GetFiles(ctx, "helm-source-document-index")
 	require.NoError(t, err)
 	require.Len(t, files, 2)
-	require.Equal(t, 0, files[0].HelmDocIndex)
-	require.Equal(t, 1, files[1].HelmDocIndex)
+	require.Equal(t, model.ResourceLine{Line: 1, Col: 0}, files[0].HelmInvocation)
+	require.Equal(t, model.ResourceLine{Line: 2, Col: 0}, files[1].HelmInvocation)
 }
 
 func TestStoreResolvedFilesKeepsCRDSuppressionLines(t *testing.T) {

--- a/pkg/runner/resolver_sink_test.go
+++ b/pkg/runner/resolver_sink_test.go
@@ -197,6 +197,34 @@ func TestStoreResolvedFilesKeepsRenderedLineInfoForHelmTemplates(t *testing.T) {
 	require.Equal(t, "api", metadata["name"])
 }
 
+func TestStoreResolvedFilesKeepsHelmSourceDocumentIndex(t *testing.T) {
+	ctx := context.Background()
+	service, store := newYAMLResolverSinkService(t, ctx)
+	original := []byte("{{- include \"first.resource\" . }}\n{{- include \"second.resource\" . }}\n")
+	service.storeResolvedFiles(ctx, model.ResolvedFiles{
+		File: []model.ResolvedHelm{
+			{
+				FileName:            "chart/templates/resources.yaml",
+				Content:             []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: first\n"),
+				OriginalData:        original,
+				SourceDocumentIndex: 0,
+			},
+			{
+				FileName:            "chart/templates/resources.yaml",
+				Content:             []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: second\n"),
+				OriginalData:        original,
+				SourceDocumentIndex: 1,
+			},
+		},
+	}, model.KindHELM, "helm-source-document-index", false, 15)
+
+	files, err := store.GetFiles(ctx, "helm-source-document-index")
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+	require.Equal(t, 0, files[0].HelmDocIndex)
+	require.Equal(t, 1, files[1].HelmDocIndex)
+}
+
 func TestStoreResolvedFilesKeepsCRDSuppressionLines(t *testing.T) {
 	ctx := context.Background()
 	service, store := newYAMLResolverSinkService(t, ctx)

--- a/test/fixtures/test_helm_conditional_invocations/Chart.yaml
+++ b/test/fixtures/test_helm_conditional_invocations/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: test-conditional-invocations
+version: 0.1.0

--- a/test/fixtures/test_helm_conditional_invocations/templates/_resources.tpl
+++ b/test/fixtures/test_helm_conditional_invocations/templates/_resources.tpl
@@ -1,0 +1,13 @@
+{{- define "resource.a" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: resource-a
+{{- end -}}
+
+{{- define "resource.b" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: resource-b
+{{- end -}}

--- a/test/fixtures/test_helm_conditional_invocations/templates/resources.yaml
+++ b/test/fixtures/test_helm_conditional_invocations/templates/resources.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.deployA }}
+{{- include "resource.a" . }}
+{{- end }}
+
+{{- include "resource.b" . }}

--- a/test/fixtures/test_helm_conditional_invocations/values.yaml
+++ b/test/fixtures/test_helm_conditional_invocations/values.yaml
@@ -1,0 +1,1 @@
+deployA: false


### PR DESCRIPTION
<!-- dd-meta {"pullId":"bedda1ed-8773-4748-852b-e6f667fdcc87","source":"chat","resourceId":"d1bbcf96-ee04-4bd6-a8e2-2901c9bff009","workflowId":"97a0042c-bcfe-41ca-be6c-fa75d76f8eb8","codeChangeId":"97a0042c-bcfe-41ca-be6c-fa75d76f8eb8","sourceType":"assistant"} -->
## Motivation

Scanner findings are silently omitted from SARIF when line detection returns `-1`: the vulnerability builder coerces th line field to 1 but leaves the resource location at zero. Production telemetry also shows a large Kubernetes cohort where many rules fail together on the same Helm files. Those files are include-only wrappers whose rendered YAML is defined in a named template, so the detector cannot find rendered YAML keys in the attributed wrapper source.

## Changes

- Anchor unmatched, markerless Helm findings to the source line invoking `include`, `template`, or `tpl`.
- Set a complete line 1, column 1 resource location whenever the vulnerability builder applies its line 1 fallback.
- Add regression coverage for include-only Helm wrappers and complete fallback resource locations.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary.
- [ ] All new and existing tests pass. Relevant packages pass; the full module run is blocked by existing path-name assumptions and a backend library API returning 502 in this sandbox.
- [ ] I have tested my changes on staging (not applicable).
- [ ] I have updated any relevant documentation (not applicable).

## QA Instruction

Run:

```bash
go test ./pkg/detector/... ./pkg/engine ./pkg/report/model ./pkg/runner ./pkg/resolver/helm -count=1
golangci-lint run -c .golangci.yml --timeout 20m
```

Verify that an include-only Helm template resolves a finding to the include invocation and that an otherwise undetected finding retains a valid line 1, column 1 SARIF resource location.

## Blast Radius

Datadog IaC Scanner finding source locations and SARIF emission across all platforms. The Helm-specific behavior only affects markerless templates that invoke named output templates.

## Additional Notes

Production evidence was checked against a representative include-only Helm wrapper that generated the same location error across many unrelated Kubernetes rules. No detection rule logic changes are included.

I submit this contribution under the Apache-2.0 license.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/d1bbcf96-ee04-4bd6-a8e2-2901c9bff009)

Comment @datadog to request changes