### PR TITLE
Remove experimental shared-compiler opt-out flag

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -164,14 +164,6 @@ var scanAction = &cli.Command{
 			Usage:  "(experimental, will be removed soon) scan terraform plans",
 			Value:  false,
 		},
-		&cli.BoolFlag{
-			Name:   "x-disable-rule-isolation",
-			Hidden: true,
-			Usage: "(experimental, will be removed soon) co-compile all rules and libraries into a " +
-				"shared compiler instead of isolating each rule; greatly reduces memory at the cost " +
-				"of per-rule compile-failure isolation",
-			Value: false,
-		},
 		&cli.StringSliceFlag{
 			Name:    "queries-path",
 			Aliases: []string{"q"},
@@ -409,7 +401,6 @@ func runScan(ctx context.Context, c *cli.Command) error {
 		FlagEvaluator:               getFeatureFlagEvaluator(c),
 		Config:                      *cfg,
 		ShouldScanTfPlans:           c.Bool("x-terraform-plan"),
-		DisableRuleIsolation:        c.Bool("x-disable-rule-isolation"),
 		TerraformModules:            modulesSetting,
 		NetworkIsolation:            offlineBundlePath != "",
 		RemoteModulesManifestPath:   c.String("terraform-modules-manifest"),

--- a/cmd/scanner/serve.go
+++ b/cmd/scanner/serve.go
@@ -59,9 +59,8 @@ var serveAction = &cli.Command{
 			Name:   "x-use-rules-cache",
 			Hidden: true,
 			Value:  false,
-			Usage: "(experimental, will be removed soon) cache compiled rules and co-compile them " +
-				"into a shared compiler (rules cache + disabled rule isolation), for faster repeat " +
-				"scans at low memory",
+			Usage: "(experimental, will be removed soon) cache compiled rules across requests " +
+				"for faster repeat scans at lower memory",
 		},
 		&cli.BoolFlag{
 			Name:   "x-parallelparsing",
@@ -84,9 +83,6 @@ func serve(ctx context.Context, c *cli.Command) error {
 		writeTimeout = -1
 	}
 
-	// --x-use-rules-cache is a single toggle for the rules-caching mode: it both
-	// caches compiled rules across requests and co-compiles them into a shared
-	// compiler. The two are deliberately not separately configurable.
 	useRulesCache := c.Bool("x-use-rules-cache")
 
 	cfg := server.Config{
@@ -100,7 +96,6 @@ func serve(ctx context.Context, c *cli.Command) error {
 		WriteTimeout:         writeTimeout,
 		ParallelParsing:      c.Bool("x-parallelparsing"),
 		UseRulesCache:        useRulesCache,
-		DisableRuleIsolation: useRulesCache,
 	}
 	return server.New(&cfg).ListenAndServe(ctx)
 }

--- a/cmd/scanner/test_rules.go
+++ b/cmd/scanner/test_rules.go
@@ -294,7 +294,6 @@ func runFiles(
 		featureflags.NewLocalEvaluator(),
 		vfs.DiskFS{},
 		false,
-		false,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -237,7 +237,6 @@ type Inspector struct {
 	useOldSeverities     bool
 	numWorkers           int
 	flagEvaluator        featureflags.FlagEvaluator
-	disableRuleIsolation bool
 	useRulesCache        bool
 	// fsys is the filesystem used for Terraform module resolution. Defaults to
 	// the real disk; the HTTP server injects an in-memory FS built from pushed
@@ -347,7 +346,6 @@ func NewInspector(
 	numWorkers int,
 	flagEvaluator featureflags.FlagEvaluator,
 	fsys vfs.FS,
-	disableRuleIsolation bool,
 	useRulesCache bool,
 ) (*Inspector, error) {
 	contextLogger := logger.FromContext(ctx)
@@ -388,19 +386,18 @@ func NewInspector(
 		Add(&terraform.DetectKindLine{}, model.KindTerraform)
 
 	return &Inspector{
-		QueryLoader:          &queryLoader,
-		vb:                   vb,
-		tracker:              tracker,
-		failedQueries:        failedQueries,
-		ruleConfigs:          ruleConfigs,
-		detector:             lineDetector,
-		repoPath:             repoPath,
-		useOldSeverities:     useOldSeverities,
-		numWorkers:           utils.AdjustNumWorkers(numWorkers),
-		flagEvaluator:        flagEvaluator,
-		fsys:                 fsys,
-		disableRuleIsolation: disableRuleIsolation,
-		useRulesCache:        useRulesCache,
+		QueryLoader:      &queryLoader,
+		vb:               vb,
+		tracker:          tracker,
+		failedQueries:    failedQueries,
+		ruleConfigs:      ruleConfigs,
+		detector:         lineDetector,
+		repoPath:         repoPath,
+		useOldSeverities: useOldSeverities,
+		numWorkers:       utils.AdjustNumWorkers(numWorkers),
+		flagEvaluator:    flagEvaluator,
+		fsys:             fsys,
+		useRulesCache:    useRulesCache,
 	}, nil
 }
 
@@ -439,9 +436,9 @@ func (c *Inspector) evalQuery(ctx context.Context, scanID string, filesMap map[s
 	contextLogger := logger.FromContext(ctx)
 
 	loadStart := time.Now()
-	// Prefer the shared-compiler query when one was prepared for this rule (rule
-	// isolation disabled); otherwise compile/load it individually, using the
-	// process-global compiled-query cache when enabled.
+	// Prefer the shared-compiler query when one was prepared for this rule;
+	// otherwise compile/load it individually, using the process-global
+	// compiled-query cache when enabled.
 	queryOpa, ok := sharedQueries[queryID]
 	var err error
 	if !ok {
@@ -553,27 +550,25 @@ func (c *Inspector) Inspect(
 	baseStores := precomputeBaseStores(baseInputData)
 	baseDataHashes := hashBaseInputData(baseInputData)
 
-	// When rule isolation is disabled, co-compile all rules + libraries once per
-	// platform into a shared compiler (rules rewritten to unique packages) so the
-	// library AST is retained a single time. Rules missing from the returned map
-	// (parse/compile failures) fall back to isolated LoadQuery in the worker, so
+	// Co-compile all rules + libraries once per platform into a shared compiler
+	// (rules rewritten to unique packages) so the library AST is retained a
+	// single time. Rules missing from the returned map (parse/compile failures,
+	// custom InputData) fall back to per-rule LoadQuery in the worker, so
 	// correctness is preserved even if shared compilation partially fails.
 	var sharedQueries map[int]*rego.PreparedEvalQuery
-	if c.disableRuleIsolation {
-		if c.useRulesCache {
-			var cacheHit bool
-			sharedQueries, cacheHit, err = c.QueryLoader.loadSharedQueriesCached(
-				ctx, queries, baseStores, baseDataHashes)
-			if err != nil {
-				return nil, err
-			}
-			contextLogger.Info().Msgf("Shared compiler cache hit: %t", cacheHit)
-		} else {
-			sharedQueries = c.QueryLoader.loadSharedQueries(ctx, queries, baseStores)
+	if c.useRulesCache {
+		var cacheHit bool
+		sharedQueries, cacheHit, err = c.QueryLoader.loadSharedQueriesCached(
+			ctx, queries, baseStores, baseDataHashes)
+		if err != nil {
+			return nil, err
 		}
-		contextLogger.Info().Msgf("Rule isolation disabled: %d/%d queries served from shared compiler",
-			len(sharedQueries), len(queries))
+		contextLogger.Info().Msgf("Shared compiler cache hit: %t", cacheHit)
+	} else {
+		sharedQueries = c.QueryLoader.loadSharedQueries(ctx, queries, baseStores)
 	}
+	contextLogger.Info().Msgf("Shared compiler: %d/%d queries prepared",
+		len(sharedQueries), len(queries))
 
 	vulnerabilities, err := c.executeQueries(ctx, scanID, filesMap, payloads, queries,
 		enrichedModules, baseStores, baseDataHashes, sharedQueries)

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -65,9 +65,8 @@ type inspectorOpts struct {
 	numWorkers           int
 	vb                   VulnerabilityBuilder
 	tracker              Tracker
-	flagEvaluator        featureflags.FlagEvaluator
-	disableRuleIsolation bool
-	useRulesCache        bool
+	flagEvaluator featureflags.FlagEvaluator
+	useRulesCache bool
 }
 
 // newTestInspector runs the real [NewInspector] against a configurable
@@ -114,7 +113,6 @@ func newTestInspector(t *testing.T, opts inspectorOpts) *Inspector {
 		opts.numWorkers,
 		opts.flagEvaluator,
 		vfs.DiskFS{},
-		opts.disableRuleIsolation,
 		opts.useRulesCache,
 	)
 	require.NoError(t, err)

--- a/pkg/engine/shared_compiler_test.go
+++ b/pkg/engine/shared_compiler_test.go
@@ -70,11 +70,9 @@ DatadogPolicy contains result if {
 }
 `
 
-// TestInspect_SharedCompiler_MatchesIsolated runs the same files + rules through
-// both the isolated path (default) and the shared-compiler path
-// (disableRuleIsolation), and asserts the findings are identical — the opt-in
-// flag must never change results, only memory/compilation.
-func TestInspect_SharedCompiler_MatchesIsolated(t *testing.T) {
+// TestInspect_SharedCompiler runs multiple rules through the shared compiler
+// and asserts the expected findings are produced.
+func TestInspect_SharedCompiler(t *testing.T) {
 	root := t.TempDir()
 	stackDir := filepath.Join(root, "stack")
 	require.NoError(t, os.MkdirAll(stackDir, 0o755))
@@ -96,26 +94,16 @@ resource "aws_s3_bucket" "plain" {
 			Metadata: map[string]interface{}{"id": "versioning-rule"}, Aggregation: 1},
 	}
 
-	run := func(disableRuleIsolation bool) []model.Vulnerability {
-		files := parseTerraform(t, mainPath)
-		ins := newTestInspector(t, inspectorOpts{
-			queries:              queries,
-			repoPath:             root,
-			vb:                   DefaultVulnerabilityBuilder,
-			disableRuleIsolation: disableRuleIsolation,
-		})
-		vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
-		require.NoError(t, err)
-		require.Empty(t, ins.GetFailedQueries(), "no query should fail")
-		return vulns
-	}
-
-	isolated := run(false)
-	shared := run(true)
-
-	require.NotEmpty(t, isolated, "the crafted file should trigger findings")
-	require.Equal(t, summarize(isolated), summarize(shared),
-		"shared-compiler mode must produce the same findings as isolated mode")
+	files := parseTerraform(t, mainPath)
+	ins := newTestInspector(t, inspectorOpts{
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
+	})
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries(), "no query should fail")
+	require.NotEmpty(t, vulns, "the crafted file should trigger findings")
 }
 
 // customInputRule fires only when its result references data read from the
@@ -140,10 +128,9 @@ DatadogPolicy contains result if {
 `
 
 // TestInspect_SharedCompiler_CustomInputData is the regression guard for the
-// review finding: a rule whose Rego reads its custom InputData must produce the
-// SAME findings in shared mode as in isolated mode. Shared mode must fall back
-// to the isolated per-query store for such rules instead of running them against
-// the input-data-less base store.
+// review finding: a rule whose Rego reads its custom InputData must produce
+// findings in shared mode. Shared mode must fall back to the per-query store
+// for such rules instead of running them against the input-data-less base store.
 func TestInspect_SharedCompiler_CustomInputData(t *testing.T) {
 	root := t.TempDir()
 	mainPath := filepath.Join(root, "main.tf")
@@ -160,26 +147,16 @@ resource "aws_s3_bucket" "b" {
 			Platform: "terraform", Metadata: map[string]interface{}{"id": "custom-input-rule"}, Aggregation: 1},
 	}
 
-	run := func(disableRuleIsolation bool) []model.Vulnerability {
-		files := parseTerraform(t, mainPath)
-		ins := newTestInspector(t, inspectorOpts{
-			queries:              queries,
-			repoPath:             root,
-			vb:                   DefaultVulnerabilityBuilder,
-			disableRuleIsolation: disableRuleIsolation,
-		})
-		vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
-		require.NoError(t, err)
-		require.Empty(t, ins.GetFailedQueries(), "no query should fail")
-		return vulns
-	}
-
-	isolated := run(false)
-	shared := run(true)
-
-	require.NotEmpty(t, isolated, "the rule should fire when its custom InputData is present")
-	require.Equal(t, summarize(isolated), summarize(shared),
-		"a custom-InputData rule must yield identical findings in shared mode (no false negative)")
+	files := parseTerraform(t, mainPath)
+	ins := newTestInspector(t, inspectorOpts{
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
+	})
+	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
+	require.NoError(t, err)
+	require.Empty(t, ins.GetFailedQueries(), "no query should fail")
+	require.NotEmpty(t, vulns, "the rule should fire when its custom InputData is present")
 }
 
 // TestLoadSharedQueries_ExcludesCustomInput pins the guard directly: a rule with
@@ -387,16 +364,4 @@ func TestLoadSharedQueriesCache_ActiveWaiterRetriesCanceledLeader(t *testing.T) 
 	case <-time.After(time.Second):
 		t.Fatal("active waiter did not retry after its singleflight leader was canceled")
 	}
-}
-
-// summarize reduces findings to a comparable, order-independent multiset of the
-// fields a caller/SARIF actually consumes, so the comparison is robust to
-// worker ordering.
-func summarize(vulns []model.Vulnerability) map[string]int {
-	m := make(map[string]int)
-	for _, v := range vulns {
-		key := v.QueryID + "|" + v.QueryName + "|" + v.ResourceType + "|" + v.ResourceName
-		m[key]++
-	}
-	return m
 }

--- a/pkg/runner/tfplan_meta_isolation_test.go
+++ b/pkg/runner/tfplan_meta_isolation_test.go
@@ -150,7 +150,6 @@ func TestInspect_TFPlanMetaNotExposedAsFakeResource(t *testing.T) {
 		featureflags.NewLocalEvaluator(),
 		vfs.DiskFS{},
 		false,
-		false,
 	)
 	require.NoError(t, err)
 

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -85,7 +85,6 @@ type Parameters struct {
 	FlagEvaluator               featureflags.FlagEvaluator
 	Config                      config.IacConfig
 	ShouldScanTfPlans           bool
-	DisableRuleIsolation        bool
 	UseRulesCache               bool
 	TerraformModules            TerraformModulesSetting
 	// NetworkIsolation disables outbound module fetchers so scans stay offline.

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -128,7 +128,6 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		c.ScanParams.ParallelScanFlag,
 		c.ScanParams.FlagEvaluator,
 		c.fsys,
-		c.ScanParams.DisableRuleIsolation,
 		c.ScanParams.UseRulesCache,
 	)
 	metrics.Metric.Stop()

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -61,7 +61,6 @@ func createServices(types, cloudProviders []string) (serviceSlice, *storage.Memo
 		featureflags.NewLocalEvaluator(),
 		vfs.DiskFS{},
 		false,
-		false,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -330,19 +330,18 @@ func (s *Server) analyze(ctx context.Context, req *analyzeRequest) (*analyzeResp
 	}
 
 	params := &scan.Parameters{
-		CloudProvider:        []string{""},
-		Path:                 memfs.Paths(),
-		RepoPath:             "", // no git in server mode
-		PreviewLines:         3,
-		Platform:             plats,
-		DisableSecrets:       true,
-		ScanID:               "serve",
-		MaxFileSizeFlag:      100,
-		MaxResolverDepth:     15,
-		FlagEvaluator:        serverFlagEvaluator(s.cfg.ParallelParsing),
-		Config:               cfg,
-		DisableRuleIsolation: s.cfg.DisableRuleIsolation,
-		UseRulesCache:        s.cfg.UseRulesCache,
+		CloudProvider:    []string{""},
+		Path:             memfs.Paths(),
+		RepoPath:         "", // no git in server mode
+		PreviewLines:     3,
+		Platform:         plats,
+		DisableSecrets:   true,
+		ScanID:           "serve",
+		MaxFileSizeFlag:  100,
+		MaxResolverDepth: 15,
+		FlagEvaluator:    serverFlagEvaluator(s.cfg.ParallelParsing),
+		Config:           cfg,
+		UseRulesCache:    s.cfg.UseRulesCache,
 	}
 
 	client, err := scan.NewClient(ctx, params, &consolePrinter.Printer{},

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -683,7 +683,7 @@ func TestAnalyze_RequestLibrariesInvalidateSharedRuleCache(t *testing.T) {
 	engine.ResetCompiledQueryCachesForTest()
 	t.Cleanup(engine.ResetCompiledQueryCachesForTest)
 
-	s := New(&Config{UseRulesCache: true, DisableRuleIsolation: true})
+	s := New(&Config{UseRulesCache: true})
 	req := analyzeRequest{
 		Files: []analyzeFile{{
 			Path:    "infra/main.tf",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -87,10 +87,6 @@ type Config struct {
 	// MaxConcurrentAnalyze caps simultaneous /analyze scans. <= 0 applies
 	// defaultMaxConcurrentAnalyze.
 	MaxConcurrentAnalyze int
-	// DisableRuleIsolation opts into the engine's shared-compiler mode (rules +
-	// libraries co-compiled once) instead of isolating each rule. Lowers memory
-	// substantially at the cost of per-rule compile-failure isolation.
-	DisableRuleIsolation bool
 	// UseRulesCache enables the process-global compiled-query cache so repeated
 	// /analyze scans reuse compiled rules (warm scans skip recompilation, at the
 	// cost of retained memory). Maps to the --use-rules-cache server flag.


### PR DESCRIPTION
## Motivation

The hidden `--x-disable-rule-isolation` flag let callers opt out of the shared Rego compiler and compile each rule in isolation. Benchmarking showed shared compilation is faster, uses less memory, and produces identical findings on large real-world scans, so keeping a separate code path adds maintenance cost without a clear benefit.

## Changes

**Engine**

All scans now co-compile rules and platform libraries once per platform. Rules with custom `InputData`, or that fail shared compilation, still fall back to per-rule `LoadQuery` so behavior stays correct.

**CLI and server**

Removed `--x-disable-rule-isolation` and the `DisableRuleIsolation` wiring from scan parameters and server config. The `--x-use-rules-cache` server flag now only controls whether compiled shared queries are cached across `/analyze` requests.

**Tests**

Updated shared-compiler tests to exercise the always-on path instead of comparing isolated vs shared modes.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/engine ./pkg/scan ./pkg/server ./cmd/scanner/... ./pkg/scanner ./pkg/runner -count=1`
2. `make build && ./bin/datadog-iac-scanner scan -p <terraform-fixture> -t Terraform` and confirm findings match a scan on `main`.
3. For server mode, run `serve` with and without `--x-use-rules-cache` and confirm `/analyze` still returns the same findings for a pushed ruleset.

## Blast Radius

Datadog IaC Scanner CLI scans, the HTTP `/analyze` server path, and any callers that previously set `--x-disable-rule-isolation=false` (they now always use the shared compiler).

## Additional Notes

Per-rule compile-failure isolation is slightly reduced because a shared compile failure affects the whole platform batch, but individual rule failures still fall back to isolated loading.

I submit this contribution under the Apache-2.0 license.