### PR TITLE
Preserve module attribution in SARIF export

### DIFF
--- a/pkg/report/commons.go
+++ b/pkg/report/commons.go
@@ -113,6 +113,16 @@ func ExportJSONReport(ctx context.Context, path, filename string, body interface
 }
 
 func getSummary(body interface{}) (sum model.Summary, err error) {
+	switch summary := body.(type) {
+	case model.Summary:
+		return summary, nil
+	case *model.Summary:
+		if summary == nil {
+			return model.Summary{}, nil
+		}
+		return *summary, nil
+	}
+
 	var summary model.Summary
 	result, err := json.Marshal(body)
 	if err != nil {

--- a/pkg/report/json.go
+++ b/pkg/report/json.go
@@ -7,6 +7,7 @@ package report
 
 import (
 	"context"
+	"slices"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/constants"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -21,6 +22,7 @@ func PrintJSONReport(ctx context.Context, path, filename string, body interface{
 		if err != nil {
 			return err
 		}
+		summary.Queries = slices.Clone(summary.Queries)
 		for idx := range summary.Queries {
 			summary.Queries[idx].CISBenchmarkName = ""
 			summary.Queries[idx].CISBenchmarkVersion = ""

--- a/pkg/report/json_test.go
+++ b/pkg/report/json_test.go
@@ -79,3 +79,26 @@ func TestPrintJSONReport(t *testing.T) {
 		})
 	}
 }
+
+func TestPrintJSONReportDoesNotMutateSummary(t *testing.T) {
+	summary := model.Summary{
+		Queries: model.QueryResultSlice{{
+			CISBenchmarkName:    "CIS AWS",
+			CISBenchmarkVersion: "1.0",
+			CISDescriptionID:    "1.2.3",
+			CISDescriptionText:  "description",
+			CISRationaleText:    "rationale",
+		}},
+	}
+
+	require.NoError(t, PrintJSONReport(
+		context.Background(), t.TempDir(), "summary", &summary, &model.SCIInfo{},
+	))
+
+	query := summary.Queries[0]
+	require.Equal(t, "CIS AWS", query.CISBenchmarkName)
+	require.Equal(t, "1.0", query.CISBenchmarkVersion)
+	require.Equal(t, "1.2.3", query.CISDescriptionID)
+	require.Equal(t, "description", query.CISDescriptionText)
+	require.Equal(t, "rationale", query.CISRationaleText)
+}

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -67,6 +67,125 @@ func TestPrintSarifReport(t *testing.T) {
 	}
 }
 
+func TestPrintSarifReportPreservesModuleAttribution(t *testing.T) {
+	tests := []struct {
+		name               string
+		attribution        *model.ModuleAttribution
+		expectedModulePath int
+	}{
+		{
+			name: "direct local",
+			attribution: &model.ModuleAttribution{
+				Name:           "network",
+				Source:         "modules/network",
+				SourceType:     "local",
+				DependencyType: "direct",
+				CodeLocation: model.SourceLocation{
+					Filename: "stack/main.tf", LineStart: 2, LineEnd: 5, ColumnStart: 1, ColumnEnd: 2,
+				},
+				ModuleCodeLocation: model.SourceLocation{
+					Filename: "main.tf", LineStart: 15, LineEnd: 25, ColumnStart: 1, ColumnEnd: 2,
+				},
+				ModuleCodeOwned: true,
+			},
+		},
+		{
+			name: "transitive remote",
+			attribution: &model.ModuleAttribution{
+				Name:           "network",
+				Source:         "registry.example.com/acme/network/aws",
+				SourceType:     "registry",
+				Version:        "1.2.3",
+				DependencyType: "transitive",
+				CodeLocation: model.SourceLocation{
+					Filename: "stack/main.tf", LineStart: 2, LineEnd: 5, ColumnStart: 1, ColumnEnd: 2,
+				},
+				ModuleCodeLocation: model.SourceLocation{
+					Filename: "main.tf", LineStart: 15, LineEnd: 25, ColumnStart: 1, ColumnEnd: 2,
+				},
+				ModulePath: []model.ModulePathHop{
+					{
+						Name: "platform", Source: "modules/platform", SourceType: "local",
+						CodeLocation: model.SourceLocation{
+							Filename: "stack/main.tf", LineStart: 2, LineEnd: 5, ColumnStart: 1, ColumnEnd: 2,
+						},
+					},
+					{
+						Name: "network", Source: "registry.example.com/acme/network/aws",
+						SourceType: "registry", Version: "1.2.3",
+						CodeLocation: model.SourceLocation{
+							Filename: "main.tf", LineStart: 8, LineEnd: 11, ColumnStart: 1, ColumnEnd: 2,
+						},
+					},
+				},
+			},
+			expectedModulePath: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summary := model.Summary{Queries: model.QueryResultSlice{{
+				QueryName: "Deletion protection disabled",
+				QueryID:   "deletion-protection-disabled",
+				Severity:  model.SeverityHigh,
+				Platform:  "Terraform",
+				Files: []model.VulnerableFile{{
+					FileName: "cached-module/main.tf",
+					Line:     18,
+					ResourceLocation: model.ResourceLocation{
+						Start: model.ResourceLine{Line: 15, Col: 1},
+						End:   model.ResourceLine{Line: 25, Col: 2},
+					},
+					ResourceType:      "aws_lb",
+					ResourceName:      "nlb",
+					ModuleAttribution: tt.attribution,
+				}},
+			}}}
+
+			outputDir := t.TempDir()
+			require.NoError(t, PrintSarifReport(
+				context.Background(), outputDir, "module", &summary, &model.SCIInfo{},
+			))
+
+			raw, err := os.ReadFile(filepath.Join(outputDir, "module.sarif"))
+			require.NoError(t, err)
+			var output struct {
+				Runs []struct {
+					Results []struct {
+						Locations []struct {
+							PhysicalLocation struct {
+								ArtifactLocation struct {
+									URI string `json:"uri"`
+								} `json:"artifactLocation"`
+							} `json:"physicalLocation"`
+						} `json:"locations"`
+						Properties map[string]json.RawMessage `json:"properties"`
+					} `json:"results"`
+				} `json:"runs"`
+			}
+			require.NoError(t, json.Unmarshal(raw, &output))
+			require.Len(t, output.Runs, 1)
+			require.Len(t, output.Runs[0].Results, 1)
+
+			result := output.Runs[0].Results[0]
+			require.Equal(t, "stack/main.tf",
+				result.Locations[0].PhysicalLocation.ArtifactLocation.URI)
+
+			var modulePayload model.ModuleAttributionSARIF
+			require.NoError(t, json.Unmarshal(result.Properties["module"], &modulePayload))
+			require.Equal(t, tt.attribution.Name, modulePayload.Name)
+			require.Equal(t, tt.attribution.Source, modulePayload.Source)
+			require.Equal(t, tt.attribution.SourceType, modulePayload.SourceType)
+			require.Equal(t, tt.attribution.Version, modulePayload.Version)
+			require.Equal(t, tt.attribution.DependencyType, modulePayload.DependencyType)
+			require.Equal(t, tt.attribution.ModuleCodeLocation, modulePayload.ModuleCodeLocation)
+			require.Equal(t, tt.attribution.ModulePath, modulePayload.ModulePath)
+			require.Len(t, modulePayload.ModulePath, tt.expectedModulePath)
+		})
+	}
+}
+
 func checkFileExists(t *testing.T, err error, tc *reportTestCase, extension string) {
 	require.NoError(t, err)
 	require.FileExists(t, filepath.Join(tc.caseTest.path, tc.caseTest.filename+fmt.Sprintf(".%s", extension)))


### PR DESCRIPTION
## Motivation

Instantiated Terraform module findings carry caller attribution in the engine, but SARIF export routed summaries through a JSON marshal/unmarshal roundtrip in `getSummary`. That dropped `ModuleAttribution`, so SARIF primary locations stayed on the module resource file instead of the caller's module block. Downstream, `@static_analysis.result.source` is populated from SARIF `locations[0].physicalLocation` only, so the UI showed shared module path rather than the deploying stack.

## Changes

**Reporting**

When the report body is already a `model.Summary`, return it directly instead of serializing and deserializing through JSON. That keeps pointer fields such as `ModuleAttribution` intact through SARIF generation.

**Tests**

Add an end-to-end SARIF export test that verifies caller primary locations and `properties.module` payloads for direct and transitive module attribution.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. Run `go test ./pkg/report/... -count=1`.
2. Build the scanner and scan a repo with local module evaluation enabled using SARIF output.
3. Confirm module findings set SARIF `locations[0].physicalLocation.uri` to the caller file (for example `datacenters/.../nlb-tgm-tester/main.tf`) and include `properties.module` with module source and inner `code_location`.

## Blast Radius

Datadog IaC Scanner SARIF reporting only. CLI and server scan paths that emit SARIF benefit; other report formats are unchanged aside from preserving summary fields more faithfully.

## Additional Notes

Fingerprinting is unchanged: `DATADOG_FINGERPRINT` still uses the module resource file plus module call chain. This fix aligns SARIF primary location with the intended product semantics for local module resolution.

I submit this contribution under the Apache-2.0 license.