### PR TITLE
feat(tfplan): map TFPlan findings back to HCL source lines

### DIFF
--- a/cmd/scanner/test_rules.go
+++ b/cmd/scanner/test_rules.go
@@ -456,7 +456,7 @@ func getFixtureParsers(ctx context.Context) ([]*parser.Parser, error) {
 		fixtureParsers, fixtureParsersErr = parser.NewBuilder(ctx).
 			Add(&jsonParser.Parser{}).
 			Add(&yamlParser.Parser{}).
-			Add(terraformParser.NewDefault()).
+			Add(terraformParser.NewDefault()). //nolint:staticcheck // no registry needed for fixture parsing
 			Add(&bicepParser.Parser{}).
 			Add(&cicdParser.Parser{}).
 			Add(&dockerParser.Parser{}).

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -59,7 +59,10 @@ func (m *MemoryStorage) getUniqueVulnerabilities() []model.Vulnerability {
 	for i := range m.vulnerabilities {
 		v := m.vulnerabilities[i]
 		// SCIInfo is constant within a scan; an empty value yields the same grouping.
-		key := model.GetDatadogFingerprintHash(
+		// Include FileID so that HCL and TFPlan findings for the same resource
+		// are not collapsed: both resolve to the same FileName (the .tf file) but
+		// originate from different source files (FileID differs).
+		key := v.FileID + "|" + model.GetDatadogFingerprintHash(
 			model.SCIInfo{},
 			v.FileName,
 			v.Platform,

--- a/internal/tracker/ci.go
+++ b/internal/tracker/ci.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-iac-scanner/internal/constants"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/registry"
 )
 
 // CITracker contains information of how many queries were loaded and executed
@@ -34,6 +35,8 @@ type CITracker struct {
 	syncFileMutex        sync.Mutex
 	FoundResources       int
 	LineInfoLoadFailures int
+	tfplanRegistry       *registry.AddressRegistry
+	moduleMappings       map[string]interface{}
 }
 
 // NewTracker will create a new instance of a tracker with the number of lines to display in results output
@@ -53,6 +56,30 @@ func NewTracker(previewLines int) (*CITracker, error) {
 // GetOutputLines returns the number of lines to display in results output
 func (c *CITracker) GetOutputLines() int {
 	return c.lines
+}
+
+// SetTFPlanRegistry sets the terraform address registry for this tracker
+// This is used by the vulnerability builder to create TFPlan detectors with the correct registry
+func (c *CITracker) SetTFPlanRegistry(reg *registry.AddressRegistry) {
+	c.tfplanRegistry = reg
+}
+
+// GetTFPlanRegistry returns the terraform address registry for this tracker
+// This implements the TFPlanDetectorRegistry interface from pkg/engine
+func (c *CITracker) GetTFPlanRegistry() *registry.AddressRegistry {
+	return c.tfplanRegistry
+}
+
+// SetModuleMappings sets the terraform module mappings for this tracker
+// This is used by the vulnerability builder to pass module mappings to TFPlan detectors
+func (c *CITracker) SetModuleMappings(mappings map[string]interface{}) {
+	c.moduleMappings = mappings
+}
+
+// GetModuleMappings returns the terraform module mappings for this tracker
+// This implements the TFPlanDetectorRegistry interface from pkg/engine
+func (c *CITracker) GetModuleMappings() map[string]interface{} {
+	return c.moduleMappings
 }
 
 // TrackQueryLoad adds a loaded query

--- a/pkg/detector/default_detect.go
+++ b/pkg/detector/default_detect.go
@@ -21,6 +21,8 @@ const (
 	// injected into the remapped plan document (see pkg/parser/json/tfplan.go),
 	// so a bare resource-level searchKey can resolve structurally too.
 	tfPlanMinAttributePathLen = 3
+	// resourceKeyword is the top-level "resource" key tfplan documents are remapped under.
+	resourceKeyword = "resource"
 )
 
 type defaultDetectLine struct {
@@ -203,11 +205,11 @@ func terraformPlanPath(searchKey string) ([]string, bool) {
 			seg = seg[closeIdx+1:]
 		}
 	}
-	explicitResourcePath := len(comps) > 0 && comps[0] == "resource"
+	explicitResourcePath := len(comps) > 0 && comps[0] == resourceKeyword
 	if explicitResourcePath {
 		comps = comps[1:]
 	}
-	return append([]string{"resource"}, comps...), explicitResourcePath
+	return append([]string{resourceKeyword}, comps...), explicitResourcePath
 }
 
 // findMatchingBracket finds the "]" closing the "[" at open in s, tracking

--- a/pkg/detector/tfplan_detect.go
+++ b/pkg/detector/tfplan_detect.go
@@ -1,0 +1,1300 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package detector
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/registry"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/rs/zerolog"
+)
+
+// Origin hint values for a TFPlan attribute, as attached by tfplan.go's
+// annotateOriginsFromConfig: where the offending value was actually set.
+const (
+	originModuleHardcoded = "module_hardcoded"
+	originModuleDefault   = "module_default"
+	originCall            = "call"
+)
+
+// TFPlanDetectLine is a detector for Terraform Plan files that maps findings back to HCL source
+//
+// ARCHITECTURE NOTE - Module Mapping Scope Limitations:
+//
+// The current implementation has a scope limitation with module mappings:
+//
+// 1. Module deduplication (pkg/parser/terraform/modules/modules.go:172):
+//   - Modules are deduplicated by SOURCE at parse time
+//   - Same source called multiple times = single module entry
+//
+// 2. Module mapping conversion (pkg/engine/inspector.go:502):
+//   - Local modules: keyed by NAME only (not source)
+//   - Remote modules: keyed by SOURCE::NAME
+//
+// 3. Impact:
+//   - Can lose call-site identity when same source is called under different names
+//   - Can lose call-site identity when same local module name appears in different scopes
+//
+// This is ACCEPTABLE for v1 because:
+//   - The address registry (which handles resource location lookup) is scope-aware
+//   - Most real-world scenarios don't hit this edge case
+//   - The transformation logic has fallback paths that preserve resource identity
+//
+// Future enhancement:
+//   - Make module mapping scope-aware to match address registry's approach
+//   - Use call-site location + source as key instead of just source/name
+type TFPlanDetectLine struct {
+	registry        *registry.AddressRegistry
+	moduleMappings  map[string]interface{}
+	defaultDetector defaultDetectLine
+}
+
+// NewTFPlanDetectLine creates a new TFPlanDetectLine with the given registry and module mappings
+func NewTFPlanDetectLine(reg *registry.AddressRegistry, modules map[string]interface{}) *TFPlanDetectLine {
+	return &TFPlanDetectLine{
+		registry:        reg,
+		moduleMappings:  modules,
+		defaultDetector: defaultDetectLine{},
+	}
+}
+
+// resolveRootResourceLocation builds the finding for an exact root-resource address match.
+//
+// CRITICAL: Canonicalize the searchKey for similarity ID deduplication
+// Root resources with count/for_each (e.g., aws_instance.web[0], aws_instance.web[1])
+// must use the same normalized key to deduplicate to a single finding.
+//
+// COUNT CONTRACT FOR ATTRIBUTE-LEVEL FINDINGS:
+//   - Attribute-level findings (e.g., "aws_instance.web[0].tags") are canonicalized
+//     to "aws_instance.web.tags" for deduplication across count/for_each instances
+//   - Result: N instances → 1 finding (pointing to HCL resource definition)
+//
+// COUNT CONTRACT FOR RESOURCE-LEVEL FINDINGS:
+//   - Resource-level findings (e.g., "aws_instance.web[0]" with no attribute) currently
+//     keep the full address including indices for similarity computation
+//   - This is ACCEPTABLE because:
+//     1. Most rules target specific attributes, not entire resources
+//     2. Resource-level findings often represent different violations per instance
+//     3. The HCL mapping still works correctly (all point to .tf files)
+//   - Future enhancement: If resource-level deduplication is desired, apply the same
+//     canonicalization by removing the index check below
+func resolveRootResourceLocation(
+	ctx context.Context, location registry.Location, searchKey string, outputLines int,
+) model.VulnerabilityLines {
+	contextLogger := logger.FromContext(ctx)
+
+	// Parse the searchKey to extract the normalized address (indices stripped)
+	parsed, err := ParseSearchKey(searchKey)
+	if err != nil || parsed.NormalizedAddr == "" {
+		// Fallback if parsing fails (shouldn't happen for valid searchKeys)
+		return buildVulnerabilityLinesFromLocation(location, outputLines)
+	}
+
+	if !parsed.HasAttribute || len(parsed.AttributePath) == 0 {
+		// Resource-level finding (no attribute)
+		// Currently using full address to preserve per-instance findings
+		// This is the documented behavior per COUNT CONTRACT above
+		contextLogger.Debug().
+			Str("searchKey", searchKey).
+			Msg("TFPlan: Resource-level finding, using full address (no canonicalization)")
+		return buildVulnerabilityLinesFromLocation(location, outputLines)
+	}
+
+	// Use the normalized address as the canonical key for similarity ID
+	// This ensures aws_instance.web[0].tags and aws_instance.web[1].tags
+	// both use "aws_instance.web.tags" for similarity computation
+	canonicalKey := parsed.NormalizedAddr + "." + strings.Join(parsed.AttributePath, ".")
+
+	contextLogger.Debug().
+		Str("originalSearchKey", searchKey).
+		Str("canonicalKey", canonicalKey).
+		Msg("TFPlan: Using canonical searchKey for root resource deduplication")
+
+	return buildVulnerabilityLinesFromLocation(location, outputLines, canonicalKey)
+}
+
+// DetectLine searches for vulnerabilities in tfplan files by mapping addresses back to HCL source
+func (t *TFPlanDetectLine) DetectLine(
+	ctx context.Context, file *model.FileMetadata, searchKey string, outputLines int,
+) model.VulnerabilityLines {
+	contextLogger := logger.FromContext(ctx)
+
+	// Registry is required - if nil, this is a programming error
+	if t.registry == nil {
+		contextLogger.Error().Msg("TFPlan detector created without registry - this is a bug")
+		return t.defaultDetector.DetectLine(ctx, file, searchKey, outputLines)
+	}
+
+	// Extract the terraform address from the document
+	address := extractAddressFromDocument(ctx, file, searchKey)
+	if address == "" {
+		// If we can't extract an address, fall back to default detection
+		contextLogger.Debug().
+			Str("searchKey", searchKey).
+			Str("file", file.FilePath).
+			Msg("TFPlan: Could not extract _dd_tf_address from document, falling back to default detection")
+		return t.defaultDetector.DetectLine(ctx, file, searchKey, outputLines)
+	}
+
+	contextLogger.Debug().
+		Str("address", address).
+		Str("searchKey", searchKey).
+		Str("tfplanFile", file.FilePath).
+		Msg("TFPlan: Extracted terraform address from document")
+
+	// Multi-level detection strategy:
+	// 1. Try to find the exact resource address (for root resources)
+	// 2. Try to find the module call (for module resources)
+	// 3. Fall back to default detection
+
+	// First, try the full address (for root resources)
+	// Use LookupWithScope to handle duplicates via scope-based disambiguation
+	if location, found := t.registry.LookupWithScope(address, file.FilePath); found {
+		contextLogger.Debug().
+			Str("address", address).
+			Str("hclFile", location.FilePath).
+			Int("line", location.Line).
+			Str("tfplanFile", file.FilePath).
+			Msg("TFPlan: Found exact address match in registry")
+
+		return resolveRootResourceLocation(ctx, location, searchKey, outputLines)
+	}
+
+	contextLogger.Debug().
+		Str("address", address).
+		Int("registrySize", t.registry.GetMappingCount()).
+		Msg("TFPlan: Exact address not found in registry, trying module extraction")
+
+	// For module resources, try to find the module call
+	moduleAddress := registry.ExtractModuleAddress(address)
+	if moduleAddress != "" {
+		contextLogger.Debug().
+			Str("fullAddress", address).
+			Str("moduleAddress", moduleAddress).
+			Msg("TFPlan: Extracted module address")
+
+		// Use LookupWithScope to handle duplicate module addresses
+		if location, found := t.registry.LookupWithScope(moduleAddress, file.FilePath); found {
+			contextLogger.Debug().
+				Str("address", address).
+				Str("moduleAddress", moduleAddress).
+				Str("hclFile", location.FilePath).
+				Int("line", location.Line).
+				Str("tfplanFile", file.FilePath).
+				Msg("TFPlan: Found module call match in registry")
+
+			return t.resolveModuleCallLocation(ctx, file, address, moduleAddress, searchKey, outputLines, location)
+		}
+
+		// Nested module not found, try parent modules iteratively
+		// Example: "module.vpc.module.subnet" → "module.vpc"
+		contextLogger.Debug().
+			Str("moduleAddress", moduleAddress).
+			Msg("TFPlan: Full nested module not found, trying parent modules")
+
+		if location, found := t.findParentModuleLocation(ctx, file, moduleAddress); found {
+			contextLogger.Debug().
+				Str("address", address).
+				Str("hclFile", location.FilePath).
+				Int("line", location.Line).
+				Str("tfplanFile", file.FilePath).
+				Msg("TFPlan: Found parent module call match in registry")
+			return buildVulnerabilityLinesFromLocation(location, outputLines)
+		}
+
+		contextLogger.Warn().
+			Str("moduleAddress", moduleAddress).
+			Msg("TFPlan: No module address found in registry (including parents)")
+	}
+
+	// If no mapping found, fall back to default detection
+	contextLogger.Warn().
+		Str("address", address).
+		Str("moduleAddress", moduleAddress).
+		Int("registrySize", t.registry.GetMappingCount()).
+		Str("tfplanFile", file.FilePath).
+		Msg("TFPlan: No address mapping found, falling back to default detection")
+	return t.defaultDetector.DetectLine(ctx, file, searchKey, outputLines)
+}
+
+// resolveModuleCallLocation builds the finding for a searchKey whose address resolved to a
+// module call (rather than a root resource): it decides call-site vs. module-definition blame
+// using the origin hint, then falls back to module-mapping-based searchKey transformation.
+func (t *TFPlanDetectLine) resolveModuleCallLocation(
+	ctx context.Context, file *model.FileMetadata, address, moduleAddress, searchKey string, outputLines int,
+	location registry.Location,
+) model.VulnerabilityLines {
+	contextLogger := logger.FromContext(ctx)
+
+	// Determine the target attribute name from the searchKey
+	var attrName string
+	if parsedKey, err := ParseSearchKey(searchKey); err == nil && len(parsedKey.AttributePath) > 0 {
+		attrName = parsedKey.AttributePath[0]
+	}
+
+	// Read the origin hint for this attribute to decide call vs definition blame
+	origin, varName, moduleDir := extractOriginFromDocument(ctx, file, searchKey, attrName)
+
+	contextLogger.Debug().
+		Str("origin", origin).
+		Str("varName", varName).
+		Str("moduleDir", moduleDir).
+		Str("attrName", attrName).
+		Msg("TFPlan: Origin hint for attribute")
+
+	// Derive the scan root from the file path of the module call
+	scanRoot := filepath.Dir(location.FilePath)
+
+	switch origin {
+	case originModuleHardcoded:
+		// Blame the module definition: find the resource attribute line inside modules/X/main.tf
+		parsed, err := ParseSearchKey(searchKey)
+		if err == nil {
+			bareAddr := parsed.ResourceType + "." + parsed.ResourceName
+			return t.resolveModuleDefinitionLocation(ctx, bareAddr, attrName, moduleDir, scanRoot, outputLines, location)
+		}
+		// ParseSearchKey failed — fall through to default call-site behavior
+
+	case originModuleDefault:
+		// Blame BOTH the variable default AND the module call block (two findings)
+		primary, secondary := t.resolveVariableDefaultLocation(ctx, varName, moduleDir, scanRoot, outputLines, location)
+		if secondary.ResolvedFile != "" {
+			// Attach secondary so the engine fan-out can emit a second finding
+			primary.SecondaryLines = &secondary
+		}
+		return primary
+	}
+
+	// origin == "call", "", or unrecognized: existing call-site path
+	// Try to transform searchKey using module mappings to find the specific attribute
+	// Build full searchKey by combining address with the original searchKey's attribute part
+	fullSearchKey := t.buildFullSearchKey(address, searchKey)
+	transformedSearchKey, transformedAttrName := t.transformSearchKeyForModule(ctx, moduleAddress, fullSearchKey)
+
+	// Decouple transformation from line lookup:
+	// - If transformation succeeds, use the transformed key even if line lookup fails
+	// - Only if transformation also succeeds, attempt to find the specific attribute line
+	if transformedSearchKey == "" || transformedAttrName == "" {
+		// Transformation failed - return module declaration line without transformed key
+		contextLogger.Debug().
+			Msg("TFPlan: Could not transform searchKey, using module declaration line")
+		return buildVulnerabilityLinesFromLocation(location, outputLines)
+	}
+
+	contextLogger.Debug().
+		Str("originalSearchKey", searchKey).
+		Str("transformedSearchKey", transformedSearchKey).
+		Str("attributeName", transformedAttrName).
+		Msg("TFPlan: Successfully transformed searchKey using module mappings")
+
+	// Try to find the specific attribute line in the module block
+	attributeLine := findAttributeLineInFile(location.FilePath, location.Line, transformedAttrName, outputLines, moduleKeyword)
+	if attributeLine <= 0 {
+		// Line lookup failed, but transformation succeeded
+		// Return module declaration line with transformed search key
+		contextLogger.Debug().
+			Msg("TFPlan: Could not find specific attribute line, using module declaration line with transformed key")
+		return buildVulnerabilityLinesFromLocation(location, outputLines, transformedSearchKey)
+	}
+
+	contextLogger.Debug().
+		Int("attributeLine", attributeLine).
+		Msg("TFPlan: Found specific attribute line in module block")
+
+	// Return the attribute line with transformed search key
+	attributeLocation := registry.Location{
+		FilePath: location.FilePath,
+		Line:     attributeLine,
+		Column:   location.Column,
+	}
+	return buildVulnerabilityLinesFromLocation(attributeLocation, outputLines, transformedSearchKey)
+}
+
+// findParentModuleLocation walks moduleAddress up to successive parent modules (stripping the
+// last "module.<name>" pair each time) until one resolves in the registry.
+// Example: "module.vpc.module.subnet" → "module.vpc"
+func (t *TFPlanDetectLine) findParentModuleLocation(
+	ctx context.Context, file *model.FileMetadata, moduleAddress string,
+) (registry.Location, bool) {
+	contextLogger := logger.FromContext(ctx)
+
+	parts := strings.Split(moduleAddress, ".")
+	for len(parts) >= 2 && parts[len(parts)-2] == moduleKeyword {
+		parts = parts[:len(parts)-2]
+		if len(parts) == 0 {
+			break
+		}
+		parentModule := strings.Join(parts, ".")
+
+		contextLogger.Debug().
+			Str("parentModule", parentModule).
+			Msg("TFPlan: Trying parent module")
+
+		if location, found := t.registry.LookupWithScope(parentModule, file.FilePath); found {
+			return location, true
+		}
+	}
+
+	return registry.Location{}, false
+}
+
+// extractAddressFromModulePath attempts to find a resource address by searching through all
+// resources in the document when the searchKey contains a module path
+// Format: module.vpc.aws_instance.bastion or module.app[0].aws_instance.web
+func extractAddressFromModulePath(ctx context.Context, file *model.FileMetadata, modulePath string) string {
+	contextLogger := logger.FromContext(ctx)
+
+	// Navigate to resource section
+	resourceSection, ok := file.LineInfoDocument["resource"]
+	if !ok {
+		contextLogger.Debug().Msg("No 'resource' section in LineInfoDocument")
+		return ""
+	}
+
+	resourceMap, ok := resourceSection.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	// We need to search through all resources to find one whose _dd_tf_address matches
+	// the module path pattern. The searchKey might be:
+	// "module.vpc.aws_instance.bastion.tags" and we need to find a resource whose
+	// _dd_tf_address starts with "module.vpc.aws_instance.bastion"
+
+	// Extract the resource path (without the final attribute)
+	// module.vpc.aws_instance.bastion.tags → module.vpc.aws_instance.bastion
+	parts := strings.Split(modulePath, ".")
+
+	// Try to find where the attribute part starts by looking for common attribute names
+	// or by checking if we can match partial paths
+	for resourceType, typeSection := range resourceMap {
+		typeMap, ok := typeSection.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		for resourceKey, resourceAttrs := range typeMap {
+			attrsMap, ok := resourceAttrs.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			address, ok := attrsMap["_dd_tf_address"]
+			if !ok {
+				continue
+			}
+
+			addressStr, ok := address.(string)
+			if !ok {
+				continue
+			}
+
+			// Check if this address matches our module path
+			// The searchKey might have attributes at the end, so we check if the address
+			// is a prefix of the search path or if the search path starts with the address
+			// IMPORTANT: Use exact match or require addressStr + "." to avoid prefix collisions
+			// e.g., "module.x.aws_instance.web" should NOT match "module.x.aws_instance.web_extra"
+			isMatch := false
+			if modulePath == addressStr {
+				// Exact match
+				isMatch = true
+			} else if strings.HasPrefix(modulePath, addressStr+".") {
+				// Prefix match, but require a dot after to avoid collisions
+				isMatch = true
+			}
+
+			if isMatch {
+				contextLogger.Debug().
+					Str("modulePath", modulePath).
+					Str("matchedAddress", addressStr).
+					Str("resourceType", resourceType).
+					Str("resourceKey", resourceKey).
+					Msg("Found matching address for module path")
+				return addressStr
+			}
+
+			// Also try the reverse: if the modulePath (without attributes) matches the address
+			// This handles cases where searchKey is "module.vpc.aws_instance.bastion.tags"
+			// and address is "module.vpc.aws_instance.bastion"
+			for i := len(parts); i >= 2; i-- {
+				partialPath := strings.Join(parts[:i], ".")
+				if partialPath == addressStr {
+					contextLogger.Debug().
+						Str("modulePath", modulePath).
+						Str("partialPath", partialPath).
+						Str("matchedAddress", addressStr).
+						Msg("Found matching address for partial module path")
+					return addressStr
+				}
+			}
+		}
+	}
+
+	contextLogger.Debug().
+		Str("modulePath", modulePath).
+		Msg("No matching address found for module path")
+	return ""
+}
+
+// extractAddressFromDocument extracts the _dd_tf_address field from the document
+// by navigating the searchKey path to find the resource
+// Uses the typed ParseSearchKey function for robust parsing
+func extractAddressFromDocument(ctx context.Context, file *model.FileMetadata, searchKey string) string {
+	contextLogger := logger.FromContext(ctx)
+
+	// Use the typed parser to handle all searchKey formats
+	parsed, err := ParseSearchKey(searchKey)
+	if err != nil {
+		contextLogger.Debug().
+			Err(err).
+			Str("searchKey", searchKey).
+			Msg("Failed to parse searchKey, will try legacy fallback")
+
+		// Fall back to extractAddressFromModulePath for module resources
+		if strings.Contains(searchKey, moduleKeyword) {
+			return extractAddressFromModulePath(ctx, file, searchKey)
+		}
+		return ""
+	}
+
+	contextLogger.Debug().
+		Str("searchKey", searchKey).
+		Str("resourceType", parsed.ResourceType).
+		Str("resourceName", parsed.ResourceName).
+		Bool("isModuleResource", parsed.IsModuleResource).
+		Msg("Parsed searchKey with typed parser")
+
+	// For module resources, search through all resources in the document
+	// to find one with a matching _dd_tf_address
+	// CRITICAL: Documents store NORMALIZED addresses (without indices), so we must search with NormalizedAddr
+	// See pkg/parser/json/tfplan.go:96-118 where _dd_tf_address is set to normalizedAddress
+	if parsed.IsModuleResource {
+		contextLogger.Debug().
+			Str("fullAddr", parsed.FullResourceAddr).
+			Str("normalizedAddr", parsed.NormalizedAddr).
+			Msg("Searching document for module resource address")
+		return extractAddressFromModulePath(ctx, file, parsed.NormalizedAddr)
+	}
+
+	// For simple resources, navigate directly to the resource
+	resourceType := parsed.ResourceType
+	resourceKey := parsed.ResourceName
+
+	// Navigate to resource section in LineInfoDocument (not Document)
+	// LineInfoDocument contains _dd_tf_address and _dd_lines before stripping
+	// Note: After JSON round-trip in parseTFPlan, nested objects are map[string]interface{}
+	resourceSection, ok := file.LineInfoDocument["resource"]
+	if !ok {
+		contextLogger.Debug().Msg("No 'resource' section in LineInfoDocument")
+		return ""
+	}
+
+	resourceMap, ok := resourceSection.(map[string]interface{})
+	if !ok {
+		contextLogger.Debug().
+			Str("actualType", fmt.Sprintf("%T", resourceSection)).
+			Msg("resource section is not a map[string]interface{}")
+		return ""
+	}
+
+	return lookupResourceAddress(ctx, resourceMap, resourceType, resourceKey, searchKey)
+}
+
+// lookupResourceAddress navigates resourceMap[resourceType][resourceKey] (falling back to a scan
+// by normalized _dd_tf_address for indexed resources) and returns that resource's _dd_tf_address.
+func lookupResourceAddress(ctx context.Context, resourceMap map[string]interface{}, resourceType, resourceKey, searchKey string) string {
+	contextLogger := logger.FromContext(ctx)
+
+	// Navigate to resource type
+	typeSection, ok := resourceMap[resourceType]
+	if !ok {
+		contextLogger.Debug().
+			Str("resourceType", resourceType).
+			Msg("Resource type not found in document")
+		return ""
+	}
+
+	typeMap, ok := typeSection.(map[string]interface{})
+	if !ok {
+		contextLogger.Debug().
+			Str("actualType", fmt.Sprintf("%T", typeSection)).
+			Msg("type section is not a map[string]interface{}")
+		return ""
+	}
+
+	// Navigate to resource key
+	// First try direct lookup (works for non-indexed resources)
+	resourceAttrs, ok := typeMap[resourceKey]
+	if !ok {
+		// Fallback: scan typeMap for matching _dd_tf_address
+		// This handles indexed resources where the key is stored as "web[0]"
+		// but we're looking up with the normalized name "web"
+		contextLogger.Debug().
+			Str("resourceType", resourceType).
+			Str("resourceKey", resourceKey).
+			Msg("Direct lookup failed, scanning for normalized _dd_tf_address")
+
+		normalizedTarget := fmt.Sprintf("%s.%s", resourceType, resourceKey)
+		resourceAttrs = findResourceByNormalizedAddress(typeMap, normalizedTarget, &contextLogger)
+
+		// If still not found, return empty
+		if resourceAttrs == nil {
+			contextLogger.Debug().
+				Str("resourceType", resourceType).
+				Str("resourceKey", resourceKey).
+				Msg("Resource not found even after _dd_tf_address scan")
+			return ""
+		}
+	}
+
+	attrsMap, ok := resourceAttrs.(map[string]interface{})
+	if !ok {
+		contextLogger.Debug().
+			Str("actualType", fmt.Sprintf("%T", resourceAttrs)).
+			Msg("resource attrs is not a map[string]interface{}")
+		return ""
+	}
+
+	// Extract _dd_tf_address
+	address, ok := attrsMap["_dd_tf_address"]
+	if !ok {
+		contextLogger.Debug().
+			Str("resourceType", resourceType).
+			Str("resourceKey", resourceKey).
+			Msg("_dd_tf_address not found in resource attributes")
+		return ""
+	}
+
+	addressStr, ok := address.(string)
+	if !ok {
+		contextLogger.Debug().Msg("_dd_tf_address is not a string")
+		return ""
+	}
+
+	contextLogger.Debug().
+		Str("searchKey", searchKey).
+		Str("resourceType", resourceType).
+		Str("resourceKey", resourceKey).
+		Str("extractedAddress", addressStr).
+		Msg("Successfully extracted address from document")
+
+	return addressStr
+}
+
+// findResourceByNormalizedAddress scans typeMap for a resource whose _dd_tf_address matches
+// normalizedTarget, used when the map key itself is index-suffixed (e.g. "web[0]").
+func findResourceByNormalizedAddress(typeMap map[string]interface{}, normalizedTarget string, contextLogger *zerolog.Logger) interface{} {
+	for key, attrs := range typeMap {
+		attrsMap, ok := attrs.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		addr, ok := attrsMap["_dd_tf_address"].(string)
+		if !ok || addr != normalizedTarget {
+			continue
+		}
+		contextLogger.Debug().
+			Str("foundKey", key).
+			Str("address", addr).
+			Msg("Found resource by _dd_tf_address scan")
+		return attrs
+	}
+	return nil
+}
+
+// extractOriginFromDocument reads the _dd_tf_origin hint for a specific attribute from the document.
+// It locates the same resource node as extractAddressFromDocument but reads _dd_tf_origin instead.
+// Returns (origin, varName, moduleDir) where origin is "call", "module_default", or "module_hardcoded".
+//
+// When attrName is empty (resource-level finding), it scans ALL attribute hints and returns
+// the "most significant" origin: module_hardcoded > module_default > call.
+// This handles resource-level Rego queries that flag the entire resource without naming an attribute.
+func extractOriginFromDocument(
+	ctx context.Context, file *model.FileMetadata, searchKey, attrName string,
+) (origin, varName, moduleDir string) {
+	contextLogger := logger.FromContext(ctx)
+
+	attrsMap := findResourceAttrsMap(file, searchKey)
+	if attrsMap == nil {
+		return "", "", ""
+	}
+
+	// Read _dd_tf_origin for this attribute
+	originMap, ok := attrsMap["_dd_tf_origin"]
+	if !ok {
+		contextLogger.Debug().Str("attrName", attrName).Msg("TFPlan: No _dd_tf_origin on resource")
+		return "", "", ""
+	}
+	originMapTyped, ok := originMap.(map[string]interface{})
+	if !ok {
+		return "", "", ""
+	}
+
+	if attrName != "" {
+		return resolveAttributeOrigin(ctx, originMapTyped, attrName)
+	}
+	return resolveResourceLevelOrigin(ctx, originMapTyped)
+}
+
+// findResourceAttrsMap locates the resource's attributes map in the document by parsing
+// searchKey, mirroring extractAddressFromDocument's navigation but returning the raw map
+// (needed here to read _dd_tf_origin rather than _dd_tf_address).
+func findResourceAttrsMap(file *model.FileMetadata, searchKey string) map[string]interface{} {
+	parsed, err := ParseSearchKey(searchKey)
+	if err != nil {
+		return nil
+	}
+
+	resourceSection, ok := file.LineInfoDocument["resource"]
+	if !ok {
+		return nil
+	}
+	resourceMap, ok := resourceSection.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	if parsed.IsModuleResource {
+		return findResourceAttrsByAddress(resourceMap, parsed.NormalizedAddr)
+	}
+
+	typeSection, ok := resourceMap[parsed.ResourceType]
+	if !ok {
+		return nil
+	}
+	typeMap, ok := typeSection.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	resourceAttrs, ok := typeMap[parsed.ResourceName]
+	if !ok {
+		return nil
+	}
+	attrsMap, ok := resourceAttrs.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return attrsMap
+}
+
+// findResourceAttrsByAddress searches every resource in resourceMap for one whose
+// _dd_tf_address equals or is a parent path of normalizedAddr (module resources).
+func findResourceAttrsByAddress(resourceMap map[string]interface{}, normalizedAddr string) map[string]interface{} {
+	for _, typeSection := range resourceMap {
+		typeMap, ok := typeSection.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, resourceAttrs := range typeMap {
+			am, ok := resourceAttrs.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			addr, _ := am["_dd_tf_address"].(string)
+			if addr == normalizedAddr || strings.HasPrefix(normalizedAddr, addr+".") {
+				return am
+			}
+		}
+	}
+	return nil
+}
+
+// resolveAttributeOrigin looks up the origin hint for one specific attribute, including a
+// dotted-prefix match for nested attributes and a module_hardcoded fallback when the module
+// never declared the attribute at all.
+func resolveAttributeOrigin(
+	ctx context.Context, originMapTyped map[string]interface{}, attrName string,
+) (origin, varName, moduleDir string) {
+	contextLogger := logger.FromContext(ctx)
+
+	hint, found := originMapTyped[attrName]
+	if !found {
+		// Try prefix match for nested attributes (e.g. attrName="metadata_options" matches
+		// "metadata_options.http_endpoint")
+		for key, h := range originMapTyped {
+			if strings.HasPrefix(key, attrName+".") {
+				hint = h
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		// The attribute is completely absent from the module resource's expressions — the module
+		// never declared it and the call cannot add it. This is module_hardcoded (hardcoded absence).
+		// Derive moduleDir from any sibling hint (they all share the same module directory).
+		derivedModuleDir := ""
+		for _, h := range originMapTyped {
+			if hm, ok := h.(map[string]interface{}); ok {
+				if d, ok := hm["moduleDir"].(string); ok && d != "" {
+					derivedModuleDir = d
+					break
+				}
+			}
+		}
+		if derivedModuleDir == "" {
+			return "", "", ""
+		}
+		contextLogger.Debug().
+			Str("attrName", attrName).
+			Str("moduleDir", derivedModuleDir).
+			Msg("TFPlan: Attribute absent from module resource expressions — treating as module_hardcoded")
+		return originModuleHardcoded, "", derivedModuleDir
+	}
+
+	hintMap, ok := hint.(map[string]interface{})
+	if !ok {
+		return "", "", ""
+	}
+	origin, _ = hintMap["origin"].(string)
+	varName, _ = hintMap["variable"].(string)
+	moduleDir, _ = hintMap["moduleDir"].(string)
+	return origin, varName, moduleDir
+}
+
+// resolveResourceLevelOrigin scans every attribute hint on a resource and returns the most
+// significant origin (module_hardcoded > module_default > call), for resource-level Rego
+// queries that flag an entire resource without naming an attribute.
+func resolveResourceLevelOrigin(ctx context.Context, originMapTyped map[string]interface{}) (origin, varName, moduleDir string) {
+	contextLogger := logger.FromContext(ctx)
+
+	originPriority := map[string]int{originModuleHardcoded: 3, originModuleDefault: 2, originCall: 1}
+
+	for _, h := range originMapTyped {
+		hintMap, ok := h.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		o, _ := hintMap["origin"].(string)
+		if originPriority[o] > originPriority[origin] {
+			origin = o
+			varName, _ = hintMap["variable"].(string)
+			moduleDir, _ = hintMap["moduleDir"].(string)
+		}
+	}
+
+	contextLogger.Debug().
+		Str("bestOrigin", origin).
+		Str("bestModuleDir", moduleDir).
+		Int("hintCount", len(originMapTyped)).
+		Msg("TFPlan: Resource-level origin scan result")
+
+	return origin, varName, moduleDir
+}
+
+// resolveModuleDefinitionLocation resolves a MODULE_HARDCODED finding to the resource attribute
+// line inside the module's own .tf file. Falls back to the module call line on failure.
+func (t *TFPlanDetectLine) resolveModuleDefinitionLocation(
+	ctx context.Context,
+	bareAddr string, // e.g. "aws_db_instance.this"
+	attrName string,
+	moduleDir string, // relative source path, e.g. "./modules/rds"
+	scanRoot string, // absolute path to scan root for resolving moduleDir
+	outputLines int,
+	callLocation registry.Location, // fallback
+) model.VulnerabilityLines {
+	contextLogger := logger.FromContext(ctx)
+
+	// Resolve module dir to an absolute path for scoped registry lookup
+	scopePath := callLocation.FilePath
+	if moduleDir != "" && scanRoot != "" {
+		abs := filepath.Join(scanRoot, moduleDir)
+		scopePath = filepath.Join(abs, "main.tf") // best-effort scope
+	} else if moduleDir != "" && callLocation.FilePath != "" {
+		// Resolve relative to the call file's directory
+		callFileDir := filepath.Dir(callLocation.FilePath)
+		abs := filepath.Join(callFileDir, moduleDir)
+		scopePath = filepath.Join(abs, "main.tf")
+	}
+
+	defLocation, found := t.registry.LookupWithScope(bareAddr, scopePath)
+	if !found {
+		contextLogger.Debug().
+			Str("bareAddr", bareAddr).
+			Str("scopePath", scopePath).
+			Msg("TFPlan: MODULE_HARDCODED: resource definition not found in registry, falling back to call site")
+		return buildVulnerabilityLinesFromLocation(callLocation, outputLines)
+	}
+
+	// Try to refine to the specific attribute line within the resource block
+	attrLine := findAttributeLineInFile(defLocation.FilePath, defLocation.Line, attrName, outputLines, "resource")
+	if attrLine > 0 {
+		attrLocation := registry.Location{
+			FilePath: defLocation.FilePath,
+			Line:     attrLine,
+			Column:   defLocation.Column,
+		}
+		contextLogger.Debug().
+			Str("file", defLocation.FilePath).
+			Int("line", attrLine).
+			Msg("TFPlan: MODULE_HARDCODED: resolved to resource attribute line")
+		return buildVulnerabilityLinesFromLocation(attrLocation, outputLines)
+	}
+
+	contextLogger.Debug().
+		Str("file", defLocation.FilePath).
+		Int("line", defLocation.Line).
+		Msg("TFPlan: MODULE_HARDCODED: resolved to resource definition line")
+	return buildVulnerabilityLinesFromLocation(defLocation, outputLines)
+}
+
+// resolveVariableDefaultLocation resolves a MODULE_DEFAULT finding to the variable's default
+// line in variables.tf. Falls back to the variable block line, then the call site.
+func (t *TFPlanDetectLine) resolveVariableDefaultLocation(
+	ctx context.Context,
+	varName string,
+	moduleDir string,
+	scanRoot string,
+	outputLines int,
+	callLocation registry.Location, // used as fallback AND as secondary location
+) (primary, secondary model.VulnerabilityLines) {
+	contextLogger := logger.FromContext(ctx)
+
+	// Build scope path for scoped registry lookup
+	scopePath := callLocation.FilePath
+	if moduleDir != "" && scanRoot != "" {
+		abs := filepath.Join(scanRoot, moduleDir)
+		scopePath = filepath.Join(abs, "variables.tf")
+	} else if moduleDir != "" && callLocation.FilePath != "" {
+		callFileDir := filepath.Dir(callLocation.FilePath)
+		abs := filepath.Join(callFileDir, moduleDir)
+		scopePath = filepath.Join(abs, "variables.tf")
+	}
+
+	varAddr := "var." + varName
+	varBlockLocation, found := t.registry.LookupWithScope(varAddr, scopePath)
+	if !found {
+		contextLogger.Debug().
+			Str("varAddr", varAddr).
+			Str("scopePath", scopePath).
+			Msg("TFPlan: MODULE_DEFAULT: variable block not found in registry, using call site only")
+		// Return only the call site finding (no dual-finding possible without the variable location)
+		return buildVulnerabilityLinesFromLocation(callLocation, outputLines), model.VulnerabilityLines{}
+	}
+
+	// Try to refine to the "default = ..." line within the variable block
+	defaultLine := findAttributeLineInFile(varBlockLocation.FilePath, varBlockLocation.Line, "default", outputLines, "variable")
+	var primaryLocation registry.Location
+	if defaultLine > 0 {
+		primaryLocation = registry.Location{
+			FilePath: varBlockLocation.FilePath,
+			Line:     defaultLine,
+			Column:   varBlockLocation.Column,
+		}
+		contextLogger.Debug().
+			Str("file", varBlockLocation.FilePath).
+			Int("line", defaultLine).
+			Msg("TFPlan: MODULE_DEFAULT: resolved to variable default line")
+	} else {
+		primaryLocation = varBlockLocation
+		contextLogger.Debug().
+			Str("file", varBlockLocation.FilePath).
+			Int("line", varBlockLocation.Line).
+			Msg("TFPlan: MODULE_DEFAULT: resolved to variable block line (no default line found)")
+	}
+
+	primaryLines := buildVulnerabilityLinesFromLocation(primaryLocation, outputLines)
+	secondaryLines := buildVulnerabilityLinesFromLocation(callLocation, outputLines)
+	return primaryLines, secondaryLines
+}
+
+// buildVulnerabilityLinesFromLocation creates VulnerabilityLines from a registry Location
+func buildVulnerabilityLinesFromLocation(
+	location registry.Location, outputLines int, transformedSearchKey ...string,
+) model.VulnerabilityLines {
+	// Read the file content to get the actual lines
+	var lines []string
+	if content, err := os.ReadFile(location.FilePath); err == nil {
+		lines = strings.Split(string(content), "\n")
+	}
+
+	// Build the vulnerability lines using the existing helper
+	// outputLines represents lines on each side, so total lines = outputLines*2 + 1
+	totalLines := outputLines*2 + 1
+	vulnLines := GetAdjacentVulnLines(location.Line-1, totalLines, lines)
+
+	// Create the location information
+	startLine := model.ResourceLine{
+		Line: location.Line,
+		Col:  location.Column,
+	}
+
+	// For end location, try to find the end of the resource block
+	endLine := startLine
+	if len(lines) > location.Line-1 {
+		// Simple heuristic: set column to end of the line
+		// This is a simplified approach - a more robust solution would parse the HCL
+		endLine.Line = location.Line
+		endLine.Col = len(lines[location.Line-1])
+	}
+
+	result := model.VulnerabilityLines{
+		Line:         location.Line,
+		VulnLines:    vulnLines,
+		ResolvedFile: location.FilePath,
+		VulnerablilityLocation: model.ResourceLocation{
+			Start: startLine,
+			End:   endLine,
+		},
+		// Set RemediationLocation to same as VulnerablilityLocation to prevent SARIF line 0 issue
+		// See pkg/report/model/sarif.go:598 where empty RemediationLocation can cause invalid locations
+		RemediationLocation: model.ResourceLocation{
+			Start: startLine,
+			End:   endLine,
+		},
+		ResourceSource: location.FilePath,
+		FileSource:     lines, // Actual file contents, not just the path
+	}
+
+	// Set transformed search key if provided
+	if len(transformedSearchKey) > 0 && transformedSearchKey[0] != "" {
+		result.TransformedSearchKey = transformedSearchKey[0]
+	}
+
+	return result
+}
+
+// NormalizeTFPlanAddress removes all count/for_each indices from a tfplan address
+// This is used to match tfplan addresses with HCL-registered addresses
+func NormalizeTFPlanAddress(address string) string {
+	return registry.NormalizeAddress(address)
+}
+
+// buildFullSearchKey combines the address with the searchKey to form a complete path
+// For example: address="module.vpc.aws_instance.web", searchKey="aws_instance.web.tags"
+// or: address="module.vpc.aws_instance.web", searchKey="module.vpc.aws_instance.web.tags"
+// Returns: "module.vpc.aws_instance.web.tags"
+func (t *TFPlanDetectLine) buildFullSearchKey(address, searchKey string) string {
+	// Use the typed parser to extract attribute information
+	parsed, err := ParseSearchKey(searchKey)
+	if err != nil {
+		// Fall back to simple concatenation if parsing fails
+		return address
+	}
+
+	// If no attribute, return address as-is
+	if !parsed.HasAttribute || len(parsed.AttributePath) == 0 {
+		return address
+	}
+
+	// Combine address with attribute path
+	// For "module.vpc.aws_instance.web.tags.Name", attributePath is ["tags", "Name"]
+	attributePart := strings.Join(parsed.AttributePath, ".")
+	return address + "." + attributePart
+}
+
+// transformSearchKeyForModule attempts to transform a searchKey using module mappings
+// For example: "module.vpc.aws_instance.web.tags" → "module.vpc.resource_tags" (if tags maps to resource_tags)
+// Returns: (transformedSearchKey, attributeName) where attributeName is the module input variable name
+func (t *TFPlanDetectLine) transformSearchKeyForModule(
+	ctx context.Context, moduleAddress, searchKey string,
+) (transformedSearchKey, attributeName string) {
+	contextLogger := logger.FromContext(ctx)
+
+	// No module mappings available
+	if t.moduleMappings == nil {
+		contextLogger.Debug().Msg("No module mappings available")
+		return "", ""
+	}
+
+	// Use the typed parser to extract attribute information
+	parsed, err := ParseSearchKey(searchKey)
+	if err != nil {
+		contextLogger.Debug().
+			Err(err).
+			Str("searchKey", searchKey).
+			Msg("Failed to parse searchKey")
+		return "", ""
+	}
+
+	// Only transform attribute-level findings, not resource-level
+	if !parsed.HasAttribute {
+		contextLogger.Debug().
+			Str("searchKey", searchKey).
+			Msg("Resource-level finding, no attribute to transform")
+		return "", ""
+	}
+
+	// Get the attribute name (first component of attribute path)
+	if len(parsed.AttributePath) == 0 {
+		contextLogger.Debug().
+			Str("searchKey", searchKey).
+			Msg("No attribute path found")
+		return "", ""
+	}
+
+	attributeName = parsed.AttributePath[0]
+
+	// Extract module name from moduleAddress (e.g., "module.vpc" → "vpc")
+	// Handle indexed modules: "module.app_servers[0]" → "app_servers"
+	moduleParts := strings.Split(moduleAddress, ".")
+	if len(moduleParts) < 2 || moduleParts[0] != moduleKeyword {
+		contextLogger.Debug().
+			Str("moduleAddress", moduleAddress).
+			Msg("Invalid module address format")
+		return "", ""
+	}
+
+	// Extract module name, handling brackets for indexed modules
+	moduleName := moduleParts[1]
+	if bracketIdx := strings.Index(moduleName, "["); bracketIdx > 0 {
+		moduleName = moduleName[:bracketIdx]
+	}
+
+	moduleMap, ok := t.lookupModuleMapping(ctx, moduleName)
+	if !ok {
+		return "", ""
+	}
+
+	variableNameStr, status := lookupModuleInputVariable(ctx, moduleMap, parsed.ResourceType, attributeName)
+	switch status {
+	case moduleInputNotFound:
+		// AttributesData/provider/inputs navigation failed outright (non-local module or
+		// unexpected shape): fall back to the normalized searchKey to preserve the full
+		// resource path and still enable deduplication.
+		return searchKey, attributeName
+	case moduleInputNonString:
+		// The attribute mapping's variable name wasn't a string: fall back to module address + attribute.
+		return moduleAddress + "." + attributeName, attributeName
+	}
+
+	// Build the transformed searchKey: moduleAddress + variableName
+	transformedSearchKey = moduleAddress + "." + variableNameStr
+
+	contextLogger.Debug().
+		Str("originalSearchKey", searchKey).
+		Str("transformedSearchKey", transformedSearchKey).
+		Str("attributeName", attributeName).
+		Str("variableName", variableNameStr).
+		Msg("Successfully transformed searchKey using module mappings")
+
+	return transformedSearchKey, variableNameStr
+}
+
+// moduleInputLookupStatus is the outcome of lookupModuleInputVariable.
+type moduleInputLookupStatus int
+
+const (
+	moduleInputFound moduleInputLookupStatus = iota
+	moduleInputNotFound
+	moduleInputNonString
+)
+
+// lookupModuleMapping finds moduleName's entry in t.moduleMappings.
+// The mapping keys can be:
+//   - Just the module name (for local modules)
+//   - source::name (for non-local modules to avoid collisions)
+//
+// It tries the simple name first, then checks all keys that end with ::name (handling the
+// same remote module being called multiple times).
+func (t *TFPlanDetectLine) lookupModuleMapping(ctx context.Context, moduleName string) (map[string]interface{}, bool) {
+	contextLogger := logger.FromContext(ctx)
+
+	moduleData, ok := t.moduleMappings[moduleName]
+	if !ok {
+		for key, data := range t.moduleMappings {
+			if strings.HasSuffix(key, "::"+moduleName) {
+				moduleData = data
+				ok = true
+				contextLogger.Debug().
+					Str("moduleName", moduleName).
+					Str("matchedKey", key).
+					Msg("Found module by source::name key")
+				break
+			}
+		}
+	}
+	if !ok {
+		contextLogger.Debug().
+			Str("moduleName", moduleName).
+			Msg("Module not found in mappings")
+		return nil, false
+	}
+
+	moduleMap, ok := moduleData.(map[string]interface{})
+	if !ok {
+		contextLogger.Debug().
+			Str("moduleName", moduleName).
+			Str("type", fmt.Sprintf("%T", moduleData)).
+			Msg("Module data is not a map")
+		return nil, false
+	}
+	return moduleMap, true
+}
+
+// lookupModuleInputVariable navigates moduleMap["AttributesData"][provider]["inputs"][attributeName]
+// (provider derived from resourceType's "_"-prefix) to find the module input variable name that
+// attributeName maps to. The status return distinguishes "navigation failed" (caller falls back
+// to the normalized searchKey) from "found but not a string" (caller falls back differently).
+func lookupModuleInputVariable(
+	ctx context.Context, moduleMap map[string]interface{}, resourceType, attributeName string,
+) (string, moduleInputLookupStatus) {
+	contextLogger := logger.FromContext(ctx)
+	providerPrefix := strings.Split(resourceType, "_")[0]
+
+	attributesData, ok := moduleMap["AttributesData"]
+	if !ok {
+		// No AttributesData (non-local module). For example:
+		// module.app[0].aws_instance.web.tags → module.app.aws_instance.web.tags
+		contextLogger.Debug().
+			Str("attributeName", attributeName).
+			Msg("No AttributesData in module (likely non-local), using fallback transformation")
+		return "", moduleInputNotFound
+	}
+	attributesMap, ok := attributesData.(map[string]interface{})
+	if !ok {
+		contextLogger.Debug().
+			Str("type", fmt.Sprintf("%T", attributesData)).
+			Msg("AttributesData is not a map, using fallback transformation")
+		return "", moduleInputNotFound
+	}
+
+	providerData, ok := attributesMap[providerPrefix]
+	if !ok {
+		contextLogger.Debug().
+			Str("provider", providerPrefix).
+			Msg("Provider not found in module AttributesData, using fallback transformation")
+		return "", moduleInputNotFound
+	}
+	providerMap, ok := providerData.(map[string]interface{})
+	if !ok {
+		contextLogger.Debug().
+			Str("provider", providerPrefix).
+			Str("type", fmt.Sprintf("%T", providerData)).
+			Msg("Provider data is not a map, using fallback transformation")
+		return "", moduleInputNotFound
+	}
+
+	inputs, ok := providerMap["inputs"]
+	if !ok {
+		contextLogger.Debug().
+			Str("provider", providerPrefix).
+			Msg("No inputs in provider data, using fallback transformation")
+		return "", moduleInputNotFound
+	}
+	inputsMap, ok := inputs.(map[string]interface{})
+	if !ok {
+		contextLogger.Debug().
+			Str("provider", providerPrefix).
+			Str("type", fmt.Sprintf("%T", inputs)).
+			Msg("Inputs is not a map, using fallback transformation")
+		return "", moduleInputNotFound
+	}
+
+	variableName, ok := inputsMap[attributeName]
+	if !ok {
+		contextLogger.Debug().
+			Str("attributeName", attributeName).
+			Msg("Attribute not found in module inputs, using fallback transformation")
+		return "", moduleInputNotFound
+	}
+	variableNameStr, ok := variableName.(string)
+	if !ok {
+		contextLogger.Debug().
+			Str("attributeName", attributeName).
+			Str("type", fmt.Sprintf("%T", variableName)).
+			Msg("Variable name is not a string, using fallback transformation")
+		return "", moduleInputNonString
+	}
+	return variableNameStr, moduleInputFound
+}
+
+// findAttributeLineInFile searches for an attribute assignment in a block of the given blockType
+// using HCL parsing. For module blocks pass blockType="module"; for resource/variable blocks pass
+// the respective type name. Returns the line number where the attribute is found, or -1 if not found.
+func findAttributeLineInFile(filePath string, startLine int, attributeName string, searchRange int, blockType string) int {
+	// Read and parse the HCL file
+	content, err := os.ReadFile(filePath) //nolint:gosec // filePath comes from the address registry, scoped to the scan root
+	if err != nil {
+		return -1
+	}
+
+	file, diags := hclsyntax.ParseConfig(content, filePath, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		// Fall back to regex-based search if HCL parsing fails
+		return findAttributeLineInFileRegex(filePath, startLine, attributeName, searchRange)
+	}
+
+	// Find the block of the requested type that contains the startLine
+	var targetBlock *hclsyntax.Block
+	for _, block := range file.Body.(*hclsyntax.Body).Blocks {
+		if block.Type != blockType {
+			continue
+		}
+
+		blockRange := block.DefRange()
+		// Check if this block contains our start line
+		if blockRange.Start.Line <= startLine && blockRange.End.Line >= startLine {
+			targetBlock = block
+			break
+		}
+	}
+
+	if targetBlock == nil {
+		// Block not found, fall back to regex
+		return findAttributeLineInFileRegex(filePath, startLine, attributeName, searchRange)
+	}
+
+	// Search for the attribute within the block
+	body := targetBlock.Body
+	for name, attr := range body.Attributes {
+		if name == attributeName {
+			return attr.NameRange.Start.Line
+		}
+	}
+
+	// Attribute not found in this block
+	return -1
+}
+
+// findAttributeLineInFileRegex is the fallback regex-based search
+// Used when HCL parsing fails or as a last resort
+func findAttributeLineInFileRegex(filePath string, startLine int, attributeName string, searchRange int) int {
+	content, err := os.ReadFile(filePath) //nolint:gosec // filePath comes from the address registry, scoped to the scan root
+	if err != nil {
+		return -1
+	}
+
+	lines := strings.Split(string(content), "\n")
+	if startLine < 1 || startLine > len(lines) {
+		return -1
+	}
+
+	// Search for the attribute in a reasonable range around startLine
+	// Module blocks can be large, so we use a generous window
+	minSearchWindow := 100
+	searchWindow := searchRange * 2
+	if searchWindow < minSearchWindow {
+		searchWindow = minSearchWindow
+	}
+
+	maxLine := startLine + searchWindow
+	if maxLine > len(lines) {
+		maxLine = len(lines)
+	}
+
+	// Pattern to match: "attributeName = ..." or "attributeName=" (with optional spaces)
+	attributePattern := fmt.Sprintf(`^\s*%s\s*=`, attributeName)
+
+	for i := startLine - 1; i < maxLine; i++ {
+		line := lines[i]
+		matched, _ := regexp.MatchString(attributePattern, line)
+		if matched {
+			return i + 1 // Return 1-indexed line number
+		}
+	}
+
+	return -1
+}

--- a/pkg/detector/tfplan_detect_test.go
+++ b/pkg/detector/tfplan_detect_test.go
@@ -1,0 +1,1055 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package detector
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/registry"
+)
+
+func TestTFPlanDetectLine(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.tf")
+
+	// Write test HCL content
+	hclContent := `resource "aws_instance" "web" {
+  ami           = "ami-123456"
+  instance_type = "t2.micro"
+}
+
+module "vpc" {
+  source = "./modules/vpc"
+  cidr   = "10.0.0.0/16"
+}
+
+resource "aws_s3_bucket" "data" {
+  bucket = "my-bucket"
+}`
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Create registry and register test addresses
+	reg := registry.New()
+	reg.Register("aws_instance.web", registry.Location{
+		FilePath: testFile,
+		Line:     1,
+		Column:   1,
+	})
+	reg.Register("module.vpc", registry.Location{
+		FilePath: testFile,
+		Line:     6,
+		Column:   1,
+	})
+	reg.Register("aws_s3_bucket.data", registry.Location{
+		FilePath: testFile,
+		Line:     11,
+		Column:   1,
+	})
+
+	ctx := context.Background()
+	detector := NewTFPlanDetectLine(reg, nil)
+
+	// Create a mock tfplan document with _dd_tf_address fields
+	mockDocument := model.Document{
+		"resource": model.Document{
+			"aws_instance": model.Document{
+				"web": model.Document{
+					"_dd_tf_address": "aws_instance.web",
+					"ami":            "ami-123456",
+					"instance_type":  "t2.micro",
+				},
+			},
+			"aws_s3_bucket": model.Document{
+				"data": model.Document{
+					"_dd_tf_address": "aws_s3_bucket.data",
+					"bucket":         "my-bucket",
+				},
+			},
+		},
+	}
+
+	// Simulate the JSON round-trip that happens in production
+	// This converts nested model.Document to map[string]interface{}
+	jsonBytes, err := json.Marshal(mockDocument)
+	if err != nil {
+		t.Fatalf("Failed to marshal document: %v", err)
+	}
+
+	var roundTrippedDoc model.Document
+	err = json.Unmarshal(jsonBytes, &roundTrippedDoc)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal document: %v", err)
+	}
+
+	// Create a mock file metadata for tfplan with the round-tripped document
+	fileMetadata := &model.FileMetadata{
+		ID:               "test-file",
+		FilePath:         "test.tfplan.json",
+		Kind:             model.KindJSON,
+		Document:         roundTrippedDoc, // This is now map[string]interface{} nested
+		LineInfoDocument: roundTrippedDoc, // TFPlan detector reads _dd_tf_address from here
+	}
+
+	tests := []struct {
+		name         string
+		searchKey    string
+		expectedLine int
+		expectedFile string
+	}{
+		{
+			name:         "root resource",
+			searchKey:    "aws_instance.web.ami",
+			expectedLine: 1,
+			expectedFile: testFile,
+		},
+		{
+			name:         "s3 bucket resource",
+			searchKey:    "resource.aws_s3_bucket.data.acl",
+			expectedLine: 11,
+			expectedFile: testFile,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detector.DetectLine(ctx, fileMetadata, tt.searchKey, 3)
+			if result.Line != tt.expectedLine {
+				t.Errorf("Expected line %d, got %d", tt.expectedLine, result.Line)
+			}
+			if result.ResolvedFile != tt.expectedFile {
+				t.Errorf("Expected file %s, got %s", tt.expectedFile, result.ResolvedFile)
+			}
+			if result.ResourceSource != tt.expectedFile {
+				t.Errorf("Expected resource source %s, got %s", tt.expectedFile, result.ResourceSource)
+			}
+		})
+	}
+}
+
+func TestTFPlanDetectLineFallback(t *testing.T) {
+	// Create empty registry to test fallback behavior
+	reg := registry.New()
+
+	ctx := context.Background()
+	detector := NewTFPlanDetectLine(reg, nil)
+
+	// Create a mock file with actual content
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.json")
+	jsonContent := `{
+  "resource": {
+    "aws_instance": {
+      "web": {
+        "ami": "ami-123456"
+      }
+    }
+  }
+}`
+	err := os.WriteFile(testFile, []byte(jsonContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Read the file content
+	content, _ := os.ReadFile(testFile)
+	lines := make([]string, 0)
+	for _, line := range string(content) {
+		lines = append(lines, string(line))
+	}
+
+	fileMetadata := &model.FileMetadata{
+		ID:                "test-file",
+		FilePath:          testFile,
+		Kind:              model.KindJSON,
+		LinesOriginalData: &lines,
+	}
+
+	// Test fallback to default detector when no mapping exists
+	result := detector.DetectLine(ctx, fileMetadata, "aws_instance.web.ami", 3)
+
+	// Should fall back to default detection
+	// Line number might be -1 or some default value since it's using fallback
+	if result.ResolvedFile != testFile {
+		t.Errorf("Expected fallback to use original file %s, got %s", testFile, result.ResolvedFile)
+	}
+}
+
+func TestNormalizeTFPlanAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no indices",
+			input:    "module.vpc.aws_instance.web",
+			expected: "module.vpc.aws_instance.web",
+		},
+		{
+			name:     "count index",
+			input:    "module.vpc[0].aws_instance.web[1]",
+			expected: "module.vpc.aws_instance.web",
+		},
+		{
+			name:     "for_each key",
+			input:    `module.network["us-east-1"].aws_vpc.main`,
+			expected: "module.network.aws_vpc.main",
+		},
+		{
+			name:     "mixed indices",
+			input:    `module.env["prod"].module.region[0].aws_instance.web["app"]`,
+			expected: "module.env.module.region.aws_instance.web",
+		},
+		{
+			name:     "nested brackets",
+			input:    `resource[0]["key"][1]`,
+			expected: "resource",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeTFPlanAddress(tt.input)
+			if result != tt.expected {
+				t.Errorf("NormalizeTFPlanAddress(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildVulnerabilityLinesFromLocation(t *testing.T) {
+	// Create a test file with known content
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.tf")
+	content := `line 1
+line 2
+line 3
+line 4
+line 5`
+	err := os.WriteFile(testFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	location := registry.Location{
+		FilePath: testFile,
+		Line:     3,
+		Column:   1,
+	}
+
+	result := buildVulnerabilityLinesFromLocation(location, 1)
+
+	// Check basic fields
+	if result.Line != 3 {
+		t.Errorf("Expected line 3, got %d", result.Line)
+	}
+	if result.ResolvedFile != testFile {
+		t.Errorf("Expected file %s, got %s", testFile, result.ResolvedFile)
+	}
+	if result.ResourceSource != testFile {
+		t.Errorf("Expected resource source %s, got %s", testFile, result.ResourceSource)
+	}
+
+	// Check vulnerability lines
+	if result.VulnLines == nil || len(*result.VulnLines) == 0 {
+		t.Error("Expected vulnerability lines to be populated")
+	} else {
+		vulnLines := *result.VulnLines
+		// Should have 3 lines (line 2, 3, 4) with outputLines=1
+		if len(vulnLines) != 3 {
+			t.Errorf("Expected 3 vulnerability lines, got %d", len(vulnLines))
+		}
+		// Check that line 3 is included
+		hasLine3 := false
+		for _, vl := range vulnLines {
+			if vl.Position == 3 {
+				hasLine3 = true
+				break
+			}
+		}
+		if !hasLine3 {
+			t.Error("Line 3 should be included in vulnerability lines")
+		}
+	}
+
+	// Check location information
+	if result.VulnerablilityLocation.Start.Line != 3 {
+		t.Errorf("Expected start line 3, got %d", result.VulnerablilityLocation.Start.Line)
+	}
+}
+
+func TestTFPlanDetectLineWithModuleMappings(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "main.tf")
+
+	// Write test HCL content with module call
+	hclContent := `module "vpc" {
+  source = "./modules/vpc"
+
+  # Line 4: Module inputs
+  resource_tags = {
+    Environment = "production"
+    Team        = "platform"
+  }
+
+  cidr_block = "10.0.0.0/16"
+}`
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Create registry and register module address
+	reg := registry.New()
+	reg.Register("module.vpc", registry.Location{
+		FilePath: testFile,
+		Line:     1, // Module declaration line
+		Column:   1,
+	})
+
+	// Create module mappings that simulate the module attribute mapping
+	// This maps "tags" attribute → "resource_tags" variable
+	moduleMappings := map[string]interface{}{
+		"vpc": map[string]interface{}{
+			"AttributesData": map[string]interface{}{
+				"aws": map[string]interface{}{
+					"inputs": map[string]interface{}{
+						"tags": "resource_tags", // tags maps to resource_tags
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	detector := NewTFPlanDetectLine(reg, moduleMappings)
+
+	// Create a mock tfplan document with _dd_tf_address for a module resource
+	mockDocument := model.Document{
+		"resource": model.Document{
+			"aws_instance": model.Document{
+				"web": model.Document{
+					"_dd_tf_address": "module.vpc.aws_instance.web",
+					"tags": map[string]interface{}{
+						"Environment": "production",
+					},
+				},
+			},
+		},
+	}
+
+	// Simulate JSON round-trip
+	jsonBytes, err := json.Marshal(mockDocument)
+	if err != nil {
+		t.Fatalf("Failed to marshal document: %v", err)
+	}
+
+	var roundTrippedDoc model.Document
+	err = json.Unmarshal(jsonBytes, &roundTrippedDoc)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal document: %v", err)
+	}
+
+	// Create file metadata with the tfplan document
+	fileMetadata := &model.FileMetadata{
+		ID:               "test-file",
+		FilePath:         filepath.Join(tmpDir, "plan.tfplan.json"),
+		Kind:             model.KindJSON,
+		Document:         roundTrippedDoc,
+		LineInfoDocument: roundTrippedDoc,
+	}
+
+	// Test that the detector maps the module resource attribute to the module input variable line
+	// searchKey should be in the format that comes from the query: "aws_instance.web.tags"
+	// The detector will extract the address from the document ("module.vpc.aws_instance.web")
+	result := detector.DetectLine(ctx, fileMetadata, "aws_instance.web.tags", 3)
+
+	// Check that it resolved to the HCL file
+	if result.ResolvedFile != testFile {
+		t.Errorf("Expected resolved file %s, got %s", testFile, result.ResolvedFile)
+	}
+
+	// Check that it resolved to the resource_tags line (line 5), not the module declaration (line 1)
+	if result.Line != 5 {
+		t.Errorf("Expected line 5 (resource_tags attribute), got line %d", result.Line)
+	}
+}
+
+func TestFindAttributeLineInFile(t *testing.T) {
+	// Create a test file
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.tf")
+	content := `module "vpc" {
+  source = "./vpc"
+
+  region = "us-east-1"
+  resource_tags = {
+    Team = "platform"
+  }
+
+  cidr_block = "10.0.0.0/16"
+}`
+	err := os.WriteFile(testFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		startLine     int
+		attributeName string
+		searchRange   int
+		expectedLine  int
+	}{
+		{
+			name:          "find resource_tags",
+			startLine:     1,
+			attributeName: "resource_tags",
+			searchRange:   10,
+			expectedLine:  5,
+		},
+		{
+			name:          "find region",
+			startLine:     1,
+			attributeName: "region",
+			searchRange:   10,
+			expectedLine:  4,
+		},
+		{
+			name:          "find cidr_block",
+			startLine:     1,
+			attributeName: "cidr_block",
+			searchRange:   10,
+			expectedLine:  9,
+		},
+		{
+			name:          "attribute not found",
+			startLine:     1,
+			attributeName: "nonexistent",
+			searchRange:   10,
+			expectedLine:  -1,
+		},
+		{
+			name:          "small search range with min window",
+			startLine:     1,
+			attributeName: "cidr_block",
+			searchRange:   2, // With min window of 100, will still find it on line 9
+			expectedLine:  9, // Now found due to minimum search window
+		},
+		{
+			name:          "start from middle of file",
+			startLine:     5,
+			attributeName: "cidr_block",
+			searchRange:   5,
+			expectedLine:  9,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findAttributeLineInFile(testFile, tt.startLine, tt.attributeName, tt.searchRange, "module")
+			if result != tt.expectedLine {
+				t.Errorf("Expected line %d, got %d", tt.expectedLine, result)
+			}
+		})
+	}
+}
+
+func TestBuildFullSearchKey(t *testing.T) {
+	detector := &TFPlanDetectLine{}
+
+	tests := []struct {
+		name        string
+		address     string
+		searchKey   string
+		expected    string
+		description string
+	}{
+		{
+			name:        "simple module resource with attribute",
+			address:     "module.vpc.aws_instance.web",
+			searchKey:   "aws_instance.web.tags",
+			expected:    "module.vpc.aws_instance.web.tags",
+			description: "Should combine address and attribute",
+		},
+		{
+			name:        "resource prefix in searchKey",
+			address:     "module.vpc.aws_instance.web",
+			searchKey:   "resource.aws_instance.web.tags",
+			expected:    "module.vpc.aws_instance.web.tags",
+			description: "Should strip resource prefix before combining",
+		},
+		{
+			name:        "no attribute in searchKey",
+			address:     "module.vpc.aws_instance.web",
+			searchKey:   "aws_instance.web",
+			expected:    "module.vpc.aws_instance.web",
+			description: "Should return address when no attribute",
+		},
+		{
+			name:        "nested attribute path",
+			address:     "module.vpc.aws_instance.web",
+			searchKey:   "aws_instance.web.root_block_device.volume_size",
+			expected:    "module.vpc.aws_instance.web.root_block_device.volume_size",
+			description: "Should handle nested attribute paths",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detector.buildFullSearchKey(tt.address, tt.searchKey)
+			if result != tt.expected {
+				t.Errorf("%s: Expected %q, got %q", tt.description, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestTransformSearchKeyForModuleEdgeCases(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name              string
+		moduleMappings    map[string]interface{}
+		moduleAddress     string
+		searchKey         string
+		expectedSearchKey string
+		expectedAttribute string
+		description       string
+	}{
+		{
+			name:              "nil module mappings",
+			moduleMappings:    nil,
+			moduleAddress:     "module.vpc",
+			searchKey:         "module.vpc.aws_instance.web.tags",
+			expectedSearchKey: "",
+			expectedAttribute: "",
+			description:       "Should return empty when no mappings",
+		},
+		{
+			name: "module not in mappings",
+			moduleMappings: map[string]interface{}{
+				"other_module": map[string]interface{}{},
+			},
+			moduleAddress:     "module.vpc",
+			searchKey:         "module.vpc.aws_instance.web.tags",
+			expectedSearchKey: "",
+			expectedAttribute: "",
+			description:       "Should return empty when module not found",
+		},
+		{
+			name: "attribute not in mappings",
+			moduleMappings: map[string]interface{}{
+				"vpc": map[string]interface{}{
+					"AttributesData": map[string]interface{}{
+						"aws": map[string]interface{}{
+							"inputs": map[string]interface{}{
+								"cidr": "vpc_cidr", // Different attribute
+							},
+						},
+					},
+				},
+			},
+			moduleAddress:     "module.vpc",
+			searchKey:         "module.vpc.aws_instance.web.tags",
+			expectedSearchKey: "module.vpc.aws_instance.web.tags", // Fallback uses full searchKey
+			expectedAttribute: "tags",
+			description:       "Should use fallback transformation when attribute not mapped",
+		},
+		{
+			name: "successful transformation",
+			moduleMappings: map[string]interface{}{
+				"vpc": map[string]interface{}{
+					"AttributesData": map[string]interface{}{
+						"aws": map[string]interface{}{
+							"inputs": map[string]interface{}{
+								"tags": "resource_tags",
+							},
+						},
+					},
+				},
+			},
+			moduleAddress:     "module.vpc",
+			searchKey:         "module.vpc.aws_instance.web.tags",
+			expectedSearchKey: "module.vpc.resource_tags",
+			expectedAttribute: "resource_tags",
+			description:       "Should successfully transform with valid mappings",
+		},
+		{
+			name: "searchKey too short",
+			moduleMappings: map[string]interface{}{
+				"vpc": map[string]interface{}{
+					"AttributesData": map[string]interface{}{
+						"aws": map[string]interface{}{
+							"inputs": map[string]interface{}{
+								"tags": "resource_tags",
+							},
+						},
+					},
+				},
+			},
+			moduleAddress:     "module.vpc",
+			searchKey:         "module.vpc",
+			expectedSearchKey: "",
+			expectedAttribute: "",
+			description:       "Should return empty when searchKey too short",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detector := NewTFPlanDetectLine(nil, tt.moduleMappings)
+			transformedKey, attribute := detector.transformSearchKeyForModule(ctx, tt.moduleAddress, tt.searchKey)
+
+			if transformedKey != tt.expectedSearchKey {
+				t.Errorf("%s: Expected searchKey %q, got %q", tt.description, tt.expectedSearchKey, transformedKey)
+			}
+			if attribute != tt.expectedAttribute {
+				t.Errorf("%s: Expected attribute %q, got %q", tt.description, tt.expectedAttribute, attribute)
+			}
+		})
+	}
+}
+
+func roundTripDocument(doc model.Document) model.Document {
+	b, err := json.Marshal(doc)
+	if err != nil {
+		panic(err)
+	}
+	var out model.Document
+	if err := json.Unmarshal(b, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+// TestOriginBranch_ModuleHardcoded verifies that a module_hardcoded origin resolves to
+// the resource definition attribute line in the module's .tf file.
+func TestOriginBranch_ModuleHardcoded(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write parent main.tf with module call
+	mainTF := filepath.Join(tmpDir, "main.tf")
+	err := os.WriteFile(mainTF, []byte(`module "rds" {
+  source = "./modules/rds"
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write module definition with hardcoded publicly_accessible
+	modulesDir := filepath.Join(tmpDir, "modules", "rds")
+	if err := os.MkdirAll(modulesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	moduleMainTF := filepath.Join(modulesDir, "main.tf")
+	err = os.WriteFile(moduleMainTF, []byte(`resource "aws_db_instance" "this" {
+  identifier          = "app-db"
+  publicly_accessible = true
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Register both the module call and the resource definition
+	reg := registry.New()
+	reg.Register("module.rds", registry.Location{FilePath: mainTF, Line: 1, Column: 1})
+	reg.Register("aws_db_instance.this", registry.Location{FilePath: moduleMainTF, Line: 1, Column: 1})
+
+	ctx := context.Background()
+	detector := NewTFPlanDetectLine(reg, nil)
+
+	// Build document with module_hardcoded origin for publicly_accessible
+	rawDoc := model.Document{
+		"resource": map[string]interface{}{
+			"aws_db_instance": map[string]interface{}{
+				"module.rds.this": map[string]interface{}{
+					"_dd_tf_address": "module.rds.aws_db_instance.this",
+					"_dd_tf_origin": map[string]interface{}{
+						"publicly_accessible": map[string]interface{}{
+							"origin":    "module_hardcoded",
+							"moduleDir": "./modules/rds",
+						},
+					},
+					"publicly_accessible": true,
+				},
+			},
+		},
+	}
+	roundTripped := roundTripDocument(rawDoc)
+
+	fileMetadata := &model.FileMetadata{
+		ID:               "plan",
+		FilePath:         filepath.Join(tmpDir, "plan.tfplan.json"),
+		Kind:             model.KindJSON,
+		Document:         roundTripped,
+		LineInfoDocument: roundTripped,
+	}
+
+	result := detector.DetectLine(ctx, fileMetadata, "module.rds.aws_db_instance.this.publicly_accessible", 3)
+
+	// Should resolve to the module DEFINITION file (modules/rds/main.tf), not main.tf
+	if result.ResolvedFile != moduleMainTF {
+		t.Errorf("expected module definition file %q, got %q", moduleMainTF, result.ResolvedFile)
+	}
+	// Line 3 is "publicly_accessible = true"
+	if result.Line != 3 {
+		t.Errorf("expected attribute line 3, got %d", result.Line)
+	}
+	// No secondary finding for hardcoded
+	if result.SecondaryLines != nil {
+		t.Error("expected no SecondaryLines for module_hardcoded")
+	}
+}
+
+// TestOriginBranch_ModuleDefault verifies that a module_default origin produces TWO findings:
+// primary at the variable default line and secondary at the module call block.
+func TestOriginBranch_ModuleDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write parent main.tf with module call (omits publicly_accessible)
+	mainTF := filepath.Join(tmpDir, "main.tf")
+	err := os.WriteFile(mainTF, []byte(`module "rds" {
+  source = "./modules/rds"
+  identifier = "app-db"
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write module variables.tf with insecure default
+	modulesDir := filepath.Join(tmpDir, "modules", "rds")
+	if err := os.MkdirAll(modulesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	variablesTF := filepath.Join(modulesDir, "variables.tf")
+	err = os.WriteFile(variablesTF, []byte(`variable "publicly_accessible" {
+  description = "Whether the DB is publicly accessible."
+  type        = bool
+  default     = true
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reg := registry.New()
+	reg.Register("module.rds", registry.Location{FilePath: mainTF, Line: 1, Column: 1})
+	reg.Register("var.publicly_accessible", registry.Location{FilePath: variablesTF, Line: 1, Column: 1})
+
+	ctx := context.Background()
+	detector := NewTFPlanDetectLine(reg, nil)
+
+	rawDoc := model.Document{
+		"resource": map[string]interface{}{
+			"aws_db_instance": map[string]interface{}{
+				"module.rds.this": map[string]interface{}{
+					"_dd_tf_address": "module.rds.aws_db_instance.this",
+					"_dd_tf_origin": map[string]interface{}{
+						"publicly_accessible": map[string]interface{}{
+							"origin":    "module_default",
+							"variable":  "publicly_accessible",
+							"moduleDir": "./modules/rds",
+						},
+					},
+					"publicly_accessible": true,
+				},
+			},
+		},
+	}
+	roundTripped := roundTripDocument(rawDoc)
+
+	fileMetadata := &model.FileMetadata{
+		ID:               "plan",
+		FilePath:         filepath.Join(tmpDir, "plan.tfplan.json"),
+		Kind:             model.KindJSON,
+		Document:         roundTripped,
+		LineInfoDocument: roundTripped,
+	}
+
+	result := detector.DetectLine(ctx, fileMetadata, "module.rds.aws_db_instance.this.publicly_accessible", 3)
+
+	// Primary should point at variables.tf default line (line 4: "default = true")
+	if result.ResolvedFile != variablesTF {
+		t.Errorf("expected variables.tf %q as primary, got %q", variablesTF, result.ResolvedFile)
+	}
+	if result.Line != 4 {
+		t.Errorf("expected default line 4, got %d", result.Line)
+	}
+
+	// Secondary should point at the module call block in main.tf
+	if result.SecondaryLines == nil {
+		t.Fatal("expected SecondaryLines for module_default, got nil")
+	}
+	if result.SecondaryLines.ResolvedFile != mainTF {
+		t.Errorf("expected secondary file %q (module call), got %q", mainTF, result.SecondaryLines.ResolvedFile)
+	}
+	if result.SecondaryLines.Line != 1 {
+		t.Errorf("expected secondary line 1 (module block), got %d", result.SecondaryLines.Line)
+	}
+}
+
+// TestOriginBranch_CallSite verifies that a call origin (or no hint) still resolves to the
+// module call block as before, with no secondary finding.
+func TestOriginBranch_CallSite(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mainTF := filepath.Join(tmpDir, "main.tf")
+	err := os.WriteFile(mainTF, []byte(`module "rds" {
+  source              = "./modules/rds"
+  publicly_accessible = true
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reg := registry.New()
+	reg.Register("module.rds", registry.Location{FilePath: mainTF, Line: 1, Column: 1})
+
+	ctx := context.Background()
+	detector := NewTFPlanDetectLine(reg, nil)
+
+	rawDoc := model.Document{
+		"resource": map[string]interface{}{
+			"aws_db_instance": map[string]interface{}{
+				"module.rds.this": map[string]interface{}{
+					"_dd_tf_address": "module.rds.aws_db_instance.this",
+					"_dd_tf_origin": map[string]interface{}{
+						"publicly_accessible": map[string]interface{}{
+							"origin":   "call",
+							"variable": "publicly_accessible",
+						},
+					},
+					"publicly_accessible": true,
+				},
+			},
+		},
+	}
+	roundTripped := roundTripDocument(rawDoc)
+
+	fileMetadata := &model.FileMetadata{
+		ID:               "plan",
+		FilePath:         filepath.Join(tmpDir, "plan.tfplan.json"),
+		Kind:             model.KindJSON,
+		Document:         roundTripped,
+		LineInfoDocument: roundTripped,
+	}
+
+	result := detector.DetectLine(ctx, fileMetadata, "module.rds.aws_db_instance.this.publicly_accessible", 3)
+
+	// Should resolve to the module call in main.tf (module declaration line without mappings)
+	if result.ResolvedFile != mainTF {
+		t.Errorf("expected call file %q, got %q", mainTF, result.ResolvedFile)
+	}
+	// Without module mappings to translate the attribute name, resolves to the module declaration line
+	if result.Line != 1 {
+		t.Errorf("expected module declaration line 1, got %d", result.Line)
+	}
+	if result.SecondaryLines != nil {
+		t.Error("expected no SecondaryLines for call origin")
+	}
+}
+
+// TestOriginBranch_AbsentAttribute verifies that when an attribute (e.g. "tags") is completely
+// absent from the module resource's expressions, it is treated as module_hardcoded and the
+// finding resolves to the module definition — not the module call. This covers the case where
+// a module simply never declares an attribute (e.g. no tags block), so the call cannot fix it.
+func TestOriginBranch_AbsentAttribute(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Parent main.tf: module call does not (and cannot) pass tags
+	mainTF := filepath.Join(tmpDir, "main.tf")
+	err := os.WriteFile(mainTF, []byte(`module "asg" {
+  source            = "./modules/asg"
+  security_group_id = ["sg-123"]
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Module definition: resource has no tags attribute at all
+	modulesDir := filepath.Join(tmpDir, "modules", "asg")
+	if err := os.MkdirAll(modulesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	moduleMainTF := filepath.Join(modulesDir, "main.tf")
+	err = os.WriteFile(moduleMainTF, []byte(`resource "aws_launch_template" "this" {
+  name                   = "web"
+  vpc_security_group_ids = var.security_group_id
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reg := registry.New()
+	reg.Register("module.asg", registry.Location{FilePath: mainTF, Line: 1, Column: 1})
+	reg.Register("aws_launch_template.this", registry.Location{FilePath: moduleMainTF, Line: 1, Column: 1})
+
+	ctx := context.Background()
+	detector := NewTFPlanDetectLine(reg, nil)
+
+	// _dd_tf_origin has hints for the attributes that ARE in expressions (name, vpc_security_group_ids),
+	// but NOT for "tags" — because it is absent from the module resource entirely.
+	rawDoc := model.Document{
+		"resource": map[string]interface{}{
+			"aws_launch_template": map[string]interface{}{
+				"module.asg.this": map[string]interface{}{
+					"_dd_tf_address": "module.asg.aws_launch_template.this",
+					"_dd_tf_origin": map[string]interface{}{
+						// "name" is hardcoded in the module ("web")
+						"name": map[string]interface{}{
+							"origin":    "module_hardcoded",
+							"moduleDir": "./modules/asg",
+						},
+						// "vpc_security_group_ids" is set by the call
+						"vpc_security_group_ids": map[string]interface{}{
+							"origin":    "call",
+							"variable":  "security_group_id",
+							"moduleDir": "./modules/asg",
+						},
+						// "tags" is intentionally absent — not in module expressions at all
+					},
+					"name":                   "web",
+					"vpc_security_group_ids": []interface{}{"sg-123"},
+				},
+			},
+		},
+	}
+	roundTripped := roundTripDocument(rawDoc)
+
+	fileMetadata := &model.FileMetadata{
+		ID:               "plan",
+		FilePath:         filepath.Join(tmpDir, "plan.tfplan.json"),
+		Kind:             model.KindJSON,
+		Document:         roundTripped,
+		LineInfoDocument: roundTripped,
+	}
+
+	// searchKey has "tags" attribute — absent from module resource expressions
+	result := detector.DetectLine(ctx, fileMetadata, "aws_launch_template[module.asg.this].tags", 3)
+
+	// Must resolve to the module DEFINITION file (where the fix needs to happen: add a tags block)
+	if result.ResolvedFile != moduleMainTF {
+		t.Errorf("expected module definition %q, got %q", moduleMainTF, result.ResolvedFile)
+	}
+	// Line 1 is the resource block declaration — the attribute line won't be found since tags is absent
+	if result.Line != 1 {
+		t.Errorf("expected resource definition line 1, got %d", result.Line)
+	}
+	// No secondary finding — this is a single-location module_hardcoded finding
+	if result.SecondaryLines != nil {
+		t.Error("expected no SecondaryLines for absent-attribute (module_hardcoded) finding")
+	}
+}
+
+// TestOriginBranch_NestedBlockHardcoded verifies that a hardcoded attribute inside a nested
+// block (e.g. metadata_options { http_endpoint = "enabled" }) is correctly classified as
+// module_hardcoded and resolves to the module definition file.
+func TestOriginBranch_NestedBlockHardcoded(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mainTF := filepath.Join(tmpDir, "main.tf")
+	err := os.WriteFile(mainTF, []byte(`module "ec2" {
+  source     = "./modules/ec2"
+  ami        = "ami-123"
+  http_tokens = "required"
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	modulesDir := filepath.Join(tmpDir, "modules", "ec2")
+	if err := os.MkdirAll(modulesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	moduleMainTF := filepath.Join(modulesDir, "main.tf")
+	err = os.WriteFile(moduleMainTF, []byte(`resource "aws_instance" "this" {
+  ami = var.ami
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = var.http_tokens
+  }
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reg := registry.New()
+	reg.Register("module.ec2", registry.Location{FilePath: mainTF, Line: 1, Column: 1})
+	reg.Register("aws_instance.this", registry.Location{FilePath: moduleMainTF, Line: 1, Column: 1})
+
+	ctx := context.Background()
+	detector := NewTFPlanDetectLine(reg, nil)
+
+	// _dd_tf_origin reflects the nested block classification:
+	// metadata_options.http_endpoint is module_hardcoded (constant "enabled")
+	// metadata_options.http_tokens is call (caller sets it)
+	rawDoc := model.Document{
+		"resource": map[string]interface{}{
+			"aws_instance": map[string]interface{}{
+				"module.ec2.this": map[string]interface{}{
+					"_dd_tf_address": "module.ec2.aws_instance.this",
+					"_dd_tf_origin": map[string]interface{}{
+						"ami": map[string]interface{}{
+							"origin":    "call",
+							"variable":  "ami",
+							"moduleDir": "./modules/ec2",
+						},
+						"metadata_options.http_endpoint": map[string]interface{}{
+							"origin":    "module_hardcoded",
+							"moduleDir": "./modules/ec2",
+						},
+						"metadata_options.http_tokens": map[string]interface{}{
+							"origin":    "call",
+							"variable":  "http_tokens",
+							"moduleDir": "./modules/ec2",
+						},
+					},
+					"ami": "ami-123",
+				},
+			},
+		},
+	}
+	roundTripped := roundTripDocument(rawDoc)
+
+	fileMetadata := &model.FileMetadata{
+		ID:               "plan",
+		FilePath:         filepath.Join(tmpDir, "plan.tfplan.json"),
+		Kind:             model.KindJSON,
+		Document:         roundTripped,
+		LineInfoDocument: roundTripped,
+	}
+
+	// Resource-level finding (no attribute): should pick module_hardcoded as the dominant origin
+	result := detector.DetectLine(ctx, fileMetadata, "aws_instance.{{module.ec2.this}}", 3)
+
+	// Must resolve to the module DEFINITION file
+	if result.ResolvedFile != moduleMainTF {
+		t.Errorf("expected module definition %q, got %q", moduleMainTF, result.ResolvedFile)
+	}
+	if result.SecondaryLines != nil {
+		t.Error("expected no SecondaryLines for module_hardcoded resource-level finding")
+	}
+}

--- a/pkg/detector/tfplan_golden_count_test.go
+++ b/pkg/detector/tfplan_golden_count_test.go
@@ -1,0 +1,214 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com/)  Copyright 2024 Datadog, Inc.
+ */
+package detector
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/registry"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTFPlanGoldenCount_ModuleIndexedResources validates that module resources
+// with count or for_each correctly deduplicate across module instances.
+//
+// This validates the transformation logic that strips indices from module paths.
+func TestTFPlanGoldenCount_ModuleIndexedResources(t *testing.T) {
+	ctx := context.Background()
+
+	// Create registry with module call site (production behavior)
+	reg := registry.New()
+	reg.Register("module.app_servers", registry.Location{
+		FilePath: "main.tf",
+		Line:     10,
+		Column:   1,
+	})
+
+	// Create TFPlan document with TWO module instances
+	tfplanDoc := model.Document{
+		"resource": model.Document{
+			"aws_instance": model.Document{
+				"app_0": model.Document{
+					"_dd_tf_address": "module.app_servers.aws_instance.app", // Normalized
+					"tags": model.Document{
+						"Environment": "prod",
+					},
+				},
+				"app_1": model.Document{
+					"_dd_tf_address": "module.app_servers.aws_instance.app", // Normalized
+					"tags": model.Document{
+						"Environment": "prod",
+					},
+				},
+			},
+		},
+	}
+
+	// Round-trip through JSON
+	jsonBytes, _ := json.Marshal(tfplanDoc)
+	var roundTrippedDoc map[string]interface{}
+	json.Unmarshal(jsonBytes, &roundTrippedDoc)
+
+	fileMetadata := &model.FileMetadata{
+		ID:               "test-tfplan",
+		FilePath:         "plan.tfplan.json",
+		Kind:             model.KindJSON,
+		Document:         roundTrippedDoc,
+		LineInfoDocument: roundTrippedDoc,
+	}
+
+	detector := NewTFPlanDetectLine(reg, nil)
+
+	// Detect line for FIRST module instance
+	result1 := detector.DetectLine(ctx, fileMetadata, "module.app_servers[0].aws_instance.app.tags", 3)
+	// Detect line for SECOND module instance
+	result2 := detector.DetectLine(ctx, fileMetadata, "module.app_servers[1].aws_instance.app.tags", 3)
+
+	// Both should resolve to the SAME module call site
+	require.Equal(t, "main.tf", result1.ResolvedFile, "First module instance should resolve to HCL")
+	require.Equal(t, "main.tf", result2.ResolvedFile, "Second module instance should resolve to HCL")
+	require.Equal(t, 10, result1.Line, "First instance should resolve to module call line")
+	require.Equal(t, 10, result2.Line, "Second instance should resolve to module call line")
+
+	// GOLDEN COUNT ASSERTION: Both module instances point to same location
+	// → Same similarity ID → Deduplicates to 1 finding
+}
+
+// TestTFPlanGoldenCount_PrefixCollisionPrevention validates that resources with
+// similar names don't incorrectly match due to prefix collisions.
+//
+// This is a regression test for Issue #2 from CRITICAL_FIXES_APPLIED.md:
+// "module.x.aws_instance.web" should NOT match "module.x.aws_instance.web_extra"
+func TestTFPlanGoldenCount_PrefixCollisionPrevention(t *testing.T) {
+	ctx := context.Background()
+
+	// Create registry with TWO different resources
+	reg := registry.New()
+	reg.Register("aws_instance.web", registry.Location{
+		FilePath: "main.tf",
+		Line:     1,
+		Column:   1,
+	})
+	reg.Register("aws_instance.web_extra", registry.Location{
+		FilePath: "main.tf",
+		Line:     10,
+		Column:   1,
+	})
+
+	// Create TFPlan document with BOTH resources
+	tfplanDoc := model.Document{
+		"resource": model.Document{
+			"aws_instance": model.Document{
+				"web": model.Document{
+					"_dd_tf_address": "aws_instance.web",
+					"ami":            "ami-111111",
+				},
+				"web_extra": model.Document{
+					"_dd_tf_address": "aws_instance.web_extra",
+					"ami":            "ami-222222",
+				},
+			},
+		},
+	}
+
+	// Round-trip through JSON
+	jsonBytes, _ := json.Marshal(tfplanDoc)
+	var roundTrippedDoc map[string]interface{}
+	json.Unmarshal(jsonBytes, &roundTrippedDoc)
+
+	fileMetadata := &model.FileMetadata{
+		ID:               "test-tfplan",
+		FilePath:         "plan.tfplan.json",
+		Kind:             model.KindJSON,
+		Document:         roundTrippedDoc,
+		LineInfoDocument: roundTrippedDoc,
+	}
+
+	detector := NewTFPlanDetectLine(reg, nil)
+
+	// Detect line for FIRST resource
+	result1 := detector.DetectLine(ctx, fileMetadata, "aws_instance.web.ami", 3)
+	// Detect line for SECOND resource
+	result2 := detector.DetectLine(ctx, fileMetadata, "aws_instance.web_extra.ami", 3)
+
+	// Both should resolve to HCL, but DIFFERENT lines
+	require.Equal(t, "main.tf", result1.ResolvedFile, "First resource should resolve to HCL")
+	require.Equal(t, "main.tf", result2.ResolvedFile, "Second resource should resolve to HCL")
+	require.Equal(t, 1, result1.Line, "First resource should resolve to line 1")
+	require.Equal(t, 10, result2.Line, "Second resource should resolve to line 10")
+
+	// GOLDEN COUNT ASSERTION: Different resources → Different lines → Different similarity IDs → 2 findings
+	require.NotEqual(t, result1.Line, result2.Line, "Different resources must resolve to different lines to prevent over-deduplication")
+}
+
+// TestTFPlanGoldenCount_ModulePrefixCollision validates that module resources
+// with similar paths don't incorrectly match.
+//
+// Example: "module.vpc.aws_instance.web" should NOT match "module.vpc_extra.aws_instance.web"
+func TestTFPlanGoldenCount_ModulePrefixCollision(t *testing.T) {
+	ctx := context.Background()
+
+	// Create registry with TWO different module call sites
+	reg := registry.New()
+	reg.Register("module.vpc", registry.Location{
+		FilePath: "main.tf",
+		Line:     1,
+		Column:   1,
+	})
+	reg.Register("module.vpc_extra", registry.Location{
+		FilePath: "main.tf",
+		Line:     20,
+		Column:   1,
+	})
+
+	// Create TFPlan document with resources in BOTH modules
+	tfplanDoc := model.Document{
+		"resource": model.Document{
+			"aws_instance": model.Document{
+				"web": model.Document{
+					"_dd_tf_address": "module.vpc.aws_instance.web",
+					"ami":            "ami-111111",
+				},
+				"web_extra": model.Document{
+					"_dd_tf_address": "module.vpc_extra.aws_instance.web",
+					"ami":            "ami-222222",
+				},
+			},
+		},
+	}
+
+	// Round-trip through JSON
+	jsonBytes, _ := json.Marshal(tfplanDoc)
+	var roundTrippedDoc map[string]interface{}
+	json.Unmarshal(jsonBytes, &roundTrippedDoc)
+
+	fileMetadata := &model.FileMetadata{
+		ID:               "test-tfplan",
+		FilePath:         "plan.tfplan.json",
+		Kind:             model.KindJSON,
+		Document:         roundTrippedDoc,
+		LineInfoDocument: roundTrippedDoc,
+	}
+
+	detector := NewTFPlanDetectLine(reg, nil)
+
+	// Detect line for FIRST module's resource
+	result1 := detector.DetectLine(ctx, fileMetadata, "module.vpc.aws_instance.web.ami", 3)
+	// Detect line for SECOND module's resource
+	result2 := detector.DetectLine(ctx, fileMetadata, "module.vpc_extra.aws_instance.web.ami", 3)
+
+	// Both should resolve to HCL, but DIFFERENT module call lines
+	require.Equal(t, "main.tf", result1.ResolvedFile, "First module resource should resolve to HCL")
+	require.Equal(t, "main.tf", result2.ResolvedFile, "Second module resource should resolve to HCL")
+	require.Equal(t, 1, result1.Line, "First module should resolve to line 1")
+	require.Equal(t, 20, result2.Line, "Second module should resolve to line 20")
+
+	// GOLDEN COUNT ASSERTION: Different modules → Different lines → 2 findings
+	require.NotEqual(t, result1.Line, result2.Line, "Different modules must resolve to different lines")
+}

--- a/pkg/detector/tfplan_integration_test.go
+++ b/pkg/detector/tfplan_integration_test.go
@@ -1,0 +1,693 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package detector
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/registry"
+)
+
+// TestTFPlanDetectLineWithJSONRoundTrip verifies that address extraction works
+// after JSON round-trips (which convert model.Document to map[string]interface{})
+func TestTFPlanDetectLineWithJSONRoundTrip(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.tf")
+
+	// Write test HCL content
+	hclContent := `resource "aws_instance" "web" {
+  ami           = "ami-123456"
+  instance_type = "t2.micro"
+}
+
+resource "aws_s3_bucket" "data" {
+  bucket = "my-bucket"
+}`
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Create registry and register test addresses
+	reg := registry.New()
+	reg.Register("aws_instance.web", registry.Location{
+		FilePath: testFile,
+		Line:     1,
+		Column:   1,
+	})
+	reg.Register("aws_s3_bucket.data", registry.Location{
+		FilePath: testFile,
+		Line:     6,
+		Column:   1,
+	})
+
+	ctx := context.Background()
+	detector := NewTFPlanDetectLine(reg, nil)
+
+	// Create a mock tfplan document with _dd_tf_address fields
+	// This mimics what parseTFPlan creates
+	mockDocument := model.Document{
+		"resource": model.Document{
+			"aws_instance": model.Document{
+				"web": model.Document{
+					"_dd_tf_address": "aws_instance.web",
+					"ami":            "ami-123456",
+					"instance_type":  "t2.micro",
+				},
+			},
+			"aws_s3_bucket": model.Document{
+				"data": model.Document{
+					"_dd_tf_address": "aws_s3_bucket.data",
+					"bucket":         "my-bucket",
+				},
+			},
+		},
+	}
+
+	// Simulate the JSON round-trip that happens in production
+	// This converts nested model.Document to map[string]interface{}
+	jsonBytes, err := json.Marshal(mockDocument)
+	if err != nil {
+		t.Fatalf("Failed to marshal document: %v", err)
+	}
+
+	var roundTrippedDoc model.Document
+	err = json.Unmarshal(jsonBytes, &roundTrippedDoc)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal document: %v", err)
+	}
+
+	// Create a mock file metadata for tfplan with the round-tripped document
+	fileMetadata := &model.FileMetadata{
+		ID:               "test-file",
+		FilePath:         "test.tfplan.json",
+		Kind:             model.KindJSON,
+		Document:         roundTrippedDoc, // This is now map[string]interface{} nested
+		LineInfoDocument: roundTrippedDoc, // TFPlan detector reads _dd_tf_address from here
+	}
+
+	tests := []struct {
+		name         string
+		searchKey    string
+		expectedLine int
+		expectedFile string
+	}{
+		{
+			name:         "root resource with dot notation",
+			searchKey:    "aws_instance.web.ami",
+			expectedLine: 1,
+			expectedFile: testFile,
+		},
+		{
+			name:         "s3 bucket resource with resource prefix",
+			searchKey:    "resource.aws_s3_bucket.data.bucket",
+			expectedLine: 6,
+			expectedFile: testFile,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detector.DetectLine(ctx, fileMetadata, tt.searchKey, 3)
+			if result.Line != tt.expectedLine {
+				t.Errorf("Expected line %d, got %d", tt.expectedLine, result.Line)
+			}
+			if result.ResolvedFile != tt.expectedFile {
+				t.Errorf("Expected file %s, got %s", tt.expectedFile, result.ResolvedFile)
+			}
+			if result.ResourceSource != tt.expectedFile {
+				t.Errorf("Expected resource source %s, got %s", tt.expectedFile, result.ResourceSource)
+			}
+		})
+	}
+}
+
+// TestTFPlanModuleAttributeMappingIntegration tests the full e2e flow of module attribute mapping
+// This verifies that findings on module resources are correctly mapped to the module input variable line
+func TestTFPlanModuleAttributeMappingIntegration(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	mainFile := filepath.Join(tmpDir, "main.tf")
+
+	// Write main.tf with module declarations
+	mainContent := `module "vpc" {
+  source = "./modules/networking"
+
+  vpc_cidr = "10.0.0.0/16"
+
+  # This is the attribute we expect to find (line 7)
+  resource_tags = {
+    Environment = "production"
+    Team        = "platform"
+  }
+
+  enable_dns_hostnames = true
+}
+
+module "app_servers" {
+  source = "./modules/compute"
+  count  = 2
+
+  instance_type = "t2.micro"
+
+  # This is the attribute we expect to find (line 22)
+  instance_tags = {
+    Environment = "staging"
+    Application = "web"
+  }
+}
+`
+	err := os.WriteFile(mainFile, []byte(mainContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write main.tf: %v", err)
+	}
+
+	// Create registry and register module addresses
+	reg := registry.New()
+	reg.Register("module.vpc", registry.Location{
+		FilePath: mainFile,
+		Line:     1, // Module declaration line
+		Column:   1,
+	})
+	reg.Register("module.app_servers", registry.Location{
+		FilePath: mainFile,
+		Line:     15, // Module declaration line
+		Column:   1,
+	})
+
+	// Create module mappings that simulate what the module parser would generate
+	moduleMappings := map[string]interface{}{
+		"vpc": map[string]interface{}{
+			"AttributesData": map[string]interface{}{
+				"aws": map[string]interface{}{
+					"inputs": map[string]interface{}{
+						"tags": "resource_tags", // tags attribute maps to resource_tags variable
+					},
+				},
+			},
+		},
+		"app_servers": map[string]interface{}{
+			"AttributesData": map[string]interface{}{
+				"aws": map[string]interface{}{
+					"inputs": map[string]interface{}{
+						"tags": "instance_tags", // tags attribute maps to instance_tags variable
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	detector := NewTFPlanDetectLine(reg, moduleMappings)
+
+	// Create a mock tfplan document representing module resources
+	mockDocument := model.Document{
+		"resource": model.Document{
+			"aws_vpc": model.Document{
+				"main": model.Document{
+					"_dd_tf_address": "module.vpc.aws_vpc.main",
+					"cidr_block":     "10.0.0.0/16",
+					"tags": map[string]interface{}{
+						"Environment": "production",
+						"Team":        "platform",
+					},
+				},
+			},
+			"aws_instance": model.Document{
+				"bastion": model.Document{
+					"_dd_tf_address": "module.vpc.aws_instance.bastion",
+					"ami":            "ami-12345678",
+					"instance_type":  "t2.micro",
+					"tags": map[string]interface{}{
+						"Environment": "production",
+						"Team":        "platform",
+					},
+				},
+				"app_0": model.Document{ // Use app_0 instead of app[0] for simpler testing
+					// NORMALIZED address (no [0] index) - matches real tfplan.go behavior at line 96
+					"_dd_tf_address": "module.app_servers.aws_instance.app",
+					"ami":            "ami-87654321",
+					"instance_type":  "t2.micro",
+					"tags": map[string]interface{}{
+						"Environment": "staging",
+						"Application": "web",
+					},
+				},
+				"app_1": model.Document{ // Use app_1 instead of app[1]
+					// NORMALIZED address (no [1] index) - matches real tfplan.go behavior at line 96
+					"_dd_tf_address": "module.app_servers.aws_instance.app",
+					"ami":            "ami-87654321",
+					"instance_type":  "t2.micro",
+					"tags": map[string]interface{}{
+						"Environment": "staging",
+						"Application": "web",
+					},
+				},
+			},
+		},
+	}
+
+	// Simulate JSON round-trip
+	jsonBytes, err := json.Marshal(mockDocument)
+	if err != nil {
+		t.Fatalf("Failed to marshal document: %v", err)
+	}
+
+	var roundTrippedDoc model.Document
+	err = json.Unmarshal(jsonBytes, &roundTrippedDoc)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal document: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		searchKey      string
+		expectedLine   int
+		expectedFile   string
+		description    string
+		tfplanFilePath string // Which tfplan file to use
+	}{
+		{
+			name:           "vpc module resource tags",
+			searchKey:      "aws_vpc.main.tags",
+			expectedLine:   7, // resource_tags line, not module declaration (line 1)
+			expectedFile:   mainFile,
+			description:    "Should map to resource_tags attribute line in module block",
+			tfplanFilePath: filepath.Join(tmpDir, "plan.tfplan.json"),
+		},
+		{
+			name:           "vpc module instance tags",
+			searchKey:      "aws_instance.bastion.tags",
+			expectedLine:   7, // Same resource_tags line
+			expectedFile:   mainFile,
+			description:    "Multiple resources in same module should map to same variable",
+			tfplanFilePath: filepath.Join(tmpDir, "plan.tfplan.json"),
+		},
+		{
+			name:           "app_servers module instance 0",
+			searchKey:      "aws_instance.app_0.tags", // Using app_0 as resource key
+			expectedLine:   22,                        // instance_tags line, not module declaration (line 15)
+			expectedFile:   mainFile,
+			description:    "Should map to instance_tags attribute line for indexed module",
+			tfplanFilePath: filepath.Join(tmpDir, "plan.tfplan.json"),
+		},
+		{
+			name:           "app_servers module instance 1",
+			searchKey:      "aws_instance.app_1.tags", // Using app_1 as resource key
+			expectedLine:   22,                        // Same instance_tags line
+			expectedFile:   mainFile,
+			description:    "Different module instances should map to same variable line",
+			tfplanFilePath: filepath.Join(tmpDir, "plan.tfplan.json"),
+		},
+		// Realistic module-prefixed search keys (as emitted by real rules)
+		{
+			name:           "vpc module with module prefix in searchKey",
+			searchKey:      "module.vpc.aws_instance.bastion.tags",
+			expectedLine:   7, // resource_tags line
+			expectedFile:   mainFile,
+			description:    "Real rule format: module.vpc.aws_instance.bastion.tags",
+			tfplanFilePath: filepath.Join(tmpDir, "plan.tfplan.json"),
+		},
+		{
+			name:           "indexed module with module prefix",
+			searchKey:      "module.app_servers[0].aws_instance.app.tags",
+			expectedLine:   22, // instance_tags line
+			expectedFile:   mainFile,
+			description:    "Real rule format with index: module.app_servers[0].aws_instance.app.tags",
+			tfplanFilePath: filepath.Join(tmpDir, "plan.tfplan.json"),
+		},
+		{
+			name:           "indexed module different instance",
+			searchKey:      "module.app_servers[1].aws_instance.app.tags",
+			expectedLine:   22, // Same instance_tags line (shared variable)
+			expectedFile:   mainFile,
+			description:    "Different indexed module instance should map to same variable",
+			tfplanFilePath: filepath.Join(tmpDir, "plan.tfplan.json"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use specific file metadata for this test
+			testFileMetadata := &model.FileMetadata{
+				ID:               "test-tfplan",
+				FilePath:         tt.tfplanFilePath,
+				Kind:             model.KindJSON,
+				Document:         roundTrippedDoc,
+				LineInfoDocument: roundTrippedDoc,
+			}
+			result := detector.DetectLine(ctx, testFileMetadata, tt.searchKey, 5) // Use larger search range
+
+			if result.ResolvedFile != tt.expectedFile {
+				t.Errorf("Expected file %s, got %s", tt.expectedFile, result.ResolvedFile)
+			}
+
+			if result.Line != tt.expectedLine {
+				t.Errorf("%s: Expected line %d, got %d", tt.description, tt.expectedLine, result.Line)
+			}
+
+			if result.ResourceSource != tt.expectedFile {
+				t.Errorf("Expected resource source %s, got %s", tt.expectedFile, result.ResourceSource)
+			}
+		})
+	}
+}
+
+// TestTFPlanModuleAttributeMappingFallback tests that the detector gracefully falls back
+// when module mappings are not available or incomplete
+func TestTFPlanModuleAttributeMappingFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainFile := filepath.Join(tmpDir, "main.tf")
+
+	mainContent := `module "vpc" {
+  source = "./modules/networking"
+  cidr   = "10.0.0.0/16"
+  tags   = { Environment = "test" }
+}
+`
+	err := os.WriteFile(mainFile, []byte(mainContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write main.tf: %v", err)
+	}
+
+	reg := registry.New()
+	reg.Register("module.vpc", registry.Location{
+		FilePath: mainFile,
+		Line:     1,
+		Column:   1,
+	})
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		moduleMappings map[string]interface{}
+		expectedLine   int
+		description    string
+	}{
+		{
+			name:           "nil module mappings",
+			moduleMappings: nil,
+			expectedLine:   1, // Falls back to module declaration
+			description:    "Should fall back to module declaration when no mappings",
+		},
+		{
+			name:           "empty module mappings",
+			moduleMappings: map[string]interface{}{},
+			expectedLine:   1, // Falls back to module declaration
+			description:    "Should fall back to module declaration when module not in mappings",
+		},
+		{
+			name: "module exists but no attribute mapping",
+			moduleMappings: map[string]interface{}{
+				"vpc": map[string]interface{}{
+					"AttributesData": map[string]interface{}{
+						"aws": map[string]interface{}{
+							"inputs": map[string]interface{}{
+								// No "tags" mapping
+								"cidr": "vpc_cidr",
+							},
+						},
+					},
+				},
+			},
+			expectedLine: 4, // Uses fallback transformation to find attribute line
+			description:  "Should use fallback transformation to find attribute when not in mappings",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detector := NewTFPlanDetectLine(reg, tt.moduleMappings)
+
+			mockDocument := model.Document{
+				"resource": model.Document{
+					"aws_vpc": model.Document{
+						"main": model.Document{
+							"_dd_tf_address": "module.vpc.aws_vpc.main",
+							"cidr_block":     "10.0.0.0/16",
+							"tags": map[string]interface{}{
+								"Environment": "test",
+							},
+						},
+					},
+				},
+			}
+
+			jsonBytes, _ := json.Marshal(mockDocument)
+			var roundTrippedDoc model.Document
+			json.Unmarshal(jsonBytes, &roundTrippedDoc)
+
+			fileMetadata := &model.FileMetadata{
+				ID:               "test-tfplan",
+				FilePath:         filepath.Join(tmpDir, "plan.tfplan.json"),
+				Kind:             model.KindJSON,
+				Document:         roundTrippedDoc,
+				LineInfoDocument: roundTrippedDoc,
+			}
+
+			result := detector.DetectLine(ctx, fileMetadata, "aws_vpc.main.tags", 3)
+
+			if result.Line != tt.expectedLine {
+				t.Errorf("%s: Expected line %d, got %d", tt.description, tt.expectedLine, result.Line)
+			}
+		})
+	}
+}
+
+// TestTFPlanDetector_NoFallbackToPlanJSON is a CRITICAL test that asserts the core promise
+// of the TFPlan feature: findings should NEVER point to .tfplan.json files, they should
+// always resolve to .tf (HCL) source files.
+//
+// This test validates various search key patterns including:
+// - Mixed notation: aws_instance.module.app_servers[0].app
+// - Bracket notation: aws_instance[module.app_servers[0].app]
+// - Template syntax: aws_instance.{{module.app_servers[0].app}}
+// - Nested modules: aws_vpc[module.vpc.main]
+//
+// All patterns should correctly resolve to HCL source files.
+func TestTFPlanDetector_NoFallbackToPlanJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainFile := filepath.Join(tmpDir, "main.tf")
+	planFile := filepath.Join(tmpDir, "plan.tfplan.json")
+
+	// Create realistic HCL with module calls
+	mainContent := `module "vpc" {
+  source = "./modules/networking"
+  vpc_cidr = "10.0.0.0/16"
+  resource_tags = {
+    Environment = "production"
+    Team        = "platform"
+  }
+}
+
+module "app_servers" {
+  source = "./modules/compute"
+  count  = 3
+  instance_type = "t2.micro"
+  instance_tags = {
+    Environment = "staging"
+    Application = "web"
+  }
+}
+
+resource "aws_instance" "web" {
+  ami           = "ami-123456"
+  instance_type = "t2.micro"
+  tags = {
+    Name = "web-server"
+  }
+}
+`
+	err := os.WriteFile(mainFile, []byte(mainContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write main.tf: %v", err)
+	}
+
+	// Create registry with all expected addresses
+	reg := registry.New()
+
+	// Register module calls
+	reg.Register("module.vpc", registry.Location{
+		FilePath: mainFile,
+		Line:     1,
+		Column:   1,
+	})
+	reg.Register("module.app_servers", registry.Location{
+		FilePath: mainFile,
+		Line:     9,
+		Column:   1,
+	})
+
+	// Register root resource
+	reg.Register("aws_instance.web", registry.Location{
+		FilePath: mainFile,
+		Line:     18,
+		Column:   1,
+	})
+
+	// Register ONLY module call sites (as production HCL parser does at terraform.go:248-265)
+	// Production NEVER registers module.vpc.aws_instance.bastion - only module.vpc
+	reg.Register("module.vpc", registry.Location{
+		FilePath: mainFile,
+		Line:     1, // Module call site
+		Column:   1,
+	})
+	reg.Register("module.app_servers", registry.Location{
+		FilePath: mainFile,
+		Line:     9, // Module call site
+		Column:   1,
+	})
+
+	// Create TFPlan document structure (simulating parsed tfplan.json)
+	tfplanDoc := model.Document{
+		"resource": model.Document{
+			"aws_instance": model.Document{
+				"web": model.Document{
+					"_dd_tf_address": "aws_instance.web",
+					"ami":            "ami-123456",
+					"tags": model.Document{
+						"Name": "web-server",
+					},
+				},
+				"bastion": model.Document{
+					"_dd_tf_address": "module.vpc.aws_instance.bastion",
+					"ami":            "ami-789012",
+				},
+				"app_0": model.Document{
+					// NORMALIZED address (no [0] index) - matches real tfplan.go behavior at line 96
+					"_dd_tf_address": "module.app_servers.aws_instance.app",
+					"ami":            "ami-345678",
+				},
+				"app_1": model.Document{
+					// NORMALIZED address (no [1] index) - matches real tfplan.go behavior at line 96
+					"_dd_tf_address": "module.app_servers.aws_instance.app",
+					"ami":            "ami-345678",
+				},
+			},
+			"aws_vpc": model.Document{
+				"main": model.Document{
+					"_dd_tf_address": "module.vpc.aws_vpc.main",
+					"cidr_block":     "10.0.0.0/16",
+				},
+			},
+		},
+	}
+
+	// Round-trip through JSON to simulate real parsing
+	jsonBytes, _ := json.Marshal(tfplanDoc)
+	var roundTrippedDoc map[string]interface{}
+	json.Unmarshal(jsonBytes, &roundTrippedDoc)
+
+	fileMetadata := &model.FileMetadata{
+		ID:               "test-tfplan",
+		FilePath:         planFile,
+		Kind:             model.KindJSON,
+		Document:         roundTrippedDoc,
+		LineInfoDocument: roundTrippedDoc,
+	}
+
+	detector := NewTFPlanDetectLine(reg, nil)
+	ctx := context.Background()
+
+	// Test cases covering all problematic search key patterns
+	tests := []struct {
+		name        string
+		searchKey   string
+		description string
+	}{
+		// Simple cases (should work)
+		{
+			name:        "simple resource",
+			searchKey:   "aws_instance.web.tags",
+			description: "Baseline: simple root resource should resolve to HCL",
+		},
+
+		// Module pattern variations
+		{
+			name:        "mixed notation with module",
+			searchKey:   "aws_instance.module.app_servers[0].app",
+			description: "Mixed notation: module path in middle of search key",
+		},
+		{
+			name:        "bracket notation with module path",
+			searchKey:   "aws_instance[module.app_servers[0].app]",
+			description: "Bracket notation containing full module path",
+		},
+		{
+			name:        "template syntax with module",
+			searchKey:   "aws_instance.{{module.app_servers[0].app}}",
+			description: "Template syntax with module path inside braces",
+		},
+		{
+			name:        "bracket with nested module",
+			searchKey:   "aws_vpc[module.vpc.main]",
+			description: "Bracket notation with simple module path",
+		},
+
+		// Real rule patterns
+		{
+			name:        "indexed module with attribute",
+			searchKey:   "module.app_servers[0].aws_instance.app.tags",
+			description: "Real rule format from production",
+		},
+		{
+			name:        "indexed module different instance",
+			searchKey:   "module.app_servers[1].aws_instance.app.tags",
+			description: "Different module index should also resolve to HCL",
+		},
+		{
+			name:        "module resource with attribute",
+			searchKey:   "module.vpc.aws_instance.bastion.tags",
+			description: "Module resource attribute finding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detector.DetectLine(ctx, fileMetadata, tt.searchKey, 3)
+
+			// CRITICAL ASSERTION: Result must NEVER point to .tfplan.json file
+			if filepath.Ext(result.ResolvedFile) == ".json" {
+				t.Errorf("FAIL: Finding points to JSON file instead of HCL source")
+				t.Errorf("  SearchKey: %s", tt.searchKey)
+				t.Errorf("  ResolvedFile: %s", result.ResolvedFile)
+				t.Errorf("  Expected: %s (or other .tf file)", mainFile)
+				t.Errorf("  Description: %s", tt.description)
+				t.Errorf("  Line: %d", result.Line)
+				t.Errorf("")
+				t.Errorf("  This indicates the detector fell back to default detection,")
+				t.Errorf("  which means the search key parser failed to extract the address.")
+				t.Errorf("")
+			}
+
+			// Also check that we resolved to an actual file (not empty)
+			if result.ResolvedFile == "" {
+				t.Errorf("FAIL: ResolvedFile is empty")
+				t.Errorf("  SearchKey: %s", tt.searchKey)
+				t.Errorf("  Description: %s", tt.description)
+			}
+
+			// Check that we got a valid line number
+			if result.Line <= 0 {
+				t.Errorf("FAIL: Invalid line number %d", result.Line)
+				t.Errorf("  SearchKey: %s", tt.searchKey)
+				t.Errorf("  ResolvedFile: %s", result.ResolvedFile)
+			}
+
+			// Success logging
+			if filepath.Ext(result.ResolvedFile) == ".tf" {
+				t.Logf("✓ Correctly resolved to HCL: %s:%d", filepath.Base(result.ResolvedFile), result.Line)
+			}
+		})
+	}
+}

--- a/pkg/detector/tfplan_nested_module_test.go
+++ b/pkg/detector/tfplan_nested_module_test.go
@@ -1,0 +1,163 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package detector
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/registry"
+)
+
+// TestTFPlanDetectLineNestedModules verifies that nested module resources
+// resolve to top-level module calls when only the top-level is registered
+func TestTFPlanDetectLineNestedModules(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "main.tf")
+
+	// Write test HCL content with a top-level module call
+	hclContent := `module "network" {
+  source = "./modules/network"
+  cidr   = "10.0.0.0/16"
+}`
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Create registry and register only the top-level module call
+	// (not the nested module.subnet)
+	reg := registry.New()
+	reg.Register("module.network", registry.Location{
+		FilePath: testFile,
+		Line:     1,
+		Column:   1,
+	})
+
+	ctx := context.Background()
+	detector := NewTFPlanDetectLine(reg, nil)
+
+	// Create a mock tfplan document with a resource in a nested module
+	// The address is: module.network.module.subnet.aws_subnet.private
+	mockDocument := model.Document{
+		"resource": model.Document{
+			"aws_subnet": model.Document{
+				"module.network.module.subnet.private": model.Document{
+					"_dd_tf_address": "module.network.module.subnet.aws_subnet.private",
+					"cidr_block":     "10.0.1.0/24",
+				},
+			},
+		},
+	}
+
+	// Simulate JSON round-trip
+	jsonBytes, err := json.Marshal(mockDocument)
+	if err != nil {
+		t.Fatalf("Failed to marshal document: %v", err)
+	}
+
+	var roundTrippedDoc model.Document
+	err = json.Unmarshal(jsonBytes, &roundTrippedDoc)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal document: %v", err)
+	}
+
+	// Create file metadata
+	fileMetadata := &model.FileMetadata{
+		ID:               "test-file",
+		FilePath:         "test.tfplan.json",
+		Kind:             model.KindJSON,
+		Document:         roundTrippedDoc,
+		LineInfoDocument: roundTrippedDoc, // TFPlan detector reads _dd_tf_address from here
+	}
+
+	// Test that nested module resource resolves to top-level module call
+	searchKey := "aws_subnet[module.network.module.subnet.private].cidr_block"
+	result := detector.DetectLine(ctx, fileMetadata, searchKey, 3)
+
+	// Should resolve to the top-level module.network call
+	if result.Line != 1 {
+		t.Errorf("Expected line 1 (top-level module call), got %d", result.Line)
+	}
+	if result.ResolvedFile != testFile {
+		t.Errorf("Expected file %s, got %s", testFile, result.ResolvedFile)
+	}
+	if result.ResourceSource != testFile {
+		t.Errorf("Expected resource source %s, got %s", testFile, result.ResourceSource)
+	}
+}
+
+// TestTFPlanDetectLineTripleNestedModules tests that deeply nested modules
+// (e.g., module.a.module.b.module.c) resolve correctly
+func TestTFPlanDetectLineTripleNestedModules(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "main.tf")
+
+	hclContent := `module "env" {
+  source = "./modules/env"
+}`
+	err := os.WriteFile(testFile, []byte(hclContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	reg := registry.New()
+	reg.Register("module.env", registry.Location{
+		FilePath: testFile,
+		Line:     1,
+		Column:   1,
+	})
+
+	ctx := context.Background()
+	detector := NewTFPlanDetectLine(reg, nil)
+
+	// Triple nested: module.env.module.region.module.vpc.aws_vpc.main
+	mockDocument := model.Document{
+		"resource": model.Document{
+			"aws_vpc": model.Document{
+				"module.env.module.region.module.vpc.main": model.Document{
+					"_dd_tf_address": "module.env.module.region.module.vpc.aws_vpc.main",
+					"cidr_block":     "10.0.0.0/16",
+				},
+			},
+		},
+	}
+
+	jsonBytes, err := json.Marshal(mockDocument)
+	if err != nil {
+		t.Fatalf("Failed to marshal document: %v", err)
+	}
+
+	var roundTrippedDoc model.Document
+	err = json.Unmarshal(jsonBytes, &roundTrippedDoc)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal document: %v", err)
+	}
+
+	fileMetadata := &model.FileMetadata{
+		ID:               "test-file",
+		FilePath:         "test.tfplan.json",
+		Kind:             model.KindJSON,
+		Document:         roundTrippedDoc,
+		LineInfoDocument: roundTrippedDoc, // TFPlan detector reads _dd_tf_address from here
+	}
+
+	searchKey := "aws_vpc[module.env.module.region.module.vpc.main].cidr_block"
+	result := detector.DetectLine(ctx, fileMetadata, searchKey, 3)
+
+	// Should resolve to the top-level module.env call
+	if result.Line != 1 {
+		t.Errorf("Expected line 1 (top-level module call), got %d", result.Line)
+	}
+	if result.ResolvedFile != testFile {
+		t.Errorf("Expected file %s, got %s", testFile, result.ResolvedFile)
+	}
+}

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -246,6 +246,10 @@ type Inspector struct {
 	remoteModuleDirs       map[string]RemoteModuleDirectory
 	remoteModuleProvenance map[string]RemoteModuleProvenance
 	externalPathRoots      map[string]bool
+	moduleMappings         map[string]interface{} // Stored after Inspect() for use by tracker
+	// moduleMappingsMu guards moduleMappings for the same reason failedQueriesMu
+	// guards failedQueries: concurrent Inspect() calls can share this Inspector.
+	moduleMappingsMu sync.Mutex
 }
 
 func (c *Inspector) SetRemoteModuleDirectories(sourceToDir map[string]RemoteModuleDirectory) {
@@ -529,6 +533,26 @@ func (c *Inspector) Inspect(
 		return nil, err
 	}
 
+	// Step 3: Convert module mappings to format expected by TFPlanDetectLine and store in inspector
+	moduleMappings := convertModuleMappings(enrichedModules)
+	c.moduleMappingsMu.Lock()
+	c.moduleMappings = moduleMappings
+	c.moduleMappingsMu.Unlock()
+	contextLogger.Info().
+		Int("moduleCount", len(moduleMappings)).
+		Msg("Converted and stored module mappings")
+
+	// Step 4: Set module mappings on tracker so they're available to vulnerability builder
+	// Check if tracker supports module mappings (TFPlanDetectorRegistry interface)
+	if trackerWithMappings, ok := c.tracker.(interface {
+		SetModuleMappings(map[string]interface{})
+	}); ok && len(moduleMappings) > 0 {
+		trackerWithMappings.SetModuleMappings(moduleMappings)
+		contextLogger.Info().
+			Int("moduleCount", len(moduleMappings)).
+			Msg("Set module mappings on tracker for use by vulnerability builder")
+	}
+
 	// Synthetic files stand in for module instantiations of a file that has
 	// already been read; they are only joined once findings need to be
 	// attributed back to a call site. Adding them any earlier would have every
@@ -734,6 +758,90 @@ func (c *Inspector) GetFailedQueries() map[string]error {
 	c.failedQueriesMu.Lock()
 	defer c.failedQueriesMu.Unlock()
 	return maps.Clone(c.failedQueries)
+}
+
+// GetModuleMappings returns the module mappings computed during Inspect().
+// It returns a copy taken under moduleMappingsMu so callers can read the
+// result safely even if a scan is still writing to the underlying map.
+func (c *Inspector) GetModuleMappings() map[string]interface{} {
+	c.moduleMappingsMu.Lock()
+	defer c.moduleMappingsMu.Unlock()
+	return maps.Clone(c.moduleMappings)
+}
+
+// convertModuleMappings converts []ParsedModule to the map format expected by TFPlanDetectLine
+// Expected format: map[moduleKey]->AttributesData->provider->inputs->map[attr]variableName
+//
+// Module key format: For local modules, use just the name since they have unique content per call site.
+// For non-local modules (registry, git), use source+name to handle multiple calls to the same module.
+// This handles collisions where the same module source is called with different names.
+func convertModuleMappings(enrichedModules []tfmodules.ParsedModule) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	// Track which keys we've seen to detect actual collisions
+	seen := make(map[string]string) // key -> module name for debugging
+
+	for i := range enrichedModules {
+		module := &enrichedModules[i]
+		// Convert AttributesData from map[string]ModuleAttributesInfo to map[string]interface{}
+		attributesData := make(map[string]interface{})
+
+		for provider, info := range module.AttributesData {
+			// Convert ModuleAttributesInfo to map[string]interface{}
+			providerData := make(map[string]interface{})
+
+			// Convert Inputs map[string]string to map[string]interface{}
+			inputs := make(map[string]interface{})
+			for k, v := range info.Inputs {
+				inputs[k] = v
+			}
+			providerData["inputs"] = inputs
+
+			// Also include resources for completeness
+			resources := make([]interface{}, len(info.Resources))
+			for i, r := range info.Resources {
+				resources[i] = r
+			}
+			providerData["resources"] = resources
+
+			attributesData[provider] = providerData
+		}
+
+		// Build the module entry
+		moduleEntry := make(map[string]interface{})
+		moduleEntry["AttributesData"] = attributesData
+		moduleEntry["Source"] = module.Source       // Store source for reference
+		moduleEntry["AbsSource"] = module.AbsSource // Store absolute source
+
+		// Determine the key to use:
+		// - For local modules: use name (each call site typically has unique local path)
+		// - For non-local: use source to handle cases where the same registry/git module
+		//   is called multiple times with different names
+		// NOTE: This still has a limitation - if the same local module is called twice
+		// with the same name but in different scopes, they will collide. However, local
+		// modules are typically designed to be called once per scope, and module instances
+		// (count/for_each) share the same variable schema.
+		var key string
+		if module.IsLocal {
+			key = module.Name
+		} else {
+			// For remote modules, use source+name to distinguish different call sites
+			// Using the same remote module source with different names
+			key = module.Source + "::" + module.Name
+		}
+
+		// Check for collisions (primarily for debugging/awareness)
+		if existingName, exists := seen[key]; exists {
+			// This is expected for module instances (count/for_each) which share the schema
+			// but could indicate a real problem for truly different modules
+			_ = existingName // Will be used for logging if needed
+		}
+
+		seen[key] = module.Name
+		result[key] = moduleEntry
+	}
+
+	return result
 }
 
 func ruleArgumentsValue(rc config.IacRuleConfig) (ast.Value, bool, error) {
@@ -979,7 +1087,35 @@ decodeLoop:
 				failedDetectLine = aux
 			}
 			if vulnerability != nil && !aux {
-				vulnerabilities = append(vulnerabilities, *vulnerability)
+				// Fan-out: if the detector produced a secondary location (module_default case),
+				// emit a second finding with the secondary location (e.g. module call block)
+				// alongside the primary (e.g. variable default line). Both are independently actionable.
+				if secondary := vulnerability.SecondaryVulnerabilityLines; secondary != nil {
+					secondaryVuln := *vulnerability
+					secondaryVuln.FileName = secondary.ResolvedFile
+					secondaryVuln.Line = secondary.Line
+					secondaryVuln.VulnerabilityLocation = model.ResourceLocation{
+						Start: secondary.VulnerablilityLocation.Start,
+						End:   secondary.VulnerablilityLocation.End,
+					}
+					secondaryVuln.RemediationLocation = model.ResourceLocation{
+						Start: secondary.RemediationLocation.Start,
+						End:   secondary.RemediationLocation.End,
+					}
+					secondaryVuln.VulnLines = secondary.VulnLines
+					secondaryVuln.ResourceSource = secondary.ResourceSource
+					secondaryVuln.FileSource = secondary.FileSource
+					secondaryVuln.BlockLocation = secondary.BlockLocation
+					if secondary.TransformedSearchKey != "" {
+						secondaryVuln.SearchKey = secondary.TransformedSearchKey
+					}
+					secondaryVuln.SecondaryVulnerabilityLines = nil
+
+					vulnerability.SecondaryVulnerabilityLines = nil
+					vulnerabilities = append(vulnerabilities, *vulnerability, secondaryVuln)
+				} else {
+					vulnerabilities = append(vulnerabilities, *vulnerability)
+				}
 			}
 		}
 	}
@@ -2004,7 +2140,7 @@ func normalizeKeyExpr(expr hclsyntax.Expression) hclsyntax.Expression {
 	expr = hclexpr.Unwrap(expr)
 
 	v := reflect.ValueOf(expr)
-	if v.Kind() == reflect.Ptr && !v.IsNil() {
+	if v.Kind() == reflect.Pointer && !v.IsNil() {
 		elem := v.Elem()
 		if elem.Kind() == reflect.Struct {
 			field := elem.FieldByName("KeyExpr")

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -38,6 +38,8 @@ type FileSystemSourceProvider struct {
 	unfiltered    map[string]struct{}
 }
 
+const jsonExtension = ".json"
+
 var (
 	queryRegexExcludeTerraCache = regexp.MustCompile(fmt.Sprintf(`^(.*?%s)?\.terra.*`, regexp.QuoteMeta(string(os.PathSeparator))))
 	// ErrNotSupportedFile - error representing when a file format is not supported by the scanner
@@ -170,7 +172,7 @@ func (s *FileSystemSourceProvider) AddUnfilteredPaths(paths []string) {
 // the scan pipeline).
 func (s *FileSystemSourceProvider) TerraformFiles(ctx context.Context) ([]string, error) {
 	hclExtensions := model.Extensions{".tf": {}}
-	jsonExtensions := model.Extensions{".json": {}}
+	jsonExtensions := model.Extensions{jsonExtension: {}}
 	seen := make(map[string]struct{})
 	var files []string
 	add := func(path string) {
@@ -220,7 +222,7 @@ func (s *FileSystemSourceProvider) TerraformFiles(ctx context.Context) ([]string
 }
 
 func (s *FileSystemSourceProvider) collectTerraformJSONModuleFiles(ctx context.Context, scanPath string) ([]string, error) {
-	extensions := model.Extensions{".json": {}}
+	extensions := model.Extensions{jsonExtension: {}}
 	var files []string
 	err := s.walkDirectory(ctx, scanPath, extensions,
 		func(ctx context.Context, path string, resolved *[]string) error {

--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/registry"
 	"github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -25,6 +26,15 @@ const (
 	formatFloat64   = 64
 	searchKeyMinLen = 3
 )
+
+// TFPlanDetectorRegistry is an optional interface that Tracker implementations
+// can provide to supply a registry instance for TFPlan detection.
+// If the tracker implements this interface, the vulnerability builder will use
+// the provided registry instead of the global singleton.
+type TFPlanDetectorRegistry interface {
+	GetTFPlanRegistry() *registry.AddressRegistry
+	GetModuleMappings() map[string]interface{} // Returns module mappings for attribute transformation
+}
 
 func modifyVulSearchKeyReference(doc interface{}, originalSearchKey string, stringVulList []string) (string, bool) {
 	for index, vulSplit := range stringVulList {
@@ -61,6 +71,151 @@ func modifyVulSearchKeyReference(doc interface{}, originalSearchKey string, stri
 	return originalSearchKey, false
 }
 
+// resolveVulnerabilityFile validates the raw rego result, merges in query metadata, marshals it
+// for the vulnerability's Output field, resolves the FileMetadata it refers to, and builds the
+// per-finding logger. It also materializes file's LineInfoDocument (lazily populated) once up
+// front, since both searchKey resolution and calculeSearchLine's searchLine resolution need it.
+func resolveVulnerabilityFile(
+	ctx context.Context, qCtx *QueryContext, tracker Tracker, v interface{},
+) (vObj map[string]interface{}, output []byte, file *model.FileMetadata, logWithFields zerolog.Logger, err error) {
+	vObj, ok := v.(map[string]interface{})
+	if !ok {
+		return nil, nil, nil, zerolog.Logger{}, ErrInvalidResult
+	}
+
+	vObj = mergeWithMetadata(vObj, qCtx.Query.Metadata.Metadata)
+
+	output, err = json.Marshal(vObj)
+	if err != nil {
+		return nil, nil, nil, zerolog.Logger{}, errors.Wrap(err, "failed to marshall query output")
+	}
+
+	fileID, err := mapKeyToString(ctx, vObj, "documentId", false)
+	if err != nil {
+		return nil, nil, nil, zerolog.Logger{}, errors.Wrap(err, "failed to recognize file id")
+	}
+
+	file, ok = qCtx.Files[*fileID]
+	if !ok {
+		return nil, nil, nil, zerolog.Logger{}, errors.New("failed to find file from query response")
+	}
+
+	logWithFields = logger.FromContext(ctx).With().
+		Str("scanID", qCtx.scanID).
+		Str("fileName", file.FilePath).
+		Str("queryName", qCtx.Query.Metadata.Query).
+		Logger()
+
+	if err := file.EnsureLineInfoDocument(ctx); err != nil {
+		logWithFields.Err(err).Msg("failed to build line-info document for file")
+		tracker.FailedLineInfoDocument()
+	}
+
+	return vObj, output, file, logWithFields, nil
+}
+
+// resolveSearchKeyAndLines resolves the finding's searchKey (rewriting $ref references, sanitizing
+// INI keys) and then locates its source line, using the TFPlan detector for terraform plan files
+// and the default detector otherwise. Returns noResult=true if the caller should short-circuit
+// with ErrNoResult (a RefMetadata-only searchKey, which carries no actionable line).
+func resolveSearchKeyAndLines(
+	ctx context.Context, tracker Tracker, detector *dec.DetectLine, file *model.FileMetadata,
+	vObj map[string]interface{}, platform, searchKey string, logWithFields *zerolog.Logger,
+) (resolvedSearchKey string, linesVulne model.VulnerabilityLines, noResult bool) {
+	intDoc := file.LineInfoDocument
+	vulsSplit := strings.Split(searchKey, ".")
+
+	if file.Kind == model.KindINI {
+		vulsSplit, searchKey = sanitizeINIKey(vulsSplit)
+	}
+
+	if strings.Contains(vulsSplit[len(vulsSplit)-1], "RefMetadata") {
+		return searchKey, linesVulne, true
+	}
+
+	// modify the search key in cases where it should be referencing a ref instead of part of the resolved object
+	searchKey, _ = modifyVulSearchKeyReference(intDoc, searchKey, vulsSplit)
+	vObj["searchKey"] = searchKey
+
+	// KindForContent (see pkg/parser/json) already refines a real tfplan's Kind to
+	// KindTerraformPlan; anything still KindJSON here is ordinary JSON, not a tfplan,
+	// and must not be routed to the TFPlan detector.
+	isTFPlanFile := file.Kind == model.KindTerraformPlan && strings.EqualFold(platform, "terraform")
+	logWithFields.Debug().
+		Str("file", file.FilePath).
+		Str("fileKind", string(file.Kind)).
+		Str("platform", platform).
+		Bool("isTFPlan", isTFPlanFile).
+		Msg("VulnBuilder: Checking if TFPlan detector should be used")
+
+	if !isTFPlanFile {
+		return searchKey, detector.DetectLine(ctx, file, searchKey), false
+	}
+
+	searchKey, linesVulne = resolveTFPlanSearchKeyAndLines(ctx, tracker, detector, file, vObj, searchKey, logWithFields)
+	return searchKey, linesVulne, false
+}
+
+// resolveTFPlanSearchKeyAndLines runs the TFPlan-specific detector path when the tracker supports
+// it. HCL-address mapping requires the tracker to implement TFPlanDetectorRegistry and expose a
+// non-nil registry; a caller that doesn't need HCL mapping (e.g. the test-rules harness's
+// noopTracker) legitimately has neither, so this falls back to the default detector rather than
+// treating it as an error. On success it also propagates any module-mapping searchKey
+// transformation back into vObj so display, SARIF output, and similarity ID all agree.
+func resolveTFPlanSearchKeyAndLines(
+	ctx context.Context, tracker Tracker, detector *dec.DetectLine, file *model.FileMetadata,
+	vObj map[string]interface{}, searchKey string, logWithFields *zerolog.Logger,
+) (string, model.VulnerabilityLines) {
+	trackerWithRegistry, ok := tracker.(TFPlanDetectorRegistry)
+	if !ok {
+		logWithFields.Debug().
+			Str("file", file.FilePath).
+			Msg("VulnBuilder: Tracker does not support HCL address mapping, using default detector")
+		return searchKey, detector.DetectLine(ctx, file, searchKey)
+	}
+
+	reg := trackerWithRegistry.GetTFPlanRegistry()
+	if reg == nil {
+		logWithFields.Debug().
+			Str("file", file.FilePath).
+			Msg("VulnBuilder: Tracker has no TFPlan registry, using default detector")
+		return searchKey, detector.DetectLine(ctx, file, searchKey)
+	}
+
+	// Get module mappings from tracker (may be nil)
+	moduleMappings := trackerWithRegistry.GetModuleMappings()
+
+	// Create TFPlan detector with registry and module mappings
+	tfplanDetector := dec.NewTFPlanDetectLine(reg, moduleMappings)
+	logWithFields.Debug().
+		Str("file", file.FilePath).
+		Str("searchKey", searchKey).
+		Int("registrySize", reg.GetMappingCount()).
+		Bool("hasModuleMappings", moduleMappings != nil).
+		Msg("VulnBuilder: Using TFPlan detector with instance registry")
+	linesVulne := tfplanDetector.DetectLine(ctx, file, searchKey, tracker.GetOutputLines())
+	logWithFields.Debug().
+		Str("file", file.FilePath).
+		Str("resolvedFile", linesVulne.ResolvedFile).
+		Int("line", linesVulne.Line).
+		Msg("VulnBuilder: TFPlan detector returned result")
+
+	// If the TFPlan detector transformed the searchKey (for module mappings),
+	// use the transformed key for vulnerability display, SARIF output, AND similarity ID.
+	// This ensures that findings pointing to the same HCL line have the same similarity ID,
+	// regardless of the original searchKey format (e.g., module.vpc.aws_instance.web vs aws_instance.web)
+	if linesVulne.TransformedSearchKey != "" {
+		logWithFields.Debug().
+			Str("originalSearchKey", searchKey).
+			Str("transformedSearchKey", linesVulne.TransformedSearchKey).
+			Msg("VulnBuilder: Using transformed searchKey from TFPlan detector")
+		searchKey = linesVulne.TransformedSearchKey
+		vObj["searchKey"] = searchKey
+	}
+
+	return searchKey, linesVulne
+}
+
 // DefaultVulnerabilityBuilder defines a vulnerability builder to execute default actions of scan
 var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 	tracker Tracker,
@@ -68,46 +223,9 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 	detector *dec.DetectLine,
 	useOldSeverities bool,
 	queryDuration time.Duration) (*model.Vulnerability, error) {
-	contextLogger := logger.FromContext(ctx)
-	vObj, ok := v.(map[string]interface{})
-	if !ok {
-		return &model.Vulnerability{}, ErrInvalidResult
-	}
-
-	vObj = mergeWithMetadata(vObj, qCtx.Query.Metadata.Metadata)
-
-	var err error
-	var output []byte
-
-	output, err = json.Marshal(vObj)
+	vObj, output, file, logWithFields, err := resolveVulnerabilityFile(ctx, qCtx, tracker, v)
 	if err != nil {
-		return &model.Vulnerability{}, errors.Wrap(err, "failed to marshall query output")
-	}
-
-	var fileID *string
-
-	fileID, err = mapKeyToString(ctx, vObj, "documentId", false)
-	if err != nil {
-		return &model.Vulnerability{}, errors.Wrap(err, "failed to recognize file id")
-	}
-
-	file, ok := qCtx.Files[*fileID]
-	if !ok {
-		return &model.Vulnerability{}, errors.New("failed to find file from query response")
-	}
-
-	logWithFields := contextLogger.With().
-		Str("scanID", qCtx.scanID).
-		Str("fileName", file.FilePath).
-		Str("queryName", qCtx.Query.Metadata.Query).
-		Logger()
-
-	// LineInfoDocument may be populated lazily (see EnsureLineInfoDocument);
-	// both branches below (searchKey resolution and calculeSearchLine's
-	// searchLine resolution) may need it, so materialize it once up front.
-	if err := file.EnsureLineInfoDocument(ctx); err != nil {
-		logWithFields.Err(err).Msg("failed to build line-info document for file")
-		tracker.FailedLineInfoDocument()
+		return &model.Vulnerability{}, err
 	}
 
 	linesVulne := model.VulnerabilityLines{
@@ -116,24 +234,22 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 		LineWithVulnerability: "",
 	}
 
+	// Extract platform early to determine which detector to use
+	overrideKey := ""
+	if s, ok := vObj["overrideKey"]; ok {
+		overrideKey = s.(string)
+	}
+	platform := getStringFromMap(ctx, "platform", "", overrideKey, vObj, &logWithFields)
+
 	searchKey := ""
 	if s, ok := vObj["searchKey"]; ok {
 		searchKey = s.(string)
-		intDoc := file.LineInfoDocument
-		vulsSplit := strings.Split(searchKey, ".")
-
-		if file.Kind == model.KindINI {
-			vulsSplit, searchKey = sanitizeINIKey(vulsSplit)
-		}
-
-		if strings.Contains(vulsSplit[len(vulsSplit)-1], "RefMetadata") {
+		var noResult bool
+		searchKey, linesVulne, noResult = resolveSearchKeyAndLines(
+			ctx, tracker, detector, file, vObj, platform, searchKey, &logWithFields)
+		if noResult {
 			return &model.Vulnerability{}, ErrNoResult
 		}
-
-		// modify the search key in cases where it should be referencing a ref instead of part of the resolved object
-		searchKey, _ = modifyVulSearchKeyReference(intDoc, searchKey, vulsSplit)
-		vObj["searchKey"] = searchKey
-		linesVulne = detector.DetectLine(ctx, file, searchKey)
 	} else {
 		logWithFields.Error().Msg("Saving result. failed to detect line")
 	}
@@ -142,7 +258,12 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 
 	// terraform detection tries to capture blocks whenever possible which is contradictory with the searchLine
 	// only .tf files use this detection, therefore, terraform plans and cdk (json) are not excluded
-	if !slices.Contains([]model.FileKind{model.KindHELM, model.KindTerraform}, file.Kind) && len(file.ResolvedFiles) == 0 {
+	// Also skip searchLine when TFPlan detector resolved to HCL (ResolvedFile != FilePath)
+	skipSearchLine := slices.Contains([]model.FileKind{model.KindHELM, model.KindTerraform}, file.Kind) ||
+		len(file.ResolvedFiles) > 0 ||
+		linesVulne.ResolvedFile != file.FilePath
+
+	if !skipSearchLine {
 		searchLineCalc := &searchLineCalculator{
 			lineNr:     -1,
 			vObj:       vObj,
@@ -164,12 +285,7 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 		searchValue = s.(string)
 	}
 
-	overrideKey := ""
-	if s, ok := vObj["overrideKey"]; ok {
-		overrideKey = s.(string)
-	}
-
-	platform := getStringFromMap(ctx, "platform", "", overrideKey, vObj, &logWithFields)
+	// overrideKey and platform already extracted above (line 116-120)
 	resourceType := PtrStringToString(mustMapKeyToString(ctx, vObj, "resourceType"))
 	if strings.EqualFold(platform, "ansible") {
 		resourceType = utils.NormalizeAnsibleResourceType(resourceType)
@@ -180,7 +296,7 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 
 	severity := getResolvedSeverity(ctx, vObj, &logWithFields, overrideKey, useOldSeverities)
 
-	return &model.Vulnerability{
+	vuln := &model.Vulnerability{
 		ID:            0,
 		ScanID:        qCtx.scanID,
 		FileID:        file.ID,
@@ -230,7 +346,14 @@ var DefaultVulnerabilityBuilder = func(ctx context.Context, qCtx *QueryContext,
 		),
 		Frameworks: append(extractDefaultFrameworks(ctx, qCtx.Query.Metadata.Metadata, qCtx.FlagEvaluator),
 			extractCustomFrameworks(ctx, qCtx.Query.Metadata.Metadata, qCtx.FlagEvaluator)...),
-	}, nil
+	}
+
+	// Carry the secondary location through so DecodeQueryResults can fan-out a second finding
+	if linesVulne.SecondaryLines != nil {
+		vuln.SecondaryVulnerabilityLines = linesVulne.SecondaryLines
+	}
+
+	return vuln, nil
 }
 
 func extractDefaultFrameworks(ctx context.Context, metadata map[string]interface{},

--- a/pkg/engine/vulnerability_builder_tfplan_test.go
+++ b/pkg/engine/vulnerability_builder_tfplan_test.go
@@ -1,0 +1,449 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com/)  Copyright 2024 Datadog, Inc.
+ */
+package engine
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/detector"
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/registry"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSkipSearchLineWhenTFPlanResolvedToHCL verifies P1 fix:
+// When TFPlan detector resolves to an HCL file, searchLine should be skipped
+// to avoid overwriting the HCL line number with JSON-derived line.
+func TestSkipSearchLineWhenTFPlanResolvedToHCL(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a mock document that simulates JSON round-trip
+	// This ensures nested maps are map[string]interface{}, not model.Document
+	mockDoc := map[string]interface{}{
+		"resource": map[string]interface{}{
+			"aws_instance": map[string]interface{}{
+				"web": map[string]interface{}{
+					"_dd_tf_address": "aws_instance.web",
+					"ami":            "ami-123456",
+					"instance_type":  "t2.micro",
+				},
+			},
+		},
+	}
+
+	// Create a mock file metadata for tfplan. KindTerraformPlan matches what
+	// KindForContent assigns in production for real tfplan JSON.
+	tfplanFile := &model.FileMetadata{
+		ID:               "tfplan-file",
+		FilePath:         "/test/plan.tfplan.json",
+		Kind:             model.KindTerraformPlan,
+		Document:         mockDoc, // Document has _dd_tf_address stripped in real code
+		LineInfoDocument: mockDoc, // LineInfoDocument preserves _dd_tf_address
+	}
+
+	// Create registry with HCL mapping
+	reg := registry.New()
+	reg.Register("aws_instance.web", registry.Location{
+		FilePath: "/test/main.tf",
+		Line:     10,
+		Column:   1,
+	})
+
+	// Create TFPlan detector (no module mappings for this test)
+	tfplanDetector := detector.NewTFPlanDetectLine(reg, nil)
+
+	// Detect line - should resolve to HCL file
+	result := tfplanDetector.DetectLine(ctx, tfplanFile, "aws_instance.web.ami", 3)
+
+	// Verify it resolved to HCL, not tfplan
+	require.Equal(t, "/test/main.tf", result.ResolvedFile, "Should resolve to HCL file")
+	require.Equal(t, 10, result.Line, "Should have HCL line number")
+	require.NotEqual(t, tfplanFile.FilePath, result.ResolvedFile, "Should NOT resolve to tfplan file")
+
+	// The key insight for P1: result.ResolvedFile != tfplanFile.FilePath
+	// This condition is used in vulnerability_builder.go to skip searchLine
+	require.NotEqual(t, result.ResolvedFile, tfplanFile.FilePath,
+		"ResolvedFile should differ from original FilePath when resolved to HCL")
+}
+
+// TestSearchLineSkipCondition verifies the skip condition logic
+func TestSearchLineSkipCondition(t *testing.T) {
+	tests := []struct {
+		name               string
+		fileKind           model.FileKind
+		resolvedFile       string
+		originalFile       string
+		resolvedFilesCount int
+		expectSkip         bool
+	}{
+		{
+			name:               "HELM files always skip",
+			fileKind:           model.KindHELM,
+			resolvedFile:       "same.yaml",
+			originalFile:       "same.yaml",
+			resolvedFilesCount: 0,
+			expectSkip:         true,
+		},
+		{
+			name:               "Terraform files always skip",
+			fileKind:           model.KindTerraform,
+			resolvedFile:       "same.tf",
+			originalFile:       "same.tf",
+			resolvedFilesCount: 0,
+			expectSkip:         true,
+		},
+		{
+			name:               "Files with resolved files skip",
+			fileKind:           model.KindJSON,
+			resolvedFile:       "main.json",
+			originalFile:       "main.json",
+			resolvedFilesCount: 1,
+			expectSkip:         true,
+		},
+		{
+			name:               "TFPlan resolved to HCL skips (P1 fix)",
+			fileKind:           model.KindJSON,
+			resolvedFile:       "main.tf",
+			originalFile:       "plan.tfplan.json",
+			resolvedFilesCount: 0,
+			expectSkip:         true,
+		},
+		{
+			name:               "Regular JSON does not skip",
+			fileKind:           model.KindJSON,
+			resolvedFile:       "config.json",
+			originalFile:       "config.json",
+			resolvedFilesCount: 0,
+			expectSkip:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the skip condition from vulnerability_builder.go
+			skipSearchLine := tt.fileKind == model.KindHELM ||
+				tt.fileKind == model.KindTerraform ||
+				tt.resolvedFilesCount > 0 ||
+				tt.resolvedFile != tt.originalFile
+
+			require.Equal(t, tt.expectSkip, skipSearchLine)
+		})
+	}
+}
+
+// TestTFPlanFallbackBehavior verifies that when no mapping is found,
+// the detector falls back to default detection on the tfplan file
+func TestTFPlanFallbackBehavior(t *testing.T) {
+	ctx := context.Background()
+
+	// Create empty registry (no HCL mappings)
+	reg := registry.New()
+
+	// Create mock document with JSON round-trip structure
+	mockDoc := map[string]interface{}{
+		"resource": map[string]interface{}{
+			"aws_instance": map[string]interface{}{
+				"web": map[string]interface{}{
+					"_dd_tf_address": "aws_instance.web",
+					"ami":            "ami-123456",
+					"instance_type":  "t2.micro",
+				},
+			},
+		},
+	}
+
+	// Create a mock tfplan file. KindTerraformPlan matches what KindForContent
+	// assigns in production for real tfplan JSON.
+	tfplanFile := &model.FileMetadata{
+		ID:                "tfplan-file",
+		FilePath:          "/test/plan.tfplan.json",
+		Kind:              model.KindTerraformPlan,
+		Document:          mockDoc,
+		LineInfoDocument:  mockDoc,
+		LinesOriginalData: createLinesData(),
+	}
+
+	// Create TFPlan detector (no module mappings for this test)
+	tfplanDetector := detector.NewTFPlanDetectLine(reg, nil)
+
+	// Should fall back to default detection since no mapping exists
+	result := tfplanDetector.DetectLine(ctx, tfplanFile, "aws_instance.web.ami", 3)
+
+	// Verify it fell back to tfplan file (not resolved to HCL)
+	require.Equal(t, tfplanFile.FilePath, result.ResolvedFile,
+		"Should fall back to tfplan file when no HCL mapping found")
+
+	// This is the problem: when HCL and tfplan are scanned together but registry is empty,
+	// both will create vulnerabilities with different FileName values, causing duplicates
+}
+
+func createLinesData() *[]string {
+	lines := []string{
+		"{",
+		`  "resource": {`,
+		`    "aws_instance": {`,
+		`      "web": {`,
+		`        "ami": "ami-123456"`,
+		"      }",
+		"    }",
+		"  }",
+		"}",
+	}
+	return &lines
+}
+
+// TestTFPlanTransformedSearchKeyAffectsFingerprint verifies that the fingerprint correctly
+// differentiates distinct resources but produces the same hash for the same canonical resource.
+// This is critical for deduplication: resources reached via different module instances should
+// be distinct findings, but the same resource queried twice should hash identically.
+//
+// The fingerprint uses resourceName (already index-stripped by NormalizeAddress) so indices
+// like [0]/[1] on module paths are handled at the address normalization layer, not here.
+func TestTFPlanTransformedSearchKeyAffectsFingerprint(t *testing.T) {
+	sciInfo := model.SCIInfo{}
+	filePath := "main.tf"
+	queryID := "test-query"
+
+	// Different resource names → different fingerprints (distinct resources)
+	hashWeb := model.GetDatadogFingerprintHash(sciInfo, filePath, "Terraform", "aws_instance", "web", queryID, "", "")
+	hashDB := model.GetDatadogFingerprintHash(sciInfo, filePath, "Terraform", "aws_instance", "db", queryID, "", "")
+	require.NotEqual(t, hashWeb, hashDB,
+		"Different resource names should produce different fingerprints")
+
+	// Same canonical resource name → same fingerprint (deduplication works)
+	hashCanon1 := model.GetDatadogFingerprintHash(sciInfo, filePath, "Terraform", "aws_instance", "web", queryID, "", "")
+	hashCanon2 := model.GetDatadogFingerprintHash(sciInfo, filePath, "Terraform", "aws_instance", "web", queryID, "", "")
+	require.Equal(t, hashCanon1, hashCanon2,
+		"Same resource inputs should produce identical fingerprints")
+
+	// Module call chain differentiates same resource reached via different module paths
+	hashMod1 := model.GetDatadogFingerprintHash(sciInfo, filePath, "Terraform", "aws_instance", "web", queryID, "", "module.vpc")
+	hashMod2 := model.GetDatadogFingerprintHash(sciInfo, filePath, "Terraform", "aws_instance", "web", queryID, "", "module.other")
+	require.NotEqual(t, hashMod1, hashMod2,
+		"Different module call chains should produce different fingerprints")
+
+	t.Logf("✓ Fingerprint differentiates correctly:")
+	t.Logf("  aws_instance.web:  %s", hashWeb[:8]+"...")
+	t.Logf("  aws_instance.db:   %s", hashDB[:8]+"...")
+	t.Logf("  aws_instance.web (via module.vpc):   %s", hashMod1[:8]+"...")
+	t.Logf("  aws_instance.web (via module.other): %s", hashMod2[:8]+"...")
+}
+
+// TestTFPlanCanonicalKeysProduceSameFingerprint validates that the fingerprint produces
+// stable, consistent hashes for canonical resource identities.
+//
+// IMPORTANT: The scanner does NOT deduplicate findings by fingerprint before output.
+// Fingerprints are used for SARIF fingerprinting only. This test validates that:
+// 1. The same resource inputs always produce the same fingerprint (stability)
+// 2. Different resources produce different fingerprints (uniqueness)
+// 3. ResourceName is index-free at fingerprint time (NormalizeAddress strips [N] upstream)
+//
+// ACTUAL BEHAVIOR: Scanning both HCL + TFPlan produces 2 findings (both pointing to HCL).
+// The contract is "remap TFPlan locations to HCL" not "deduplicate findings."
+func TestTFPlanCanonicalKeysProduceSameFingerprint(t *testing.T) {
+	sciInfo := model.SCIInfo{}
+	filePath := "/test/main.tf"
+	queryID := "test-query"
+
+	// ResourceName is normalized by NormalizeAddress before reaching the fingerprint,
+	// so aws_instance.web[0] and aws_instance.web[1] both yield resourceName="web".
+	// The fingerprint therefore produces the same hash for both — stable identity.
+	hashWeb1 := model.GetDatadogFingerprintHash(sciInfo, filePath, "Terraform", "aws_instance", "web", queryID, "", "")
+	hashWeb2 := model.GetDatadogFingerprintHash(sciInfo, filePath, "Terraform", "aws_instance", "web", queryID, "", "")
+	require.Equal(t, hashWeb1, hashWeb2,
+		"Same canonical resource should produce identical fingerprints")
+
+	// A different resource produces a different fingerprint
+	hashDB := model.GetDatadogFingerprintHash(sciInfo, filePath, "Terraform", "aws_instance", "db", queryID, "", "")
+	require.NotEqual(t, hashWeb1, hashDB,
+		"Different resource names should produce different fingerprints")
+
+	t.Logf("✓ CANONICAL FINGERPRINT MECHANISM TEST PASSED:")
+	t.Logf("  aws_instance.web (call 1): %s", hashWeb1[:8]+"...")
+	t.Logf("  aws_instance.web (call 2): %s", hashWeb2[:8]+"...")
+	t.Logf("  aws_instance.db:           %s", hashDB[:8]+"...")
+	t.Logf("  Result: Same resource → same fingerprint, different resource → different fingerprint")
+	t.Logf("  NOTE: Scanner does NOT deduplicate by fingerprint")
+	t.Logf("  ACTUAL: HCL + TFPlan scan → 2 findings, both pointing to HCL")
+}
+
+// mockTrackerWithRegistry implements TFPlanDetectorRegistry for testing
+type mockTrackerWithRegistry struct {
+	registry       *registry.AddressRegistry
+	moduleMappings map[string]interface{}
+	outputLines    int
+}
+
+func (m *mockTrackerWithRegistry) GetTFPlanRegistry() *registry.AddressRegistry {
+	return m.registry
+}
+
+func (m *mockTrackerWithRegistry) GetModuleMappings() map[string]interface{} {
+	return m.moduleMappings
+}
+
+func (m *mockTrackerWithRegistry) GetOutputLines() int {
+	return m.outputLines
+}
+
+func (m *mockTrackerWithRegistry) TrackQueryLoad(int)      {}
+func (m *mockTrackerWithRegistry) TrackQueryExecuting(int) {}
+func (m *mockTrackerWithRegistry) TrackQueryExecution(int) {}
+func (m *mockTrackerWithRegistry) FailedDetectLine()       {}
+func (m *mockTrackerWithRegistry) FailedLineInfoDocument() {}
+
+// noRegistryTracker implements engine.Tracker but not TFPlanDetectorRegistry,
+// mirroring cmd/scanner/test_rules.go's noopTracker.
+type noRegistryTracker struct{}
+
+func (noRegistryTracker) TrackQueryLoad(int)      {}
+func (noRegistryTracker) TrackQueryExecuting(int) {}
+func (noRegistryTracker) TrackQueryExecution(int) {}
+func (noRegistryTracker) FailedDetectLine()       {}
+func (noRegistryTracker) FailedLineInfoDocument() {}
+func (noRegistryTracker) GetOutputLines() int     { return 0 }
+
+// newQueryContextForFile builds a minimal QueryContext/PreparedQuery pair for exercising
+// DefaultVulnerabilityBuilder's file-kind routing with a single file and platform.
+func newQueryContextForFile(file *model.FileMetadata, platform string) *QueryContext {
+	return &QueryContext{
+		scanID: "ScanID",
+		Query: &PreparedQuery{
+			Metadata: model.QueryMetadata{
+				Metadata: map[string]interface{}{
+					"queryName": "TestQuery",
+					"platform":  platform,
+					"searchKey": "aws_instance.web.ami",
+				},
+				Query: "TestQuery",
+			},
+		},
+		Files: map[string]*model.FileMetadata{"file1": file},
+	}
+}
+
+// TestDefaultVulnerabilityBuilder_OnlyRoutesRealTFPlanToDetector verifies that a file whose Kind
+// is still KindJSON (i.e. KindForContent did not recognize it as a real tfplan) is NOT routed to
+// the TFPlan detector, even under the "terraform" platform.
+func TestDefaultVulnerabilityBuilder_OnlyRoutesRealTFPlanToDetector(t *testing.T) {
+	ctx := context.Background()
+	lineDetector := detector.NewDetectLine(0)
+
+	jsonFile := &model.FileMetadata{
+		ID:                "file1",
+		FilePath:          "config.json",
+		Kind:              model.KindJSON,
+		Document:          model.Document{},
+		LineInfoDocument:  model.Document{},
+		LinesOriginalData: &[]string{"{}"},
+	}
+
+	qCtx := newQueryContextForFile(jsonFile, "terraform")
+	vuln, err := DefaultVulnerabilityBuilder(ctx, qCtx, noRegistryTracker{}, map[string]interface{}{
+		"documentId": "file1",
+		"searchKey":  "aws_instance.web.ami",
+	}, lineDetector, false, time.Millisecond)
+
+	require.NoError(t, err)
+	require.Equal(t, jsonFile.FilePath, vuln.FileName,
+		"a non-tfplan KindJSON file should resolve against itself, not attempt HCL mapping")
+}
+
+// TestDefaultVulnerabilityBuilder_TFPlanWithoutRegistrySupportFallsBackQuietly verifies that a
+// genuine tfplan file (KindTerraformPlan) scanned with a tracker that doesn't implement
+// TFPlanDetectorRegistry (e.g. the test-rules harness's noopTracker, or any caller that doesn't
+// need HCL-address mapping) falls back to the default detector WITHOUT logging at error level.
+// Regression test: this fallback is a legitimate, common path — most terraform-platform rule
+// fixtures are themselves tfplan-shaped JSON — not a bug, and must not be logged as one.
+func TestDefaultVulnerabilityBuilder_TFPlanWithoutRegistrySupportFallsBackQuietly(t *testing.T) {
+	var logBuf bytes.Buffer
+	ctx := zerolog.New(&logBuf).WithContext(context.Background())
+	lineDetector := detector.NewDetectLine(0)
+
+	mockDoc := map[string]interface{}{
+		"resource": map[string]interface{}{
+			"aws_instance": map[string]interface{}{
+				"web": map[string]interface{}{
+					"_dd_tf_address": "aws_instance.web",
+					"ami":            "ami-123456",
+				},
+			},
+		},
+	}
+	tfplanFile := &model.FileMetadata{
+		ID:                "file1",
+		FilePath:          "plan.tfplan.json",
+		Kind:              model.KindTerraformPlan,
+		Document:          mockDoc,
+		LineInfoDocument:  mockDoc,
+		LinesOriginalData: &[]string{"{}"},
+	}
+
+	qCtx := newQueryContextForFile(tfplanFile, "terraform")
+	vuln, err := DefaultVulnerabilityBuilder(ctx, qCtx, noRegistryTracker{}, map[string]interface{}{
+		"documentId": "file1",
+		"searchKey":  "aws_instance.web.ami",
+	}, lineDetector, false, time.Millisecond)
+
+	require.NoError(t, err)
+	require.Equal(t, tfplanFile.FilePath, vuln.FileName,
+		"should fall back to the tfplan file itself when the tracker has no registry")
+
+	logs := logBuf.String()
+	require.NotContains(t, logs, "this is a bug",
+		"a tracker without HCL-mapping support is a legitimate caller, not a bug")
+	for _, line := range strings.Split(strings.TrimSpace(logs), "\n") {
+		if strings.Contains(line, "TFPlanDetectorRegistry") || strings.Contains(line, "TFPlan registry") {
+			require.NotContains(t, line, `"level":"error"`,
+				"falling back for a tracker without registry support must not log at error level: %s", line)
+		}
+	}
+}
+
+// TestDefaultVulnerabilityBuilder_RealTFPlanStillRoutesToDetector verifies that a file whose Kind
+// is KindTerraformPlan (the real signal KindForContent assigns for genuine tfplan JSON) still uses
+// the TFPlan detector and resolves through the registry to the mapped HCL location.
+func TestDefaultVulnerabilityBuilder_RealTFPlanStillRoutesToDetector(t *testing.T) {
+	ctx := context.Background()
+	lineDetector := detector.NewDetectLine(0)
+
+	mockDoc := map[string]interface{}{
+		"resource": map[string]interface{}{
+			"aws_instance": map[string]interface{}{
+				"web": map[string]interface{}{
+					"_dd_tf_address": "aws_instance.web",
+					"ami":            "ami-123456",
+				},
+			},
+		},
+	}
+	tfplanFile := &model.FileMetadata{
+		ID:               "file1",
+		FilePath:         "plan.tfplan.json",
+		Kind:             model.KindTerraformPlan,
+		Document:         mockDoc,
+		LineInfoDocument: mockDoc,
+	}
+
+	reg := registry.New()
+	reg.Register("aws_instance.web", registry.Location{FilePath: "main.tf", Line: 10, Column: 1})
+	tracker := &mockTrackerWithRegistry{registry: reg}
+
+	qCtx := newQueryContextForFile(tfplanFile, "terraform")
+	vuln, err := DefaultVulnerabilityBuilder(ctx, qCtx, tracker, map[string]interface{}{
+		"documentId": "file1",
+		"searchKey":  "aws_instance.web.ami",
+	}, lineDetector, false, time.Millisecond)
+
+	require.NoError(t, err)
+	require.Equal(t, "main.tf", vuln.FileName, "a real tfplan file should resolve to its mapped HCL location")
+	require.Equal(t, 10, vuln.Line)
+}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -96,6 +96,13 @@ type VulnerabilityLines struct {
 	ResourceSource         string
 	FileSource             []string
 	BlockLocation          ResourceLocation
+	// TransformedSearchKey is set for TFPlan: the transformed searchKey after module mapping
+	// (e.g., "module.vpc.resource_tags" instead of "module.vpc.aws_instance.web.tags").
+	TransformedSearchKey string
+	// SecondaryLines is set for module_default findings where the insecure default was not
+	// overridden by the module call. Both locations are independently actionable:
+	// the primary points at the variable default in variables.tf, the secondary at the call block.
+	SecondaryLines *VulnerabilityLines
 }
 
 // CommentCommand represents a command given from a comment
@@ -303,6 +310,10 @@ type Vulnerability struct {
 	ModuleCallChain string `json:"moduleCallChain,omitempty"`
 	// ModuleAttribution: declaration and body locations for instantiated module findings.
 	ModuleAttribution *ModuleAttribution `json:"-"`
+	// SecondaryVulnerabilityLines is set transiently when a module_default finding has two
+	// independently actionable locations (variable default + module call block). The engine
+	// decode loop emits a second Vulnerability from this field. Not persisted to DB/JSON.
+	SecondaryVulnerabilityLines *VulnerabilityLines `json:"-" db:"-"`
 }
 
 // Framework represents a framework mapping for a query

--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/registry"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hcl_plan "github.com/hashicorp/terraform-json"
@@ -389,6 +390,15 @@ func readPlan(
 		kp.readPriorStateData(plan.PriorState.Values.RootModule, "", resourceLines, deletedAddresses(plan.ResourceChanges))
 	}
 
+	// Derive per-attribute origin hints from the plan's configuration section.
+	// This tells the detector whether a faulty attribute came from the call site,
+	// is hardcoded in the module definition, or uses an insecure variable default.
+	if plan.Config != nil && plan.Config.RootModule != nil {
+		origins := make(map[string]map[string]interface{})
+		annotateOriginsFromConfig(plan.Config.RootModule, "", origins)
+		attachOriginHints(kp.Resource, origins)
+	}
+
 	doc := model.Document{}
 
 	tmpDocBytes, err := json.Marshal(kp)
@@ -401,6 +411,157 @@ func readPlan(
 	}
 
 	return doc
+}
+
+// annotateOriginsFromConfig recursively walks the plan's configuration module tree and builds
+// a map of normalizedResourceAddr -> attrName -> origin hint.
+// origins is keyed by the same normalized address stored in _dd_tf_address.
+func annotateOriginsFromConfig(cfg *hcl_plan.ConfigModule, moduleAddr string, origins map[string]map[string]interface{}) {
+	if cfg == nil {
+		return
+	}
+
+	for callName, mc := range cfg.ModuleCalls {
+		if mc == nil {
+			continue
+		}
+
+		// Build child module address matching the _dd_tf_address format
+		var childAddr string
+		if moduleAddr == "" {
+			childAddr = "module." + callName
+		} else {
+			childAddr = moduleAddr + ".module." + callName
+		}
+		childDir := mc.Source
+
+		if mc.Module == nil {
+			continue
+		}
+
+		// Classify each attribute on each resource in this module
+		for _, r := range mc.Module.Resources {
+			if r == nil {
+				continue
+			}
+			// Build the normalized resource address (no indices)
+			resourceAddr := registry.NormalizeAddress(childAddr + "." + r.Type + "." + r.Name)
+
+			classifyResourceExpressions(r.Expressions, mc, resourceAddr, childDir, "", origins)
+		}
+
+		// Recurse into nested modules
+		annotateOriginsFromConfig(mc.Module, childAddr, origins)
+	}
+}
+
+// classifyResourceExpressions classifies all attributes in a resource's Expressions map,
+// including recursing into NestedBlocks (e.g. metadata_options { http_endpoint = "enabled" }).
+// attrPrefix is the dotted prefix accumulated through recursion (e.g. "metadata_options").
+func classifyResourceExpressions(
+	expressions map[string]*hcl_plan.Expression,
+	mc *hcl_plan.ModuleCall,
+	resourceAddr string,
+	moduleDir string,
+	attrPrefix string,
+	origins map[string]map[string]interface{},
+) {
+	for attrName, expr := range expressions {
+		if expr == nil {
+			continue
+		}
+
+		// Build the full dotted attribute key for nested attributes
+		fullAttr := attrName
+		if attrPrefix != "" {
+			fullAttr = attrPrefix + "." + attrName
+		}
+
+		// Handle nested blocks: recurse into each block's sub-expressions
+		if len(expr.NestedBlocks) > 0 {
+			for _, block := range expr.NestedBlocks {
+				classifyResourceExpressions(block, mc, resourceAddr, moduleDir, fullAttr, origins)
+			}
+			continue
+		}
+
+		origin, varName := classifyExpression(expr, mc)
+		if origin == "" {
+			continue
+		}
+
+		if origins[resourceAddr] == nil {
+			origins[resourceAddr] = make(map[string]interface{})
+		}
+		hint := map[string]interface{}{
+			"origin":    origin,
+			"moduleDir": moduleDir,
+		}
+		if varName != "" {
+			hint["variable"] = varName
+		}
+		origins[resourceAddr][fullAttr] = hint
+	}
+}
+
+// classifyExpression determines the origin of an attribute expression:
+//   - "call" if the call site explicitly sets the variable
+//   - "module_default" if the attribute references a variable the call does not set
+//   - "module_hardcoded" if the attribute has a constant value with no variable reference
+//
+// Returns ("", "") if the expression cannot be classified (computed/unknown).
+// NOTE: References must be checked before ConstantValue because when References is non-empty
+// the terraform-json library sets ConstantValue = UnknownConstantValue.
+func classifyExpression(expr *hcl_plan.Expression, mc *hcl_plan.ModuleCall) (origin, varName string) {
+	if expr == nil || expr.ExpressionData == nil {
+		return "", ""
+	}
+
+	if len(expr.References) > 0 {
+		// Find a "var." reference — the attribute is driven by a module input variable
+		for _, ref := range expr.References {
+			if strings.HasPrefix(ref, "var.") {
+				v := strings.TrimPrefix(ref, "var.")
+				// Check whether the call site explicitly passes this variable
+				if mc.Expressions != nil {
+					if _, callSets := mc.Expressions[v]; callSets {
+						return "call", v
+					}
+				}
+				// Call omits it — insecure module default will apply
+				return "module_default", v
+			}
+		}
+		// References exist but none are var.* — computed/unknown, don't annotate
+		return "", ""
+	}
+
+	// No references: value is a constant hardcoded in the module definition
+	if expr.ConstantValue != nil {
+		return "module_hardcoded", ""
+	}
+
+	return "", ""
+}
+
+// attachOriginHints writes _dd_tf_origin onto each resource's AttributeValues by
+// matching its _dd_tf_address against the origins map built from plan.Config.
+func attachOriginHints(resources map[string]TFPlanResource, origins map[string]map[string]interface{}) {
+	for _, typeMap := range resources {
+		for _, res := range typeMap {
+			namedResource, ok := res.(TFPlanNamedResource)
+			if !ok {
+				continue
+			}
+			addr, ok := namedResource["_dd_tf_address"].(string)
+			if !ok || addr == "" {
+				continue
+			}
+			if hints, found := origins[addr]; found {
+				namedResource["_dd_tf_origin"] = hints
+			}
+		}
+	}
 }
 
 // readModule recursively accumulates resources from every module into the
@@ -427,6 +588,19 @@ func (kp *TFPlan) readModule(
 		if resource.Index != nil {
 			resourceKey = formatResourceKeyWithIndex(resourceKey, resource.Index)
 		}
+
+		// Build the full terraform address (type.name) and normalize away
+		// count/for_each indices so it matches HCL-registered addresses.
+		fullAddress := resource.Type + "." + resource.Name
+		if moduleAddress != "" {
+			fullAddress = moduleAddress + "." + resource.Type + "." + resource.Name
+		}
+		normalizedAddress := registry.NormalizeAddress(fullAddress)
+
+		if resource.AttributeValues == nil {
+			resource.AttributeValues = make(map[string]interface{})
+		}
+		resource.AttributeValues["_dd_tf_address"] = normalizedAddress
 
 		typeRes[resourceKey] = TFPlanNamedResource(resource.AttributeValues)
 

--- a/pkg/parser/json/tfplan_test.go
+++ b/pkg/parser/json/tfplan_test.go
@@ -57,8 +57,9 @@ func TestJson_parseTFPlan(t *testing.T) {
 				"resource": map[string]interface{}{
 					"fakewebservices_database": map[string]interface{}{
 						"prod_db": map[string]interface{}{
-							"name": "Production DB",
-							"size": (float64)(256),
+							"_dd_tf_address": "fakewebservices_database.prod_db",
+							"name":           "Production DB",
+							"size":           (float64)(256),
 						},
 					},
 				},
@@ -137,7 +138,8 @@ func TestJson_parseTFPlan(t *testing.T) {
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
 						"main": map[string]interface{}{
-							"bucket": "main-bucket",
+							"bucket":         "main-bucket",
+							"_dd_tf_address": "aws_s3_bucket.main",
 						},
 					},
 				},
@@ -262,17 +264,20 @@ func TestJson_parseTFPlan(t *testing.T) {
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
 						"main": map[string]interface{}{
-							"bucket": "main-bucket",
-							"acl":    "private",
+							"_dd_tf_address": "aws_s3_bucket.main",
+							"bucket":         "main-bucket",
+							"acl":            "private",
 						},
 						"module.storage.backup": map[string]interface{}{
-							"bucket": "backup-bucket",
-							"acl":    "private",
+							"_dd_tf_address": "module.storage.aws_s3_bucket.backup",
+							"bucket":         "backup-bucket",
+							"acl":            "private",
 						},
 					},
 					"aws_instance": map[string]interface{}{
 						"web": map[string]interface{}{
-							"instance_type": "t2.micro",
+							"_dd_tf_address": "aws_instance.web",
+							"instance_type":  "t2.micro",
 						},
 					},
 				},
@@ -343,13 +348,15 @@ func TestJson_parseTFPlan(t *testing.T) {
 				"resource": map[string]interface{}{
 					"aws_instance": map[string]interface{}{
 						"web": map[string]interface{}{
-							"instance_type": "t2.large",
+							"_dd_tf_address": "aws_instance.web",
+							"instance_type":  "t2.large",
 							"tags": map[string]interface{}{
 								"Environment": "production",
 							},
 						},
 						"module.staging.web": map[string]interface{}{
-							"instance_type": "t2.micro",
+							"_dd_tf_address": "module.staging.aws_instance.web",
+							"instance_type":  "t2.micro",
 							"tags": map[string]interface{}{
 								"Environment": "staging",
 							},
@@ -428,17 +435,20 @@ func TestJson_parseTFPlan(t *testing.T) {
 				"resource": map[string]interface{}{
 					"aws_vpc": map[string]interface{}{
 						"main": map[string]interface{}{
-							"cidr_block": "10.0.0.0/16",
+							"_dd_tf_address": "aws_vpc.main",
+							"cidr_block":     "10.0.0.0/16",
 						},
 					},
 					"aws_subnet": map[string]interface{}{
 						"module.networking.public": map[string]interface{}{
-							"cidr_block": "10.0.1.0/24",
+							"_dd_tf_address": "module.networking.aws_subnet.public",
+							"cidr_block":     "10.0.1.0/24",
 						},
 					},
 					"aws_security_group": map[string]interface{}{
 						"module.networking.module.security.web": map[string]interface{}{
-							"description": "Web traffic",
+							"_dd_tf_address": "module.networking.module.security.aws_security_group.web",
+							"description":    "Web traffic",
 						},
 					},
 				},
@@ -509,10 +519,12 @@ func TestJson_parseTFPlan(t *testing.T) {
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
 						"module.app1.data": map[string]interface{}{
-							"bucket": "app1-data",
+							"_dd_tf_address": "module.app1.aws_s3_bucket.data",
+							"bucket":         "app1-data",
 						},
 						"module.app2.data": map[string]interface{}{
-							"bucket": "app2-data",
+							"_dd_tf_address": "module.app2.aws_s3_bucket.data",
+							"bucket":         "app2-data",
 						},
 					},
 				},
@@ -589,21 +601,24 @@ func TestJson_parseTFPlan(t *testing.T) {
 				"resource": map[string]interface{}{
 					"aws_instance": map[string]interface{}{
 						"web[0]": map[string]interface{}{
-							"instance_type": "t2.micro",
+							"_dd_tf_address": "aws_instance.web",
+							"instance_type":  "t2.micro",
 							"tags": map[string]interface{}{
 								"Name":  "web-0",
 								"Index": float64(0),
 							},
 						},
 						"web[1]": map[string]interface{}{
-							"instance_type": "t2.micro",
+							"_dd_tf_address": "aws_instance.web",
+							"instance_type":  "t2.micro",
 							"tags": map[string]interface{}{
 								"Name":  "web-1",
 								"Index": float64(1),
 							},
 						},
 						"web[2]": map[string]interface{}{
-							"instance_type": "t2.micro",
+							"_dd_tf_address": "aws_instance.web",
+							"instance_type":  "t2.micro",
 							"tags": map[string]interface{}{
 								"Name":  "web-2",
 								"Index": float64(2),
@@ -678,16 +693,19 @@ func TestJson_parseTFPlan(t *testing.T) {
 				"resource": map[string]interface{}{
 					"aws_s3_bucket": map[string]interface{}{
 						"data[\"prod\"]": map[string]interface{}{
-							"bucket": "prod-data-bucket",
-							"acl":    "private",
+							"_dd_tf_address": "aws_s3_bucket.data",
+							"bucket":         "prod-data-bucket",
+							"acl":            "private",
 						},
 						"data[\"staging\"]": map[string]interface{}{
-							"bucket": "staging-data-bucket",
-							"acl":    "private",
+							"_dd_tf_address": "aws_s3_bucket.data",
+							"bucket":         "staging-data-bucket",
+							"acl":            "private",
 						},
 						"data[\"dev\"]": map[string]interface{}{
-							"bucket": "dev-data-bucket",
-							"acl":    "private",
+							"_dd_tf_address": "aws_s3_bucket.data",
+							"bucket":         "dev-data-bucket",
+							"acl":            "private",
 						},
 					},
 				},
@@ -751,8 +769,9 @@ func TestJson_parseTFPlan(t *testing.T) {
 							"_dd_prod_db": map[string]any{"_dd_line": (float64)(7)},
 						},
 						"prod_db": map[string]any{
-							"name": "Production DB",
-							"size": (float64)(256),
+							"name":           "Production DB",
+							"size":           (float64)(256),
+							"_dd_tf_address": "fakewebservices_database.prod_db",
 						},
 					},
 				},
@@ -2060,4 +2079,335 @@ func TestJson_parseTFPlan_dd_tfplan_meta_call_site_chain_grows_linearly_not_expo
 		depth, full, depth/2, half)
 	require.Less(t, full, 100,
 		"call_site_expressions should stay proportional to the number of real call sites (depth=%d), not explode to %d", depth, full)
+}
+
+// TestOriginHints_FromPlanConfig verifies that _dd_tf_origin is correctly derived from
+// the plan's configuration section and embedded alongside _dd_tf_address.
+func TestOriginHints_FromPlanConfig(t *testing.T) {
+	// Build a minimal plan document that exercises all three origin cases:
+	// 1. module_hardcoded: attribute has a constant value in the module resource
+	// 2. call: attribute references a variable that the call site sets
+	// 3. module_default: attribute references a variable that the call site omits
+	doc := model.Document{
+		"format_version":    "1.0",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"child_modules": []interface{}{
+					map[string]interface{}{
+						"address": "module.rds",
+						"resources": []interface{}{
+							map[string]interface{}{
+								"address": "module.rds.aws_db_instance.this",
+								"mode":    "managed",
+								"type":    "aws_db_instance",
+								"name":    "this",
+								"values": map[string]interface{}{
+									"publicly_accessible": false,
+									"storage_encrypted":   true,
+									"identifier":          "app-db",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"module_calls": map[string]interface{}{
+					"rds": map[string]interface{}{
+						"source": "./modules/rds",
+						// Call sets storage_encrypted but omits publicly_accessible
+						"expressions": map[string]interface{}{
+							"storage_encrypted": map[string]interface{}{
+								"constant_value": true,
+							},
+						},
+						"module": map[string]interface{}{
+							"resources": []interface{}{
+								map[string]interface{}{
+									"address": "aws_db_instance.this",
+									"type":    "aws_db_instance",
+									"name":    "this",
+									"expressions": map[string]interface{}{
+										// module_hardcoded: literal constant, no variable reference
+										"identifier": map[string]interface{}{
+											"constant_value": "hardcoded-db",
+										},
+										// call: references a variable that the call sets
+										"storage_encrypted": map[string]interface{}{
+											"references": []interface{}{"var.storage_encrypted"},
+										},
+										// module_default: references a variable the call does NOT set
+										"publicly_accessible": map[string]interface{}{
+											"references": []interface{}{"var.publicly_accessible"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	// Navigate to the resource
+	resourceSection, ok := got["resource"]
+	require.True(t, ok, "expected 'resource' key in document")
+	resourceMap, ok := resourceSection.(map[string]interface{})
+	require.True(t, ok)
+	dbSection, ok := resourceMap["aws_db_instance"]
+	require.True(t, ok, "expected aws_db_instance in resource map")
+	dbMap, ok := dbSection.(map[string]interface{})
+	require.True(t, ok)
+
+	// Find the module.rds instance (stored under a key containing the module path)
+	var attrs map[string]interface{}
+	for _, v := range dbMap {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if addr, _ := m["_dd_tf_address"].(string); addr == "module.rds.aws_db_instance.this" {
+			attrs = m
+			break
+		}
+	}
+	require.NotNil(t, attrs, "could not find module.rds.aws_db_instance.this in resource map")
+
+	// _dd_tf_origin must be present
+	originRaw, ok := attrs["_dd_tf_origin"]
+	require.True(t, ok, "_dd_tf_origin should be attached to the resource")
+	originMap, ok := originRaw.(map[string]interface{})
+	require.True(t, ok)
+
+	getHint := func(attr string) map[string]interface{} {
+		h, ok := originMap[attr]
+		require.True(t, ok, "origin hint missing for attribute %q", attr)
+		m, ok := h.(map[string]interface{})
+		require.True(t, ok)
+		return m
+	}
+
+	// 1. identifier: hardcoded constant in module resource
+	identHint := getHint("identifier")
+	require.Equal(t, "module_hardcoded", identHint["origin"])
+	require.Equal(t, "./modules/rds", identHint["moduleDir"])
+
+	// 2. storage_encrypted: variable reference, call sets it
+	encHint := getHint("storage_encrypted")
+	require.Equal(t, "call", encHint["origin"])
+
+	// 3. publicly_accessible: variable reference, call omits it
+	pubHint := getHint("publicly_accessible")
+	require.Equal(t, "module_default", pubHint["origin"])
+	require.Equal(t, "publicly_accessible", pubHint["variable"])
+	require.Equal(t, "./modules/rds", pubHint["moduleDir"])
+}
+
+// TestOriginHints_AbsentAttribute verifies that when a module resource has no "tags" attribute
+// in its expressions, the parser still populates _dd_tf_origin for the attributes it does know
+// about (so the detector can detect the absent-attribute case at query time).
+func TestOriginHints_AbsentAttribute(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.0",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"child_modules": []interface{}{
+					map[string]interface{}{
+						"address": "module.asg",
+						"resources": []interface{}{
+							map[string]interface{}{
+								"address": "module.asg.aws_launch_template.this",
+								"mode":    "managed",
+								"type":    "aws_launch_template",
+								"name":    "this",
+								"values": map[string]interface{}{
+									"name":                   "web",
+									"vpc_security_group_ids": []interface{}{"sg-123"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"module_calls": map[string]interface{}{
+					"asg": map[string]interface{}{
+						"source": "./modules/asg",
+						"expressions": map[string]interface{}{
+							"security_group_id": map[string]interface{}{
+								"constant_value": []interface{}{"sg-123"},
+							},
+						},
+						"module": map[string]interface{}{
+							"resources": []interface{}{
+								map[string]interface{}{
+									"address": "aws_launch_template.this",
+									"type":    "aws_launch_template",
+									"name":    "this",
+									"expressions": map[string]interface{}{
+										// "name" is hardcoded — no variable
+										"name": map[string]interface{}{
+											"constant_value": "web",
+										},
+										// "vpc_security_group_ids" is driven by a variable the call sets
+										"vpc_security_group_ids": map[string]interface{}{
+											"references": []interface{}{"var.security_group_id"},
+										},
+										// "tags" is intentionally absent — the module resource never declares it
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	// Navigate to the resource
+	resourceSection := got["resource"].(map[string]interface{})
+	ltSection := resourceSection["aws_launch_template"].(map[string]interface{})
+
+	var attrs map[string]interface{}
+	for _, v := range ltSection {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if addr, _ := m["_dd_tf_address"].(string); addr == "module.asg.aws_launch_template.this" {
+			attrs = m
+			break
+		}
+	}
+	require.NotNil(t, attrs)
+
+	// _dd_tf_origin must be present (populated for the attributes that ARE declared)
+	originRaw, ok := attrs["_dd_tf_origin"]
+	require.True(t, ok, "_dd_tf_origin should be present")
+	originMap := originRaw.(map[string]interface{})
+
+	// "name" should be module_hardcoded (constant in module resource)
+	nameHint := originMap["name"].(map[string]interface{})
+	require.Equal(t, "module_hardcoded", nameHint["origin"])
+	require.Equal(t, "./modules/asg", nameHint["moduleDir"])
+
+	// "vpc_security_group_ids" should be call (call sets security_group_id)
+	sgHint := originMap["vpc_security_group_ids"].(map[string]interface{})
+	require.Equal(t, "call", sgHint["origin"])
+
+	// "tags" must NOT appear in the origin map — its absence is what the detector checks at query time
+	_, tagsPresent := originMap["tags"]
+	require.False(t, tagsPresent, "tags should be absent from _dd_tf_origin since it is not declared in the module resource")
+}
+
+// TestOriginHints_NestedBlocks verifies that hardcoded attributes inside nested blocks
+// (e.g. metadata_options { http_endpoint = "enabled" }) are classified correctly.
+func TestOriginHints_NestedBlocks(t *testing.T) {
+	doc := model.Document{
+		"format_version":    "1.0",
+		"terraform_version": "1.5.0",
+		"planned_values": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"child_modules": []interface{}{
+					map[string]interface{}{
+						"address": "module.ec2",
+						"resources": []interface{}{
+							map[string]interface{}{
+								"address": "module.ec2.aws_instance.this",
+								"mode":    "managed",
+								"type":    "aws_instance",
+								"name":    "this",
+								"values":  map[string]interface{}{"ami": "ami-123"},
+							},
+						},
+					},
+				},
+			},
+		},
+		"configuration": map[string]interface{}{
+			"root_module": map[string]interface{}{
+				"module_calls": map[string]interface{}{
+					"ec2": map[string]interface{}{
+						"source": "./modules/ec2",
+						"expressions": map[string]interface{}{
+							"ami":         map[string]interface{}{"constant_value": "ami-123"},
+							"http_tokens": map[string]interface{}{"constant_value": "required"},
+						},
+						"module": map[string]interface{}{
+							"resources": []interface{}{
+								map[string]interface{}{
+									"address": "aws_instance.this",
+									"type":    "aws_instance",
+									"name":    "this",
+									"expressions": map[string]interface{}{
+										"ami": map[string]interface{}{
+											"references": []interface{}{"var.ami"},
+										},
+										// metadata_options is a nested block — expressed as a list of maps
+										"metadata_options": []interface{}{
+											map[string]interface{}{
+												"http_endpoint": map[string]interface{}{
+													"constant_value": "enabled",
+												},
+												"http_tokens": map[string]interface{}{
+													"references": []interface{}{"var.http_tokens"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := parseTFPlan(doc)
+	require.NoError(t, err)
+
+	resourceSection := got["resource"].(map[string]interface{})
+	instanceSection := resourceSection["aws_instance"].(map[string]interface{})
+
+	var attrs map[string]interface{}
+	for _, v := range instanceSection {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if addr, _ := m["_dd_tf_address"].(string); addr == "module.ec2.aws_instance.this" {
+			attrs = m
+			break
+		}
+	}
+	require.NotNil(t, attrs)
+
+	originMap := attrs["_dd_tf_origin"].(map[string]interface{})
+
+	// ami is set by call
+	amiHint := originMap["ami"].(map[string]interface{})
+	require.Equal(t, "call", amiHint["origin"])
+
+	// metadata_options.http_endpoint is hardcoded in the module
+	httpEndpointHint := originMap["metadata_options.http_endpoint"].(map[string]interface{})
+	require.Equal(t, "module_hardcoded", httpEndpointHint["origin"])
+	require.Equal(t, "./modules/ec2", httpEndpointHint["moduleDir"])
+
+	// metadata_options.http_tokens is set by call
+	httpTokensHint := originMap["metadata_options.http_tokens"].(map[string]interface{})
+	require.Equal(t, "call", httpTokensHint["origin"])
 }

--- a/pkg/parser/terraform/data_source.go
+++ b/pkg/parser/terraform/data_source.go
@@ -29,6 +29,9 @@ import (
 // still matches the block type exactly below.
 const iamPolicyDocumentType = "aws_iam_policy_document"
 
+// specFieldType is the hcldec object-spec key/attribute name for a principal's "type" field.
+const specFieldType = "type"
+
 var iamPolicyDocumentTypeMarker = []byte(iamPolicyDocumentType)
 
 // iamPolicyDocumentTypePrefix catches HCL unicode-escaped spellings such as
@@ -227,8 +230,8 @@ func decodeDataSourcePolicy(ctx context.Context, value cty.Value) dataSourcePoli
 
 func getPrincipalSpec() *hcldec.ObjectSpec {
 	return &hcldec.ObjectSpec{
-		"type": &hcldec.AttrSpec{
-			Name:     "type",
+		specFieldType: &hcldec.AttrSpec{
+			Name:     specFieldType,
 			Type:     cty.String,
 			Required: false,
 		},

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -7,6 +7,7 @@ package terraform
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -17,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/comment"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/registry"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/utils"
 	masterUtils "github.com/DataDog/datadog-iac-scanner/pkg/utils"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
@@ -32,6 +34,7 @@ const (
 	// RetriesDefaultValue is default number of times a parser will retry to execute
 	RetriesDefaultValue     = 50
 	terraformDataIdentifier = "data"
+	terraformVariableBlock  = "variable"
 )
 
 // Converter returns content json, error line, error
@@ -53,18 +56,35 @@ type Parser struct {
 	// it). Scoped to the Parser instance, which is created once per scan.
 	dirVarsCache sync.Map // dir -> converter.VariableMap
 	dirVarsSF    singleflight.Group
+
+	// Registry keeps track of the plan addresses and links them to files
+	registry *registry.AddressRegistry
 }
 
 // NewDefault initializes a parser with Parser default values
+//
+// Deprecated: use New() with a registry instance instead
 func NewDefault() *Parser {
 	return &Parser{
 		numOfRetries: RetriesDefaultValue,
 		convertFunc:  converter.DefaultConverted,
 		fsys:         vfs.DiskFS{},
+		registry:     nil, // No registry - will log error if used
+	}
+}
+
+// New creates a new parser with an instance registry
+func New(reg *registry.AddressRegistry) *Parser {
+	return &Parser{
+		numOfRetries: RetriesDefaultValue,
+		convertFunc:  converter.DefaultConverted,
+		fsys:         vfs.DiskFS{},
+		registry:     reg,
 	}
 }
 
 // nolint:gocritic
+// DEPRECATED: Use NewWithParams() with a registry instance instead
 func NewDefaultWithParams(fsys vfs.FS, terraformVarsPath string, sciInfo model.SCIInfo) *Parser {
 	parser := NewDefault()
 	if fsys != nil {
@@ -73,6 +93,22 @@ func NewDefaultWithParams(fsys vfs.FS, terraformVarsPath string, sciInfo model.S
 	parser.terraformVarsPath = terraformVarsPath
 	parser.sciInfo = sciInfo
 	return parser
+}
+
+// NewWithParams creates a parser with registry, vars path, and sci info
+func NewWithParams(fsys vfs.FS, reg *registry.AddressRegistry, terraformVarsPath string, sciInfo *model.SCIInfo) *Parser {
+	p := &Parser{
+		numOfRetries:      RetriesDefaultValue,
+		convertFunc:       converter.DefaultConverted,
+		fsys:              vfs.DiskFS{},
+		registry:          reg,
+		terraformVarsPath: terraformVarsPath,
+		sciInfo:           *sciInfo,
+	}
+	if fsys != nil {
+		p.fsys = fsys
+	}
+	return p
 }
 
 // Resolve - replace or modifies in-memory content before parsing
@@ -255,6 +291,98 @@ func quoteDataSourceTraversals(source []byte, file *hcl.File) []byte {
 	return source
 }
 
+// extractAndRegisterAddresses extracts Terraform resource and module addresses from the parsed HCL file
+// and registers them in the address registry for later tfplan mapping
+func extractAndRegisterAddresses(ctx context.Context, file *hcl.File, filePath string, reg *registry.AddressRegistry) {
+	// If no registry provided, silently skip address registration
+	// This allows NewDefault() to be used for non-scan scenarios (e.g., unit tests)
+	if reg == nil {
+		return
+	}
+
+	contextLogger := logger.FromContext(ctx)
+
+	// Get the body as hclsyntax.Body
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		contextLogger.Debug().Str("file", filePath).Msg("Could not cast HCL body to hclsyntax.Body")
+		return
+	}
+
+	resourceCount := 0
+	moduleCount := 0
+
+	// Iterate through all blocks in the file
+	for _, block := range body.Blocks {
+		switch block.Type {
+		case "resource":
+			// Resource blocks have format: resource "type" "name"
+			if len(block.Labels) >= 2 {
+				address := fmt.Sprintf("%s.%s", block.Labels[0], block.Labels[1])
+				defRange := block.DefRange()
+				location := registry.Location{
+					FilePath: filePath,
+					Line:     defRange.Start.Line,
+					Column:   defRange.Start.Column,
+				}
+				reg.Register(address, location)
+				contextLogger.Info().
+					Str("address", address).
+					Str("file", filePath).
+					Int("line", location.Line).
+					Msg("HCL: Registered resource address")
+				resourceCount++
+			}
+
+		case "module":
+			// Module blocks have format: module "name"
+			if len(block.Labels) >= 1 {
+				address := fmt.Sprintf("module.%s", block.Labels[0])
+				defRange := block.DefRange()
+				location := registry.Location{
+					FilePath: filePath,
+					Line:     defRange.Start.Line,
+					Column:   defRange.Start.Column,
+				}
+				reg.Register(address, location)
+				contextLogger.Info().
+					Str("address", address).
+					Str("file", filePath).
+					Int("line", location.Line).
+					Msg("HCL: Registered module address")
+				moduleCount++
+			}
+
+		case terraformVariableBlock:
+			// Variable blocks have format: variable "name"
+			// Register as "var.<name>" so the tfplan detector can resolve module_default
+			// findings to the variable's default = ... line in variables.tf
+			if len(block.Labels) >= 1 {
+				address := fmt.Sprintf("var.%s", block.Labels[0])
+				defRange := block.DefRange()
+				location := registry.Location{
+					FilePath: filePath,
+					Line:     defRange.Start.Line,
+					Column:   defRange.Start.Column,
+				}
+				reg.Register(address, location)
+				contextLogger.Debug().
+					Str("address", address).
+					Str("file", filePath).
+					Int("line", location.Line).
+					Msg("HCL: Registered variable address")
+			}
+		}
+	}
+
+	contextLogger.Info().
+		Str("file", filePath).
+		Int("resources", resourceCount).
+		Int("modules", moduleCount).
+		Int("totalRegistry", reg.GetMappingCount()).
+		Msg("HCL: Completed address registration for file")
+}
+
 // Parse execute parser for the content in a file
 func (p *Parser) Parse(ctx context.Context, fileContent []byte, path string,
 	resolveReferences bool, maxResolverDepth int) (
@@ -280,6 +408,9 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, path string,
 		err := diagnostics.Errs()[0]
 		return nil, nil, nil, nil, err
 	}
+
+	// Extract and register Terraform addresses for tfplan mapping
+	extractAndRegisterAddresses(ctx, file, path, p.registry)
 
 	ignore, err := comment.ParseComments(resolved, path)
 	if err != nil {

--- a/pkg/parser/terraform/terraform_test.go
+++ b/pkg/parser/terraform/terraform_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/registry"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/require"
@@ -477,4 +478,44 @@ resource "aws_s3_bucket" "b%d" {
 		}(i)
 	}
 	wg.Wait()
+}
+
+// TestExtractAndRegisterAddresses_VariableBlocks verifies that variable blocks in .tf files
+// are registered under the "var.<name>" key so the tfplan detector can resolve module_default
+// findings to the variable's default line.
+func TestExtractAndRegisterAddresses_VariableBlocks(t *testing.T) {
+	tmpDir := t.TempDir()
+	variablesTF := filepath.Join(tmpDir, "variables.tf")
+	content := `variable "publicly_accessible" {
+  description = "Whether publicly accessible."
+  type        = bool
+  default     = true
+}
+
+variable "storage_encrypted" {
+  type    = bool
+  default = false
+}
+`
+	err := os.WriteFile(variablesTF, []byte(content), 0644)
+	require.NoError(t, err)
+
+	reg := registry.New()
+	ctx := context.Background()
+	parser := New(reg)
+
+	_, _, _, _, parseErr := parser.Parse(ctx, []byte(content), variablesTF, false, 1)
+	require.NoError(t, parseErr)
+
+	// var.publicly_accessible should be registered at line 1
+	loc, found := reg.LookupWithScope("var.publicly_accessible", variablesTF)
+	require.True(t, found, "var.publicly_accessible should be in the registry")
+	require.Equal(t, variablesTF, loc.FilePath)
+	require.Equal(t, 1, loc.Line)
+
+	// var.storage_encrypted should be registered at line 7
+	loc2, found2 := reg.LookupWithScope("var.storage_encrypted", variablesTF)
+	require.True(t, found2, "var.storage_encrypted should be in the registry")
+	require.Equal(t, variablesTF, loc2.FilePath)
+	require.Equal(t, 7, loc2.Line)
 }

--- a/pkg/parser/terraform/variables.go
+++ b/pkg/parser/terraform/variables.go
@@ -84,7 +84,7 @@ func extractInputVariables(body *hclsyntax.Body, filename string) converter.Vari
 	// Case 2: .tf variable "x" { default = ... }
 	hasVariableBlock := false
 	for _, block := range body.Blocks {
-		if block.Type == "variable" && len(block.Labels) == 1 && block.Labels[0] != "" {
+		if block.Type == terraformVariableBlock && len(block.Labels) == 1 && block.Labels[0] != "" {
 			hasVariableBlock = true
 			varName := block.Labels[0]
 			if defaultAttr, exists := block.Body.Attributes["default"]; exists {

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -380,6 +380,7 @@ func prepareScanDocumentNode(body interface{}, kind model.FileKind, resolveFilte
 
 func prepareScanDocumentValue(bodyType map[string]interface{}, kind model.FileKind, resolveFilters, atDocumentRoot bool) {
 	delete(bodyType, "_dd_lines")
+	delete(bodyType, "_dd_tf_address")
 	for key, v := range bodyType {
 		childResolveFilters := resolveFilters
 		if kind == model.KindTerraformPlan && atDocumentRoot {

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -28,6 +28,7 @@ import (
 	protoParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/grpc"
 	jsonParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/json"
 	terraformParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/registry"
 	cicdParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/cicd"
 	yamlParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/yaml/default"
 	"github.com/DataDog/datadog-iac-scanner/pkg/resolver"
@@ -50,6 +51,7 @@ type executeScanParameters struct {
 	extractedPaths    provider.ExtractedPath
 	moduleCleanup     func()
 	remoteModulePaths []string
+	registry          *registry.AddressRegistry
 }
 
 func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
@@ -77,6 +79,14 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 	if len(extractedPaths.Path) == 0 {
 		return nil, nil
 	}
+
+	// Create a fresh registry instance for this scan to avoid cross-scan pollution
+	addressRegistry := registry.New()
+	contextLogger.Info().Msg("Created new address registry for this scan")
+
+	// Inject the registry into the tracker so the vulnerability builder can access it
+	c.Tracker.SetTFPlanRegistry(addressRegistry)
+	contextLogger.Info().Msg("Injected registry into tracker")
 
 	paramsPlatforms := c.ScanParams.GetEffectivePlatforms()
 
@@ -158,6 +168,7 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		c.ScanParams.CloudProvider,
 		c.FlagEvaluator,
 		filePlatform,
+		addressRegistry,
 	)
 	if err != nil {
 		contextLogger.Err(err).Msgf("failed to create service %v", err)
@@ -171,6 +182,7 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		extractedPaths:    extractedPaths,
 		moduleCleanup:     moduleCleanup,
 		remoteModulePaths: remoteModulePaths,
+		registry:          addressRegistry,
 	}, nil
 }
 
@@ -212,6 +224,10 @@ func (c *Client) createQuerySource(ctx context.Context, paramsPlatforms []string
 
 func (c *Client) executeScan(ctx context.Context) (*Results, error) {
 	contextLogger := logger.FromContext(ctx)
+
+	// Note: We now create a fresh registry instance per scan in initScan()
+	// instead of clearing a global registry, which prevents race conditions
+
 	executeScanParameters, err := c.initScan(ctx)
 
 	if err != nil {
@@ -317,7 +333,8 @@ func (c *Client) createService(
 	types []string,
 	cloudProviders []string,
 	flagEvaluator featureflags.FlagEvaluator,
-	filePlatform map[string]string) ([]*runner.Service, error) {
+	filePlatform map[string]string,
+	reg *registry.AddressRegistry) ([]*runner.Service, error) {
 	var filesSource provider.SourceProvider
 	if c.inMemory {
 		allPaths := append([]string{}, paths...)
@@ -335,11 +352,10 @@ func (c *Client) createService(
 		fsSource.AddUnfilteredPaths(remoteModulePaths)
 		filesSource = fsSource
 	}
-
 	combinedParserBuilder := parser.NewBuilder(ctx).
 		WithFS(c.fsys).
 		Add(&yamlParser.Parser{}).
-		Add(terraformParser.NewDefaultWithParams(c.fsys, c.ScanParams.TerraformVarsPath, c.ScanParams.SCIInfo)).
+		Add(terraformParser.NewWithParams(c.fsys, reg, c.ScanParams.TerraformVarsPath, &c.ScanParams.SCIInfo)).
 		Add(&bicepParser.Parser{}).
 		Add(&cicdParser.Parser{}).
 		Add(&dockerParser.Parser{}).

--- a/pkg/scan/tfplan_flag_test.go
+++ b/pkg/scan/tfplan_flag_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/internal/tracker"
 	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/registry"
 	"github.com/DataDog/datadog-iac-scanner/pkg/runner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,6 +60,7 @@ func TestJSONParserRegistration(t *testing.T) {
 			cloudProviders := []string{""}
 
 			// Call createService which contains the conditional JSON parser registration
+			reg := registry.New()
 			services, err := client.createService(
 				ctx,
 				nil, // inspector - not needed for this test
@@ -70,6 +72,7 @@ func TestJSONParserRegistration(t *testing.T) {
 				cloudProviders,
 				client.FlagEvaluator,
 				nil,
+				reg,
 			)
 
 			require.NoError(t, err)
@@ -122,6 +125,7 @@ func TestJSONParserBuilder(t *testing.T) {
 	platforms := []string{"terraform", "kubernetes", "cloudformation"}
 	cloudProviders := []string{""}
 
+	reg1 := registry.New()
 	servicesWithoutFlag, err := clientWithoutFlag.createService(
 		ctx,
 		nil,
@@ -133,6 +137,7 @@ func TestJSONParserBuilder(t *testing.T) {
 		cloudProviders,
 		clientWithoutFlag.FlagEvaluator,
 		nil,
+		reg1,
 	)
 
 	require.NoError(t, err)
@@ -168,6 +173,7 @@ func TestJSONParserBuilder(t *testing.T) {
 		FlagEvaluator: featureflags.NewLocalEvaluator(),
 	}
 
+	reg2 := registry.New()
 	servicesWithFlag, err := clientWithFlag.createService(
 		ctx,
 		nil,
@@ -179,6 +185,7 @@ func TestJSONParserBuilder(t *testing.T) {
 		cloudProviders,
 		clientWithFlag.FlagEvaluator,
 		nil,
+		reg2,
 	)
 
 	require.NoError(t, err)
@@ -223,6 +230,7 @@ func TestCreateServiceWithTfPlanFlag(t *testing.T) {
 			FlagEvaluator: featureflags.NewLocalEvaluator(),
 		}
 
+		reg := registry.New()
 		services, err := client.createService(
 			ctx,
 			nil,
@@ -234,6 +242,7 @@ func TestCreateServiceWithTfPlanFlag(t *testing.T) {
 			[]string{""},
 			client.FlagEvaluator,
 			nil,
+			reg,
 		)
 
 		require.NoError(t, err)
@@ -258,6 +267,7 @@ func TestCreateServiceWithTfPlanFlag(t *testing.T) {
 			FlagEvaluator: featureflags.NewLocalEvaluator(),
 		}
 
+		reg := registry.New()
 		services, err := client.createService(
 			ctx,
 			nil,
@@ -269,6 +279,7 @@ func TestCreateServiceWithTfPlanFlag(t *testing.T) {
 			[]string{""},
 			client.FlagEvaluator,
 			nil,
+			reg,
 		)
 
 		require.NoError(t, err)
@@ -312,6 +323,7 @@ func TestJSONParserNotDoubleRegistered(t *testing.T) {
 
 	// Call createService multiple times
 	for i := 0; i < 3; i++ {
+		reg := registry.New()
 		services, err := client.createService(
 			ctx,
 			nil,
@@ -323,6 +335,7 @@ func TestJSONParserNotDoubleRegistered(t *testing.T) {
 			[]string{""},
 			client.FlagEvaluator,
 			nil,
+			reg,
 		)
 
 		require.NoError(t, err)

--- a/test/fixtures/tfplan_module_mapping/main.tf
+++ b/test/fixtures/tfplan_module_mapping/main.tf
@@ -1,0 +1,29 @@
+# Root configuration that uses a module
+module "vpc" {
+  source = "./modules/networking"
+
+  vpc_cidr = "10.0.0.0/16"
+
+  # This is the module input that maps to the tags attribute
+  # Expected finding should point to this line (line 7), not line 2
+  resource_tags = {
+    Environment = "production"
+    Team        = "platform"
+  }
+
+  enable_dns_hostnames = true
+}
+
+# Another module instance with count
+module "app_servers" {
+  source = "./modules/compute"
+  count  = 3
+
+  instance_type = "t2.micro"
+
+  # Expected finding should point to this line (line 24)
+  instance_tags = {
+    Environment = "staging"
+    Application = "web"
+  }
+}

--- a/test/fixtures/tfplan_module_mapping/modules/compute/main.tf
+++ b/test/fixtures/tfplan_module_mapping/modules/compute/main.tf
@@ -1,0 +1,19 @@
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "instance_tags" {
+  description = "Tags for EC2 instances"
+  type        = map(string)
+  default     = {}
+}
+
+resource "aws_instance" "app" {
+  ami           = "ami-87654321"
+  instance_type = var.instance_type
+
+  # Tags attribute maps to instance_tags variable
+  tags = var.instance_tags
+}

--- a/test/fixtures/tfplan_module_mapping/modules/networking/main.tf
+++ b/test/fixtures/tfplan_module_mapping/modules/networking/main.tf
@@ -1,0 +1,41 @@
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+}
+
+variable "resource_tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable_dns_hostnames" {
+  description = "Enable DNS hostnames in VPC"
+  type        = bool
+  default     = true
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = var.enable_dns_hostnames
+
+  # Tags attribute maps to resource_tags variable
+  tags = var.resource_tags
+}
+
+resource "aws_subnet" "public" {
+  vpc_id     = aws_vpc.main.id
+  cidr_block = cidrsubnet(var.vpc_cidr, 8, 1)
+
+  # Tags attribute maps to resource_tags variable
+  tags = var.resource_tags
+}
+
+resource "aws_instance" "bastion" {
+  ami           = "ami-12345678"
+  instance_type = "t2.micro"
+  subnet_id     = aws_subnet.public.id
+
+  # Tags attribute maps to resource_tags variable
+  tags = var.resource_tags
+}

--- a/test/fixtures/tfplan_module_mapping/plan.tfplan.json
+++ b/test/fixtures/tfplan_module_mapping/plan.tfplan.json
@@ -1,0 +1,126 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.5.0",
+  "planned_values": {
+    "root_module": {
+      "resources": [],
+      "child_modules": [
+        {
+          "address": "module.vpc",
+          "resources": [
+            {
+              "address": "module.vpc.aws_vpc.main",
+              "mode": "managed",
+              "type": "aws_vpc",
+              "name": "main",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "values": {
+                "cidr_block": "10.0.0.0/16",
+                "enable_dns_hostnames": true,
+                "tags": {
+                  "Environment": "production",
+                  "Team": "platform"
+                }
+              }
+            },
+            {
+              "address": "module.vpc.aws_subnet.public",
+              "mode": "managed",
+              "type": "aws_subnet",
+              "name": "public",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "values": {
+                "vpc_id": "vpc-12345",
+                "cidr_block": "10.0.1.0/24",
+                "tags": {
+                  "Environment": "production",
+                  "Team": "platform"
+                }
+              }
+            },
+            {
+              "address": "module.vpc.aws_instance.bastion",
+              "mode": "managed",
+              "type": "aws_instance",
+              "name": "bastion",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "values": {
+                "ami": "ami-12345678",
+                "instance_type": "t2.micro",
+                "subnet_id": "subnet-12345",
+                "tags": {
+                  "Environment": "production",
+                  "Team": "platform"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "address": "module.app_servers[0]",
+          "resources": [
+            {
+              "address": "module.app_servers[0].aws_instance.app",
+              "mode": "managed",
+              "type": "aws_instance",
+              "name": "app",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "values": {
+                "ami": "ami-87654321",
+                "instance_type": "t2.micro",
+                "tags": {
+                  "Environment": "staging",
+                  "Application": "web"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "address": "module.app_servers[1]",
+          "resources": [
+            {
+              "address": "module.app_servers[1].aws_instance.app",
+              "mode": "managed",
+              "type": "aws_instance",
+              "name": "app",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "values": {
+                "ami": "ami-87654321",
+                "instance_type": "t2.micro",
+                "tags": {
+                  "Environment": "staging",
+                  "Application": "web"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "address": "module.app_servers[2]",
+          "resources": [
+            {
+              "address": "module.app_servers[2].aws_instance.app",
+              "mode": "managed",
+              "type": "aws_instance",
+              "name": "app",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "values": {
+                "ami": "ami-87654321",
+                "instance_type": "t2.micro",
+                "tags": {
+                  "Environment": "staging",
+                  "Application": "web"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "resource_changes": [],
+  "configuration": {
+    "root_module": {}
+  }
+}

--- a/test/fixtures/tfplan_to_hcl_mapping/main.tf
+++ b/test/fixtures/tfplan_to_hcl_mapping/main.tf
@@ -1,0 +1,9 @@
+resource "aws_instance" "web" {
+  ami           = "ami-123456"
+  instance_type = "t2.micro"
+}
+
+resource "aws_s3_bucket" "data" {
+  bucket = "my-test-bucket"
+  acl    = "private"
+}

--- a/test/fixtures/tfplan_to_hcl_mapping/plan.tfplan.json
+++ b/test/fixtures/tfplan_to_hcl_mapping/plan.tfplan.json
@@ -1,0 +1,34 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.0.0",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_instance.web",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "web",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "values": {
+            "ami": "ami-123456",
+            "instance_type": "t2.micro"
+          }
+        },
+        {
+          "address": "aws_s3_bucket.data",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "data",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "bucket": "my-test-bucket",
+            "acl": "private"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Wires the `AddressRegistry` (#348) and `ParseSearchKey` (#349) into a full TFPlan-to-HCL detection pipeline.
- `pkg/detector/tfplan_detect.go`: `TFPlanDetectLine` resolves a tfplan finding's searchKey to its HCL source location, handling root resources, module calls (incl. nested/parent modules), module-default vs. module-hardcoded vs. call-site attribute origin, and count/for_each index normalization for dedup.
- `pkg/parser/json/tfplan.go`: extends the tfplan JSON parser to inject per-resource address/origin metadata (`_dd_tf_address`, `_dd_tf_origin`), correlate `resource_changes`/`configuration`, and handle prior_state data sources.
- `pkg/parser/terraform/terraform.go`: registers HCL resource/module/variable addresses into the registry during parsing.
- `pkg/engine/inspector.go`, `vulnerability_builder.go`: wire the registry and module mappings through the scan pipeline, with a mutex-guarded `moduleMappings` field (concurrent `Inspect()` calls can share an Inspector) and TFPlan-vs-default detector routing.
- `internal/storage/memory.go`: include `FileID` in the vulnerability dedup key so HCL and TFPlan findings for the same resource aren't collapsed.
- New fixtures and integration/golden tests exercising module mapping, nested modules, and end-to-end TFPlan-to-HCL line resolution.

Third of three PRs split out of #204, stacked on #348 (registry) and #349 (searchKey parser). This one carries the bulk of the feature and review risk; the first two are small, low-risk foundations.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all pass except pre-existing local-environment-only e2e/git failures, unrelated to this change)
- [x] `golangci-lint run ./...` (clean; one pre-existing unrelated goconst finding in `e2e/testcases`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)