### PR TITLE
Remove Terraform local module evaluation flag

### DIFF
--- a/cmd/scanner/scan.go
+++ b/cmd/scanner/scan.go
@@ -89,13 +89,6 @@ var scanAction = &cli.Command{
 			Usage:  "(experimental, will be removed soon) parse files in parallel",
 			Value:  true,
 		},
-		&cli.BoolFlag{
-			Name:   "x-local-module-eval",
-			Hidden: true,
-			Usage: "(experimental) resolve Terraform local module variables before scanning; " +
-				"independent of --terraform-modules",
-			Value: false,
-		},
 		&cli.StringFlag{
 			Name:  "terraform-modules",
 			Usage: "enable remote Terraform module resolution: off or on",
@@ -739,20 +732,10 @@ func selectPlatforms(platforms []string) []string {
 	return out
 }
 
-func localModuleEvalEnabled(legacyLocalModuleEval bool, modulesSetting scan.TerraformModulesSetting) bool {
-	return legacyLocalModuleEval || modulesSetting != scan.TerraformModulesOff
-}
-
 func getFeatureFlagEvaluator(c *cli.Command) featureflags.FlagEvaluator {
-	modulesSetting, _ := scan.ParseTerraformModules(c.String("terraform-modules"))
-	overrides := map[string]bool{
+	return featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
 		featureflags.IaCEnableKicsParallelFileParsing: c.Bool("x-parallelparsing"),
-		featureflags.IacEnableLocalModuleEval: localModuleEvalEnabled(
-			c.Bool("x-local-module-eval"),
-			modulesSetting,
-		),
-	}
-	return featureflags.NewLocalEvaluatorWithOverrides(overrides)
+	})
 }
 
 func getAbsolutePath(path string) (string, error) {

--- a/cmd/scanner/scan_test.go
+++ b/cmd/scanner/scan_test.go
@@ -200,41 +200,7 @@ func TestTerraformModuleFlagsUseAuthoritativeMode(t *testing.T) {
 	require.True(t, names["module-cache-max-bytes"])
 	require.True(t, names["module-allowed-hosts"])
 	require.False(t, names["x-remote-modules"])
-	require.True(t, names["x-local-module-eval"])
-}
-
-func TestLocalModuleEvalEnabled(t *testing.T) {
-	tests := []struct {
-		name       string
-		legacyFlag bool
-		setting    scan.TerraformModulesSetting
-		want       bool
-	}{
-		{
-			name:       "default prod path keeps local eval without module pre-scan mode",
-			legacyFlag: true,
-			setting:    scan.TerraformModulesOff,
-			want:       true,
-		},
-		{
-			name:       "mode off without legacy flag disables local eval",
-			legacyFlag: false,
-			setting:    scan.TerraformModulesOff,
-			want:       false,
-		},
-		{
-			name:       "on mode enables local eval for remote resolution",
-			legacyFlag: false,
-			setting:    scan.TerraformModulesOn,
-			want:       true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, localModuleEvalEnabled(tt.legacyFlag, tt.setting))
-		})
-	}
+	require.False(t, names["x-local-module-eval"])
 }
 
 func TestValidateQueriesPaths(t *testing.T) {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -246,6 +246,9 @@ type Inspector struct {
 	remoteModuleDirs       map[string]RemoteModuleDirectory
 	remoteModuleProvenance map[string]RemoteModuleProvenance
 	externalPathRoots      map[string]bool
+	// skipLocalModuleEval is set for content-push scans. tfeval reads directories
+	// off the real disk, which is unsafe when paths come from pushed content.
+	skipLocalModuleEval bool
 }
 
 func (c *Inspector) SetRemoteModuleDirectories(sourceToDir map[string]RemoteModuleDirectory) {
@@ -282,6 +285,10 @@ func (c *Inspector) buildModuleProvenanceLookup() moduleProvenanceLookup {
 		}
 		return RemoteModuleProvenance{}, false
 	}
+}
+
+func (c *Inspector) SkipLocalModuleEval() {
+	c.skipLocalModuleEval = true
 }
 
 func (c *Inspector) SetExternalModulePaths(paths []string) {
@@ -490,15 +497,12 @@ func (c *Inspector) Inspect(
 	contextLogger := logger.FromContext(ctx)
 	contextLogger.Debug().Msg("engine.Inspect()")
 
-	// Terraform local-module instantiation is gated so it can be disabled remotely.
 	queries := c.getQueriesByPlat(platforms)
 
 	var moduleDocs []model.Document
 	var moduleExtras map[string][]extraCallerInfo
 	var syntheticFiles []*model.FileMetadata
-	if shouldInstantiateLocalModules(platforms, files) &&
-		c.flagEvaluator != nil &&
-		c.flagEvaluator.EvaluateWithOrg(featureflags.IacEnableLocalModuleEval) {
+	if shouldInstantiateLocalModules(platforms, files) && !c.skipLocalModuleEval {
 		targets := ruleTargetedResourceTypes(queries, c.terraformRuleLibraries()...)
 		moduleDocs, syntheticFiles, moduleExtras = c.instantiateLocalModules(ctx, files, targets)
 		memwatch.Sample(ctx, memwatch.PhaseModuleEval)

--- a/pkg/engine/module_attribution_sarif_integration_test.go
+++ b/pkg/engine/module_attribution_sarif_integration_test.go
@@ -75,10 +75,9 @@ resource "aws_s3_bucket" "this" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:       queries,
-		repoPath:      root,
-		vb:            DefaultVulnerabilityBuilder,
-		flagEvaluator: moduleEvalEnabled(),
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})

--- a/pkg/engine/module_resolve_integration_test.go
+++ b/pkg/engine/module_resolve_integration_test.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-iac-scanner/pkg/featureflags"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	terraformParser "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform"
 	scanUtils "github.com/DataDog/datadog-iac-scanner/pkg/utils"
@@ -22,13 +21,6 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
-
-// moduleEvalEnabled returns a FlagEvaluator with local module evaluation turned on.
-func moduleEvalEnabled() featureflags.FlagEvaluator {
-	return featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
-		featureflags.IacEnableLocalModuleEval: true,
-	})
-}
 
 // aclRule fires when an aws_s3_bucket has acl == "public-read". It only matches
 // after a module is instantiated with that concrete value.
@@ -134,10 +126,9 @@ resource "aws_s3_bucket" "this" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:       queries,
-		repoPath:      root,
-		vb:            DefaultVulnerabilityBuilder,
-		flagEvaluator: moduleEvalEnabled(),
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -204,9 +195,8 @@ resource "google_sql_database_instance" "this" {
 			Metadata:    map[string]interface{}{"id": "dynamic-block-rule"},
 			Aggregation: 1,
 		}},
-		repoPath:      root,
-		vb:            DefaultVulnerabilityBuilder,
-		flagEvaluator: moduleEvalEnabled(),
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -244,7 +234,6 @@ resource "aws_s3_bucket" "this" { acl = var.acl }
 
 	ins := newTestInspector(t, inspectorOpts{
 		queries: queries, repoPath: root, vb: DefaultVulnerabilityBuilder,
-		flagEvaluator: moduleEvalEnabled(),
 	})
 
 	var logs bytes.Buffer
@@ -313,10 +302,9 @@ resource "aws_s3_bucket" "this" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:       queries,
-		repoPath:      root,
-		vb:            DefaultVulnerabilityBuilder,
-		flagEvaluator: moduleEvalEnabled(),
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -400,10 +388,9 @@ resource "aws_s3_bucket" "this" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:       queries,
-		repoPath:      root,
-		vb:            DefaultVulnerabilityBuilder,
-		flagEvaluator: moduleEvalEnabled(),
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -475,10 +462,9 @@ resource "aws_s3_bucket" "this" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:       queries,
-		repoPath:      root,
-		vb:            DefaultVulnerabilityBuilder,
-		flagEvaluator: moduleEvalEnabled(),
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -570,10 +556,9 @@ resource "aws_s3_bucket" "this" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:       queries,
-		repoPath:      root,
-		vb:            DefaultVulnerabilityBuilder,
-		flagEvaluator: moduleEvalEnabled(),
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -668,10 +653,9 @@ resource "aws_instance" "app" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:       queries,
-		repoPath:      root,
-		vb:            DefaultVulnerabilityBuilder,
-		flagEvaluator: moduleEvalEnabled(),
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -718,9 +702,8 @@ resource "aws_instance" "app" {
 			Metadata:    map[string]interface{}{"id": "sg-not-used"},
 			Aggregation: 1,
 		}},
-		repoPath:      dir,
-		vb:            DefaultVulnerabilityBuilder,
-		flagEvaluator: moduleEvalEnabled(),
+		repoPath: dir,
+		vb:       DefaultVulnerabilityBuilder,
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -774,10 +757,9 @@ resource "aws_instance" "app" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:       queries,
-		repoPath:      root,
-		vb:            DefaultVulnerabilityBuilder,
-		flagEvaluator: moduleEvalEnabled(),
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -841,10 +823,9 @@ resource "aws_instance" "server" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:       queries,
-		repoPath:      root,
-		vb:            DefaultVulnerabilityBuilder,
-		flagEvaluator: moduleEvalEnabled(),
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -902,10 +883,9 @@ resource "aws_s3_bucket" "replica" {
 	}}
 
 	ins := newTestInspector(t, inspectorOpts{
-		queries:       queries,
-		repoPath:      root,
-		vb:            DefaultVulnerabilityBuilder,
-		flagEvaluator: moduleEvalEnabled(),
+		queries:  queries,
+		repoPath: root,
+		vb:       DefaultVulnerabilityBuilder,
 	})
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
@@ -954,9 +934,7 @@ resource "aws_s3_bucket" "this" {
 	require.Len(t, vulns, numQueries)
 }
 
-// TestInspect_LocalModuleEvalWithFlagEnabled confirms that local module evaluation
-// runs when the feature flag is on and synthetic docs are injected for resolved modules.
-func TestInspect_LocalModuleEvalWithFlagEnabled(t *testing.T) {
+func TestInspect_SkipsLocalModuleEvalForContentPush(t *testing.T) {
 	root := t.TempDir()
 	rootPath := filepath.Join(root, "main.tf")
 	modDir := filepath.Join(root, "modules", "s3")
@@ -978,26 +956,17 @@ resource "aws_s3_bucket" "this" { acl = var.acl }
 	files = append(files, parseTerraform(t, rootPath)...)
 	files = append(files, parseTerraform(t, modPath)...)
 
-	queries := []model.QueryMetadata{{
-		Query:       "acl_rule",
-		Content:     aclRule,
-		InputData:   "{}",
-		Platform:    "terraform",
-		Metadata:    map[string]interface{}{"id": "acl-rule"},
-		Aggregation: 1,
-	}}
-
 	ins := newTestInspector(t, inspectorOpts{
-		queries:  queries,
+		queries: []model.QueryMetadata{{
+			Query: "acl_rule", Content: aclRule, InputData: "{}", Platform: "terraform",
+			Metadata: map[string]interface{}{"id": "acl-rule"}, Aggregation: 1,
+		}},
 		repoPath: root,
 		vb:       DefaultVulnerabilityBuilder,
-		flagEvaluator: featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
-			featureflags.IacEnableLocalModuleEval: true,
-		}),
 	})
+	ins.SkipLocalModuleEval()
 
 	vulns, err := ins.Inspect(context.Background(), "test", files, []string{"terraform"})
 	require.NoError(t, err)
-	require.Empty(t, ins.GetFailedQueries())
-	require.NotEmpty(t, vulns, "module eval with flag enabled: rule should fire on resolved module resource")
+	require.Empty(t, vulns, "content-push scans must not instantiate local modules")
 }

--- a/pkg/engine/module_resolve_remote_integration_test.go
+++ b/pkg/engine/module_resolve_remote_integration_test.go
@@ -118,7 +118,7 @@ func inspectRemoteBucket(t *testing.T, fx remoteBucketFixture, callerPaths []str
 			Query: "acl_rule", Content: rule, InputData: "{}", Platform: "terraform",
 			Metadata: map[string]interface{}{"id": "acl-rule"}, Aggregation: 1,
 		}},
-		repoPath: fx.root, vb: DefaultVulnerabilityBuilder, flagEvaluator: moduleEvalEnabled(),
+		repoPath: fx.root, vb: DefaultVulnerabilityBuilder,
 	})
 	registerRemoteBucket(ins, fx.callerRoot, fx.cacheDir)
 
@@ -225,7 +225,7 @@ module "bucket" {
 			Query: "acl_rule", Content: aclRule, InputData: "{}", Platform: "terraform",
 			Metadata: map[string]interface{}{"id": "acl-rule"}, Aggregation: 1,
 		}},
-		repoPath: fx.root, vb: DefaultVulnerabilityBuilder, flagEvaluator: moduleEvalEnabled(),
+		repoPath: fx.root, vb: DefaultVulnerabilityBuilder,
 	})
 	ins.SetRemoteModuleDirectories(map[string]RemoteModuleDirectory{
 		RemoteModuleKey(aRoot, remoteBucketSource, remoteBucketVersion): {Path: fx.cacheDir, PackageRoot: fx.cacheDir},
@@ -269,7 +269,7 @@ module "bucket" {
 			Query: "acl_rule", Content: aclRule, InputData: "{}", Platform: "terraform",
 			Metadata: map[string]interface{}{"id": "acl-rule"}, Aggregation: 1,
 		}},
-		repoPath: fx.root, vb: DefaultVulnerabilityBuilder, flagEvaluator: moduleEvalEnabled(),
+		repoPath: fx.root, vb: DefaultVulnerabilityBuilder,
 	})
 	ins.SetRemoteModuleDirectories(map[string]RemoteModuleDirectory{
 		RemoteModuleKey(aRoot, remoteBucketSource, remoteBucketVersion): {Path: fx.cacheDir, PackageRoot: fx.cacheDir},
@@ -342,7 +342,7 @@ module "bucket" {
 			Query: "variable_type_rule", Content: variableTypeRule, InputData: "{}", Platform: "terraform",
 			Metadata: map[string]interface{}{"id": "variable-type-rule"}, Aggregation: 1,
 		}},
-		repoPath: fx.root, vb: DefaultVulnerabilityBuilder, flagEvaluator: moduleEvalEnabled(),
+		repoPath: fx.root, vb: DefaultVulnerabilityBuilder,
 	})
 	registerRemoteBucket(ins, fx.callerRoot, fx.cacheDir)
 
@@ -385,7 +385,7 @@ module "bucket" {
 			Query: "acl_rule", Content: aclRule, InputData: "{}", Platform: "terraform",
 			Metadata: map[string]interface{}{"id": "acl-rule"}, Aggregation: 1,
 		}},
-		repoPath: fx.root, vb: DefaultVulnerabilityBuilder, flagEvaluator: moduleEvalEnabled(),
+		repoPath: fx.root, vb: DefaultVulnerabilityBuilder,
 	})
 	// Deliberately omit SetRemoteModuleDirectories.
 

--- a/pkg/featureflags/evaluator.go
+++ b/pkg/featureflags/evaluator.go
@@ -7,8 +7,6 @@ const (
 	IacEnableKicsPlatform            = "k9-iac-enable-kics-platform"
 	IacEnableKicsHelmResolver        = "k9-iac-enable-kics-helm-resolver"
 	IaCEnableKicsParallelFileParsing = "k9-iac-enable-kics-parallel-file-parsing"
-	// IacEnableLocalModuleEval gates Terraform local-module instantiation.
-	IacEnableLocalModuleEval = "k9-iac-enable-local-module-eval"
 )
 
 type FlagEvaluator interface {

--- a/pkg/featureflags/local_evaluator.go
+++ b/pkg/featureflags/local_evaluator.go
@@ -12,7 +12,6 @@ func NewLocalEvaluatorWithOverrides(overrides map[string]bool) *LocalEvaluator {
 		IacEnableKicsPlatform:            true,
 		IacEnableKicsHelmResolver:        true,
 		IaCEnableKicsParallelFileParsing: true,
-		IacEnableLocalModuleEval:         false,
 	}
 
 	for k, v := range overrides {

--- a/pkg/scan/remote_modules_test.go
+++ b/pkg/scan/remote_modules_test.go
@@ -299,9 +299,7 @@ func remoteModuleScanParams(root string) *Parameters {
 		MaxFileSizeFlag:         100,
 		MaxResolverDepth:        15,
 		ModuleMaxDepth:          DefaultRemoteModuleMaxDepth,
-		FlagEvaluator: featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
-			featureflags.IacEnableLocalModuleEval: true,
-		}),
+		FlagEvaluator:           featureflags.NewLocalEvaluator(),
 	}
 }
 

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -137,6 +137,9 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		return nil, err
 	}
 
+	if c.inMemory {
+		inspector.SkipLocalModuleEval()
+	}
 	if len(remoteSourceDirs) > 0 {
 		inspector.SetRemoteModuleDirectories(remoteSourceDirs)
 	}

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -246,8 +246,8 @@ func ruleLibraryKey(platform string) (string, error) {
 // (the CLI absolutizes all of its input before running the same pipeline).
 //
 // The disk read this check used to stand in for is Terraform local-module
-// evaluation, pinned off for server mode in serverFlagEvaluator. That pin, not
-// this check, is what bounds it. It is not the only read that escapes the
+// evaluation, which content-push mode skips because tfeval reads the real disk.
+// That skip, not this check, is what bounds it. It is not the only read that escapes the
 // in-memory FS: the YAML/JSON file resolver opens paths taken from pushed
 // content. That one predates this change and is reachable with a relative path
 // as well, so path shape does not bound it either; it is tracked separately in
@@ -278,20 +278,11 @@ func validateFilePath(p string) error {
 // Helm rendering shells out to a chart on disk, which content-push mode has no
 // way to materialize, so the resolver is off.
 //
-// Terraform local-module evaluation is off because it reads directories derived
-// from pushed paths off the real disk: tfeval's LoadRootVars and parseDir call
-// os.ReadDir directly instead of going through the request's in-memory FS.
-// Pushed paths may be absolute, so do not rely on the flag's default staying
-// safe: pinning it here ensures server mode never enables an arbitrary-directory
-// read via local-module evaluation, and is what lets validateFilePath accept
-// absolute paths.
-//
 // Parallel file parsing fans the per-file parse across CPUs; enabled by default
 // and can be disabled with --x-parallelparsing=false.
 func serverFlagEvaluator(parallelParsing bool) featureflags.FlagEvaluator {
 	return featureflags.NewLocalEvaluatorWithOverrides(map[string]bool{
 		featureflags.IacEnableKicsHelmResolver:        false,
-		featureflags.IacEnableLocalModuleEval:         false,
 		featureflags.IaCEnableKicsParallelFileParsing: parallelParsing,
 	})
 }

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -348,19 +348,9 @@ func TestAnalyze_MixedAbsoluteAndRelativePaths(t *testing.T) {
 	}
 }
 
-// TestServerFlagEvaluator pins the flags server mode depends on. The
-// local-module-eval pin is what makes accepting absolute paths defensible: it is
-// the only thing keeping tfeval's direct os.ReadDir off directories derived from
-// pushed paths, which would otherwise be an arbitrary-directory read on a server
-// reachable cross-origin. If this test fails, validateFilePath's acceptance of
-// absolute paths is no longer safe.
 func TestServerFlagEvaluator(t *testing.T) {
 	evaluator := serverFlagEvaluator(false)
 
-	if evaluator.EvaluateWithOrg(featureflags.IacEnableLocalModuleEval) {
-		t.Error("IacEnableLocalModuleEval must be pinned false in server mode: " +
-			"local module evaluation reads directories derived from pushed paths off the real disk")
-	}
 	if evaluator.EvaluateWithOrg(featureflags.IacEnableKicsHelmResolver) {
 		t.Error("IacEnableKicsHelmResolver must be pinned false in server mode: " +
 			"Helm rendering needs a chart on disk, which content-push mode cannot materialize")


### PR DESCRIPTION
## Motivation

The `--x-local-module-eval` flag and `k9-iac-enable-local-module-eval` feature flag only existed to roll out Terraform local module instantiation. Now that it has been released for two weeks, we are free from removing it from the code.

## Changes

**CLI and feature flags**

Removed `--x-local-module-eval` and `IacEnableLocalModuleEval`. Local module instantiation no longer depends on a flag or on `--terraform-modules`. Remote module fetching remains opt-in via `--terraform-modules=on`.

**Engine**

Inspect instantiates local modules whenever the scan includes Terraform configuration files.

**Server / content-push**

Content-push scans still skip local module evaluation. tfeval reads directories from the real disk, so in-memory analyze requests must not follow module sources derived from pushed paths.

## Author Checklist

- [ ] I have reviewed my own PR.
- [ ] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [ ] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./cmd/scanner/... ./pkg/server/... ./pkg/engine/... ./pkg/scan/... -count=1`
2. `make build` and scan a repo with local Terraform modules without passing any extra flags. Confirm findings come from instantiated module resources.
3. Confirm `--x-local-module-eval` is no longer a defined flag.
4. Confirm `serve` / analyze still does not instantiate local modules (`TestInspect_SkipsLocalModuleEvalForContentPush`).

## Blast Radius

CLI and library Terraform scans now always instantiate local modules. Content-push / server mode is unchanged. Remote module downloads are unchanged.

## Additional Notes

Callers that still pass `--x-local-module-eval` will get an unknown-flag error unless they already ignore experimental flags.

I submit this contribution under the Apache-2.0 license.
