### PR TITLE
Fix production IaC scanning error signatures

### DIFF
--- a/pkg/builder/engine/engine.go
+++ b/pkg/builder/engine/engine.go
@@ -7,6 +7,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -17,6 +18,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	ctyConvert "github.com/zclconf/go-cty/cty/convert"
 )
+
+var ErrNullLiteral = errors.New("can't convert null literal to string")
 
 // Engine contains the conditions of rules and comments positions
 type Engine struct {
@@ -180,7 +183,7 @@ func (e *Engine) expToStringLiteralValue(t *hclsyntax.LiteralValueExpr) (string,
 	// panics on both, so a literal `null` in a body would take down the whole
 	// enclosing resolve rather than this one expression.
 	if s.IsNull() {
-		return "", fmt.Errorf("can't convert null literal to string")
+		return "", ErrNullLiteral
 	}
 	if !s.IsKnown() {
 		return "", fmt.Errorf("can't convert unknown literal to string")

--- a/pkg/detector/helper.go
+++ b/pkg/detector/helper.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	nameRegex          = regexp.MustCompile(`^([A-Za-z\d-_]+)\[([A-Za-z\d-_{}]+)]$`)
-	nameRegexDocker    = regexp.MustCompile(`{{(.*?)}}`)
+	nameRegexDocker    = regexp.MustCompile(`{{(\d+)}}`)
 	indentRegex        = regexp.MustCompile(`^\s+`)
 	whitespacesRegex   = regexp.MustCompile(`\s+`)
 	yamlMultilineRegex = regexp.MustCompile(
@@ -233,7 +233,13 @@ func ExtractLineFragment(line, substr string, key bool) string {
 	if key && idx >= 0 {
 		return line[:idx]
 	}
+	if line == "" {
+		return ""
+	}
 	start := strings.Index(line, substr)
+	if start < 0 {
+		return line
+	}
 	end := start + len(substr)
 
 	for start >= 0 {
@@ -256,6 +262,10 @@ func ExtractLineFragment(line, substr string, key bool) string {
 }
 
 func removeExtras(result string, start, end int) string {
+	if result == "" || end <= 0 || start+1 >= len(result) {
+		return result
+	}
+
 	// workaround for selecting yaml keys
 	if result[end-1] == ':' {
 		end--

--- a/pkg/detector/helper_test.go
+++ b/pkg/detector/helper_test.go
@@ -6,12 +6,15 @@
 package detector
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 	"github.com/DataDog/datadog-iac-scanner/test"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -428,4 +431,25 @@ func TestDetectCurrentLine(t *testing.T) {
 		})
 	}
 
+}
+
+func TestExtractLineFragmentMissingSubstring(t *testing.T) {
+	line := `"http://www.example.com"`
+
+	require.Equal(t, line, ExtractLineFragment(line, "unrelated multiline content", false))
+}
+
+func TestExtractLineFragmentEmptyInput(t *testing.T) {
+	require.Empty(t, ExtractLineFragment("", "", false))
+}
+
+func TestGenerateSubstringsDoesNotTreatTemplateSyntaxAsPlaceholder(t *testing.T) {
+	var logs bytes.Buffer
+	ctx := zerolog.New(&logs).WithContext(context.Background())
+
+	first, second := GenerateSubstrings(ctx, `${{ github.ref }}`, nil, nil, 0)
+
+	require.Equal(t, `${{ github.ref }}`, first)
+	require.Empty(t, second)
+	require.Empty(t, logs.String())
 }

--- a/pkg/detector/terraform/terraform_detect.go
+++ b/pkg/detector/terraform/terraform_detect.go
@@ -153,41 +153,96 @@ func locateTerraformBlock(
 ) (model.VulnerabilityLines, error) {
 	contextLogger := logger.FromContext(ctx)
 
-	if identifyingLine <= 0 || identifyingLine > len(strLines) {
+	if len(strLines) == 0 {
 		err := fmt.Errorf("line %d is out of range", identifyingLine)
 		contextLogger.Error().Msg(err.Error())
 		return model.VulnerabilityLines{}, err
 	}
-
-	for _, block := range body.Blocks {
-		start := block.TypeRange.Start
-		end := block.Body.SrcRange.End
-		if identifyingLine >= start.Line && identifyingLine <= end.Line {
-			blockSrc := extractBlockSource(strLines, start.Line, end.Line)
-
-			insertionLine, insertionCol := calculateInsertionPoint(block, identifyingLine, strLines)
-			return model.VulnerabilityLines{
-				VulnerablilityLocation: model.ResourceLocation{
-					Start: toResourceLine(start),
-					End:   toResourceLine(end),
-				},
-				RemediationLocation: model.ResourceLocation{
-					Start: model.ResourceLine{Line: insertionLine, Col: insertionCol},
-					End:   model.ResourceLine{Line: insertionLine, Col: insertionCol},
-				},
-				BlockLocation: model.ResourceLocation{
-					Start: toResourceLine(start),
-					End:   toResourceLine(end),
-				},
-				LineWithVulnerability: (strLines[identifyingLine-1]),
-				ResourceSource:        blockSrc,
-			}, nil
-		}
+	if identifyingLine <= 0 || identifyingLine > len(strLines) {
+		identifyingLine = min(max(identifyingLine, 1), len(strLines))
 	}
 
-	err := fmt.Errorf("failed to locate block for line %d", identifyingLine)
-	contextLogger.Error().Msg(err.Error())
-	return model.VulnerabilityLines{}, err
+	if block := blockContainingLine(body.Blocks, identifyingLine); block != nil {
+		return vulnerabilityLinesFromBlock(block, identifyingLine, strLines), nil
+	}
+	if block := nearestBlock(body.Blocks, identifyingLine); block != nil {
+		return vulnerabilityLinesFromBlock(block, identifyingLine, strLines), nil
+	}
+
+	contextLogger.Warn().Msgf("using line %d as location because no HCL block was found", identifyingLine)
+	return syntheticVulnerabilityLines(identifyingLine, strLines), nil
+}
+
+func blockContainingLine(blocks hclsyntax.Blocks, line int) *hclsyntax.Block {
+	for _, block := range blocks {
+		if line >= block.TypeRange.Start.Line && line <= block.Body.SrcRange.End.Line {
+			return block
+		}
+	}
+	return nil
+}
+
+func nearestBlock(blocks hclsyntax.Blocks, line int) *hclsyntax.Block {
+	var nearest *hclsyntax.Block
+	best := -1
+	for _, block := range blocks {
+		dist := lineDistance(line, block.TypeRange.Start.Line, block.Body.SrcRange.End.Line)
+		if nearest == nil || dist < best {
+			nearest = block
+			best = dist
+		}
+	}
+	return nearest
+}
+
+func lineDistance(line, start, end int) int {
+	if line < start {
+		return start - line
+	}
+	if line > end {
+		return line - end
+	}
+	return 0
+}
+
+func vulnerabilityLinesFromBlock(block *hclsyntax.Block, identifyingLine int, strLines []string) model.VulnerabilityLines {
+	start := block.TypeRange.Start
+	end := block.Body.SrcRange.End
+	anchor := identifyingLine
+	if identifyingLine < start.Line || identifyingLine > end.Line {
+		anchor = start.Line
+	}
+	insertionLine, insertionCol := calculateInsertionPoint(block, anchor, strLines)
+	return model.VulnerabilityLines{
+		VulnerablilityLocation: model.ResourceLocation{
+			Start: toResourceLine(start),
+			End:   toResourceLine(end),
+		},
+		RemediationLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: insertionLine, Col: insertionCol},
+			End:   model.ResourceLine{Line: insertionLine, Col: insertionCol},
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: toResourceLine(start),
+			End:   toResourceLine(end),
+		},
+		LineWithVulnerability: strLines[identifyingLine-1],
+		ResourceSource:        extractBlockSource(strLines, start.Line, end.Line),
+	}
+}
+
+func syntheticVulnerabilityLines(line int, strLines []string) model.VulnerabilityLines {
+	loc := model.ResourceLocation{
+		Start: model.ResourceLine{Line: line, Col: 1},
+		End:   model.ResourceLine{Line: line, Col: len(strLines[line-1]) + 1},
+	}
+	return model.VulnerabilityLines{
+		VulnerablilityLocation: loc,
+		RemediationLocation:    loc,
+		BlockLocation:          loc,
+		LineWithVulnerability:  strLines[line-1],
+		ResourceSource:         strLines[line-1] + "\n",
+	}
 }
 
 func toResourceLine(pos hcl.Pos) model.ResourceLine {
@@ -246,6 +301,7 @@ func calculateInsertionPoint(block *hclsyntax.Block, line int, lines []string) (
 		caseType = strBlockBody
 	}
 
+	insertionLine = min(max(insertionLine, 1), len(lines))
 	col = determineInsertionIndent(lines, insertionLine, caseType, nestedStart.Line, nestedEnd.Line) + 1
 	trimmed := strings.TrimSpace(lines[insertionLine-1])
 	if caseType == "block-start" && (strings.Contains(trimmed, "}") || isHeredocTerminator(trimmed, lines, insertionLine-1)) {

--- a/pkg/detector/terraform/terraform_detect_test.go
+++ b/pkg/detector/terraform/terraform_detect_test.go
@@ -1006,3 +1006,27 @@ func TestDetectLinePolicyStatementPrincipalHeredocJSON(t *testing.T) {
 	got := (&DetectKindLine{}).DetectLine(ctx, file, `aws_ecr_repository_policy[x].policy.Statement[0].Principal`, 3)
 	require.Equal(t, 9, got.Line)
 }
+
+func TestLocateTerraformBlockUsesNearestBlockForHeaderComments(t *testing.T) {
+	source := "# license\n# owner\n\nresource \"aws_s3_bucket\" \"helm\" {\n  bucket = \"x\"\n}\n"
+	lines := strings.Split(source, "\n")
+	body, err := (&DetectKindLine{}).cachedParseBody([]byte(source), "helm_bucket.tf")
+	require.NoError(t, err)
+
+	got, err := locateTerraformBlock(context.Background(), body, 2, lines)
+	require.NoError(t, err)
+	require.Equal(t, 4, got.BlockLocation.Start.Line)
+	require.Equal(t, "# owner", got.LineWithVulnerability)
+}
+
+func TestCalculateInsertionPointClampsFunctionWrapperAtEndOfFile(t *testing.T) {
+	source := "variable \"name\" {\n  default = merge({\n  })\n}"
+	lines := strings.Split(source, "\n")[:3]
+	body, err := (&DetectKindLine{}).cachedParseBody([]byte(source), "variable.tf")
+	require.NoError(t, err)
+	require.Len(t, body.Blocks, 1)
+
+	line, _ := calculateInsertionPoint(body.Blocks[0], len(lines), lines)
+
+	require.Equal(t, len(lines), line)
+}

--- a/pkg/parser/terraform/data_source.go
+++ b/pkg/parser/terraform/data_source.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strings"
 
@@ -419,7 +420,7 @@ func resolveTuple(ctx context.Context, expr hclsyntax.Expression) {
 			striExpr, err := e.ExpToString(ctx, ex)
 
 			if err != nil {
-				if literal, ok := ex.(*hclsyntax.LiteralValueExpr); !ok || !literal.Val.IsNull() {
+				if !errors.Is(err, engine.ErrNullLiteral) {
 					contextLogger.Error().Msgf("Error trying to ExpToString: %s", err)
 				}
 				continue

--- a/pkg/parser/terraform/data_source_test.go
+++ b/pkg/parser/terraform/data_source_test.go
@@ -41,6 +41,24 @@ func TestResolveTuplePreservesNullValues(t *testing.T) {
 	require.Empty(t, logs.String())
 }
 
+func TestResolveTupleDoesNotLogNestedNullLiterals(t *testing.T) {
+	expr, diagnostics := hclsyntax.ParseExpression(
+		[]byte(`[var.enabled ? "enabled" : null]`),
+		"policy.tf",
+		hcl.InitialPos,
+	)
+	require.False(t, diagnostics.HasErrors())
+	tuple := expr.(*hclsyntax.TupleConsExpr)
+	var logs bytes.Buffer
+	ctx := zerolog.New(&logs).WithContext(context.Background())
+
+	resolveTuple(ctx, tuple)
+
+	_, isConditional := tuple.Exprs[0].(*hclsyntax.ConditionalExpr)
+	require.True(t, isConditional)
+	require.Empty(t, logs.String())
+}
+
 func Test_getDataSourcePolicy(t *testing.T) {
 	type args struct {
 		currentPath  string

--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -45,7 +45,7 @@ func Parse(ctx context.Context, fileContent []byte, filePath string,
 
 	ignore := &model.Ignore{}
 
-	// Parse all documents as nodes
+	contextLogger := logger.FromContext(ctx)
 	dec := yaml.NewDecoder(bytes.NewReader(resolved))
 	for {
 		var node yaml.Node
@@ -53,19 +53,22 @@ func Parse(ctx context.Context, fileContent []byte, filePath string,
 			break
 		}
 
-		// Process each document node
-		if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
-			// Get the actual content (not the document wrapper)
-			contentNode := node.Content[0]
-			doc := model.Document{}
-			if err := doc.UnmarshalYAML(ctx, contentNode, ignore); err != nil {
-				return []byte{}, nil, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(err, "failed to unmarshal yaml")
-			}
+		if node.Kind != yaml.DocumentNode || len(node.Content) == 0 {
+			continue
+		}
+		contentNode := node.Content[0]
+		if isEmptyYAMLDocument(contentNode) {
+			continue
+		}
+		doc := model.Document{}
+		if err := doc.UnmarshalYAML(ctx, contentNode, ignore); err != nil {
+			contextLogger.Warn().Err(err).Msgf("skipping unparseable yaml document in %s", filePath)
+			continue
+		}
 
-			if len(doc) > 0 {
-				doc["_path"] = filePath
-				documents = append(documents, doc)
-			}
+		if len(doc) > 0 {
+			doc["_path"] = filePath
+			documents = append(documents, doc)
 		}
 	}
 
@@ -76,6 +79,16 @@ func Parse(ctx context.Context, fileContent []byte, filePath string,
 	linesToIgnore := ignore.GetLines()
 
 	return resolved, documents, linesToIgnore, resolvedFiles, nil
+}
+
+func isEmptyYAMLDocument(node *yaml.Node) bool {
+	if node == nil {
+		return true
+	}
+	if node.Kind == yaml.ScalarNode {
+		return node.Value == "" || node.Tag == "!!null"
+	}
+	return false
 }
 
 // convertKeysToString goes through every document to convert map[interface{}]interface{}

--- a/pkg/parser/yaml/parser_test.go
+++ b/pkg/parser/yaml/parser_test.go
@@ -449,3 +449,18 @@ func TestModel_TestYamlParser(t *testing.T) {
 		})
 	}
 }
+
+func TestParseIgnoresTrailingDocumentSeparator(t *testing.T) {
+	content := []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: example\n---\n")
+	_, docs, _, _, err := Parse(context.Background(), content, "crds.yaml", false, 15)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	require.Equal(t, "ConfigMap", docs[0]["kind"])
+}
+
+func TestParseSkipsUnparseableDocumentAndKeepsOthers(t *testing.T) {
+	content := []byte("kind: ConfigMap\n---\njust a scalar\n---\nkind: Secret\n")
+	_, docs, _, _, err := Parse(context.Background(), content, "mixed.yaml", false, 15)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(docs), 1)
+}

--- a/pkg/report/remediations/remediations_helper.go
+++ b/pkg/report/remediations/remediations_helper.go
@@ -47,8 +47,13 @@ func buildReplacementFix(ctx context.Context, vuln model.VulnerableFile,
 	keyValRegex := regexp.MustCompile(`(?m)["']?(\w+)["']?\s*[:=]\s*(\[.*?\]|".*?"|[^#]+)`)
 	matches := keyValRegex.FindStringSubmatch(vuln.LineWithVulnerability)
 	if isBlockHeader(vuln.LineWithVulnerability) || len(matches) < 3 {
-		line, lineNumber, found := findReplacementTarget(&vuln, before, keyValRegex)
+		line, lineNumber, found, keyPresent := findReplacementTarget(&vuln, before, keyValRegex)
 		if !found {
+			if keyPresent {
+				err := fmt.Errorf("attribute already present with a different value in %s", vuln.FileName)
+				contextLogger.Warn().Msg(err.Error())
+				return model.SarifFix{}, err
+			}
 			return fallbackReplacementToAddition(&vuln, before, after, startLocation)
 		}
 		vuln.LineWithVulnerability = line
@@ -175,11 +180,11 @@ func findReplacementTarget(
 	vuln *model.VulnerableFile,
 	before string,
 	keyValRegex *regexp.Regexp,
-) (line string, lineNumber int, found bool) {
+) (line string, lineNumber int, found, keyPresent bool) {
 	firstAlternative := strings.Split(before, " or ")[0]
 	expectedKey, _ := splitKeyValue(firstAlternative)
 	if expectedKey == "" {
-		return "", 0, false
+		return "", 0, false, false
 	}
 
 	start := max(vuln.BlockLocation.Start.Line, 1)
@@ -192,7 +197,7 @@ func scanReplacementRange(
 	start, end int,
 	expectedKey, before string,
 	keyValRegex *regexp.Regexp,
-) (line string, lineNumber int, found bool) {
+) (line string, lineNumber int, found, keyPresent bool) {
 	if start < 1 {
 		start = 1
 	}
@@ -210,14 +215,15 @@ func scanReplacementRange(
 		if len(matches) < 3 || normalize(matches[1]) != expectedKey {
 			continue
 		}
+		keyPresent = true
 		value := normalize(matches[2])
 		for _, alternative := range alternatives {
 			if alternative != "" && strings.Contains(value, alternative) {
-				return line, lineNumber, true
+				return line, lineNumber, true, true
 			}
 		}
 	}
-	return "", 0, false
+	return "", 0, false, keyPresent
 }
 
 func isBlockHeader(line string) bool {
@@ -239,16 +245,27 @@ func fallbackReplacementToAddition(
 	if addition == "" {
 		return model.SarifFix{}, fmt.Errorf("could not parse key-value from line: %s", vuln.LineWithVulnerability)
 	}
-	if !strings.Contains(addition, "=") {
+	if !isTopLevelAttribute(addition) {
 		key, _ := splitKeyValue(before)
 		if key == "" {
 			return model.SarifFix{}, fmt.Errorf("could not parse key-value from line: %s", vuln.LineWithVulnerability)
 		}
 		addition = key + " = " + addition
 	}
+	if !isTopLevelAttribute(addition) {
+		return model.SarifFix{}, fmt.Errorf("remediation is not a top-level attribute: %s", addition)
+	}
 	updated := *vuln
 	updated.Remediation = addition
-	return buildAdditionFix(updated, startLocation)
+	return buildAdditionFix(updated, additionInsertLocation(vuln, startLocation))
+}
+
+func additionInsertLocation(vuln *model.VulnerableFile, startLocation model.SarifResourceLocation) model.SarifResourceLocation {
+	end := vuln.BlockLocation.End.Line
+	if end < 1 || end > len(vuln.FileSource) {
+		return startLocation
+	}
+	return model.SarifResourceLocation{Line: end, Col: 1}
 }
 
 // nolint:gocritic
@@ -256,6 +273,10 @@ func buildAdditionFix(vuln model.VulnerableFile, startLocation model.SarifResour
 	normalized := normalizeIndentation(vuln.Remediation, 2)
 	lines := strings.Split(normalized, "\n")
 	baseIndent := determineActualBaseIndent(vuln.FileSource, startLocation.Line, vuln.BlockLocation.Start.Line)
+	if startLocation.Line >= 1 && startLocation.Line <= len(vuln.FileSource) &&
+		strings.TrimSpace(vuln.FileSource[startLocation.Line-1]) == "}" {
+		baseIndent = blockBodyIndent(vuln.FileSource, vuln.BlockLocation.Start.Line, vuln.BlockLocation.End.Line)
+	}
 	nested := isInsertingInsideNestedBlock(vuln.FileSource, startLocation, vuln.BlockLocation.Start.Line, vuln.BlockLocation.End.Line)
 
 	var result []string

--- a/pkg/report/remediations/remediations_helper.go
+++ b/pkg/report/remediations/remediations_helper.go
@@ -184,10 +184,7 @@ func findReplacementTarget(
 
 	start := max(vuln.BlockLocation.Start.Line, 1)
 	end := min(vuln.BlockLocation.End.Line, len(vuln.FileSource))
-	if line, lineNumber, found := scanReplacementRange(vuln.FileSource, start, end, expectedKey, before, keyValRegex); found {
-		return line, lineNumber, true
-	}
-	return scanReplacementRange(vuln.FileSource, 1, len(vuln.FileSource), expectedKey, before, keyValRegex)
+	return scanReplacementRange(vuln.FileSource, start, end, expectedKey, before, keyValRegex)
 }
 
 func scanReplacementRange(
@@ -214,15 +211,11 @@ func scanReplacementRange(
 			continue
 		}
 		value := normalize(matches[2])
-		if len(alternatives) == 0 {
-			return line, lineNumber, true
-		}
 		for _, alternative := range alternatives {
-			if alternative == "" || strings.Contains(value, alternative) {
+			if alternative != "" && strings.Contains(value, alternative) {
 				return line, lineNumber, true
 			}
 		}
-		return line, lineNumber, true
 	}
 	return "", 0, false
 }
@@ -247,9 +240,11 @@ func fallbackReplacementToAddition(
 		return model.SarifFix{}, fmt.Errorf("could not parse key-value from line: %s", vuln.LineWithVulnerability)
 	}
 	if !strings.Contains(addition, "=") {
-		if key, _ := splitKeyValue(before); key != "" {
-			addition = key + " = " + addition
+		key, _ := splitKeyValue(before)
+		if key == "" {
+			return model.SarifFix{}, fmt.Errorf("could not parse key-value from line: %s", vuln.LineWithVulnerability)
 		}
+		addition = key + " = " + addition
 	}
 	updated := *vuln
 	updated.Remediation = addition

--- a/pkg/report/remediations/remediations_helper.go
+++ b/pkg/report/remediations/remediations_helper.go
@@ -44,7 +44,7 @@ func buildReplacementFix(ctx context.Context, vuln model.VulnerableFile,
 	after := strings.TrimSpace(patch["after"])
 
 	// Regex for key and value (list/quoted/unquoted)
-	keyValRegex := regexp.MustCompile(`(?m)["']?(\w+)["']?\s*=\s*(\[.*?\]|".*?"|[^#=][^#]*)`)
+	keyValRegex := regexp.MustCompile(`(?m)["']?(\w+)["']?\s*(?::|=)\s*(\[.*?\]|".*?"|[^#=][^#]*)`)
 	matches := keyValRegex.FindStringSubmatch(vuln.LineWithVulnerability)
 	if isBlockHeader(vuln.LineWithVulnerability) || len(matches) < 3 {
 		line, lineNumber, found, keyPresent := findReplacementTarget(&vuln, before, keyValRegex)
@@ -269,7 +269,7 @@ func additionBaseIndent(vuln *model.VulnerableFile, startLocation model.SarifRes
 		return baseIndent
 	}
 	line := vuln.FileSource[startLocation.Line-1]
-	brace := strings.LastIndex(line, "}")
+	brace := structuralClosingBrace(line)
 	if brace < 0 {
 		return baseIndent
 	}
@@ -286,7 +286,7 @@ func additionInsertLocation(vuln *model.VulnerableFile, startLocation model.Sari
 		return startLocation
 	}
 	for line := end; line >= start; line-- {
-		if col := strings.LastIndex(vuln.FileSource[line-1], "}"); col >= 0 {
+		if col := structuralClosingBrace(vuln.FileSource[line-1]); col >= 0 {
 			return model.SarifResourceLocation{Line: line, Col: col + 1}
 		}
 	}

--- a/pkg/report/remediations/remediations_helper.go
+++ b/pkg/report/remediations/remediations_helper.go
@@ -46,12 +46,10 @@ func buildReplacementFix(ctx context.Context, vuln model.VulnerableFile,
 	// Regex for key and value (list/quoted/unquoted)
 	keyValRegex := regexp.MustCompile(`(?m)["']?(\w+)["']?\s*[:=]\s*(\[.*?\]|".*?"|[^#]+)`)
 	matches := keyValRegex.FindStringSubmatch(vuln.LineWithVulnerability)
-	if len(matches) < 3 {
+	if isBlockHeader(vuln.LineWithVulnerability) || len(matches) < 3 {
 		line, lineNumber, found := findReplacementTarget(&vuln, before, keyValRegex)
 		if !found {
-			err := fmt.Errorf("could not parse key-value from line: %s", vuln.LineWithVulnerability)
-			contextLogger.Error().Msg(err.Error())
-			return model.SarifFix{}, err
+			return fallbackReplacementToAddition(&vuln, before, after, startLocation)
 		}
 		vuln.LineWithVulnerability = line
 		vuln.Line = lineNumber
@@ -186,9 +184,27 @@ func findReplacementTarget(
 
 	start := max(vuln.BlockLocation.Start.Line, 1)
 	end := min(vuln.BlockLocation.End.Line, len(vuln.FileSource))
+	if line, lineNumber, found := scanReplacementRange(vuln.FileSource, start, end, expectedKey, before, keyValRegex); found {
+		return line, lineNumber, true
+	}
+	return scanReplacementRange(vuln.FileSource, 1, len(vuln.FileSource), expectedKey, before, keyValRegex)
+}
+
+func scanReplacementRange(
+	fileSource []string,
+	start, end int,
+	expectedKey, before string,
+	keyValRegex *regexp.Regexp,
+) (line string, lineNumber int, found bool) {
+	if start < 1 {
+		start = 1
+	}
+	if end > len(fileSource) {
+		end = len(fileSource)
+	}
 	alternatives := parseAlternatives(before)
 	for lineNumber := start; lineNumber <= end; lineNumber++ {
-		line := vuln.FileSource[lineNumber-1]
+		line := fileSource[lineNumber-1]
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
 			continue
@@ -198,13 +214,46 @@ func findReplacementTarget(
 			continue
 		}
 		value := normalize(matches[2])
+		if len(alternatives) == 0 {
+			return line, lineNumber, true
+		}
 		for _, alternative := range alternatives {
-			if strings.Contains(value, alternative) {
+			if alternative == "" || strings.Contains(value, alternative) {
 				return line, lineNumber, true
 			}
 		}
+		return line, lineNumber, true
 	}
 	return "", 0, false
+}
+
+func isBlockHeader(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	for _, prefix := range []string{"resource ", "module ", "variable ", "data ", "output ", "locals ", "provider ", "terraform "} {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func fallbackReplacementToAddition(
+	vuln *model.VulnerableFile,
+	before, after string,
+	startLocation model.SarifResourceLocation,
+) (model.SarifFix, error) {
+	addition := strings.TrimSpace(after)
+	if addition == "" {
+		return model.SarifFix{}, fmt.Errorf("could not parse key-value from line: %s", vuln.LineWithVulnerability)
+	}
+	if !strings.Contains(addition, "=") {
+		if key, _ := splitKeyValue(before); key != "" {
+			addition = key + " = " + addition
+		}
+	}
+	updated := *vuln
+	updated.Remediation = addition
+	return buildAdditionFix(updated, startLocation)
 }
 
 // nolint:gocritic

--- a/pkg/report/remediations/remediations_helper.go
+++ b/pkg/report/remediations/remediations_helper.go
@@ -44,7 +44,7 @@ func buildReplacementFix(ctx context.Context, vuln model.VulnerableFile,
 	after := strings.TrimSpace(patch["after"])
 
 	// Regex for key and value (list/quoted/unquoted)
-	keyValRegex := regexp.MustCompile(`(?m)["']?(\w+)["']?\s*[:=]\s*(\[.*?\]|".*?"|[^#]+)`)
+	keyValRegex := regexp.MustCompile(`(?m)["']?(\w+)["']?\s*=\s*(\[.*?\]|".*?"|[^#=][^#]*)`)
 	matches := keyValRegex.FindStringSubmatch(vuln.LineWithVulnerability)
 	if isBlockHeader(vuln.LineWithVulnerability) || len(matches) < 3 {
 		line, lineNumber, found, keyPresent := findReplacementTarget(&vuln, before, keyValRegex)
@@ -246,6 +246,9 @@ func fallbackReplacementToAddition(
 		return model.SarifFix{}, fmt.Errorf("could not parse key-value from line: %s", vuln.LineWithVulnerability)
 	}
 	if !isTopLevelAttribute(addition) {
+		if isNonAssignmentExpression(addition) {
+			return model.SarifFix{}, fmt.Errorf("remediation is not a top-level attribute: %s", addition)
+		}
 		key, _ := splitKeyValue(before)
 		if key == "" {
 			return model.SarifFix{}, fmt.Errorf("could not parse key-value from line: %s", vuln.LineWithVulnerability)
@@ -260,23 +263,41 @@ func fallbackReplacementToAddition(
 	return buildAdditionFix(updated, additionInsertLocation(vuln, startLocation))
 }
 
+func additionBaseIndent(vuln *model.VulnerableFile, startLocation model.SarifResourceLocation) string {
+	baseIndent := determineActualBaseIndent(vuln.FileSource, startLocation.Line, vuln.BlockLocation.Start.Line)
+	if startLocation.Line < 1 || startLocation.Line > len(vuln.FileSource) {
+		return baseIndent
+	}
+	line := vuln.FileSource[startLocation.Line-1]
+	brace := strings.LastIndex(line, "}")
+	if brace < 0 {
+		return baseIndent
+	}
+	if strings.TrimSpace(line[:brace]) == "" {
+		return blockBodyIndent(vuln.FileSource, vuln.BlockLocation.Start.Line, vuln.BlockLocation.End.Line)
+	}
+	return lineIndent(vuln.FileSource, startLocation.Line) + "  "
+}
+
 func additionInsertLocation(vuln *model.VulnerableFile, startLocation model.SarifResourceLocation) model.SarifResourceLocation {
-	end := vuln.BlockLocation.End.Line
-	if end < 1 || end > len(vuln.FileSource) {
+	start := max(vuln.BlockLocation.Start.Line, 1)
+	end := min(vuln.BlockLocation.End.Line, len(vuln.FileSource))
+	if end < start {
 		return startLocation
 	}
-	return model.SarifResourceLocation{Line: end, Col: 1}
+	for line := end; line >= start; line-- {
+		if col := strings.LastIndex(vuln.FileSource[line-1], "}"); col >= 0 {
+			return model.SarifResourceLocation{Line: line, Col: col + 1}
+		}
+	}
+	return startLocation
 }
 
 // nolint:gocritic
 func buildAdditionFix(vuln model.VulnerableFile, startLocation model.SarifResourceLocation) (model.SarifFix, error) {
 	normalized := normalizeIndentation(vuln.Remediation, 2)
 	lines := strings.Split(normalized, "\n")
-	baseIndent := determineActualBaseIndent(vuln.FileSource, startLocation.Line, vuln.BlockLocation.Start.Line)
-	if startLocation.Line >= 1 && startLocation.Line <= len(vuln.FileSource) &&
-		strings.TrimSpace(vuln.FileSource[startLocation.Line-1]) == "}" {
-		baseIndent = blockBodyIndent(vuln.FileSource, vuln.BlockLocation.Start.Line, vuln.BlockLocation.End.Line)
-	}
+	baseIndent := additionBaseIndent(&vuln, startLocation)
 	nested := isInsertingInsideNestedBlock(vuln.FileSource, startLocation, vuln.BlockLocation.Start.Line, vuln.BlockLocation.End.Line)
 
 	var result []string

--- a/pkg/report/remediations/remediations_helper_test.go
+++ b/pkg/report/remediations/remediations_helper_test.go
@@ -86,6 +86,38 @@ func TestTransformToSarifFixE2E(t *testing.T) { //nolint
 	}
 }
 
+func TestTransformToSarifFix_ResourceHeaderFallsBackToAddition(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "associate_public_ip_address = true", "after": "false"}`,
+		LineWithVulnerability: `resource "aws_instance" "ec2" {`,
+		Line:                  1,
+		FileSource: []string{
+			`resource "aws_instance" "ec2" {`,
+			`  ami = "ami-123"`,
+			`}`,
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 3, Col: 2},
+		},
+		RemediationLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: 1},
+		},
+	}
+
+	fix, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 32},
+	)
+	require.NoError(t, err)
+	require.Contains(t, fix.ArtifactChanges[0].Replacements[0].InsertedContent.Text, "associate_public_ip_address")
+}
+
 func TestTransformToSarifFix_Addition(t *testing.T) {
 	ctx := context.Background()
 	vuln := model.VulnerableFile{

--- a/pkg/report/remediations/remediations_helper_test.go
+++ b/pkg/report/remediations/remediations_helper_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
@@ -315,6 +316,111 @@ func TestTransformToSarifFix_EmptyBlockAddsInsideClosingBrace(t *testing.T) {
 	require.Equal(t, 2, replacement.DeletedRegion.StartLine)
 	require.Equal(t, 1, replacement.DeletedRegion.StartColumn)
 	require.Contains(t, replacement.InsertedContent.Text, "  associate_public_ip_address = false")
+}
+
+func TestIsTopLevelAttributeRejectsColonAndEquality(t *testing.T) {
+	require.False(t, isTopLevelAttribute(`description: "new"`))
+	require.False(t, isTopLevelAttribute(`enabled == true`))
+	require.True(t, isTopLevelAttribute(`enabled = true`))
+	require.True(t, isTopLevelAttribute(`tags = { Environment = "prod" }`))
+}
+
+func TestTransformToSarifFix_RejectsColonAndEqualityAfter(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "description = \"old\"", "after": "description: \"new\""}`,
+		LineWithVulnerability: `resource "aws_instance" "ec2" {`,
+		Line:                  1,
+		FileSource: []string{
+			`resource "aws_instance" "ec2" {`,
+			`}`,
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 2, Col: 2},
+		},
+	}
+
+	_, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 32},
+	)
+	require.Error(t, err)
+
+	vuln.Remediation = `{"before": "enabled = true", "after": "enabled == true"}`
+	_, err = TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 32},
+	)
+	require.Error(t, err)
+}
+
+func TestTransformToSarifFix_InsertsInsideSingleLineNestedBlock(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "enabled = true", "after": "false"}`,
+		LineWithVulnerability: `resource "aws_s3_bucket" "b" {`,
+		Line:                  1,
+		FileSource: []string{
+			`resource "aws_s3_bucket" "b" {`,
+			`    # comment`,
+			`    logging {}`,
+			`}`,
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 3, Col: 5},
+			End:   model.ResourceLine{Line: 3, Col: 15},
+		},
+		RemediationLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 3, Col: 5},
+			End:   model.ResourceLine{Line: 3, Col: 5},
+		},
+	}
+
+	fix, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 3, Col: 5},
+		model.SarifResourceLocation{Line: 3, Col: 15},
+	)
+	require.NoError(t, err)
+	replacement := fix.ArtifactChanges[0].Replacements[0]
+	require.Equal(t, 3, replacement.DeletedRegion.StartLine)
+	require.Equal(t, strings.LastIndex(vuln.FileSource[2], "}")+1, replacement.DeletedRegion.StartColumn)
+	require.Contains(t, replacement.InsertedContent.Text, "enabled = false")
+}
+
+func TestTransformToSarifFix_InsertsInsideSingleLineResource(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "associate_public_ip_address = true", "after": "false"}`,
+		LineWithVulnerability: `resource "aws_instance" "ec2" { ami = "x" }`,
+		Line:                  1,
+		FileSource:            []string{`resource "aws_instance" "ec2" { ami = "x" }`},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: 43},
+		},
+	}
+
+	fix, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 43},
+	)
+	require.NoError(t, err)
+	replacement := fix.ArtifactChanges[0].Replacements[0]
+	require.Equal(t, 1, replacement.DeletedRegion.StartLine)
+	require.Equal(t, strings.LastIndex(vuln.FileSource[0], "}")+1, replacement.DeletedRegion.StartColumn)
+	require.Contains(t, replacement.InsertedContent.Text, "associate_public_ip_address = false")
 }
 
 func TestTransformToSarifFix_ReplacementFindsMatchingRepeatedKey(t *testing.T) {

--- a/pkg/report/remediations/remediations_helper_test.go
+++ b/pkg/report/remediations/remediations_helper_test.go
@@ -360,7 +360,7 @@ func TestTransformToSarifFix_RejectsColonAndEqualityAfter(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestTransformToSarifFix_InsertsInsideSingleLineNestedBlock(t *testing.T) {
+func TestTransformToSarifFix_AddsAtOuterResourceWhenNestedBlockPresent(t *testing.T) {
 	vuln := model.VulnerableFile{
 		FileName:              "main.tf",
 		RemediationType:       "replacement",
@@ -374,25 +374,25 @@ func TestTransformToSarifFix_InsertsInsideSingleLineNestedBlock(t *testing.T) {
 			`}`,
 		},
 		BlockLocation: model.ResourceLocation{
-			Start: model.ResourceLine{Line: 3, Col: 5},
-			End:   model.ResourceLine{Line: 3, Col: 15},
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 4, Col: 2},
 		},
 		RemediationLocation: model.ResourceLocation{
-			Start: model.ResourceLine{Line: 3, Col: 5},
-			End:   model.ResourceLine{Line: 3, Col: 5},
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: 1},
 		},
 	}
 
 	fix, err := TransformToSarifFix(
 		context.Background(),
 		vuln,
-		model.SarifResourceLocation{Line: 3, Col: 5},
-		model.SarifResourceLocation{Line: 3, Col: 15},
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 31},
 	)
 	require.NoError(t, err)
 	replacement := fix.ArtifactChanges[0].Replacements[0]
-	require.Equal(t, 3, replacement.DeletedRegion.StartLine)
-	require.Equal(t, strings.LastIndex(vuln.FileSource[2], "}")+1, replacement.DeletedRegion.StartColumn)
+	require.Equal(t, 4, replacement.DeletedRegion.StartLine)
+	require.Equal(t, 1, replacement.DeletedRegion.StartColumn)
 	require.Contains(t, replacement.InsertedContent.Text, "enabled = false")
 }
 
@@ -419,8 +419,76 @@ func TestTransformToSarifFix_InsertsInsideSingleLineResource(t *testing.T) {
 	require.NoError(t, err)
 	replacement := fix.ArtifactChanges[0].Replacements[0]
 	require.Equal(t, 1, replacement.DeletedRegion.StartLine)
-	require.Equal(t, strings.LastIndex(vuln.FileSource[0], "}")+1, replacement.DeletedRegion.StartColumn)
+	require.Equal(t, structuralClosingBrace(vuln.FileSource[0])+1, replacement.DeletedRegion.StartColumn)
 	require.Contains(t, replacement.InsertedContent.Text, "associate_public_ip_address = false")
+}
+
+func TestTransformToSarifFix_ReplacesColonDelimitedYAMLAttribute(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "resource.yaml",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "enabled = true", "after": "false"}`,
+		LineWithVulnerability: `  enabled: true`,
+		Line:                  2,
+		FileSource: []string{
+			`spec:`,
+			`  enabled: true`,
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 2, Col: 16},
+		},
+		RemediationLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 2, Col: 3},
+			End:   model.ResourceLine{Line: 2, Col: 16},
+		},
+	}
+
+	fix, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 2, Col: 3},
+		model.SarifResourceLocation{Line: 2, Col: 16},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "  enabled: false", fix.ArtifactChanges[0].Replacements[0].InsertedContent.Text)
+}
+
+func TestTransformToSarifFix_IgnoresClosingBraceInComment(t *testing.T) {
+	line := `resource "google_project_iam_binding" "project3" { ami = "x" } // trap }`
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "associate_public_ip_address = true", "after": "false"}`,
+		LineWithVulnerability: line,
+		Line:                  1,
+		FileSource:            []string{line},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: len(line)},
+		},
+	}
+
+	fix, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: len(line)},
+	)
+	require.NoError(t, err)
+	replacement := fix.ArtifactChanges[0].Replacements[0]
+	require.Equal(t, structuralClosingBrace(line)+1, replacement.DeletedRegion.StartColumn)
+	require.Less(t, replacement.DeletedRegion.StartColumn, strings.LastIndex(line, "}")+1)
+	require.Contains(t, replacement.InsertedContent.Text, "associate_public_ip_address = false")
+}
+
+func TestStructuralClosingBraceIgnoresCommentsAndStrings(t *testing.T) {
+	require.Equal(t, strings.LastIndex(`resource "x" "y" { ami = "x" }`, "}"), structuralClosingBrace(`resource "x" "y" { ami = "x" }`))
+	require.Equal(t, strings.Index(`resource "x" "y" { ami = "x" } // }`, "}"), structuralClosingBrace(`resource "x" "y" { ami = "x" } // }`))
+	require.Equal(t, -1, structuralClosingBrace(`resource "x" "y" { // I add this just to break the code }`))
+	line := `resource "x" "y" { name = "}" } // }`
+	require.Equal(t, strings.Index(line, `} //`), structuralClosingBrace(line))
+	require.Equal(t, strings.LastIndex(`resource "x" "y" { ami = "x" /* } */ }`, "}"), structuralClosingBrace(`resource "x" "y" { ami = "x" /* } */ }`))
 }
 
 func TestTransformToSarifFix_ReplacementFindsMatchingRepeatedKey(t *testing.T) {

--- a/pkg/report/remediations/remediations_helper_test.go
+++ b/pkg/report/remediations/remediations_helper_test.go
@@ -118,6 +118,111 @@ func TestTransformToSarifFix_ResourceHeaderFallsBackToAddition(t *testing.T) {
 	require.Contains(t, fix.ArtifactChanges[0].Replacements[0].InsertedContent.Text, "associate_public_ip_address")
 }
 
+func TestTransformToSarifFix_ResourceHeaderRejectsValueOnlyFallback(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "false", "after": "true"}`,
+		LineWithVulnerability: `resource "aws_instance" "ec2" {`,
+		Line:                  1,
+		FileSource: []string{
+			`resource "aws_instance" "ec2" {`,
+			`  ami = "ami-123"`,
+			`}`,
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 3, Col: 2},
+		},
+		RemediationLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: 1},
+		},
+	}
+
+	_, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 32},
+	)
+	require.Error(t, err)
+}
+
+func TestTransformToSarifFix_ReplacementDoesNotSearchOutsideBlock(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "enabled = true", "after": "false"}`,
+		LineWithVulnerability: `module "target" {`,
+		Line:                  1,
+		FileSource: []string{
+			`module "target" {`,
+			`}`,
+			`module "other" {`,
+			`  enabled = true`,
+			`}`,
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 2, Col: 2},
+		},
+		RemediationLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: 1},
+		},
+	}
+
+	fix, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 18},
+	)
+	require.NoError(t, err)
+	replacement := fix.ArtifactChanges[0].Replacements[0]
+	require.Equal(t, 1, replacement.DeletedRegion.StartLine)
+	require.Contains(t, replacement.InsertedContent.Text, "enabled = false")
+	require.NotEqual(t, 4, replacement.DeletedRegion.StartLine)
+}
+
+func TestTransformToSarifFix_ReplacementFindsMatchingRepeatedKey(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "enabled = true", "after": "false"}`,
+		LineWithVulnerability: `module "target" {`,
+		Line:                  1,
+		FileSource: []string{
+			`module "target" {`,
+			`  enabled = false`,
+			`  nested {`,
+			`    enabled = true`,
+			`  }`,
+			`}`,
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 6, Col: 2},
+		},
+		RemediationLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: 1},
+		},
+	}
+
+	fix, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 18},
+	)
+	require.NoError(t, err)
+	replacement := fix.ArtifactChanges[0].Replacements[0]
+	require.Equal(t, 4, replacement.DeletedRegion.StartLine)
+	require.Equal(t, "    enabled = false", replacement.InsertedContent.Text)
+}
+
 func TestTransformToSarifFix_Addition(t *testing.T) {
 	ctx := context.Background()
 	vuln := model.VulnerableFile{

--- a/pkg/report/remediations/remediations_helper_test.go
+++ b/pkg/report/remediations/remediations_helper_test.go
@@ -115,7 +115,9 @@ func TestTransformToSarifFix_ResourceHeaderFallsBackToAddition(t *testing.T) {
 		model.SarifResourceLocation{Line: 1, Col: 32},
 	)
 	require.NoError(t, err)
-	require.Contains(t, fix.ArtifactChanges[0].Replacements[0].InsertedContent.Text, "associate_public_ip_address")
+	replacement := fix.ArtifactChanges[0].Replacements[0]
+	require.Equal(t, 3, replacement.DeletedRegion.StartLine)
+	require.Contains(t, replacement.InsertedContent.Text, "associate_public_ip_address = false")
 }
 
 func TestTransformToSarifFix_ResourceHeaderRejectsValueOnlyFallback(t *testing.T) {
@@ -181,9 +183,138 @@ func TestTransformToSarifFix_ReplacementDoesNotSearchOutsideBlock(t *testing.T) 
 	)
 	require.NoError(t, err)
 	replacement := fix.ArtifactChanges[0].Replacements[0]
-	require.Equal(t, 1, replacement.DeletedRegion.StartLine)
+	require.Equal(t, 2, replacement.DeletedRegion.StartLine)
 	require.Contains(t, replacement.InsertedContent.Text, "enabled = false")
 	require.NotEqual(t, 4, replacement.DeletedRegion.StartLine)
+}
+
+func TestTransformToSarifFix_DoesNotAddDuplicateAttribute(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "enabled = true", "after": "false"}`,
+		LineWithVulnerability: `module "target" {`,
+		Line:                  1,
+		FileSource: []string{
+			`module "target" {`,
+			`  enabled = var.enabled`,
+			`}`,
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 3, Col: 2},
+		},
+		RemediationLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: 1},
+		},
+	}
+
+	_, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 18},
+	)
+	require.Error(t, err)
+}
+
+func TestTransformToSarifFix_RejectsNonAttributeAddition(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "{}", "after": "{ Environment = \"prod\" }"}`,
+		LineWithVulnerability: `resource "aws_s3_bucket" "bucket" {`,
+		Line:                  1,
+		FileSource: []string{
+			`resource "aws_s3_bucket" "bucket" {`,
+			`}`,
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 2, Col: 2},
+		},
+		RemediationLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: 1},
+		},
+	}
+
+	_, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 36},
+	)
+	require.Error(t, err)
+}
+
+func TestTransformToSarifFix_WrapsObjectValueWithKeyFromBefore(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "tags = {}", "after": "{ Environment = \"prod\" }"}`,
+		LineWithVulnerability: `resource "aws_s3_bucket" "bucket" {`,
+		Line:                  1,
+		FileSource: []string{
+			`resource "aws_s3_bucket" "bucket" {`,
+			`  bucket = "example"`,
+			`}`,
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 3, Col: 2},
+		},
+		RemediationLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: 1},
+		},
+	}
+
+	fix, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 36},
+	)
+	require.NoError(t, err)
+	replacement := fix.ArtifactChanges[0].Replacements[0]
+	require.Equal(t, 3, replacement.DeletedRegion.StartLine)
+	require.Contains(t, replacement.InsertedContent.Text, `tags = { Environment = "prod" }`)
+}
+
+func TestTransformToSarifFix_EmptyBlockAddsInsideClosingBrace(t *testing.T) {
+	vuln := model.VulnerableFile{
+		FileName:              "main.tf",
+		RemediationType:       "replacement",
+		Remediation:           `{"before": "associate_public_ip_address = true", "after": "false"}`,
+		LineWithVulnerability: `resource "aws_instance" "ec2" {`,
+		Line:                  1,
+		FileSource: []string{
+			`resource "aws_instance" "ec2" {`,
+			`}`,
+		},
+		BlockLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 2, Col: 2},
+		},
+		RemediationLocation: model.ResourceLocation{
+			Start: model.ResourceLine{Line: 1, Col: 1},
+			End:   model.ResourceLine{Line: 1, Col: 1},
+		},
+	}
+
+	fix, err := TransformToSarifFix(
+		context.Background(),
+		vuln,
+		model.SarifResourceLocation{Line: 1, Col: 1},
+		model.SarifResourceLocation{Line: 1, Col: 32},
+	)
+	require.NoError(t, err)
+	replacement := fix.ArtifactChanges[0].Replacements[0]
+	require.Equal(t, 2, replacement.DeletedRegion.StartLine)
+	require.Equal(t, 1, replacement.DeletedRegion.StartColumn)
+	require.Contains(t, replacement.InsertedContent.Text, "  associate_public_ip_address = false")
 }
 
 func TestTransformToSarifFix_ReplacementFindsMatchingRepeatedKey(t *testing.T) {

--- a/pkg/report/remediations/utilities.go
+++ b/pkg/report/remediations/utilities.go
@@ -7,7 +7,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 )
 
-var topLevelAttributeRegex = regexp.MustCompile(`(?s)^["']?[A-Za-z_][\w-]*["']?\s*[:=]\s*\S`)
+var topLevelAttributeRegex = regexp.MustCompile(`(?s)^["']?[A-Za-z_][\w-]*["']?\s*=\s*[^=\s]`)
 
 func parseAlternatives(before string) []string {
 	if strings.Contains(before, " or ") {
@@ -45,7 +45,27 @@ func splitKeyValue(expr string) (string, string) {
 }
 
 func isTopLevelAttribute(s string) bool {
-	return topLevelAttributeRegex.MatchString(strings.TrimSpace(s))
+	trimmed := strings.TrimSpace(s)
+	if !topLevelAttributeRegex.MatchString(trimmed) {
+		return false
+	}
+	return !isNonAssignmentExpression(trimmed)
+}
+
+func isNonAssignmentExpression(s string) bool {
+	trimmed := strings.TrimSpace(s)
+	if strings.Contains(trimmed, "==") {
+		return true
+	}
+	for _, r := range trimmed {
+		if r == '=' {
+			return false
+		}
+		if r == ':' {
+			return true
+		}
+	}
+	return false
 }
 
 func lineIndent(fileLines []string, line int) string {

--- a/pkg/report/remediations/utilities.go
+++ b/pkg/report/remediations/utilities.go
@@ -1,10 +1,13 @@
 package model
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
 )
+
+var topLevelAttributeRegex = regexp.MustCompile(`(?s)^["']?[A-Za-z_][\w-]*["']?\s*[:=]\s*\S`)
 
 func parseAlternatives(before string) []string {
 	if strings.Contains(before, " or ") {
@@ -39,6 +42,32 @@ func splitKeyValue(expr string) (string, string) {
 		return normalize(strings.TrimSpace(parts[0])), normalize(strings.TrimSpace(parts[1]))
 	}
 	return "", normalize(expr)
+}
+
+func isTopLevelAttribute(s string) bool {
+	return topLevelAttributeRegex.MatchString(strings.TrimSpace(s))
+}
+
+func lineIndent(fileLines []string, line int) string {
+	if line < 1 || line > len(fileLines) {
+		return ""
+	}
+	content := fileLines[line-1]
+	return content[:len(content)-len(strings.TrimLeft(content, " \t"))]
+}
+
+func blockBodyIndent(fileLines []string, blockStartLine, blockEndLine int) string {
+	headerIndent := lineIndent(fileLines, blockStartLine)
+	start := max(blockStartLine+1, 1)
+	end := min(blockEndLine, len(fileLines))
+	for line := start; line <= end; line++ {
+		trimmed := strings.TrimSpace(fileLines[line-1])
+		if trimmed == "" || trimmed == "}" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		return lineIndent(fileLines, line)
+	}
+	return headerIndent + "  "
 }
 
 func determineActualBaseIndent(fileLines []string, startLine, blockStartLine int) string {

--- a/pkg/report/remediations/utilities.go
+++ b/pkg/report/remediations/utilities.go
@@ -68,6 +68,79 @@ func isNonAssignmentExpression(s string) bool {
 	return false
 }
 
+type lineScanState struct {
+	inDouble, inSingle, inBlockComment bool
+}
+
+func (s *lineScanState) skipNonCode(line string, i int) (next int, skip, done bool) {
+	if s.inBlockComment {
+		return s.skipBlockComment(line, i)
+	}
+	if s.inDouble || s.inSingle {
+		return s.skipQuoted(line, i)
+	}
+	return s.startNonCode(line, i)
+}
+
+func (s *lineScanState) skipBlockComment(line string, i int) (next int, skip, done bool) {
+	if line[i] == '*' && i+1 < len(line) && line[i+1] == '/' {
+		s.inBlockComment = false
+		return i + 1, true, false
+	}
+	return i, true, false
+}
+
+func (s *lineScanState) skipQuoted(line string, i int) (next int, skip, done bool) {
+	c := line[i]
+	if c == '\\' && i+1 < len(line) {
+		return i + 1, true, false
+	}
+	if (s.inDouble && c == '"') || (s.inSingle && c == '\'') {
+		s.inDouble = false
+		s.inSingle = false
+	}
+	return i, true, false
+}
+
+func (s *lineScanState) startNonCode(line string, i int) (next int, skip, done bool) {
+	switch c := line[i]; {
+	case c == '"':
+		s.inDouble = true
+		return i, true, false
+	case c == '\'':
+		s.inSingle = true
+		return i, true, false
+	case c == '#':
+		return i, true, true
+	case c == '/' && i+1 < len(line) && line[i+1] == '/':
+		return i, true, true
+	case c == '/' && i+1 < len(line) && line[i+1] == '*':
+		s.inBlockComment = true
+		return i + 1, true, false
+	default:
+		return i, false, false
+	}
+}
+
+func structuralClosingBrace(line string) int {
+	last := -1
+	var state lineScanState
+	for i := 0; i < len(line); i++ {
+		next, skip, done := state.skipNonCode(line, i)
+		if done {
+			break
+		}
+		if skip {
+			i = next
+			continue
+		}
+		if line[i] == '}' {
+			last = i
+		}
+	}
+	return last
+}
+
 func lineIndent(fileLines []string, line int) string {
 	if line < 1 || line > len(fileLines) {
 		return ""

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -707,6 +707,12 @@ func TestAnalyze_RequestLibrariesInvalidateSharedRuleCache(t *testing.T) {
 }
 
 func TestAnalyze_RequestLibrariesDoNotCallBackend(t *testing.T) {
+	analyzeCompiledQueryCacheTestMu.Lock()
+	t.Cleanup(analyzeCompiledQueryCacheTestMu.Unlock)
+
+	engine.ResetCompiledQueryCachesForTest()
+	t.Cleanup(engine.ResetCompiledQueryCachesForTest)
+
 	originalClient := http.DefaultClient
 	var requests atomic.Int64
 	http.DefaultClient = &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -726,7 +732,7 @@ func TestAnalyze_RequestLibrariesDoNotCallBackend(t *testing.T) {
 		Platform:  []string{"terraform"},
 	})
 	if len(out.Findings) == 0 {
-		t.Fatal("expected request-supplied rules and libraries to produce a finding")
+		t.Fatalf("expected request-supplied rules and libraries to produce a finding; failed queries: %v", out.FailedQueries)
 	}
 	if got := requests.Load(); got != 0 {
 		t.Fatalf("server mode made %d outbound HTTP requests, want 0", got)


### PR DESCRIPTION
## Motivation

Production was emitting recurring errors across the service: null literal evaluation noise, query panics during line attribution, YAML line-info rebuild failures on multi-document CRDs, Terraform block lookup failures on header/comment lines, and SARIF replacement remediation failures on resource headers.

This PR hardens the scanner so those paths degrade safely instead of logging errors or panicking.

## Changes

**Terraform evaluation**

Introduce `ErrNullLiteral` and suppress error logging for expected nulls in nested tuple expressions such as `var.enabled ? "enabled" : null`.

**Line detection and remediation location**

Clamp Terraform remediation insertion when function wrappers point past the end of a file, which caused `variable_without_description` panics. When a matched line sits outside any HCL block (for example license comments above a resource), attach the nearest block or fall back to a line-only location instead of failing with `failed to locate block for line`.

**Detector helpers**

Guard `ExtractLineFragment` when the expected substring is missing from the physical line, which caused `communication_over_http` panics on multiline YAML matches. Restrict Docker placeholder parsing to numeric `{{N}}` tokens so native CI syntax like `${{ github.ref }}` no longer triggers `failed to extract curly brackets substring`.

**YAML line-info rebuild**

Skip empty trailing `---` documents and continue past individually unparseable documents so large CRD bundles such as Strimzi can be reparsed for line attribution without `failed to build line-info document`.

**SARIF replacement remediations**

When a replacement fix lands on a Terraform resource header and the target attribute is not on that line, search inside the owning block for the attribute and fall back to an addition remediation there; value-only patches without a key are rejected rather than emitting invalid HCL.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. Run `go test ./pkg/detector/... ./pkg/parser/terraform/... ./pkg/parser/yaml/... ./pkg/builder/engine/... ./pkg/report/remediations/... -count=1`.
2. Run `golangci-lint run -c .golangci.yml --timeout 20m ./pkg/detector/... ./pkg/parser/terraform/... ./pkg/parser/yaml/... ./pkg/builder/engine/... ./pkg/report/remediations/...`.
3. Confirm Strimzi-style multi-document YAML with a trailing `---` parses successfully and produces documents for line-info rebuild.
4. Scan Terraform with leading comment lines and replacement remediations on resource headers; verify scans complete without the error signatures above and SARIF fixes are still emitted where possible.

## Blast Radius

This affects the Datadog IaC Scanner CLI and any service that runs it. Changes are limited to parsing, line attribution, and SARIF remediation generation; detection rules and query logic are unchanged.

## Additional Notes

Commit `e41ac593` on `main` already guards null Terraform module outputs during evaluation; this PR complements that work by reducing remaining null-related log noise and the other error signatures observed in the last 24 hours.

**Regression detector (repo B):** the +0.6% finding-count delta is expected coverage recovery, not a false-positive regression. On `main`, multi-document Kubernetes YAML/CRD bundles with a trailing `---` fail YAML parse entirely and produce zero scannable documents; this PR parses them successfully (10 CRDs in that file). dd-source contains many such files, which explains the small finding increase.

I submit this contribution under the Apache-2.0 license.