### PR TITLE
Register common Terraform evaluation functions

### DIFF
--- a/.copyright-overrides.yml
+++ b/.copyright-overrides.yml
@@ -302,6 +302,9 @@ github.com/kr/text: Copyright 2012 Keith Rarick
 github.com/anchore/go-struct-converter: "" # At date, this repository have no copyright
 github.com/santhosh-tekuri/jsonschema/*: Copyright Santhosh Tekuri
 github.com/DataDog/jsonapi: Copyright 2022-Present Datadog, Inc
+github.com/zclconf/go-cty-yaml:
+  - Copyright 2011-2016 Canonical Ltd.
+  - Copyright 2019 Martin Atkins
 
 # Apache-2.0 projects whose LICENSE files contain only boilerplate (no copyright line)
 cel.dev/expr: Copyright 2018 Google LLC

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -463,6 +463,7 @@ core,github.com/hashicorp/hcl/json/scanner,MPL-2.0,"Copyright © 2014-2018 Hashi
 core,github.com/hashicorp/hcl/json/token,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/hcl/v2,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/hcl/v2/ext/customdecode,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
+core,github.com/hashicorp/hcl/v2/ext/tryfunc,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/hcl/v2/hcldec,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/hcl/v2/hclsyntax,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/hcl/v2/hclwrite,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
@@ -791,6 +792,7 @@ core,github.com/xlab/treeprint,MIT,Copyright © 2016 Maxim Kupriianov <max@kc.vc
 core,github.com/xo/terminfo,MIT,Copyright (c) 2016 Anmol Sethi
 core,github.com/yargevad/filepathx,MIT,Copyright 2016 The filepathx Authors
 core,github.com/yashtewari/glob-intersection,Apache-2.0,Copyright (c) 2018 Yash Tewari (yashtewari)
+core,github.com/zclconf/go-cty-yaml,Apache-2.0,Copyright 2011-2016 Canonical Ltd. | Copyright 2019 Martin Atkins
 core,github.com/zclconf/go-cty/cty,MIT,Copyright (c) 2017-2026 Martin Atkins and various other contributors
 core,github.com/zclconf/go-cty/cty/convert,MIT,Copyright (c) 2017-2026 Martin Atkins and various other contributors
 core,github.com/zclconf/go-cty/cty/ctymarks,MIT,Copyright (c) 2017-2026 Martin Atkins and various other contributors

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/yargevad/filepathx v1.0.0
 	github.com/zclconf/go-cty v1.18.0
+	github.com/zclconf/go-cty-yaml v1.1.0
 	golang.org/x/net v0.53.0
 	golang.org/x/text v0.36.0
 	golang.org/x/tools/godoc v0.1.0-deprecated
@@ -274,7 +275,7 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect

--- a/go.sum
+++ b/go.sum
@@ -659,6 +659,8 @@ github.com/zclconf/go-cty v1.18.0 h1:pJ8+HNI4gFoyRNqVE37wWbJWVw43BZczFo7KUoRczaA
 github.com/zclconf/go-cty v1.18.0/go.mod h1:qpnV6EDNgC1sns/AleL1fvatHw72j+S+nS+MJ+T2CSg=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+github.com/zclconf/go-cty-yaml v1.1.0 h1:nP+jp0qPHv2IhUVqmQSzjvqAWcObN0KBkUl2rWBdig0=
+github.com/zclconf/go-cty-yaml v1.1.0/go.mod h1:9YLUH4g7lOhVWqUbctnVlZ5KLpg7JAprQNgxSZ1Gyxs=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/bridges/prometheus v0.57.0 h1:UW0+QyeyBVhn+COBec3nGhfnFe5lwB0ic1JBVjzhk0w=

--- a/pkg/parser/terraform/converter/stdlib_functions_test.go
+++ b/pkg/parser/terraform/converter/stdlib_functions_test.go
@@ -1,0 +1,136 @@
+package converter_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+func TestStdlibFunctionEvaluation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		attr  string
+		want  cty.Value
+	}{
+		{
+			name:  "length string",
+			input: `block "t" { n = length("hello") }`,
+			attr:  "n",
+			want:  cty.NumberIntVal(5),
+		},
+		{
+			name:  "coalesce empty string",
+			input: `block "t" { n = coalesce("", "kept") }`,
+			attr:  "n",
+			want:  cty.StringVal("kept"),
+		},
+		{
+			name:  "lookup default",
+			input: `block "t" { n = lookup({a = "x"}, "b", "d") }`,
+			attr:  "n",
+			want:  cty.StringVal("d"),
+		},
+		{
+			name:  "index",
+			input: `block "t" { n = index(["a", "b"], "b") }`,
+			attr:  "n",
+			want:  cty.NumberIntVal(1),
+		},
+		{
+			name:  "replace",
+			input: `block "t" { n = replace("a-b", "-", "_") }`,
+			attr:  "n",
+			want:  cty.StringVal("a_b"),
+		},
+		{
+			name:  "tostring",
+			input: `block "t" { n = tostring(5) }`,
+			attr:  "n",
+			want:  cty.StringVal("5"),
+		},
+		{
+			name:  "try fallback",
+			input: `block "t" { n = try(var.missing, "fallback") }`,
+			attr:  "n",
+			want:  cty.StringVal("fallback"),
+		},
+		{
+			name:  "can unknown",
+			input: `block "t" { n = can(var.missing) }`,
+			attr:  "n",
+			want:  cty.False,
+		},
+		{
+			name:  "yamldecode",
+			input: "block \"t\" { n = yamldecode(\"a: 1\\n\") }",
+			attr:  "n",
+			want:  cty.ObjectVal(map[string]cty.Value{"a": cty.NumberIntVal(1)}),
+		},
+	}
+
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			file, diags := hclsyntax.ParseConfig([]byte(tt.input), "test.tf", hcl.Pos{Byte: 0, Line: 1, Column: 1})
+			if diags.HasErrors() {
+				t.Fatalf("parse: %v", diags)
+			}
+			doc, err := converter.DefaultConverted(ctx, file, converter.VariableMap{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, ok := doc["block"].(model.Document)["t"].(model.Document)[tt.attr].(ctyjson.SimpleJSONValue)
+			if !ok {
+				t.Fatalf("attr %s = %#v, want evaluated cty value", tt.attr, doc["block"].(model.Document)["t"].(model.Document)[tt.attr])
+			}
+			if !got.Value.RawEquals(tt.want) {
+				t.Fatalf("got %#v, want %#v", got.Value, tt.want)
+			}
+		})
+	}
+}
+
+func TestTryCanDoNotAssumeUnsetRequiredInput(t *testing.T) {
+	t.Parallel()
+
+	vars := converter.VariableMap{
+		"var": cty.ObjectVal(map[string]cty.Value{
+			"required": cty.UnknownVal(cty.DynamicPseudoType),
+		}),
+	}
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "try", input: `block "t" { n = try(var.required, false) }`},
+		{name: "can", input: `block "t" { n = can(var.required) }`},
+	}
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			file, diags := hclsyntax.ParseConfig([]byte(tt.input), "test.tf", hcl.Pos{Byte: 0, Line: 1, Column: 1})
+			if diags.HasErrors() {
+				t.Fatalf("parse: %v", diags)
+			}
+			doc, err := converter.DefaultConverted(ctx, file, vars)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := doc["block"].(model.Document)["t"].(model.Document)["n"]
+			if val, ok := got.(ctyjson.SimpleJSONValue); ok && val.Value.IsWhollyKnown() {
+				t.Fatalf("got known %#v, want unresolved interpolation for unset required input", val.Value)
+			}
+		})
+	}
+}

--- a/pkg/parser/terraform/functions/compat.go
+++ b/pkg/parser/terraform/functions/compat.go
@@ -1,0 +1,223 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package functions
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+	ctyconvert "github.com/zclconf/go-cty/cty/convert"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+// CoalesceFunc matches Terraform: first non-null, non-empty-string argument.
+var CoalesceFunc = function.New(&function.Spec{
+	Params: []function.Parameter{},
+	VarParam: &function.Parameter{
+		Name:             "vals",
+		Type:             cty.DynamicPseudoType,
+		AllowUnknown:     true,
+		AllowDynamicType: true,
+		AllowNull:        true,
+	},
+	Type: func(args []cty.Value) (cty.Type, error) {
+		argTypes := make([]cty.Type, len(args))
+		for i, val := range args {
+			argTypes[i] = val.Type()
+		}
+		retType, _ := ctyconvert.UnifyUnsafe(argTypes)
+		if retType == cty.NilType {
+			return cty.NilType, errors.New("all arguments must have the same type")
+		}
+		return retType, nil
+	},
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		for _, argVal := range args {
+			converted, err := ctyconvert.Convert(argVal, retType)
+			if err != nil {
+				return cty.NilVal, err
+			}
+			if !converted.IsKnown() {
+				return cty.UnknownVal(retType), nil
+			}
+			if converted.IsNull() {
+				continue
+			}
+			if retType == cty.String && converted.RawEquals(cty.StringVal("")) {
+				continue
+			}
+			return converted, nil
+		}
+		return cty.NilVal, errors.New("no non-null, non-empty-string arguments")
+	},
+})
+
+// LengthFunc matches Terraform: strings, collections, and objects.
+var LengthFunc = function.New(&function.Spec{
+	Params: []function.Parameter{{
+		Name:             "value",
+		Type:             cty.DynamicPseudoType,
+		AllowDynamicType: true,
+		AllowUnknown:     true,
+		AllowMarked:      true,
+	}},
+	Type: function.StaticReturnType(cty.Number),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		val := args[0]
+		ty := val.Type()
+		switch {
+		case ty == cty.String:
+			return stdlib.Strlen(val)
+		case ty.IsObjectType():
+			if !val.IsKnown() {
+				return cty.UnknownVal(cty.Number), nil
+			}
+			return cty.NumberIntVal(int64(len(ty.AttributeTypes()))), nil
+		default:
+			return stdlib.Length(val)
+		}
+	},
+})
+
+// LookupFunc matches Terraform: optional default, maps and objects.
+var LookupFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name:         "inputMap",
+			Type:         cty.DynamicPseudoType,
+			AllowMarked:  true,
+			AllowUnknown: true,
+		},
+		{
+			Name:         "key",
+			Type:         cty.String,
+			AllowMarked:  true,
+			AllowUnknown: true,
+		},
+	},
+	VarParam: &function.Parameter{
+		Name:             "default",
+		Type:             cty.DynamicPseudoType,
+		AllowUnknown:     true,
+		AllowDynamicType: true,
+		AllowNull:        true,
+		AllowMarked:      true,
+	},
+	Type: func(args []cty.Value) (cty.Type, error) {
+		if len(args) > 3 {
+			return cty.NilType, fmt.Errorf("lookup() takes two or three arguments, got %d", len(args))
+		}
+		ty := args[0].Type()
+		switch {
+		case ty.IsObjectType():
+			if !args[1].IsKnown() {
+				return cty.DynamicPseudoType, nil
+			}
+			keyVal, _ := args[1].Unmark()
+			key := keyVal.AsString()
+			if ty.HasAttribute(key) {
+				return args[0].GetAttr(key).Type(), nil
+			}
+			if len(args) == 3 {
+				return args[2].Type(), nil
+			}
+			return cty.DynamicPseudoType, function.NewArgErrorf(0, "the given object has no attribute %q", key)
+		case ty.IsMapType():
+			if len(args) == 3 {
+				if _, err := ctyconvert.Convert(args[2], ty.ElementType()); err != nil {
+					return cty.NilType, function.NewArgErrorf(2, "the default value must have the same type as the map elements")
+				}
+			}
+			return ty.ElementType(), nil
+		default:
+			return cty.NilType, function.NewArgErrorf(0, "lookup() requires a map as the first argument")
+		}
+	},
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		mapVar, mapMarks := args[0].Unmark()
+		keyVal, keyMarks := args[1].Unmark()
+
+		if !mapVar.IsKnown() || !keyVal.IsKnown() {
+			return cty.UnknownVal(retType).WithMarks(mapMarks, keyMarks), nil
+		}
+
+		lookupKey := keyVal.AsString()
+		found := cty.NilVal
+		switch {
+		case mapVar.Type().IsObjectType() && mapVar.Type().HasAttribute(lookupKey):
+			found = mapVar.GetAttr(lookupKey)
+		case mapVar.Type().IsMapType() && mapVar.HasIndex(cty.StringVal(lookupKey)) == cty.True:
+			found = mapVar.Index(cty.StringVal(lookupKey))
+		}
+		if found != cty.NilVal {
+			return found.WithMarks(mapMarks, keyMarks), nil
+		}
+		if len(args) == 3 {
+			defaultVal, err := ctyconvert.Convert(args[2], retType)
+			if err != nil {
+				return cty.NilVal, err
+			}
+			return defaultVal.WithMarks(mapMarks, keyMarks), nil
+		}
+		return cty.NilVal, fmt.Errorf("lookup failed to find key %s", lookupKey)
+	},
+})
+
+// IndexFunc matches Terraform: first index of value in a list or tuple.
+var IndexFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{Name: "list", Type: cty.DynamicPseudoType},
+		{Name: "value", Type: cty.DynamicPseudoType},
+	},
+	Type: function.StaticReturnType(cty.Number),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		list := args[0]
+		if !list.Type().IsListType() && !list.Type().IsTupleType() {
+			return cty.NilVal, errors.New("argument must be a list or tuple")
+		}
+		if !list.IsKnown() {
+			return cty.UnknownVal(cty.Number), nil
+		}
+		if list.LengthInt() == 0 {
+			return cty.NilVal, errors.New("cannot search an empty list")
+		}
+		for it := list.ElementIterator(); it.Next(); {
+			i, v := it.Element()
+			eq, err := stdlib.Equal(v, args[1])
+			if err != nil {
+				return cty.NilVal, err
+			}
+			if !eq.IsKnown() {
+				return cty.UnknownVal(cty.Number), nil
+			}
+			if eq.True() {
+				return i, nil
+			}
+		}
+		return cty.NilVal, errors.New("item not found")
+	},
+})
+
+// ReplaceFunc matches Terraform: /pattern/ is a regular expression.
+var ReplaceFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{Name: "str", Type: cty.String},
+		{Name: "substr", Type: cty.String},
+		{Name: "replace", Type: cty.String},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		substr := args[1].AsString()
+		if len(substr) > 1 && strings.HasPrefix(substr, "/") && strings.HasSuffix(substr, "/") {
+			pattern := cty.StringVal(substr[1 : len(substr)-1])
+			return stdlib.RegexReplace(args[0], pattern, args[2])
+		}
+		return stdlib.Replace(args[0], args[1], args[2])
+	},
+})

--- a/pkg/parser/terraform/functions/compat_test.go
+++ b/pkg/parser/terraform/functions/compat_test.go
@@ -1,0 +1,111 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package functions
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestLengthString(t *testing.T) {
+	t.Parallel()
+
+	got, err := LengthFunc.Call([]cty.Value{cty.StringVal("hello")})
+	if err != nil {
+		t.Fatalf("LengthFunc.Call() error = %v", err)
+	}
+	if !got.RawEquals(cty.NumberIntVal(5)) {
+		t.Fatalf("length = %#v, want 5", got)
+	}
+}
+
+func TestLengthList(t *testing.T) {
+	t.Parallel()
+
+	got, err := LengthFunc.Call([]cty.Value{cty.ListVal([]cty.Value{
+		cty.StringVal("a"),
+		cty.StringVal("b"),
+	})})
+	if err != nil {
+		t.Fatalf("LengthFunc.Call() error = %v", err)
+	}
+	if !got.RawEquals(cty.NumberIntVal(2)) {
+		t.Fatalf("length = %#v, want 2", got)
+	}
+}
+
+func TestCoalesceSkipsEmptyString(t *testing.T) {
+	t.Parallel()
+
+	got, err := CoalesceFunc.Call([]cty.Value{
+		cty.NullVal(cty.String),
+		cty.StringVal(""),
+		cty.StringVal("fallback"),
+	})
+	if err != nil {
+		t.Fatalf("CoalesceFunc.Call() error = %v", err)
+	}
+	if !got.RawEquals(cty.StringVal("fallback")) {
+		t.Fatalf("coalesce = %#v, want fallback", got)
+	}
+}
+
+func TestLookupDefault(t *testing.T) {
+	t.Parallel()
+
+	input := cty.MapVal(map[string]cty.Value{"a": cty.StringVal("x")})
+	got, err := LookupFunc.Call([]cty.Value{input, cty.StringVal("b"), cty.StringVal("d")})
+	if err != nil {
+		t.Fatalf("LookupFunc.Call() error = %v", err)
+	}
+	if !got.RawEquals(cty.StringVal("d")) {
+		t.Fatalf("lookup = %#v, want d", got)
+	}
+}
+
+func TestIndexFindsValue(t *testing.T) {
+	t.Parallel()
+
+	got, err := IndexFunc.Call([]cty.Value{
+		cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+		cty.StringVal("b"),
+	})
+	if err != nil {
+		t.Fatalf("IndexFunc.Call() error = %v", err)
+	}
+	if !got.RawEquals(cty.NumberIntVal(1)) {
+		t.Fatalf("index = %#v, want 1", got)
+	}
+}
+
+func TestReplaceLiteralAndRegex(t *testing.T) {
+	t.Parallel()
+
+	got, err := ReplaceFunc.Call([]cty.Value{
+		cty.StringVal("a-b-c"),
+		cty.StringVal("-"),
+		cty.StringVal("_"),
+	})
+	if err != nil {
+		t.Fatalf("ReplaceFunc.Call() error = %v", err)
+	}
+	if !got.RawEquals(cty.StringVal("a_b_c")) {
+		t.Fatalf("replace = %#v, want a_b_c", got)
+	}
+
+	got, err = ReplaceFunc.Call([]cty.Value{
+		cty.StringVal("hello 123"),
+		cty.StringVal("/[0-9]+/"),
+		cty.StringVal("N"),
+	})
+	if err != nil {
+		t.Fatalf("ReplaceFunc.Call() regex error = %v", err)
+	}
+	if !got.RawEquals(cty.StringVal("hello N")) {
+		t.Fatalf("replace regex = %#v, want hello N", got)
+	}
+}

--- a/pkg/parser/terraform/functions/default.go
+++ b/pkg/parser/terraform/functions/default.go
@@ -8,6 +8,8 @@ package functions
 import (
 	"encoding/base64"
 
+	"github.com/hashicorp/hcl/v2/ext/tryfunc"
+	ctyyaml "github.com/zclconf/go-cty-yaml"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
@@ -48,8 +50,10 @@ var Base64EncodeFunc = function.New(&function.Spec{
 var TerraformFuncs = map[string]function.Function{
 	"abs":             stdlib.AbsoluteFunc,
 	"base64encode":    Base64EncodeFunc,
+	"can":             tryfunc.CanFunc,
 	"ceil":            stdlib.CeilFunc,
 	"chomp":           stdlib.ChompFunc,
+	"coalesce":        CoalesceFunc,
 	"coalescelist":    stdlib.CoalesceListFunc,
 	"compact":         stdlib.CompactFunc,
 	"concat":          stdlib.ConcatFunc,
@@ -64,11 +68,14 @@ var TerraformFuncs = map[string]function.Function{
 	"formatdate":      stdlib.FormatDateFunc,
 	"formatlist":      stdlib.FormatListFunc,
 	"indent":          stdlib.IndentFunc,
+	"index":           IndexFunc,
 	"join":            stdlib.JoinFunc,
 	"jsondecode":      stdlib.JSONDecodeFunc,
 	"jsonencode":      stdlib.JSONEncodeFunc,
 	"keys":            stdlib.KeysFunc,
+	"length":          LengthFunc,
 	"log":             stdlib.LogFunc,
+	"lookup":          LookupFunc,
 	"lower":           stdlib.LowerFunc,
 	"max":             stdlib.MaxFunc,
 	"merge":           stdlib.MergeFunc,
@@ -78,6 +85,7 @@ var TerraformFuncs = map[string]function.Function{
 	"range":           stdlib.RangeFunc,
 	"regex":           stdlib.RegexFunc,
 	"regexall":        stdlib.RegexAllFunc,
+	"replace":         ReplaceFunc,
 	"reverse":         stdlib.ReverseListFunc,
 	"setintersection": stdlib.SetIntersectionFunc,
 	"setproduct":      stdlib.SetProductFunc,
@@ -91,14 +99,20 @@ var TerraformFuncs = map[string]function.Function{
 	"substr":          stdlib.SubstrFunc,
 	"timeadd":         stdlib.TimeAddFunc,
 	"title":           stdlib.TitleFunc,
+	"tobool":          stdlib.MakeToFunc(cty.Bool),
 	"tolist":          ToListFunc,
 	"tomap":           ToMapFunc,
+	"tonumber":        stdlib.MakeToFunc(cty.Number),
 	"toset":           ToSetFunc,
+	"tostring":        stdlib.MakeToFunc(cty.String),
 	"trim":            stdlib.TrimFunc,
 	"trimprefix":      stdlib.TrimPrefixFunc,
 	"trimspace":       stdlib.TrimSpaceFunc,
 	"trimsuffix":      stdlib.TrimSuffixFunc,
+	"try":             tryfunc.TryFunc,
 	"upper":           stdlib.UpperFunc,
 	"values":          stdlib.ValuesFunc,
+	"yamldecode":      ctyyaml.YAMLDecodeFunc,
+	"yamlencode":      ctyyaml.YAMLEncodeFunc,
 	"zipmap":          stdlib.ZipmapFunc,
 }

--- a/pkg/parser/terraform/variables.go
+++ b/pkg/parser/terraform/variables.go
@@ -91,8 +91,11 @@ func extractInputVariables(body *hclsyntax.Body, filename string) converter.Vari
 				val, diags := defaultAttr.Expr.Value(&hcl.EvalContext{})
 				if !diags.HasErrors() && val.IsKnown() {
 					variables[varName] = val
+					continue
 				}
 			}
+			// Declared but unset: keep the attribute so try/can see unknown, not a missing key.
+			variables[varName] = cty.UnknownVal(cty.DynamicPseudoType)
 		}
 	}
 
@@ -154,8 +157,7 @@ func extractLocals(body *hclsyntax.Body) converter.VariableMap {
 func sanitizeCtyMap(in map[string]cty.Value) map[string]cty.Value {
 	out := make(map[string]cty.Value)
 	for k, v := range in {
-		if !v.IsKnown() || v.IsNull() {
-			// default to empty string or another valid fallback
+		if v.IsNull() {
 			out[k] = cty.NullVal(v.Type())
 			continue
 		}

--- a/pkg/parser/terraform/variables_test.go
+++ b/pkg/parser/terraform/variables_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -186,6 +187,14 @@ func TestGetInputVariablesFromFile(t *testing.T) {
 	}
 }
 
+func TestExtractInputVariablesUnsetRequiredIsUnknown(t *testing.T) {
+	src := []byte(`variable "required" { type = string }`)
+	file, diags := hclsyntax.ParseConfig(src, "variables.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), diags)
+	got := extractInputVariables(file.Body.(*hclsyntax.Body), "variables.tf")
+	require.True(t, got["required"].RawEquals(cty.UnknownVal(cty.DynamicPseudoType)))
+}
+
 func TestGetInputVariables(t *testing.T) {
 	tests := []inputVarTest{
 		{
@@ -207,6 +216,7 @@ func TestGetInputVariables(t *testing.T) {
 					"test_terraform":    cty.StringVal("terraform.tfvars"),
 					"default_var_file":  cty.StringVal("default_var_file"),
 					"local_default_var": cty.StringVal("local_default"),
+					"invalid_attr":      cty.UnknownVal(cty.DynamicPseudoType),
 				}),
 				"local": cty.EmptyObjectVal,
 			},

--- a/pkg/server/analyze_test.go
+++ b/pkg/server/analyze_test.go
@@ -748,9 +748,7 @@ func TestAnalyze_LogsFailedQueryCount(t *testing.T) {
 
 import rego.v1
 
-DatadogPolicy contains result if {
-	undefined_reference
-}`)
+DatadogPolicy contains result if {`)
 	req := analyzeRequest{
 		Files: []analyzeFile{{
 			Path:    "infra/main.tf",


### PR DESCRIPTION
## Motivation

Terraform expression evaluation only knew a subset of built-in functions, so common calls such as `length`, `lookup`, `try`, and `replace` stayed unresolved interpolations and rules missed the resulting values.

## Changes

**Terraform evaluation**

Register `try`, `can`, type conversions, YAML encode/decode, and Terraform-compatible `length`, `coalesce`, `lookup`, `index`, and `replace`. Stdlib implementations that differ from Terraform (string `length`, empty-string `coalesce`, optional `lookup` default, find-by-value `index`, `/regex/` `replace`) use thin wrappers so known arguments evaluate instead of wrapping as `${...}`.

Unknown or failing calls still wrap, so impure or incomplete expressions stay scan-safe.

## Author Checklist

- [ ] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/parser/terraform/functions/ ./pkg/parser/terraform/converter/ ./pkg/parser/terraform/tfeval/ -count=1`
2. Confirm `length("hello")`, `try(var.missing, "fallback")`, and `lookup({a = "x"}, "b", "d")` evaluate in converter tests rather than remaining interpolations.

## Blast Radius

This PR only changes Terraform expression evaluation in the scanner. Findings can increase where attributes previously stayed as unresolved function calls and now resolve to concrete values.

## Additional Notes

Filesystem functions (`file`, `templatefile`) and impure functions (`timestamp`, `uuid`) are intentionally still unregistered.

I submit this contribution under the Apache-2.0 license.