### PR TITLE
[K9CODESEC-6288] Scan Terraform JSON source config files

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -93,6 +93,8 @@ var (
 		extUbi8:        true,
 		extTf:          true,
 		extTofu:        true,
+		extTfJSON:      true,
+		extTofuJSON:    true,
 		extTfvars:      true,
 		extProto:       true,
 		extCfg:         true,
@@ -160,6 +162,8 @@ const (
 	extDebian             = ".debian"
 	extTf                 = tfpath.ExtTF
 	extTofu               = tfpath.ExtTofu
+	extTfJSON             = tfpath.ExtTFJSON
+	extTofuJSON           = tfpath.ExtTofuJSON
 	extTfvars             = tfpath.ExtTFVars
 	extBicepFile          = ".bicep"
 	extProto              = ".proto"
@@ -807,7 +811,7 @@ func classifyFile(ctx context.Context, fsys vfs.FS, path string, content []byte,
 			return dockerfile
 		}
 		return ""
-	case extTf, extTofu, extTfvars:
+	case extTf, extTofu, extTfJSON, extTofuJSON, extTfvars:
 		return terraform
 	case extBicepFile:
 		return bicep

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -477,6 +477,33 @@ func TestAnalyze_ValidSymlink(t *testing.T) {
 	require.Empty(t, got.Exc)
 }
 
+func TestAnalyze_JSONConfigClassifiesAsTerraform(t *testing.T) {
+	dir := t.TempDir()
+	tfJSON := filepath.Join(dir, "main.tf.json")
+	tofuJSON := filepath.Join(dir, "main.tofu.json")
+	plainJSON := filepath.Join(dir, "data.json")
+	require.NoError(t, os.WriteFile(tfJSON, []byte(`{"resource":{"aws_s3_bucket":{"b":{"acl":"public-read"}}}}`), 0o600))
+	require.NoError(t, os.WriteFile(tofuJSON, []byte(`{"resource":{"aws_s3_bucket":{"c":{"acl":"private"}}}}`), 0o600))
+	require.NoError(t, os.WriteFile(plainJSON, []byte(`{"hello":"world"}`), 0o600))
+
+	got, err := Analyze(context.Background(), &Analyzer{
+		RepoPath:    dir,
+		Paths:       []string{dir},
+		Types:       []string{""},
+		MaxFileSize: -1,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{terraform}, got.Types)
+	require.Equal(t, terraform, got.FilePlatform[filepath.ToSlash(tfJSON)])
+	require.Equal(t, terraform, got.FilePlatform[filepath.ToSlash(tofuJSON)])
+	require.ElementsMatch(t, []string{
+		filepath.ToSlash(tfJSON),
+		filepath.ToSlash(tofuJSON),
+	}, got.Inventory)
+	require.NotContains(t, got.Inventory, filepath.ToSlash(plainJSON))
+}
+
 func TestAnalyze_TofuClassifiesAsTerraform(t *testing.T) {
 	dir := t.TempDir()
 	tofu := filepath.Join(dir, "main.tofu")

--- a/pkg/detector/terraform/terraform_detect.go
+++ b/pkg/detector/terraform/terraform_detect.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/detector"
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/tfpath"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
@@ -89,6 +90,10 @@ func (d *DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadat
 
 	lines := *file.LinesOriginalData
 
+	if tfpath.IsJSONConfig(file.FilePath) {
+		return detectJSONConfigLine(ctx, file, keyParts, extracted, outputLines)
+	}
+
 	for _, part := range keyParts {
 		// Parse the entire file in case of array detection, thus the file.OriginalData
 		s1, s2, idx := GenerateSubstrings(ctx, part, extracted, lines, detection.CurrentLine, []byte(file.OriginalData))
@@ -125,6 +130,74 @@ func (d *DetectKindLine) DetectLine(ctx context.Context, file *model.FileMetadat
 
 	contextLogger.Warn().Msgf("Failed to detect Terraform line, query response %s", normalizedKey)
 	return buildEmptyVulnerabilityLines(file)
+}
+
+func detectJSONConfigLine(
+	ctx context.Context, file *model.FileMetadata, keyParts []string, extracted [][]string, outputLines int,
+) model.VulnerabilityLines {
+	lines := *file.LinesOriginalData
+	current := 0
+	found := false
+	for _, part := range keyParts {
+		s1, s2, idx := GenerateSubstrings(ctx, part, extracted, lines, current, []byte(file.OriginalData))
+		if idx != 0 {
+			current = idx
+			found = true
+			continue
+		}
+		if line, ok := findJSONKeyLine(lines, current, s1); ok {
+			current = line
+			found = true
+		}
+		if s2 != "" {
+			if line, ok := findJSONKeyLine(lines, current, s2); ok {
+				current = line
+				found = true
+			}
+		}
+	}
+	if !found {
+		return buildEmptyVulnerabilityLines(file)
+	}
+	line := current + 1
+	if line < 1 || line > len(lines) {
+		return buildEmptyVulnerabilityLines(file)
+	}
+	got := syntheticVulnerabilityLines(line, lines)
+	got.Line = line
+	got.VulnLines = detector.GetAdjacentVulnLines(current, outputLines, lines)
+	got.ResolvedFile = file.FilePath
+	got.FileSource = lines
+	return got
+}
+
+func findJSONKeyLine(lines []string, from int, key string) (int, bool) {
+	if key == "" {
+		return from, false
+	}
+	quoted := `"` + key + `"`
+	for i := from; i < len(lines); i++ {
+		if jsonLineDeclaresKey(lines[i], quoted) {
+			return i, true
+		}
+	}
+	return from, false
+}
+
+func jsonLineDeclaresKey(line, quoted string) bool {
+	start := 0
+	for {
+		rel := strings.Index(line[start:], quoted)
+		if rel < 0 {
+			return false
+		}
+		idx := start + rel
+		rest := strings.TrimLeft(line[idx+len(quoted):], " \t")
+		if strings.HasPrefix(rest, ":") {
+			return true
+		}
+		start = idx + len(quoted)
+	}
 }
 
 func buildEmptyVulnerabilityLines(file *model.FileMetadata) model.VulnerabilityLines {

--- a/pkg/detector/terraform/terraform_detect_test.go
+++ b/pkg/detector/terraform/terraform_detect_test.go
@@ -1030,3 +1030,95 @@ func TestCalculateInsertionPointClampsFunctionWrapperAtEndOfFile(t *testing.T) {
 
 	require.Equal(t, len(lines), line)
 }
+
+func TestDetectLineJSONConfig(t *testing.T) {
+	src := `{
+  "resource": {
+    "aws_s3_bucket": {
+      "b": {
+        "acl": "public-read"
+      }
+    }
+  }
+}`
+	file := &model.FileMetadata{
+		FilePath:          "main.tf.json",
+		Kind:              model.KindTerraform,
+		OriginalData:      src,
+		LinesOriginalData: utils.SplitLines(src),
+	}
+	got := (&DetectKindLine{}).DetectLine(context.Background(), file, "aws_s3_bucket[b].acl", 3)
+	require.Equal(t, 5, got.Line)
+	require.Equal(t, "main.tf.json", got.ResolvedFile)
+	require.Equal(t, 5, got.VulnerablilityLocation.Start.Line)
+	require.Equal(t, 5, got.VulnerablilityLocation.End.Line)
+	require.Equal(t, 5, got.RemediationLocation.Start.Line)
+	require.Equal(t, 5, got.BlockLocation.Start.Line)
+}
+
+func TestDetectLineJSONConfigArrayIndex(t *testing.T) {
+	src := `{
+  "resource": {
+    "aws_security_group": {
+      "sg": {
+        "ingress": [
+          {
+            "cidr_blocks": ["0.0.0.0/0"]
+          },
+          {
+            "cidr_blocks": ["10.0.0.0/8"]
+          }
+        ]
+      }
+    }
+  }
+}`
+	file := &model.FileMetadata{
+		FilePath:          "main.tf.json",
+		Kind:              model.KindTerraform,
+		OriginalData:      src,
+		LinesOriginalData: utils.SplitLines(src),
+	}
+	got := (&DetectKindLine{}).DetectLine(context.Background(), file, "aws_security_group[sg].ingress[1].cidr_blocks", 3)
+	require.Equal(t, 10, got.Line)
+}
+
+func TestDetectLineJSONConfigIgnoresQuotedValue(t *testing.T) {
+	src := `{
+  "resource": {
+    "aws_s3_bucket": {
+      "prod": {
+        "bucket": "acl"
+      }
+    }
+  }
+}`
+	file := &model.FileMetadata{
+		FilePath:          "main.tf.json",
+		Kind:              model.KindTerraform,
+		OriginalData:      src,
+		LinesOriginalData: utils.SplitLines(src),
+	}
+	got := (&DetectKindLine{}).DetectLine(context.Background(), file, "acl", 3)
+	require.Equal(t, -1, got.Line)
+}
+
+func TestDetectLineJSONConfigIgnoresUnquotedSubstring(t *testing.T) {
+	src := `{
+  "resource": {
+    "aws_s3_bucket": {
+      "prod": {
+        "bucket": "mentions-acl-in-value"
+      }
+    }
+  }
+}`
+	file := &model.FileMetadata{
+		FilePath:          "main.tf.json",
+		Kind:              model.KindTerraform,
+		OriginalData:      src,
+		LinesOriginalData: utils.SplitLines(src),
+	}
+	got := (&DetectKindLine{}).DetectLine(context.Background(), file, "acl", 3)
+	require.Equal(t, -1, got.Line)
+}

--- a/pkg/engine/provider/filesystem.go
+++ b/pkg/engine/provider/filesystem.go
@@ -167,11 +167,11 @@ func (s *FileSystemSourceProvider) AddUnfilteredPaths(paths []string) {
 }
 
 // TerraformFiles returns Terraform/OpenTofu config paths used for module discovery
-// before scanning: native .tf/.tofu files plus .tf.json/.tofu.json files (still
-// classified as .json for the scan pipeline).
+// before scanning: native .tf/.tofu files plus .tf.json/.tofu.json files.
 func (s *FileSystemSourceProvider) TerraformFiles(ctx context.Context) ([]string, error) {
-	hclExtensions := model.Extensions{tfpath.ExtTF: {}, tfpath.ExtTofu: {}}
-	jsonExtensions := model.Extensions{".json": {}}
+	configExtensions := model.Extensions{
+		tfpath.ExtTF: {}, tfpath.ExtTofu: {}, tfpath.ExtTFJSON: {}, tfpath.ExtTofuJSON: {},
+	}
 	seen := make(map[string]struct{})
 	var files []string
 	add := func(path string) {
@@ -189,52 +189,22 @@ func (s *FileSystemSourceProvider) TerraformFiles(ctx context.Context) ([]string
 			return nil, errors.Wrap(err, "failed to open path")
 		}
 		if !fileInfo.IsDir() {
-			if shouldSkip, _, _ := s.checkConditions(ctx, fileInfo, hclExtensions, scanPath, nil); !shouldSkip {
+			if shouldSkip, _, _ := s.checkConditions(ctx, fileInfo, configExtensions, scanPath, nil); !shouldSkip {
 				add(scanPath)
-			}
-			if tfpath.IsJSONConfig(scanPath) {
-				if shouldSkip, _, _ := s.checkConditions(ctx, fileInfo, jsonExtensions, scanPath, nil); !shouldSkip {
-					add(scanPath)
-				}
 			}
 			continue
 		}
 
-		collected, err := s.collectFiles(ctx, scanPath, unavailableResolverSink, hclExtensions)
+		collected, err := s.collectFiles(ctx, scanPath, unavailableResolverSink, configExtensions)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to collect files")
 		}
 		for _, path := range collected {
 			add(path)
 		}
-
-		jsonCollected, err := s.collectTerraformJSONModuleFiles(ctx, scanPath)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to collect terraform json module files")
-		}
-		for _, path := range jsonCollected {
-			add(path)
-		}
 	}
 	sort.Strings(files)
 	return files, nil
-}
-
-func (s *FileSystemSourceProvider) collectTerraformJSONModuleFiles(ctx context.Context, scanPath string) ([]string, error) {
-	extensions := model.Extensions{".json": {}}
-	var files []string
-	err := s.walkDirectory(ctx, scanPath, extensions,
-		func(ctx context.Context, path string, resolved *[]string) error {
-			return s.resolveChartDir(ctx, path, unavailableResolverSink, resolved)
-		},
-		func(_ context.Context, path, _ string) error {
-			if !tfpath.IsJSONConfig(path) {
-				return nil
-			}
-			files = append(files, strings.ReplaceAll(path, "\\", "/"))
-			return nil
-		})
-	return files, err
 }
 
 func unavailableResolverSink(context.Context, string) ([]string, error) {

--- a/pkg/engine/provider/filesystem_test.go
+++ b/pkg/engine/provider/filesystem_test.go
@@ -854,7 +854,7 @@ func TestWalkInventoryTofuShadowing(t *testing.T) {
 	require.NoError(t, err)
 
 	noChart := func(context.Context, string) bool { return false }
-	extensions := model.Extensions{".tf": {}, ".tofu": {}, ".json": {}}
+	extensions := model.Extensions{".tf": {}, ".tofu": {}, ".tf.json": {}, ".tofu.json": {}}
 	files, err := fs.WalkInventory(ctx, extensions, noChart)
 	require.NoError(t, err)
 

--- a/pkg/engine/provider/memory.go
+++ b/pkg/engine/provider/memory.go
@@ -123,7 +123,7 @@ func (m *MemorySourceProvider) GetParallelSources(ctx context.Context,
 // utils.GetExtension it never stats the file, since pushed content has no
 // on-disk presence.
 func memExtension(p string) string {
-	if ext := filepath.Ext(p); ext != "" {
+	if ext := utils.ExtensionFromPath(p); ext != "" {
 		return ext
 	}
 	return filepath.Base(p)

--- a/pkg/engine/provider/memory_test.go
+++ b/pkg/engine/provider/memory_test.go
@@ -101,7 +101,7 @@ func TestMemorySourceProvider_TofuShadowing(t *testing.T) {
 		"infra/other.tf":     []byte("other"),
 	})
 	p := NewMemorySourceProvider(mem, mem.Paths(), nil, nil)
-	exts := model.Extensions{".tf": {}, ".tofu": {}, ".json": {}}
+	exts := model.Extensions{".tf": {}, ".tofu": {}, ".tf.json": {}}
 
 	collectConc := func(parallel bool) map[string]string {
 		var mu sync.Mutex

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -365,7 +365,7 @@ func (e Extensions) MatchedFilesRegex() string {
 
 	var parts []string
 	for ext := range e {
-		parts = append(parts, "\\"+ext)
+		parts = append(parts, regexp.QuoteMeta(ext))
 	}
 
 	sort.Strings(parts)

--- a/pkg/parser/terraform/data_source.go
+++ b/pkg/parser/terraform/data_source.go
@@ -17,10 +17,12 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/functions"
+	"github.com/DataDog/datadog-iac-scanner/pkg/tfpath"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	hcljson "github.com/hashicorp/hcl/v2/json"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
@@ -108,29 +110,11 @@ func getDataSourcePolicy(
 		if !fileMayDeclareIAMPolicyDocument(content) {
 			continue
 		}
-		parsedFile, diags := parseFileContent(content, tfFile, true)
-		if diags != nil && diags.HasErrors() {
-			contextLogger.Debug().Msgf("Error trying to parse file %s for data source.", tfFile)
+		if tfpath.IsJSONConfig(tfFile) {
+			collectJSONDataSourcePolicies(ctx, content, tfFile, inputVariables, jsonMap)
 			continue
 		}
-		if parsedFile == nil {
-			contextLogger.Debug().Msgf("Error trying to parse file %s for data source.", tfFile)
-			continue
-		}
-		body, ok := parsedFile.Body.(*hclsyntax.Body)
-		if !ok {
-			continue
-		}
-		for _, block := range body.Blocks {
-			if block.Type == terraformDataIdentifier &&
-				len(block.Labels) > 1 &&
-				block.Labels[0] == iamPolicyDocumentType {
-				policyJSON := parseDataSourceBody(ctx, block.Body, inputVariables)
-				jsonMap[block.Labels[1]] = map[string]string{
-					"json": policyJSON,
-				}
-			}
-		}
+		collectHCLDataSourcePolicies(ctx, content, tfFile, inputVariables, jsonMap)
 	}
 	policyResource := map[string]map[string]map[string]string{
 		"aws_iam_policy_document": jsonMap,
@@ -143,6 +127,58 @@ func getDataSourcePolicy(
 
 	inputVariables["data"] = data
 	return inputVariables
+}
+
+func collectHCLDataSourcePolicies(
+	ctx context.Context, content []byte, tfFile string, inputVariables converter.VariableMap, jsonMap map[string]map[string]string,
+) {
+	contextLogger := logger.FromContext(ctx)
+	parsedFile, diags := parseFileContent(content, tfFile, true)
+	if diags != nil && diags.HasErrors() {
+		contextLogger.Debug().Msgf("Error trying to parse file %s for data source.", tfFile)
+		return
+	}
+	if parsedFile == nil {
+		contextLogger.Debug().Msgf("Error trying to parse file %s for data source.", tfFile)
+		return
+	}
+	body, ok := parsedFile.Body.(*hclsyntax.Body)
+	if !ok {
+		return
+	}
+	for _, block := range body.Blocks {
+		if block.Type == terraformDataIdentifier &&
+			len(block.Labels) > 1 &&
+			block.Labels[0] == iamPolicyDocumentType {
+			jsonMap[block.Labels[1]] = map[string]string{
+				"json": parseDataSourceBody(ctx, block.Body, inputVariables, nil),
+			}
+		}
+	}
+}
+
+func collectJSONDataSourcePolicies(
+	ctx context.Context, src []byte, filename string, inputVariables converter.VariableMap, jsonMap map[string]map[string]string,
+) {
+	parsed, diags := hcljson.Parse(src, filename)
+	if diags.HasErrors() {
+		return
+	}
+	content, _, _ := parsed.Body.PartialContent(jsonConfigSchema)
+	if content == nil {
+		return
+	}
+	for _, block := range content.Blocks {
+		if block.Type != terraformDataIdentifier || len(block.Labels) < 2 {
+			continue
+		}
+		if block.Labels[0] != iamPolicyDocumentType {
+			continue
+		}
+		jsonMap[block.Labels[1]] = map[string]string{
+			"json": parseDataSourceBody(ctx, block.Body, inputVariables, src),
+		}
+	}
 }
 
 // fileMayDeclareIAMPolicyDocument is a fast precheck before parseFileContent.
@@ -309,7 +345,10 @@ func getStatementSpec() *hcldec.BlockListSpec {
 	}
 }
 
-func parseDataSourceBody(ctx context.Context, body *hclsyntax.Body, inputVariables converter.VariableMap) string {
+func parseDataSourceBody(ctx context.Context, body hcl.Body, inputVariables converter.VariableMap, src []byte) string {
+	if syn, ok := body.(*hclsyntax.Body); ok {
+		resolveDataResources(ctx, syn)
+	}
 	contextLogger := logger.FromContext(ctx)
 	dataSourceSpec := &hcldec.ObjectSpec{
 		"id": &hcldec.AttrSpec{
@@ -324,8 +363,6 @@ func parseDataSourceBody(ctx context.Context, body *hclsyntax.Body, inputVariabl
 		},
 		"statement": getStatementSpec(),
 	}
-
-	resolveDataResources(ctx, body)
 
 	target, decodeErrs := hcldec.Decode(body, dataSourceSpec, &hcl.EvalContext{
 		Variables: inputVariables,
@@ -348,6 +385,9 @@ func parseDataSourceBody(ctx context.Context, body *hclsyntax.Body, inputVariabl
 	}
 
 	dataSourceJSON := decodeDataSourcePolicy(ctx, target)
+	if len(src) > 0 {
+		fillJSONPolicyResources(dataSourceJSON.Statement, body, src)
+	}
 	convertedDataSource := convertedPolicy{
 		ID:      dataSourceJSON.ID,
 		Version: dataSourceJSON.Version,
@@ -398,6 +438,122 @@ func parseDataSourceBody(ctx context.Context, body *hclsyntax.Body, inputVariabl
 		return ""
 	}
 	return buffer.String()
+}
+
+func fillJSONPolicyResources(statements []dataSourcePolicyStatement, body hcl.Body, src []byte) {
+	lists := jsonPolicyResourceLists(body, src)
+	for i := range statements {
+		if i >= len(lists) {
+			return
+		}
+		if jsonPolicyResourcesMissing(statements[i].Resources) && len(lists[i]) > 0 {
+			statements[i].Resources = lists[i]
+		}
+	}
+}
+
+func jsonPolicyResourcesMissing(resources []string) bool {
+	if len(resources) == 0 {
+		return true
+	}
+	for _, resource := range resources {
+		if resource != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func jsonPolicyResourceLists(body hcl.Body, src []byte) [][]string {
+	if lists := jsonPolicyResourceListsFromBlocks(body, src); len(lists) > 0 {
+		return lists
+	}
+	return jsonPolicyResourceListsFromAttr(body, src)
+}
+
+func jsonPolicyResourceListsFromBlocks(body hcl.Body, src []byte) [][]string {
+	content, _, _ := body.PartialContent(&hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{{Type: "statement"}},
+	})
+	if content == nil {
+		return nil
+	}
+	out := make([][]string, 0, len(content.Blocks))
+	for _, block := range content.Blocks {
+		attrs, _ := block.Body.JustAttributes()
+		out = append(out, jsonPolicyResourcesFromAttr(attrs["resources"], src))
+	}
+	return out
+}
+
+func jsonPolicyResourceListsFromAttr(body hcl.Body, src []byte) [][]string {
+	attrs, _ := body.JustAttributes()
+	attr, ok := attrs["statement"]
+	if !ok {
+		return nil
+	}
+	statements, diags := hcl.ExprList(attr.Expr)
+	if diags.HasErrors() {
+		return nil
+	}
+	out := make([][]string, 0, len(statements))
+	for _, statement := range statements {
+		pairs, pairDiags := hcl.ExprMap(statement)
+		if pairDiags.HasErrors() {
+			out = append(out, nil)
+			continue
+		}
+		var resources hcl.Expression
+		for _, pair := range pairs {
+			key, keyDiags := pair.Key.Value(&hcl.EvalContext{})
+			if keyDiags.HasErrors() || !key.IsKnown() || key.Type() != cty.String || key.AsString() != "resources" {
+				continue
+			}
+			resources = pair.Value
+			break
+		}
+		out = append(out, jsonPolicyResourcesFromExpr(resources, src))
+	}
+	return out
+}
+
+func jsonPolicyResourcesFromAttr(attr *hcl.Attribute, src []byte) []string {
+	if attr == nil {
+		return nil
+	}
+	return jsonPolicyResourcesFromExpr(attr.Expr, src)
+}
+
+func jsonPolicyResourcesFromExpr(expr hcl.Expression, src []byte) []string {
+	if expr == nil {
+		return nil
+	}
+	items, diags := hcl.ExprList(expr)
+	if diags.HasErrors() {
+		return nil
+	}
+	resources := make([]string, 0, len(items))
+	for _, item := range items {
+		if s := jsonPolicyResourceString(item, src); s != "" {
+			resources = append(resources, s)
+		}
+	}
+	return resources
+}
+
+func jsonPolicyResourceString(expr hcl.Expression, src []byte) string {
+	val, diags := expr.Value(&hcl.EvalContext{})
+	if !diags.HasErrors() && val.IsWhollyKnown() && !val.IsNull() && val.Type() == cty.String {
+		return val.AsString()
+	}
+	s := wrapJSONRange(expr.Range(), "", src)
+	if strings.HasPrefix(s, "${") && strings.HasSuffix(s, "}") {
+		inner := s[2 : len(s)-1]
+		if !strings.Contains(inner, "${") {
+			return inner
+		}
+	}
+	return s
 }
 
 // resolveDataResources resolves the data resources expressions into LiteralValueExpr

--- a/pkg/parser/terraform/data_source_test.go
+++ b/pkg/parser/terraform/data_source_test.go
@@ -137,6 +137,70 @@ func Test_getDataSourcePolicy(t *testing.T) {
 	}
 }
 
+func Test_getDataSourcePolicy_JSONConfig(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "policy.tf.json"), []byte(`{
+  "data": {
+    "aws_iam_policy_document": {
+      "doc": {
+        "statement": [{
+          "actions": ["s3:GetObject"],
+          "resources": ["arn:aws:s3:::from-json/*"]
+        }]
+      }
+    }
+  }
+}`), 0o600))
+
+	result := getDataSourcePolicy(context.Background(), vfs.DiskFS{}, dir, make(converter.VariableMap), nil, "")
+	data, ok := result["data"]
+	require.True(t, ok)
+	var awsPolicyMap map[string]map[string]map[string]string
+	require.NoError(t, gocty.FromCtyValue(data, &awsPolicyMap))
+	require.Contains(t, awsPolicyMap["aws_iam_policy_document"]["doc"]["json"], "from-json")
+}
+
+func Test_getDataSourcePolicy_JSONConfigResourceTraversal(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "policy.tf.json"), []byte(`{
+  "data": {
+    "aws_iam_policy_document": {
+      "doc": {
+        "statement": [{
+          "actions": ["s3:GetObject"],
+          "resources": ["${aws_s3_bucket.b.arn}"]
+        }]
+      }
+    }
+  }
+}`), 0o600))
+
+	result := getDataSourcePolicy(context.Background(), vfs.DiskFS{}, dir, make(converter.VariableMap), nil, "")
+	data, ok := result["data"]
+	require.True(t, ok)
+	var awsPolicyMap map[string]map[string]map[string]string
+	require.NoError(t, gocty.FromCtyValue(data, &awsPolicyMap))
+	require.Contains(t, awsPolicyMap["aws_iam_policy_document"]["doc"]["json"], "aws_s3_bucket.b.arn")
+}
+
+func Test_getDataSourcePolicy_TofuJSONShadowsTfJSON(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "policy.tf.json"), []byte(`{
+  "data": {"aws_iam_policy_document": {"doc": {"statement": [{"resources": ["arn:aws:s3:::from-tf/*"]}]}}}
+}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "policy.tofu.json"), []byte(`{
+  "data": {"aws_iam_policy_document": {"doc": {"statement": [{"resources": ["arn:aws:s3:::from-tofu/*"]}]}}}
+}`), 0o600))
+
+	result := getDataSourcePolicy(context.Background(), vfs.DiskFS{}, dir, make(converter.VariableMap), nil, "")
+	data, ok := result["data"]
+	require.True(t, ok)
+	var awsPolicyMap map[string]map[string]map[string]string
+	require.NoError(t, gocty.FromCtyValue(data, &awsPolicyMap))
+	require.Contains(t, awsPolicyMap["aws_iam_policy_document"]["doc"]["json"], "from-tofu")
+	require.NotContains(t, awsPolicyMap["aws_iam_policy_document"]["doc"]["json"], "from-tf")
+}
+
 func Test_getDataSourcePolicy_TofuShadowsTf(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "policy.tf"), []byte(`

--- a/pkg/parser/terraform/json_config.go
+++ b/pkg/parser/terraform/json_config.go
@@ -1,0 +1,218 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package terraform
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
+	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/functions"
+	"github.com/hashicorp/hcl/v2"
+	hcljson "github.com/hashicorp/hcl/v2/json"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+var jsonConfigSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "terraform"},
+		{Type: blockTypeLocals},
+		{Type: "moved"},
+		{Type: "import"},
+		{Type: "removed"},
+		{Type: blockTypeVariable, LabelNames: []string{"name"}},
+		{Type: "output", LabelNames: []string{"name"}},
+		{Type: "module", LabelNames: []string{"name"}},
+		{Type: "provider", LabelNames: []string{"name"}},
+		{Type: "check", LabelNames: []string{"name"}},
+		{Type: "resource", LabelNames: []string{"type", "name"}},
+		{Type: "data", LabelNames: []string{"type", "name"}},
+		{Type: "ephemeral", LabelNames: []string{"type", "name"}},
+	},
+}
+
+func parseJSONConfig(src []byte, filename string, inputVars converter.VariableMap) (model.Document, error) {
+	file, diags := hcljson.Parse(src, filename)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	content, _, diags := file.Body.PartialContent(jsonConfigSchema)
+	if diags.HasErrors() && content == nil {
+		return nil, diags
+	}
+
+	evalCtx := &hcl.EvalContext{
+		Variables: inputVars,
+		Functions: functions.TerraformFuncs,
+	}
+	out := make(model.Document)
+	ddLines := map[string]model.LineObject{
+		"_dd__default": {Line: 1},
+	}
+	for _, block := range content.Blocks {
+		body, skip := convertJSONBody(block.Body, evalCtx, src, block.DefRange.Start.Line)
+		if skip {
+			continue
+		}
+		ddLines["_dd_"+block.Type] = model.LineObject{Line: block.TypeRange.Start.Line}
+		nestJSONBlock(out, block, body)
+	}
+	out["_dd_lines"] = ddLines
+	return out, nil
+}
+
+func convertJSONBody(body hcl.Body, evalCtx *hcl.EvalContext, src []byte, defLine int) (model.Document, bool) {
+	attrs, _ := body.JustAttributes()
+	if countZero(attrs, evalCtx) {
+		return nil, true
+	}
+
+	out := make(model.Document)
+	ddLines := map[string]model.LineObject{
+		"_dd__default": {Line: defLine},
+	}
+	for name, attr := range attrs {
+		ddLines["_dd_"+name] = model.LineObject{Line: attr.NameRange.Start.Line}
+		out[name] = convertJSONExpr(attr.Expr, evalCtx, src, name)
+	}
+	out["_dd_lines"] = ddLines
+	return out, false
+}
+
+func nestJSONBlock(out model.Document, block *hcl.Block, body model.Document) {
+	cur := out
+	key := block.Type
+	for _, label := range block.Labels {
+		if inner, exists := cur[key]; exists {
+			next, ok := inner.(model.Document)
+			if !ok {
+				return
+			}
+			cur = next
+		} else {
+			next := make(model.Document)
+			cur[key] = next
+			cur = next
+		}
+		key = label
+	}
+	if current, exists := cur[key]; exists {
+		if list, ok := current.([]interface{}); ok {
+			cur[key] = append(list, body)
+		} else {
+			cur[key] = []interface{}{current, body}
+		}
+		return
+	}
+	cur[key] = body
+}
+
+func countZero(attrs hcl.Attributes, evalCtx *hcl.EvalContext) bool {
+	attr, ok := attrs["count"]
+	if !ok {
+		return false
+	}
+	val, diags := attr.Expr.Value(evalCtx)
+	if diags.HasErrors() || !val.IsKnown() || val.IsNull() {
+		return false
+	}
+	switch val.Type() {
+	case cty.Number:
+		f, _ := val.AsBigFloat().Float64()
+		return f == 0
+	case cty.String:
+		n, err := strconv.Atoi(val.AsString())
+		return err == nil && n == 0
+	default:
+		return false
+	}
+}
+
+func ctyToJSONDocument(v cty.Value) interface{} {
+	if v.IsNull() {
+		return nil
+	}
+	t := v.Type()
+	switch {
+	case t.IsPrimitiveType():
+		return ctyjson.SimpleJSONValue{Value: v}
+	case t.IsObjectType() || t.IsMapType():
+		m := make(model.Document, v.LengthInt())
+		for k, ev := range v.AsValueMap() {
+			m[k] = ctyToJSONDocument(ev)
+		}
+		return m
+	case t.IsListType() || t.IsTupleType() || t.IsSetType():
+		list := make([]interface{}, 0, v.LengthInt())
+		for _, ev := range v.AsValueSlice() {
+			list = append(list, ctyToJSONDocument(ev))
+		}
+		return list
+	default:
+		return ctyjson.SimpleJSONValue{Value: v}
+	}
+}
+
+func convertJSONExpr(expr hcl.Expression, evalCtx *hcl.EvalContext, src []byte, fallback string) interface{} {
+	val, diags := expr.Value(evalCtx)
+	if !diags.HasErrors() && val.IsWhollyKnown() {
+		return ctyToJSONDocument(val)
+	}
+	if obj, ok := convertJSONObjectExpr(expr, evalCtx, src); ok {
+		return obj
+	}
+	if list, ok := convertJSONListExpr(expr, evalCtx, src, fallback); ok {
+		return list
+	}
+	return wrapJSONRange(expr.Range(), fallback, src)
+}
+
+func convertJSONObjectExpr(expr hcl.Expression, evalCtx *hcl.EvalContext, src []byte) (model.Document, bool) {
+	pairs, diags := hcl.ExprMap(expr)
+	if diags.HasErrors() || len(pairs) == 0 {
+		return nil, false
+	}
+	out := make(model.Document, len(pairs))
+	for _, pair := range pairs {
+		keyVal, keyDiags := pair.Key.Value(evalCtx)
+		if keyDiags.HasErrors() || !keyVal.IsKnown() || keyVal.Type() != cty.String {
+			continue
+		}
+		key := keyVal.AsString()
+		out[key] = convertJSONExpr(pair.Value, evalCtx, src, key)
+	}
+	return out, true
+}
+
+func convertJSONListExpr(
+	expr hcl.Expression, evalCtx *hcl.EvalContext, src []byte, fallback string,
+) ([]interface{}, bool) {
+	items, diags := hcl.ExprList(expr)
+	if diags.HasErrors() || len(items) == 0 {
+		return nil, false
+	}
+	out := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		out = append(out, convertJSONExpr(item, evalCtx, src, fallback))
+	}
+	return out, true
+}
+
+func wrapJSONRange(r hcl.Range, fallback string, src []byte) string {
+	if r.Start.Byte < 0 || r.End.Byte > len(src) || r.Start.Byte >= r.End.Byte {
+		return "${" + fallback + "}"
+	}
+	raw := strings.TrimSpace(string(src[r.Start.Byte:r.End.Byte]))
+	if unquoted, err := strconv.Unquote(raw); err == nil {
+		if strings.Contains(unquoted, "${") {
+			return unquoted
+		}
+		return "${" + unquoted + "}"
+	}
+	return "${" + raw + "}"
+}

--- a/pkg/parser/terraform/json_config_test.go
+++ b/pkg/parser/terraform/json_config_test.go
@@ -1,0 +1,265 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+package terraform
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-iac-scanner/pkg/model"
+	"github.com/stretchr/testify/require"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+func TestParseJSONConfigResource(t *testing.T) {
+	src := []byte(`{
+  "resource": {
+    "aws_s3_bucket": {
+      "b": {
+        "bucket": "S3B_541",
+        "acl": "public-read",
+        "versioning": {
+          "enabled": true
+        }
+      }
+    }
+  }
+}`)
+	doc, err := parseJSONConfig(src, "main.tf.json", nil)
+	require.NoError(t, err)
+
+	bucket := doc["resource"].(model.Document)["aws_s3_bucket"].(model.Document)["b"].(model.Document)
+	require.Equal(t, "public-read", bucket["acl"].(ctyjson.SimpleJSONValue).AsString())
+	require.Equal(t, "S3B_541", bucket["bucket"].(ctyjson.SimpleJSONValue).AsString())
+	require.Equal(t, true, bucket["versioning"].(model.Document)["enabled"].(ctyjson.SimpleJSONValue).True())
+
+	lines := bucket["_dd_lines"].(map[string]model.LineObject)
+	require.Equal(t, 6, lines["_dd_acl"].Line)
+}
+
+func TestParseJSONConfigCountZeroSkipped(t *testing.T) {
+	src := []byte(`{
+  "resource": {
+    "aws_instance": {
+      "gone": { "count": 0, "ami": "ami-123" },
+      "kept": { "ami": "ami-123" }
+    }
+  }
+}`)
+	doc, err := parseJSONConfig(src, "main.tf.json", nil)
+	require.NoError(t, err)
+	instances := doc["resource"].(model.Document)["aws_instance"].(model.Document)
+	_, gone := instances["gone"]
+	require.False(t, gone)
+	_, kept := instances["kept"]
+	require.True(t, kept)
+}
+
+func TestParser_JSONConfigAndTofuJSON(t *testing.T) {
+	ctx := context.Background()
+	parser := NewDefault()
+	src := []byte(`{"resource":{"aws_s3_bucket":{"b":{"acl":"public-read"}}}}`)
+
+	for _, name := range []string{"main.tf.json", "main.tofu.json"} {
+		_, document, ignore, _, err := parser.Parse(ctx, src, name, true, 15)
+		require.NoError(t, err, name)
+		require.Empty(t, ignore, name)
+		require.Len(t, document, 1, name)
+		require.Contains(t, document[0]["resource"], "aws_s3_bucket", name)
+	}
+}
+
+func TestParser_JSONConfigUsesIAMPolicyDocument(t *testing.T) {
+	dir := t.TempDir()
+	main := filepath.Join(dir, "main.tf.json")
+	src := []byte(`{
+  "data": {
+    "aws_iam_policy_document": {
+      "doc": {
+        "statement": [{
+          "sid": "1",
+          "actions": ["s3:GetObject"],
+          "resources": ["arn:aws:s3:::example/*"]
+        }]
+      }
+    }
+  },
+  "resource": {
+    "aws_iam_policy": {
+      "p": {
+        "policy": "${data.aws_iam_policy_document.doc.json}"
+      }
+    }
+  }
+}`)
+	require.NoError(t, os.WriteFile(main, src, 0o600))
+
+	_, document, _, _, err := NewDefault().Parse(context.Background(), src, main, true, 15)
+	require.NoError(t, err)
+	policy := document[0]["resource"].(model.Document)["aws_iam_policy"].(model.Document)["p"].(model.Document)["policy"]
+	require.Contains(t, stringifyValue(policy), "s3:GetObject")
+	require.Contains(t, stringifyValue(policy), "arn:aws:s3:::example/*")
+}
+
+func TestParser_JSONConfigUsesSiblingVariableDefaults(t *testing.T) {
+	dir := t.TempDir()
+	vars := filepath.Join(dir, "variables.tf")
+	main := filepath.Join(dir, "main.tf.json")
+	require.NoError(t, os.WriteFile(vars, []byte(`
+variable "acl" { default = "public-read" }
+`), 0o600))
+	src := []byte(`{"resource":{"aws_s3_bucket":{"b":{"acl":"${var.acl}"}}}}`)
+	require.NoError(t, os.WriteFile(main, src, 0o600))
+
+	_, document, _, _, err := NewDefault().Parse(context.Background(), src, main, true, 15)
+	require.NoError(t, err)
+	bucket := document[0]["resource"].(model.Document)["aws_s3_bucket"].(model.Document)["b"].(model.Document)
+	require.Equal(t, "public-read", bucket["acl"].(ctyjson.SimpleJSONValue).AsString())
+}
+
+func TestParser_JSONConfigUsesSiblingJSONVariables(t *testing.T) {
+	dir := t.TempDir()
+	vars := filepath.Join(dir, "variables.tf.json")
+	main := filepath.Join(dir, "main.tf.json")
+	require.NoError(t, os.WriteFile(vars, []byte(`{"variable":{"acl":{"default":"public-read"}}}`), 0o600))
+	src := []byte(`{"resource":{"aws_s3_bucket":{"b":{"acl":"${var.acl}"}}}}`)
+	require.NoError(t, os.WriteFile(main, src, 0o600))
+
+	_, document, _, _, err := NewDefault().Parse(context.Background(), src, main, true, 15)
+	require.NoError(t, err)
+	bucket := document[0]["resource"].(model.Document)["aws_s3_bucket"].(model.Document)["b"].(model.Document)
+	require.Equal(t, "public-read", bucket["acl"].(ctyjson.SimpleJSONValue).AsString())
+}
+
+func TestParseJSONConfigKeepsKnownNestedSiblings(t *testing.T) {
+	src := []byte(`{
+  "resource": {
+    "aws_s3_bucket": {
+      "b": {
+        "tags": {
+          "Environment": "prod",
+          "Name": "${var.missing}"
+        }
+      }
+    }
+  }
+}`)
+	doc, err := parseJSONConfig(src, "main.tf.json", nil)
+	require.NoError(t, err)
+	tags := doc["resource"].(model.Document)["aws_s3_bucket"].(model.Document)["b"].(model.Document)["tags"].(model.Document)
+	require.Equal(t, "prod", tags["Environment"].(ctyjson.SimpleJSONValue).AsString())
+	require.Equal(t, "${var.missing}", tags["Name"])
+}
+
+func TestParseJSONConfigWrapsUnresolvedExprFromValue(t *testing.T) {
+	src := []byte(`{
+  "resource": {
+    "aws_s3_bucket": {
+      "b": {
+        "acl": "${var.missing}"
+      }
+    }
+  }
+}`)
+	doc, err := parseJSONConfig(src, "main.tf.json", nil)
+	require.NoError(t, err)
+	bucket := doc["resource"].(model.Document)["aws_s3_bucket"].(model.Document)["b"].(model.Document)
+	require.Equal(t, "${var.missing}", bucket["acl"])
+}
+
+func TestParseJSONConfigPreservesPartialTemplate(t *testing.T) {
+	src := []byte(`{
+  "resource": {
+    "aws_s3_bucket": {
+      "b": {
+        "arn": "arn:aws:s3:::${var.missing}/*"
+      }
+    }
+  }
+}`)
+	doc, err := parseJSONConfig(src, "main.tf.json", nil)
+	require.NoError(t, err)
+	bucket := doc["resource"].(model.Document)["aws_s3_bucket"].(model.Document)["b"].(model.Document)
+	require.Equal(t, "arn:aws:s3:::${var.missing}/*", bucket["arn"])
+}
+
+func TestParser_JSONConfigDoesNotTreatResourcesAsVars(t *testing.T) {
+	dir := t.TempDir()
+	vars := filepath.Join(dir, "variables.tf.json")
+	main := filepath.Join(dir, "main.tf.json")
+	require.NoError(t, os.WriteFile(vars, []byte(`{"variable":{"resource":{"default":"from-var"}}}`), 0o600))
+	src := []byte(`{"resource":{"aws_s3_bucket":{"b":{"bucket":"${var.resource}"}}}}`)
+	require.NoError(t, os.WriteFile(main, src, 0o600))
+
+	_, document, _, _, err := NewDefault().Parse(context.Background(), src, main, true, 15)
+	require.NoError(t, err)
+	bucket := document[0]["resource"].(model.Document)["aws_s3_bucket"].(model.Document)["b"].(model.Document)
+	require.Equal(t, "from-var", bucket["bucket"].(ctyjson.SimpleJSONValue).AsString())
+}
+
+func TestParser_JSONLocalsResolveAcrossPasses(t *testing.T) {
+	dir := t.TempDir()
+	main := filepath.Join(dir, "main.tf.json")
+	src := []byte(`{
+  "locals": {
+    "b": "${local.a}",
+    "a": "resolved"
+  },
+  "resource": {
+    "aws_s3_bucket": {
+      "b": { "bucket": "${local.b}" }
+    }
+  }
+}`)
+	require.NoError(t, os.WriteFile(main, src, 0o600))
+
+	_, document, _, _, err := NewDefault().Parse(context.Background(), src, main, true, 15)
+	require.NoError(t, err)
+	bucket := document[0]["resource"].(model.Document)["aws_s3_bucket"].(model.Document)["b"].(model.Document)
+	require.Equal(t, "resolved", bucket["bucket"].(ctyjson.SimpleJSONValue).AsString())
+}
+
+func TestParser_JSONTwinsKeepOwnVars(t *testing.T) {
+	dir := t.TempDir()
+	tfJSON := filepath.Join(dir, "main.tf.json")
+	tofuJSON := filepath.Join(dir, "main.tofu.json")
+	tfSrc := []byte(`{"variable":{"name":{"default":"from-tf"}},"resource":{"aws_s3_bucket":{"b":{"bucket":"${var.name}"}}}}`)
+	tofuSrc := []byte(`{"variable":{"name":{"default":"from-tofu"}},"resource":{"aws_s3_bucket":{"b":{"bucket":"${var.name}"}}}}`)
+	require.NoError(t, os.WriteFile(tfJSON, tfSrc, 0o600))
+	require.NoError(t, os.WriteFile(tofuJSON, tofuSrc, 0o600))
+
+	parser := NewDefault()
+	parser.SetMergeAllow([]string{tfJSON, tofuJSON})
+
+	_, tfDoc, _, _, err := parser.Parse(context.Background(), tfSrc, tfJSON, true, 15)
+	require.NoError(t, err)
+	tfBucket := fmtSprintBucket(tfDoc)
+	require.Contains(t, tfBucket, "from-tf")
+	require.NotContains(t, tfBucket, "from-tofu")
+
+	_, tofuDoc, _, _, err := parser.Parse(context.Background(), tofuSrc, tofuJSON, true, 15)
+	require.NoError(t, err)
+	tofuBucket := fmtSprintBucket(tofuDoc)
+	require.Contains(t, tofuBucket, "from-tofu")
+	require.NotContains(t, tofuBucket, "from-tf")
+}
+
+func fmtSprintBucket(doc []model.Document) string {
+	return stringifyValue(doc[0]["resource"].(model.Document)["aws_s3_bucket"].(model.Document)["b"].(model.Document)["bucket"])
+}
+
+func stringifyValue(v interface{}) string {
+	switch t := v.(type) {
+	case ctyjson.SimpleJSONValue:
+		return t.AsString()
+	case string:
+		return t
+	default:
+		return ""
+	}
+}

--- a/pkg/parser/terraform/modules/dir.go
+++ b/pkg/parser/terraform/modules/dir.go
@@ -53,6 +53,17 @@ func mergeAllowed(allow map[string]struct{}, dir, name string) bool {
 // limited to allow and then OpenTofu-shadowed within that set. keep, when set,
 // is never dropped from a scan-set merge.
 func SelectHCLConfigNames(entries []fs.DirEntry, dir string, allow map[string]struct{}, keep string) []string {
+	return selectConfigNames(entries, dir, allow, keep, tfpath.IsHCLConfig)
+}
+
+// SelectConfigNames is SelectHCLConfigNames plus JSON config files.
+func SelectConfigNames(entries []fs.DirEntry, dir string, allow map[string]struct{}, keep string) []string {
+	return selectConfigNames(entries, dir, allow, keep, tfpath.IsConfig)
+}
+
+func selectConfigNames(
+	entries []fs.DirEntry, dir string, allow map[string]struct{}, keep string, pred func(string) bool,
+) []string {
 	all := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -76,17 +87,16 @@ func SelectHCLConfigNames(entries []fs.DirEntry, dir string, allow map[string]st
 	}
 	if keep != "" {
 		return tfpath.SelectKeepingWithTofuPrecedence(
-			all, tfpath.IsHCLConfig, filepath.Base(keep), preferTofu,
+			all, pred, filepath.Base(keep), preferTofu,
 		)
 	}
-	return tfpath.SelectWithTofuPrecedence(all, tfpath.IsHCLConfig, preferTofu)
+	return tfpath.SelectWithTofuPrecedence(all, pred, preferTofu)
 }
 
 // ConfinedFilePath reports whether a directory entry is a regular file the
-// Terraform parser can scan. JSON configuration is handled separately for
-// module discovery but is not emitted in HCL-only scan paths.
-// Regular files are accepted. Symlinks are accepted only when their target is a
-// regular file confined within packageRoot (or dir when packageRoot is empty).
+// Terraform parser can scan. Regular files are accepted. Symlinks are accepted
+// only when their target is a regular file confined within packageRoot (or dir
+// when packageRoot is empty).
 func ConfinedFilePath(ctx context.Context, entry fs.DirEntry, dir, packageRoot string) (string, bool) {
 	if entry.IsDir() {
 		return "", false

--- a/pkg/parser/terraform/modules/files_test.go
+++ b/pkg/parser/terraform/modules/files_test.go
@@ -82,3 +82,16 @@ func TestSelectHCLConfigNamesRespectsMergeAllow(t *testing.T) {
 	require.Equal(t, []string{"main.tofu", "variables.tf"}, SelectHCLConfigNames(entries, dir, both, "main.tofu"))
 	require.Equal(t, []string{"main.tofu", "variables.tf"}, SelectHCLConfigNames(entries, dir, both, ""))
 }
+
+func TestSelectConfigNamesIncludesJSON(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`resource "x" "tf" {}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tofu"), []byte(`resource "x" "tofu" {}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.tf.json"), []byte(`{"resource":{}}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.tofu.json"), []byte(`{"resource":{}}`), 0o644))
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	got := SelectConfigNames(entries, dir, nil, "")
+	require.ElementsMatch(t, []string{"main.tofu", "extra.tofu.json"}, got)
+}

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -291,6 +291,15 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, path string,
 		return nil, nil, nil, nil, err
 	}
 
+	if tfpath.IsJSONConfig(path) {
+		fc, parseErr := parseJSONConfig(resolved, path, inputVariables)
+		json, extraErr := addExtraInfo(ctx, []model.Document{fc}, path)
+		if extraErr != nil {
+			return []byte{}, json, []int{}, map[string]model.ResolvedFile{}, errors.Wrap(extraErr, "failed terraform parse")
+		}
+		return resolved, json, nil, resolvedFiles, errors.Wrap(parseErr, "failed terraform parse")
+	}
+
 	file, diagnostics := hclsyntax.ParseConfig(resolved, filepath.Base(path), hcl.Pos{Byte: 0, Line: 1, Column: 1})
 	defer func() {
 		if r := recover(); r != nil {
@@ -321,7 +330,7 @@ func (p *Parser) Parse(ctx context.Context, fileContent []byte, path string,
 
 // SupportedExtensions returns Terraform/OpenTofu extensions.
 func (p *Parser) SupportedExtensions() []string {
-	return []string{tfpath.ExtTF, tfpath.ExtTofu, tfpath.ExtTFVars}
+	return []string{tfpath.ExtTF, tfpath.ExtTofu, tfpath.ExtTFJSON, tfpath.ExtTofuJSON, tfpath.ExtTFVars}
 }
 
 // SupportedTypes returns types supported by this parser, which are terraform

--- a/pkg/parser/terraform/terraform_test.go
+++ b/pkg/parser/terraform/terraform_test.go
@@ -122,7 +122,7 @@ func TestParser_SupportedTypes(t *testing.T) {
 // TestParser_SupportedExtensions tests the functions [SupportedExtensions()] and all the methods called by them
 func TestParser_SupportedExtensions(t *testing.T) {
 	p := &Parser{}
-	require.Equal(t, []string{".tf", ".tofu", ".tfvars"}, p.SupportedExtensions())
+	require.Equal(t, []string{".tf", ".tofu", ".tf.json", ".tofu.json", ".tfvars"}, p.SupportedExtensions())
 }
 
 // Test_Parser tests the functions [Parser()] and all the methods called by them

--- a/pkg/parser/terraform/tfeval/evaluator_test.go
+++ b/pkg/parser/terraform/tfeval/evaluator_test.go
@@ -98,6 +98,109 @@ resource "aws_s3_bucket" "this" {
 	requireString(t, r.Attributes, "bucket", "my-bucket")
 }
 
+func TestEvaluateModule_JSONConfigInputPropagated(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf.json": `{
+  "variable": {
+    "bucket_name": { "type": "string" }
+  },
+  "locals": {
+    "prefixed": "${var.bucket_name}-json"
+  },
+  "resource": {
+    "aws_s3_bucket": {
+      "this": {
+        "bucket": "${local.prefixed}"
+      }
+    }
+  }
+}`,
+	})
+
+	inputs := map[string]cty.Value{"bucket_name": cty.StringVal("my-bucket")}
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, inputs)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+
+	r := findResource(t, resources, "aws_s3_bucket", "this")
+	requireString(t, r.Attributes, "bucket", "my-bucket-json")
+}
+
+func TestEvaluateModule_JSONNullDefault(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf.json": `{
+  "variable": {
+    "acl": { "default": null }
+  },
+  "resource": {
+    "aws_s3_bucket": {
+      "this": {
+        "acl": null
+      }
+    }
+  }
+}`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	r := findResource(t, resources, "aws_s3_bucket", "this")
+	v, ok := r.Attributes["acl"]
+	if !ok {
+		t.Fatal("attribute acl missing")
+	}
+	if !v.IsNull() {
+		t.Fatalf("attribute acl = %#v, want null", v)
+	}
+}
+
+func TestEvaluateModule_JSONChildModule(t *testing.T) {
+	root := t.TempDir()
+	writeModule(t, root, "child", map[string]string{
+		"main.tf.json": `{
+  "variable": { "name": { "type": "string" } },
+  "resource": { "aws_s3_bucket": { "leaf": { "bucket": "${var.name}" } } }
+}`,
+	})
+	rootDir := writeModule(t, root, "root", map[string]string{
+		"main.tf.json": `{
+  "module": { "child": { "source": "../child", "name": "from-json" } }
+}`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), rootDir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	r := findResource(t, resources, "aws_s3_bucket", "leaf")
+	requireString(t, r.Attributes, "bucket", "from-json")
+	if r.ModuleAddress != "module.child" {
+		t.Fatalf("ModuleAddress = %q, want module.child", r.ModuleAddress)
+	}
+}
+
+func TestEvaluateModule_TofuJSONShadowsTfJSON(t *testing.T) {
+	root := t.TempDir()
+	dir := writeModule(t, root, "mod", map[string]string{
+		"main.tf.json":   `{"resource":{"aws_s3_bucket":{"shadowed":{"bucket":"from-tf"}}}}`,
+		"main.tofu.json": `{"resource":{"aws_s3_bucket":{"live":{"bucket":"from-tofu"}}}}`,
+	})
+
+	resources, _, _, err := New().EvaluateModule(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("EvaluateModule: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("got %d resources, want 1: %#v", len(resources), resources)
+	}
+	requireString(t, findResource(t, resources, "aws_s3_bucket", "live").Attributes, "bucket", "from-tofu")
+}
+
 func TestEvaluateModule_TofuShadowsTf(t *testing.T) {
 	root := t.TempDir()
 	dir := writeModule(t, root, "mod", map[string]string{

--- a/pkg/parser/terraform/tfeval/parse.go
+++ b/pkg/parser/terraform/tfeval/parse.go
@@ -20,6 +20,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/tfpath"
 )
 
 const blockTypeModule = "module"
@@ -34,8 +35,8 @@ var reservedModuleAttrs = map[string]bool{
 	"depends_on": true,
 }
 
-// parseDir parses all HCL config in dir (non-recursively) and returns their
-// bodies. Files that fail to parse are skipped. JSON config is not evaluated here.
+// parseDir parses HCL and JSON config in dir (non-recursively) and returns
+// their bodies. Files that fail to parse are skipped.
 func parseDir(ctx context.Context, dir, packageRoot string, allow map[string]struct{}) ([]*hclsyntax.Body, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -48,7 +49,7 @@ func parseDir(ctx context.Context, dir, packageRoot string, allow map[string]str
 			byName[entry.Name()] = entry
 		}
 	}
-	names := tfmodules.SelectHCLConfigNames(entries, dir, allow, "")
+	names := tfmodules.SelectConfigNames(entries, dir, allow, "")
 	sort.Strings(names)
 
 	bodies := make([]*hclsyntax.Body, 0, len(names))
@@ -65,15 +66,23 @@ func parseDir(ctx context.Context, dir, packageRoot string, allow map[string]str
 		if rErr != nil {
 			continue
 		}
-		f, diags := hclsyntax.ParseConfig(src, path, hcl.Pos{Line: 1, Column: 1})
-		if diags.HasErrors() {
-			continue
-		}
-		if body, ok := f.Body.(*hclsyntax.Body); ok {
+		if body, ok := parseConfigBody(src, path); ok {
 			bodies = append(bodies, body)
 		}
 	}
 	return bodies, nil
+}
+
+func parseConfigBody(src []byte, path string) (*hclsyntax.Body, bool) {
+	if tfpath.IsJSONConfig(path) {
+		return parseJSONAsHCLBody(src, path)
+	}
+	f, diags := hclsyntax.ParseConfig(src, path, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, false
+	}
+	body, ok := f.Body.(*hclsyntax.Body)
+	return body, ok
 }
 
 // collectBlocks partitions blocks across all bodies into variables, locals,

--- a/pkg/parser/terraform/tfeval/parse_json.go
+++ b/pkg/parser/terraform/tfeval/parse_json.go
@@ -1,0 +1,148 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com)  Copyright 2024 Datadog, Inc.
+ */
+
+package tfeval
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	hcljson "github.com/hashicorp/hcl/v2/json"
+	"github.com/zclconf/go-cty/cty"
+)
+
+var jsonConfigSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "terraform"},
+		{Type: "locals"},
+		{Type: "variable", LabelNames: []string{"name"}},
+		{Type: "output", LabelNames: []string{"name"}},
+		{Type: blockTypeModule, LabelNames: []string{"name"}},
+		{Type: "resource", LabelNames: []string{"type", "name"}},
+		{Type: "data", LabelNames: []string{"type", "name"}},
+	},
+}
+
+func parseJSONAsHCLBody(src []byte, filename string) (*hclsyntax.Body, bool) {
+	file, diags := hcljson.Parse(src, filename)
+	if diags.HasErrors() {
+		return nil, false
+	}
+	content, _, _ := file.Body.PartialContent(jsonConfigSchema)
+	if content == nil {
+		return nil, false
+	}
+	body := &hclsyntax.Body{
+		Attributes: make(hclsyntax.Attributes),
+		SrcRange:   hcl.Range{Filename: filename, Start: hcl.Pos{Line: 1, Column: 1, Byte: 0}},
+	}
+	for _, block := range content.Blocks {
+		body.Blocks = append(body.Blocks, jsonBlockToHCL(block, src))
+	}
+	return body, true
+}
+
+func jsonBlockToHCL(block *hcl.Block, src []byte) *hclsyntax.Block {
+	return &hclsyntax.Block{
+		Type:            block.Type,
+		Labels:          block.Labels,
+		Body:            jsonBodyToHCL(block.Body, src, block.DefRange),
+		TypeRange:       block.TypeRange,
+		LabelRanges:     block.LabelRanges,
+		OpenBraceRange:  block.DefRange,
+		CloseBraceRange: block.DefRange,
+	}
+}
+
+func jsonBodyToHCL(body hcl.Body, src []byte, defRange hcl.Range) *hclsyntax.Body {
+	attrs, _ := body.JustAttributes()
+	out := &hclsyntax.Body{
+		Attributes: make(hclsyntax.Attributes, len(attrs)),
+		SrcRange:   defRange,
+	}
+	for name, attr := range attrs {
+		out.Attributes[name] = &hclsyntax.Attribute{
+			Name:      name,
+			Expr:      jsonExprToHCL(attr.Expr, src),
+			NameRange: attr.NameRange,
+			SrcRange:  attr.Range,
+		}
+	}
+	return out
+}
+
+func jsonExprToHCL(expr hcl.Expression, src []byte) hclsyntax.Expression {
+	if obj, ok := jsonObjectExprToHCL(expr, src); ok {
+		return obj
+	}
+	if list, ok := jsonListExprToHCL(expr, src); ok {
+		return list
+	}
+	val, diags := expr.Value(&hcl.EvalContext{})
+	if !diags.HasErrors() && val.IsWhollyKnown() {
+		return &hclsyntax.LiteralValueExpr{Val: val, SrcRange: expr.Range()}
+	}
+	if parsed := parseJSONInterpolation(expr, src); parsed != nil {
+		return parsed
+	}
+	return &hclsyntax.LiteralValueExpr{Val: cty.UnknownVal(cty.DynamicPseudoType), SrcRange: expr.Range()}
+}
+
+func jsonObjectExprToHCL(expr hcl.Expression, src []byte) (hclsyntax.Expression, bool) {
+	pairs, diags := hcl.ExprMap(expr)
+	if diags.HasErrors() || len(pairs) == 0 {
+		return nil, false
+	}
+	items := make([]hclsyntax.ObjectConsItem, 0, len(pairs))
+	for _, pair := range pairs {
+		items = append(items, hclsyntax.ObjectConsItem{
+			KeyExpr:   jsonExprToHCL(pair.Key, src),
+			ValueExpr: jsonExprToHCL(pair.Value, src),
+		})
+	}
+	return &hclsyntax.ObjectConsExpr{Items: items, SrcRange: expr.Range()}, true
+}
+
+func jsonListExprToHCL(expr hcl.Expression, src []byte) (hclsyntax.Expression, bool) {
+	items, diags := hcl.ExprList(expr)
+	if diags.HasErrors() || len(items) == 0 {
+		return nil, false
+	}
+	exprs := make([]hclsyntax.Expression, 0, len(items))
+	for _, item := range items {
+		exprs = append(exprs, jsonExprToHCL(item, src))
+	}
+	return &hclsyntax.TupleConsExpr{Exprs: exprs, SrcRange: expr.Range()}, true
+}
+
+func parseJSONInterpolation(expr hcl.Expression, src []byte) hclsyntax.Expression {
+	raw := jsonExprSource(expr, src)
+	if raw == "" {
+		return nil
+	}
+	if raw == "null" {
+		return &hclsyntax.LiteralValueExpr{Val: cty.NullVal(cty.DynamicPseudoType), SrcRange: expr.Range()}
+	}
+	unquoted, err := strconv.Unquote(raw)
+	if err != nil {
+		unquoted = strings.TrimSpace(raw)
+	}
+	parsed, diags := hclsyntax.ParseExpression([]byte(strconv.Quote(unquoted)), "", expr.Range().Start)
+	if diags.HasErrors() {
+		return nil
+	}
+	return parsed
+}
+
+func jsonExprSource(expr hcl.Expression, src []byte) string {
+	r := expr.Range()
+	if r.Start.Byte < 0 || r.End.Byte > len(src) || r.Start.Byte >= r.End.Byte {
+		return ""
+	}
+	return strings.TrimSpace(string(src[r.Start.Byte:r.End.Byte]))
+}

--- a/pkg/parser/terraform/variables.go
+++ b/pkg/parser/terraform/variables.go
@@ -14,14 +14,20 @@ import (
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
 	"github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/converter"
 	tfmodules "github.com/DataDog/datadog-iac-scanner/pkg/parser/terraform/modules"
+	"github.com/DataDog/datadog-iac-scanner/pkg/tfpath"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	hcljson "github.com/hashicorp/hcl/v2/json"
 	"github.com/zclconf/go-cty/cty"
 )
 
-// terraformVarsPathDirective is the inline comment prefix that overrides the tfvars path for a file.
-const terraformVarsPathDirective = "kics_terraform_vars"
+const (
+	// terraformVarsPathDirective is the inline comment prefix that overrides the tfvars path for a file.
+	terraformVarsPathDirective = "kics_terraform_vars"
+	blockTypeVariable          = "variable"
+	blockTypeLocals            = "locals"
+)
 
 var terraformVarsPathRegex = regexp.MustCompile(`(?m)^\s*// ` + terraformVarsPathDirective + `: ([\w/\\.:-]+)\r?\n`)
 
@@ -57,6 +63,9 @@ func getInputVariablesFromFile(fsys vfs.FS, filename string) (converter.Variable
 func getInputVariablesAndLocalsFromFile(
 	fsys vfs.FS, filename string,
 ) (vars, locals converter.VariableMap, err error) {
+	if tfpath.IsJSONConfig(filename) {
+		return extractVarsAndLocalsFromJSON(fsys, filename)
+	}
 	body, err := parseHCLBody(fsys, filename)
 	if err != nil {
 		return nil, nil, err
@@ -85,7 +94,7 @@ func extractInputVariables(body *hclsyntax.Body, filename string) converter.Vari
 	// Case 2: .tf variable "x" { default = ... }
 	hasVariableBlock := false
 	for _, block := range body.Blocks {
-		if block.Type == "variable" && len(block.Labels) == 1 && block.Labels[0] != "" {
+		if block.Type == blockTypeVariable && len(block.Labels) == 1 && block.Labels[0] != "" {
 			hasVariableBlock = true
 			varName := block.Labels[0]
 			if defaultAttr, exists := block.Body.Attributes["default"]; exists {
@@ -113,6 +122,71 @@ func extractInputVariables(body *hclsyntax.Body, filename string) converter.Vari
 	return variables
 }
 
+func extractVarsAndLocalsFromJSON(fsys vfs.FS, filename string) (vars, locals converter.VariableMap, err error) {
+	src, err := fsys.ReadFile(filepath.Clean(filename))
+	if err != nil {
+		return nil, nil, err
+	}
+	parsed, diags := hcljson.Parse(src, filename)
+	if diags.HasErrors() {
+		return nil, nil, diags
+	}
+	content, _, diags := parsed.Body.PartialContent(jsonConfigSchema)
+	if diags.HasErrors() && content == nil {
+		return nil, nil, diags
+	}
+
+	vars, locals = varsAndLocalsFromJSONBlocks(content.Blocks)
+	return vars, locals, nil
+}
+
+func varsAndLocalsFromJSONBlocks(blocks hcl.Blocks) (vars, locals converter.VariableMap) {
+	vars = make(converter.VariableMap)
+	locals = make(converter.VariableMap)
+	evalCtx := &hcl.EvalContext{}
+	for _, block := range blocks {
+		switch block.Type {
+		case blockTypeVariable:
+			if len(block.Labels) != 1 || block.Labels[0] == "" {
+				continue
+			}
+			vars[block.Labels[0]] = knownAttrOrUnknown(block.Body, "default", evalCtx)
+		case blockTypeLocals:
+			mergeKnownAttributes(locals, block.Body)
+		}
+	}
+	return vars, locals
+}
+
+func knownAttrOrUnknown(body hcl.Body, name string, evalCtx *hcl.EvalContext) cty.Value {
+	attrs, _ := body.JustAttributes()
+	if def, ok := attrs[name]; ok {
+		val, diags := def.Expr.Value(evalCtx)
+		if !diags.HasErrors() && val.IsKnown() {
+			return val
+		}
+	}
+	return cty.UnknownVal(cty.DynamicPseudoType)
+}
+
+func mergeKnownAttributes(dst converter.VariableMap, body hcl.Body) {
+	attrs, _ := body.JustAttributes()
+	for pass := 0; pass < 3; pass++ {
+		evalCtx := &hcl.EvalContext{
+			Variables: map[string]cty.Value{"local": cty.ObjectVal(dst)},
+		}
+		for name, attr := range attrs {
+			if _, ok := dst[name]; ok {
+				continue
+			}
+			val, diags := attr.Expr.Value(evalCtx)
+			if !diags.HasErrors() && val.IsKnown() {
+				dst[name] = val
+			}
+		}
+	}
+}
+
 func extractLocals(body *hclsyntax.Body) converter.VariableMap {
 	locals := make(converter.VariableMap)
 	if body == nil {
@@ -127,7 +201,7 @@ func extractLocals(body *hclsyntax.Body) converter.VariableMap {
 
 	// Collect all locals
 	for _, block := range body.Blocks {
-		if block.Type != "locals" {
+		if block.Type != blockTypeLocals {
 			continue
 		}
 		for name, attr := range block.Body.Attributes {
@@ -250,7 +324,7 @@ func hclConfigFiles(ctx context.Context, fsys vfs.FS, dir string, allow map[stri
 		contextLogger.Error().Msg("Error listing Terraform configuration files")
 		return nil
 	}
-	names := tfmodules.SelectHCLConfigNames(entries, dir, allow, keep)
+	names := tfmodules.SelectConfigNames(entries, dir, allow, keep)
 	out := make([]string, len(names))
 	for i, name := range names {
 		out[i] = filepath.Join(dir, name)

--- a/pkg/server/supported_files.go
+++ b/pkg/server/supported_files.go
@@ -42,6 +42,8 @@ type SupportedFileEntry struct {
 var strategyByPattern = map[string]fileStrategy{
 	".tf":         strategyDirectory,
 	".tofu":       strategyDirectory,
+	".tf.json":    strategyDirectory,
+	".tofu.json":  strategyDirectory,
 	".tfvars":     strategyDirectory,
 	".yaml":       strategyDirectory,
 	".yml":        strategyDirectory,

--- a/pkg/tfpath/tfpath.go
+++ b/pkg/tfpath/tfpath.go
@@ -20,10 +20,26 @@ const (
 	ExtTFVars   = ".tfvars"
 )
 
+// Extension returns the Terraform/OpenTofu config suffix, including compound
+// JSON suffixes that filepath.Ext would truncate to ".json".
+func Extension(path string) string {
+	switch {
+	case hasExtSuffix(path, ExtTofuJSON):
+		return ExtTofuJSON
+	case hasExtSuffix(path, ExtTFJSON):
+		return ExtTFJSON
+	default:
+		return filepath.Ext(path)
+	}
+}
+
 // IsJSONConfig reports whether path uses Terraform/OpenTofu JSON configuration syntax.
 func IsJSONConfig(path string) bool {
-	lower := strings.ToLower(path)
-	return strings.HasSuffix(lower, ExtTFJSON) || strings.HasSuffix(lower, ExtTofuJSON)
+	return hasExtSuffix(path, ExtTofuJSON) || hasExtSuffix(path, ExtTFJSON)
+}
+
+func hasExtSuffix(path, ext string) bool {
+	return len(path) >= len(ext) && strings.EqualFold(path[len(path)-len(ext):], ext)
 }
 
 // IsHCLConfig reports whether path is a native Terraform/OpenTofu HCL configuration file.

--- a/pkg/tfpath/tfpath_test.go
+++ b/pkg/tfpath/tfpath_test.go
@@ -12,6 +12,26 @@ import (
 	"testing"
 )
 
+func TestExtension(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "main.tf", want: ".tf"},
+		{path: "main.tofu", want: ".tofu"},
+		{path: "main.tf.json", want: ".tf.json"},
+		{path: "main.tofu.json", want: ".tofu.json"},
+		{path: "dir/MAIN.TOFU.JSON", want: ".tofu.json"},
+		{path: "data.json", want: ".json"},
+		{path: "vars.tfvars", want: ".tfvars"},
+	}
+	for _, tt := range tests {
+		if got := Extension(tt.path); got != tt.want {
+			t.Errorf("Extension(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
 func TestIsJSONConfig(t *testing.T) {
 	tests := []struct {
 		path string

--- a/pkg/utils/get_extension.go
+++ b/pkg/utils/get_extension.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-iac-scanner/pkg/logger"
+	"github.com/DataDog/datadog-iac-scanner/pkg/tfpath"
 	"github.com/DataDog/datadog-iac-scanner/pkg/vfs"
 	"golang.org/x/tools/godoc/util"
 )
@@ -21,7 +22,7 @@ var extensionNameTargets = []string{"tfvars", "Dockerfile", "possibleDockerfile"
 
 // ExtensionFromPath returns the extension from path alone (no stat/read).
 func ExtensionFromPath(path string) string {
-	ext := filepath.Ext(path)
+	ext := tfpath.Extension(path)
 	if ext != "" {
 		return ext
 	}
@@ -61,7 +62,7 @@ func GetExtensionWithFS(ctx context.Context, fsys vfs.FS, path string) (string, 
 		return "", err
 	}
 
-	ext := filepath.Ext(path)
+	ext := tfpath.Extension(path)
 	if ext == "" {
 		base := filepath.Base(path)
 

--- a/pkg/utils/get_extension_test.go
+++ b/pkg/utils/get_extension_test.go
@@ -20,6 +20,10 @@ func TestExtensionFromPath(t *testing.T) {
 		want string
 	}{
 		{path: "/repo/main.tf", want: ".tf"},
+		{path: "/repo/main.tf.json", want: ".tf.json"},
+		{path: "/repo/main.tofu.json", want: ".tofu.json"},
+		{path: "/repo/MAIN.TF.JSON", want: ".tf.json"},
+		{path: "/repo/data.json", want: ".json"},
 		{path: "/repo/Dockerfile", want: "Dockerfile"},
 		{path: "/repo/vars.tfvars", want: ".tfvars"},
 		{path: "/repo/terraform.tfvars", want: ".tfvars"},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -129,6 +129,28 @@ func Test_E2ETofuScannedAsTerraform(t *testing.T) {
 	require.True(t, fired, "terraform-aws-team-tag-not-present must fire on a .tofu file")
 }
 
+func Test_E2EJSONConfigScannedAsTerraform(t *testing.T) {
+	queriesPaths := []string{mustAbs(t, filepath.Join("testdata", "rules", "terraform"))}
+
+	for _, fixture := range []string{
+		filepath.Join("fixtures", "positive.tf.json"),
+		filepath.Join("fixtures", "positive.tofu.json"),
+	} {
+		t.Run(filepath.Base(fixture), func(t *testing.T) {
+			stats := runScan(t, fixture, queriesPaths)
+			require.Equal(t, 1, stats.Files, "%s must be scanned", fixture)
+			require.NotEmpty(t, stats.ViolationBreakdowns, "no violations on %s: check queriesPaths", fixture)
+			fired := false
+			for _, slugs := range stats.ViolationBreakdowns {
+				if _, ok := slugs["terraform-aws-team-tag-not-present"]; ok {
+					fired = true
+				}
+			}
+			require.True(t, fired, "terraform-aws-team-tag-not-present must fire on %s", fixture)
+		})
+	}
+}
+
 // Test_E2ETerraformPlanFlag verifies that:
 // 1. Terraform plan JSON files are scanned when the flag is enabled
 // 2. CloudFormation JSON files are NOT scanned (even though they are JSON)

--- a/test/e2e/fixtures/positive.tf.json
+++ b/test/e2e/fixtures/positive.tf.json
@@ -1,0 +1,19 @@
+{
+  "provider": {
+    "aws": {
+      "region": "us-east-1"
+    }
+  },
+  "resource": {
+    "aws_s3_bucket": {
+      "positive1": {
+        "bucket": "my-tf-json-test-bucket",
+        "acl": "private",
+        "tags": {
+          "Name": "My bucket",
+          "Environment": "Dev"
+        }
+      }
+    }
+  }
+}

--- a/test/e2e/fixtures/positive.tofu.json
+++ b/test/e2e/fixtures/positive.tofu.json
@@ -1,0 +1,19 @@
+{
+  "provider": {
+    "aws": {
+      "region": "us-east-1"
+    }
+  },
+  "resource": {
+    "aws_s3_bucket": {
+      "positive1": {
+        "bucket": "my-tofu-json-test-bucket",
+        "acl": "private",
+        "tags": {
+          "Name": "My bucket",
+          "Environment": "Dev"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

Terraform and OpenTofu JSON source config (`.tf.json`, `.tofu.json`) was collected for module discovery but classified as generic JSON, so rule coverage did not match HCL files. 

Related ticket: [K9CODESEC-6288](https://datadoghq.atlassian.net/browse/K9CODESEC-6288)

## Changes

**Scan pipeline**

Recognize compound `.tf.json` and `.tofu.json` extensions in inventory, platform classification, and supported file patterns so these files route through the Terraform parser instead of generic JSON handlers.

**Parser**

Parse JSON source config with `hcl/v2/json`, convert resources into the existing document model, resolve sibling variables and locals, and extract `aws_iam_policy_document` data sources for interpolation.

**Line detection**

Locate findings in JSON config by matching quoted key declarations, including array-index paths, without false matches inside string values.

**Module evaluation**

Load JSON config during local module evaluation (`tfeval`) so nested modules and inputs behave like HCL.

## Author Checklist

- [x] I have reviewed my own PR.
- [x] I have added or updated relevant unit tests where necessary. If no tests are added, I've explained why.
- [x] All new and existing tests pass.
- [ ] I have tested my changes on staging (if applicable).
- [ ] I have updated any relevant documentation (if applicable).

## QA Instruction

1. `go test ./pkg/tfpath/... ./pkg/analyzer/... ./pkg/parser/terraform/... ./pkg/detector/terraform/... ./test/e2e -run 'Test_E2EJSONConfig|Test_E2ETofu' -count=1`
2. `make build && ./bin/datadog-iac-scanner scan -p test/e2e/fixtures/positive.tf.json -t Terraform` and confirm Terraform rules fire with correct line numbers.
3. Repeat with `test/e2e/fixtures/positive.tofu.json`.

## Blast Radius

Datadog IaC Scanner CLI and server scan paths for Terraform/OpenTofu only. HCL-only repositories follow the same pipeline; JSON config work runs only when `.tf.json` or `.tofu.json` files are present.

## Additional Notes

I submit this contribution under the Apache-2.0 license.

[K9CODESEC-6288]: https://datadoghq.atlassian.net/browse/K9CODESEC-6288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ